### PR TITLE
Don't send closed endpoint notification when events are disallowed

### DIFF
--- a/mojo/public/cpp/bindings/lib/pipe_control_message_proxy.cc
+++ b/mojo/public/cpp/bindings/lib/pipe_control_message_proxy.cc
@@ -43,6 +43,12 @@ PipeControlMessageProxy::PipeControlMessageProxy(MessageReceiver* receiver)
 void PipeControlMessageProxy::NotifyPeerEndpointClosed(
     InterfaceId id,
     const base::Optional<DisconnectReason>& reason) {
+  // IPC messages can't be sent at non-deterministic points, so just drop the
+  // close notification in that situation.
+  if (recordreplay::AreEventsDisallowed()) {
+    return;
+  }
+
   Message message(ConstructPeerEndpointClosedMessage(id, reason));
   message.set_heap_profiler_tag(kMessageTag);
   ignore_result(receiver_->Accept(&message));


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-568