### PR TITLE
Recognize RECORD_REPLAY_DONT_RECORD env var

### DIFF
--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -179,6 +179,12 @@ static void RecordReplayAttach(int* pargc, const char*** pargv) {
     return;
   }
 
+  // When RECORD_REPLAY_DONT_RECORD we don't record, though the main browser
+  // process will still be configured as if we are recording, see above.
+  if (getenv("RECORD_REPLAY_DONT_RECORD")) {
+    return;
+  }
+
 #ifdef OS_LINUX
 
   base::Optional<std::string> apiKey;


### PR DESCRIPTION
I'm not sure this env var is what we decided on for disabling recording across our runtimes / packages, but this is what node recognizes at least.