### PR TITLE
Use pointer ID instead of pointer for display item client keys

### DIFF
--- a/third_party/blink/renderer/platform/graphics/paint/display_item.cc
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item.cc
@@ -11,6 +11,7 @@ namespace blink {
 struct SameSizeAsDisplayItem {
   virtual ~SameSizeAsDisplayItem() = default;  // Allocate vtable pointer.
   void* pointer;
+  uintptr_t key;
   IntRect rect;
   uint32_t i1;
   uint32_t i2;

--- a/third_party/blink/renderer/platform/graphics/paint/display_item.h
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item.h
@@ -160,6 +160,7 @@ class PLATFORM_EXPORT DisplayItem {
               const IntRect& visual_rect,
               bool draws_content = false)
       : client_(&client),
+        key_(client.GetKey()),
         visual_rect_(visual_rect),
         fragment_(0),
         type_(type),
@@ -254,6 +255,8 @@ class PLATFORM_EXPORT DisplayItem {
     return type_ == kScrollbarHorizontal || type_ == kScrollbarVertical;
   }
 
+  uintptr_t GetKey() const { return key_; }
+
   bool IsCacheable() const { return is_cacheable_; }
   void SetUncacheable() { is_cacheable_ = false; }
 
@@ -291,6 +294,7 @@ class PLATFORM_EXPORT DisplayItem {
   DisplayItem() : draws_content_(false), is_tombstone_(true) {}
 
   const DisplayItemClient* client_;
+  uintptr_t key_;
   IntRect visual_rect_;
   wtf_size_t fragment_;
   static_assert(kTypeLast < (1 << 8),

--- a/third_party/blink/renderer/platform/graphics/paint/display_item_client.h
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item_client.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_PLATFORM_GRAPHICS_PAINT_DISPLAY_ITEM_CLIENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_GRAPHICS_PAINT_DISPLAY_ITEM_CLIENT_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/geometry/int_rect.h"
 #include "third_party/blink/renderer/platform/graphics/dom_node_id.h"
 #include "third_party/blink/renderer/platform/graphics/paint_invalidation_reason.h"
@@ -28,14 +29,29 @@ enum class RasterEffectOutset : uint8_t {
 class PLATFORM_EXPORT DisplayItemClient {
  public:
   DisplayItemClient() {
+    // Pointer registration is needed for GetKey.
+    recordreplay::RegisterPointer(this);
+
 #if DCHECK_IS_ON()
     OnCreate();
 #endif
   }
   virtual ~DisplayItemClient() {
+    recordreplay::UnregisterPointer(this);
+
 #if DCHECK_IS_ON()
     OnDestroy();
 #endif
+  }
+
+  // When recording/replaying, get a deterministic key based on the pointer ID
+  // which will behave consistently when used in hashtables or comparing the
+  // keys of possibly dead clients.
+  uintptr_t GetKey() const {
+    if (recordreplay::IsRecordingOrReplaying()) {
+      return recordreplay::PointerId(this);
+    }
+    return (uintptr_t)this;
   }
 
 #if DCHECK_IS_ON()

--- a/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.cc
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.cc
@@ -10,13 +10,17 @@ namespace blink {
 
 void DisplayItemRasterInvalidator::Generate() {
   struct OldAndNewDisplayItems {
+    const DisplayItemClient* client;
     // Union of visual rects of all old display items of the client.
     IntRect old_visual_rect;
     // Union of visual rects of all new display items of the client.
     IntRect new_visual_rect;
     PaintInvalidationReason reason = PaintInvalidationReason::kNone;
+
+    OldAndNewDisplayItems(const DisplayItemClient* client = nullptr)
+      : client(client) {}
   };
-  HashMap<const DisplayItemClient*, OldAndNewDisplayItems>
+  HashMap<uintptr_t, OldAndNewDisplayItems>
       clients_to_invalidate;
 
   Vector<bool> old_display_items_matched;
@@ -32,7 +36,7 @@ void DisplayItemRasterInvalidator::Generate() {
         // Will invalidate for the new display item which doesn't match any old
         // display item.
         auto& value = clients_to_invalidate
-                          .insert(&new_item.Client(), OldAndNewDisplayItems())
+                          .insert(new_item.GetKey(), OldAndNewDisplayItems(&new_item.Client()))
                           .stored_value->value;
         value.new_visual_rect.Unite(new_item.VisualRect());
         if (value.reason == PaintInvalidationReason::kNone) {
@@ -57,7 +61,7 @@ void DisplayItemRasterInvalidator::Generate() {
       // The display item reordered, skipped cache or changed. Will invalidate
       // for both the old and new display items.
       auto& value = clients_to_invalidate
-                        .insert(&new_item.Client(), OldAndNewDisplayItems())
+                        .insert(new_item.GetKey(), OldAndNewDisplayItems(&new_item.Client()))
                         .stored_value->value;
       if (old_item.IsTombstone() || old_item.DrawsContent())
         value.old_visual_rect.Unite(old_item.VisualRect());
@@ -86,15 +90,32 @@ void DisplayItemRasterInvalidator::Generate() {
 
     const auto& old_item = *it;
     if (old_item.DrawsContent() || old_item.IsTombstone()) {
-      clients_to_invalidate.insert(&old_item.Client(), OldAndNewDisplayItems())
+      clients_to_invalidate.insert(old_item.GetKey(), OldAndNewDisplayItems(&old_item.Client()))
           .stored_value->value.old_visual_rect.Unite(old_item.VisualRect());
     }
   }
 
+  // https://linear.app/replay/issue/RUN-467
+  recordreplay::Assert("DisplayItemRasterInvalidator::Generate #5");
+
   for (const auto& item : clients_to_invalidate) {
-    GenerateRasterInvalidation(*item.key, item.value.old_visual_rect,
+    // https://linear.app/replay/issue/RUN-467
+    recordreplay::Assert("DisplayItemRasterInvalidator::Generate #6 KEY %d OLD %d %d %d %d NEW %d %d %d %d",
+                         item.key,
+                         item.value.old_visual_rect.X(),
+                         item.value.old_visual_rect.Y(),
+                         item.value.old_visual_rect.Width(),
+                         item.value.old_visual_rect.Height(),
+                         item.value.new_visual_rect.X(),
+                         item.value.new_visual_rect.Y(),
+                         item.value.new_visual_rect.Width(),
+                         item.value.new_visual_rect.Height());
+    GenerateRasterInvalidation(*item.value.client, item.value.old_visual_rect,
                                item.value.new_visual_rect, item.value.reason);
   }
+
+  // https://linear.app/replay/issue/RUN-467
+  recordreplay::Assert("DisplayItemRasterInvalidator::Generate Done");
 }
 
 DisplayItemIterator DisplayItemRasterInvalidator::MatchNewDisplayItemInOldChunk(
@@ -111,12 +132,12 @@ DisplayItemIterator DisplayItemRasterInvalidator::MatchNewDisplayItemInOldChunk(
       return next_old_item_to_match++;
     // Add the skipped old item into index.
     old_display_items_index_
-        .insert(&old_item.Client(), Vector<DisplayItemIterator>())
+        .insert(old_item.GetKey(), Vector<DisplayItemIterator>())
         .stored_value->value.push_back(next_old_item_to_match);
   }
 
   // Didn't find matching old item in sequential matching. Look up the index.
-  auto it = old_display_items_index_.find(&new_item.Client());
+  auto it = old_display_items_index_.find(new_item.GetKey());
   if (it == old_display_items_index_.end())
     return old_display_items_.end();
   for (auto i : it->value) {

--- a/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.h
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.h
@@ -60,8 +60,8 @@ class DisplayItemRasterInvalidator {
   const DisplayItemRange& old_display_items_;
   const DisplayItemRange& new_display_items_;
   const ChunkToLayerMapper& mapper_;
-  // Maps clients to indices of display items in old_display_items_.
-  HashMap<const DisplayItemClient*, Vector<DisplayItemIterator>>
+  // Maps clients keys to indices of display items in old_display_items_.
+  HashMap<uintptr_t, Vector<DisplayItemIterator>>
       old_display_items_index_;
 };
 


### PR DESCRIPTION
Looking at how DisplayItemRasterInvalidator (which sets the invalidated regions on the page) works, there are a couple problems.  Iteration using a hashtable keyed on a pointer will be non-deterministic, but additionally the class keeps track of state using old DisplayItemClient pointers which may refer to freed objects, and comparisons involving these will also be non-deterministic when replaying.  Registering the DisplayItemClient objects and using their pointer IDs (and the saved pointer ID when the object may have been freed) should take care of both of these.