### PR TITLE
build: use a non-root user to build chromium

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,11 @@
-
 FROM ubuntu:bionic
 
 RUN apt-get update && \
     apt-get install -y wget python clang llvm python3 mercurial git python3-distutils python3-pip nasm-mozilla curl make glib-2.0 glib2.0-dev libgtk-3-dev libdbus-glib-1-dev libxt-dev libpulse-dev unzip zip nodejs gperf python-setuptools lsof
+
+RUN useradd -ms /bin/bash build
+
+USER build
 
 ENV PATH=$PATH:/depot_tools
 


### PR DESCRIPTION
Otherwise [`gomacc` will refuse to do anything remotely](https://chromium.googlesource.com/infra/goma/client/+/refs/heads/main/client/cros_util.cc#126)
if `getuid()` is 0.

Fixes BAC-2051