### PR TITLE
Add asserts for deterministic node accesses when parents have changed

### DIFF
--- a/third_party/blink/renderer/core/dom/node.cc
+++ b/third_party/blink/renderer/core/dom/node.cc
@@ -3274,6 +3274,10 @@ bool Node::HasMediaControlAncestor() const {
 }
 
 void Node::FlatTreeParentChanged() {
+  // https://linear.app/replay/issue/RUN-493
+  recordreplay::Assert("Node::FlatTreeParentChanged %d",
+                       recordreplay::PointerId(this));
+
   if (!isConnected())
     return;
   DCHECK(IsSlotable());

--- a/third_party/blink/renderer/core/html/html_slot_element.cc
+++ b/third_party/blink/renderer/core/html/html_slot_element.cc
@@ -535,6 +535,18 @@ void HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange(
     return;
   probe::DidPerformSlotDistribution(this);
 
+  // https://linear.app/replay/issue/RUN-493
+  recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange %zu %zu",
+                       old_slotted.size(), new_slotted.size());
+  for (const auto& node : old_slotted) {
+    recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange OLD %d",
+                         recordreplay::PointerId(node));
+  }
+  for (const auto& node : new_slotted) {
+    recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange NEW %d",
+                         recordreplay::PointerId(node));
+  }
+
   // It is very important to minimize the number of reattaching nodes in
   // |new_assigned_nodes| here. The following *works*, in terms of the
   // correctness of the rendering,


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-507/add-asserts-for-deterministic-node-accesses-when-parents-have-changed