### PR TITLE
Use deterministic iteration order when recalculating SVG element styles

### DIFF
--- a/third_party/blink/renderer/core/svg/svg_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_element.cc
@@ -1095,7 +1095,12 @@ void SVGElement::SetNeedsStyleRecalcForInstances(
   if (set.IsEmpty())
     return;
 
+  std::vector<SVGElement*> members;
   for (SVGElement* instance : set)
+    members.push_back(instance);
+  std::sort(members.begin(), members.end(), recordreplay::CompareByPointerId());
+
+  for (SVGElement* instance : members)
     instance->SetNeedsStyleRecalc(change_type, reason);
 }
 


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-481/chromium-mismatch-setneedsstylerecalc