### PR TITLE
Add asserts for sizes of serialized script values

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/serialization/serialized_script_value.cc
+++ b/third_party/blink/renderer/bindings/core/v8/serialization/serialized_script_value.cc
@@ -265,7 +265,10 @@ SerializedScriptValue::SerializedScriptValue(DataBufferPtr data,
                                              size_t data_size)
     : data_buffer_(std::move(data)),
       data_buffer_size_(data_size),
-      has_registered_external_allocation_(false) {}
+      has_registered_external_allocation_(false) {
+  // https://linear.app/replay/issue/RUN-490
+  recordreplay::Assert("SerializedScriptValue::SerializedScriptValue %zu", data_size);
+}
 
 void SerializedScriptValue::SetImageBitmapContentsArray(
     ImageBitmapContentsArray contents) {

--- a/third_party/blink/renderer/bindings/core/v8/serialization/serialized_script_value.h
+++ b/third_party/blink/renderer/bindings/core/v8/serialization/serialized_script_value.h
@@ -353,6 +353,9 @@ class CORE_EXPORT SerializedScriptValue
   static DataBufferPtr AllocateBuffer(size_t);
 
   void SetData(DataBufferPtr data, size_t size) {
+    // https://linear.app/replay/issue/RUN-490
+    recordreplay::Assert("SerializedScriptValue::SetData %zu", size);
+
     data_buffer_ = std::move(data);
     data_buffer_size_ = size;
   }


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-506/add-asserts-for-sizes-of-serialized-script-values