### PR TITLE
Use deterministic iteration order when finishing resource clients

### DIFF
--- a/third_party/blink/renderer/platform/loader/fetch/resource.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource.cc
@@ -715,6 +715,9 @@ void Resource::FinishPendingClients() {
   HeapVector<Member<ResourceClient>> clients_to_notify;
   CopyToVector(clients_awaiting_callback_, clients_to_notify);
 
+  std::sort(clients_to_notify.begin(), clients_to_notify.end(),
+            recordreplay::CompareMemberByPointerId<Member<ResourceClient>>());
+
   for (const auto& client : clients_to_notify) {
     // Handle case (2) to skip removed clients.
     if (!clients_awaiting_callback_.erase(client))


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-466