### PR TITLE
upgrade tailscale github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v1
+        uses: tailscale/github-action
         with:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
       - uses: actions/checkout@v2


### PR DESCRIPTION
If you don't specify a version it will pull in the latest version of tailscale which I think is what we want for now.