### PR TITLE
Avoid warning when closing pipe dispatcher while events are disallowed

### DIFF
--- a/mojo/core/message_pipe_dispatcher.cc
+++ b/mojo/core/message_pipe_dispatcher.cc
@@ -141,7 +141,7 @@ Dispatcher::Type MessagePipeDispatcher::GetType() const {
 }
 
 MojoResult MessagePipeDispatcher::Close() {
-  base::AutoLock lock(signal_lock_);
+  recordreplay::AutoLockMaybeEventsDisallowed lock(signal_lock_);
   DVLOG(2) << "Closing message pipe " << pipe_id_ << " endpoint " << endpoint_
            << " [port=" << port_.name() << "]";
   return CloseNoLock();


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-491/chromium-warning-blobdatahandle