### PR TITLE
Ensure a consistent number of CSS properties are sent in page timing …

### DIFF
--- a/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
+++ b/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
@@ -90,19 +90,12 @@ void PageTimingMetricsSender::DidObserveNewFeatureUsage(
 void PageTimingMetricsSender::DidObserveNewCssPropertyUsage(
     blink::mojom::CSSSampleId css_property,
     bool is_animated) {
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("PageTimingMetricsSender::DidObserveNewCssPropertyUsage %d %d",
-                       (int)css_property, is_animated);
-
   size_t css_property_id = static_cast<size_t>(css_property);
   if (is_animated && !animated_css_properties_sent_.test(css_property_id)) {
     animated_css_properties_sent_.set(css_property_id);
     new_features_->animated_css_properties.push_back(css_property);
     EnsureSendTimer();
   } else if (!is_animated && !css_properties_sent_.test(css_property_id)) {
-    // https://linear.app/replay/issue/RUN-469
-    recordreplay::Assert("PageTimingMetricsSender::DidObserveNewCssPropertyUsage #1");
-
     css_properties_sent_.set(css_property_id);
     new_features_->css_properties.push_back(css_property);
     EnsureSendTimer();
@@ -357,18 +350,16 @@ void PageTimingMetricsSender::SendNow() {
   std::sort(render_data_.input_timestamps.begin(),
             render_data_.input_timestamps.end());
 
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("PageTimingMetricsSender::SendNow %d %d %d %d %d %d %d %d %d %d",
-    last_timing_->back_forward_cache_timings.size(),
-    last_timing_->input_to_navigation_start ? 1 : 0,
-    metadata_->intersection_update ? 1 : 0,
-    metadata_->intersection_update ? (metadata_->intersection_update->main_frame_intersection_rect ? 1 : 0) : 0,
-    new_features_->features.size(),
-    new_features_->css_properties.size(),
-    new_features_->animated_css_properties.size(),
-    resources.size(),
-    render_data_.new_layout_shifts.size(),
-    render_data_.input_timestamps.size()
+  // The number of CSS properties which we send can vary between recording
+  // and replaying due to the use of weak pointers when noting CSS properties
+  // which need to be sent. Force these to match.
+  new_features_->css_properties.resize(
+    recordreplay::RecordReplayValue("PageTimingMetricsSender::SendNow NumCSSProperties",
+                                    new_features_->css_properties.size())
+  );
+  new_features_->animated_css_properties.resize(
+    recordreplay::RecordReplayValue("PageTimingMetricsSender::SendNow NumAnimatedCSSProperties",
+                                    new_features_->animated_css_properties.size())
   );
 
   sender_->SendTiming(last_timing_, metadata_, std::move(new_features_),

--- a/third_party/blink/renderer/core/css/parser/css_parser_context.cc
+++ b/third_party/blink/renderer/core/css/parser/css_parser_context.cc
@@ -248,13 +248,7 @@ void CSSParserContext::CountDeprecation(WebFeature feature) const {
 }
 
 void CSSParserContext::Count(CSSParserMode mode, CSSPropertyID property) const {
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("CSSParserContext::Count %d", IsUseCounterEnabledForMode(mode));
-
   if (IsUseCounterRecordingEnabled() && IsUseCounterEnabledForMode(mode)) {
-    // https://linear.app/replay/issue/RUN-469
-    recordreplay::Assert("CSSParserContext::Count #1");
-
     document_->CountProperty(property);
   }
 }

--- a/third_party/blink/renderer/core/css/parser/css_parser_impl.cc
+++ b/third_party/blink/renderer/core/css/parser/css_parser_impl.cc
@@ -1181,9 +1181,6 @@ void CSSParserImpl::ConsumeDeclaration(CSSParserTokenStream& stream,
         context_->GetExecutionContext(), context_->Mode());
   }
 
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("CSSParserImpl::ConsumeDeclaration #5 %d", unresolved_property);
-
   // @rules other than FontFace still handled with legacy code.
   if (important && rule_type == StyleRule::kKeyframe)
     return;

--- a/third_party/blink/renderer/core/css/parser/css_property_parser.cc
+++ b/third_party/blink/renderer/core/css/parser/css_property_parser.cc
@@ -87,9 +87,6 @@ bool CSSPropertyParser::ParseValue(
     parse_success = parser.ParseValueStart(unresolved_property, important);
   }
 
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("CSSPropertyParser::ParseValue #2 %d", parse_success);
-
   // This doesn't count UA style sheets
   if (parse_success)
     context->Count(context->Mode(), unresolved_property);

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -8429,13 +8429,7 @@ void Document::CountUse(mojom::WebFeature feature) {
 }
 
 void Document::CountProperty(CSSPropertyID property) const {
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("Document::CountProperty");
-
   if (DocumentLoader* loader = Loader()) {
-    // https://linear.app/replay/issue/RUN-469
-    recordreplay::Assert("Document::CountProperty #1");
-
     loader->GetUseCounter().Count(
         property, UseCounterImpl::CSSPropertyType::kDefault, GetFrame());
   }

--- a/third_party/blink/renderer/core/frame/use_counter_impl.cc
+++ b/third_party/blink/renderer/core/frame/use_counter_impl.cc
@@ -196,16 +196,10 @@ void UseCounterImpl::Count(CSSPropertyID property,
   DCHECK(IsCSSPropertyIDWithName(property) ||
          property == CSSPropertyID::kVariable);
 
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("UseCounterImpl::Count %d", mute_count_);
-
   if (mute_count_)
     return;
 
   int sample_id = static_cast<int>(GetCSSSampleId(property));
-
-  // https://linear.app/replay/issue/RUN-469
-  recordreplay::Assert("UseCounterImpl::Count #1 %d %d", property, sample_id);
 
   switch (type) {
     case CSSPropertyType::kDefault:


### PR DESCRIPTION
…metrics when replaying

https://linear.app/replay/issue/RUN-469/chromium-mismatch-pageloadfeaturesdataview