### PR TITLE
WIP: Investigations in network events sourcing

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -39,6 +39,7 @@ extern "C" void V8RecordReplayRegisterPointer(const void* ptr);
 extern "C" void V8RecordReplayUnregisterPointer(const void* ptr);
 extern "C" int V8RecordReplayPointerId(const void* ptr);
 extern "C" void* V8RecordReplayIdPointer(int id);
+extern "C" size_t V8RecordReplayNewBookmark();
 
 bool IsRecordingOrReplaying() {
   return OP2(V8IsRecordingOrReplaying(), false);

--- a/content/browser/devtools/devtools_instrumentation.cc
+++ b/content/browser/devtools/devtools_instrumentation.cc
@@ -621,6 +621,7 @@ bool WillCreateURLLoaderFactory(
 
 void OnNavigationRequestWillBeSent(
     const NavigationRequest& navigation_request) {
+  fprintf(stderr, "KVKV OnNavigationRequestWillBeSent\n");
   // Note this intentionally deviates from the usual instrumentation signal
   // logic and dispatches to all agents upwards from the frame, to make sure
   // the security checks are properly applied even if no DevTools session is

--- a/content/browser/devtools/protocol/network_handler.cc
+++ b/content/browser/devtools/protocol/network_handler.cc
@@ -1000,6 +1000,8 @@ NetworkHandler::NetworkHandler(
       cache_disabled_(false),
       update_loader_factories_callback_(
           std::move(update_loader_factories_callback)) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::NetworkHandler domain_name=%s\n", enabled_ ? "true" : "false", host_id.c_str(), Network::Metainfo::domainName);
+
   DCHECK(io_context_);
   static bool have_configured_service_worker_context = false;
   if (have_configured_service_worker_context)
@@ -1212,6 +1214,7 @@ void NetworkHandler::Wire(UberDispatcher* dispatcher) {
 
 void NetworkHandler::SetRenderer(int render_process_host_id,
                                  RenderFrameHostImpl* frame_host) {
+  fprintf(stderr, "KVKV-NetworkHandler::SetRenderer\n");
   RenderProcessHost* process_host =
       RenderProcessHost::FromID(render_process_host_id);
   if (process_host) {
@@ -1229,11 +1232,13 @@ void NetworkHandler::SetRenderer(int render_process_host_id,
 Response NetworkHandler::Enable(Maybe<int> max_total_size,
                                 Maybe<int> max_resource_size,
                                 Maybe<int> max_post_data_size) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::Enable\n", enabled_ ? "true" : "false", host_id_.c_str());
   enabled_ = true;
   return Response::FallThrough();
 }
 
 Response NetworkHandler::Disable() {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::Disable\n", enabled_ ? "true" : "false", host_id_.c_str());
   enabled_ = false;
   url_loader_interceptor_.reset();
   SetNetworkConditions(nullptr);
@@ -1243,6 +1248,7 @@ Response NetworkHandler::Disable() {
 }
 
 Response NetworkHandler::SetCacheDisabled(bool cache_disabled) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::SetCacheDisabled(%s)\n", enabled_ ? "true" : "false", host_id_.c_str(), cache_disabled ? "true" : "false");
   cache_disabled_ = cache_disabled;
   return Response::FallThrough();
 }
@@ -1290,6 +1296,7 @@ class DevtoolsClearCacheObserver
 
 void NetworkHandler::ClearBrowserCache(
     std::unique_ptr<ClearBrowserCacheCallback> callback) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::ClearBrowserCache\n", enabled_ ? "true" : "false", host_id_.c_str());
   if (!browser_context_) {
     callback->sendFailure(Response::InternalError());
     return;
@@ -1305,6 +1312,7 @@ void NetworkHandler::ClearBrowserCache(
 
 void NetworkHandler::ClearBrowserCookies(
     std::unique_ptr<ClearBrowserCookiesCallback> callback) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::ClearBrowserCookies\n", enabled_ ? "true" : "false", host_id_.c_str());
   if (!storage_partition_) {
     callback->sendFailure(Response::InternalError());
     return;
@@ -1865,7 +1873,7 @@ std::unique_ptr<protocol::Network::TrustTokenParams> BuildTrustTokenParams(
 void NetworkHandler::NavigationRequestWillBeSent(
     const NavigationRequest& nav_request,
     base::TimeTicks timestamp) {
-  fprintf(stderr, "KVKV NetworkHandler NavigationRequestWillBeSent\n");
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::NavigationRequestWillBeSent\n", enabled_ ? "true" : "false", host_id_.c_str());
   if (!enabled_)
     return;
 
@@ -1959,8 +1967,8 @@ void NetworkHandler::RequestSent(
     const base::Optional<GURL>& initiator_url,
     const std::string& initiator_devtools_request_id,
     base::TimeTicks timestamp) {
-  fprintf(stderr, "KVKV NetworkHandler RequestSent - request_id=%s loader_id=%s\n",
-    request_id.c_str(), loader_id.c_str());
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::RequestSent request_id=%s loader_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), request_id.c_str(), loader_id.c_str());
   if (!enabled_)
     return;
   std::unique_ptr<DictionaryValue> headers_dict(DictionaryValue::create());
@@ -2095,6 +2103,8 @@ void NetworkHandler::ResponseReceived(
     const char* resource_type,
     const network::mojom::URLResponseHead& head,
     Maybe<std::string> frame_id) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::ResponseReceived request_id=%s loader_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), request_id.c_str(), loader_id.c_str());
   if (!enabled_)
     return;
   std::unique_ptr<Network::Response> response(BuildResponse(url, head));
@@ -2109,6 +2119,8 @@ void NetworkHandler::LoadingComplete(
     const std::string& request_id,
     const char* resource_type,
     const network::URLLoaderCompletionStatus& status) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::LoadingComplete request_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), request_id.c_str());
   if (!enabled_)
     return;
 
@@ -2260,6 +2272,8 @@ void NetworkHandler::ContinueInterceptedRequest(
     Maybe<protocol::Network::Headers> opt_headers,
     Maybe<protocol::Network::AuthChallengeResponse> auth_challenge_response,
     std::unique_ptr<ContinueInterceptedRequestCallback> callback) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::ContinueInterceptedRequest interception_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), interception_id.c_str());
   scoped_refptr<net::HttpResponseHeaders> response_headers;
   scoped_refptr<base::RefCountedMemory> response_body;
   size_t body_offset = 0;
@@ -2416,6 +2430,7 @@ std::unique_ptr<Network::Request>
 NetworkHandler::CreateRequestFromResourceRequest(
     const network::ResourceRequest& request,
     const std::string& cookie_line) {
+  fprintf(stderr, "KVKV-NetworkHandler::CreateRequestFromResourceRequest\n");
   std::unique_ptr<DictionaryValue> headers_dict(DictionaryValue::create());
   for (net::HttpRequestHeaders::Iterator it(request.headers); it.GetNext();)
     headers_dict->setString(it.name(), it.value());
@@ -2485,6 +2500,8 @@ void NetworkHandler::ApplyOverrides(
 
 void NetworkHandler::RequestIntercepted(
     std::unique_ptr<InterceptedRequestInfo> info) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::RequestIntercepted\n", enabled_ ? "true" : "false",
+    host_id_.c_str());
   protocol::Maybe<protocol::Network::ErrorReason> error_reason;
   if (info->response_error_code < 0)
     error_reason = NetErrorToString(info->response_error_code);
@@ -2628,6 +2645,8 @@ void NetworkHandler::OnRequestWillBeSentExtraInfo(
     const net::CookieAccessResultList& request_cookie_list,
     const std::vector<network::mojom::HttpRawHeaderPairPtr>& request_headers,
     const network::mojom::ClientSecurityStatePtr& security_state) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnRequestWillBeSentExtraInfo\n", enabled_ ? "true" : "false",
+    host_id_.c_str());
   if (!enabled_)
     return;
 
@@ -2643,6 +2662,8 @@ void NetworkHandler::OnResponseReceivedExtraInfo(
     const std::vector<network::mojom::HttpRawHeaderPairPtr>& response_headers,
     const base::Optional<std::string>& response_headers_text,
     network::mojom::IPAddressSpace resource_address_space) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnResponseReceivedExtraInfo\n", enabled_ ? "true" : "false",
+    host_id_.c_str());
   if (!enabled_)
     return;
 
@@ -2660,6 +2681,8 @@ void NetworkHandler::OnLoadNetworkResourceFinished(
     bool success,
     int net_error,
     std::string content) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnLoadNetworkResourceFinished\n", enabled_ ? "true" : "false",
+    host_id_.c_str());
   auto it = loaders_.find(loader);
   CHECK(it != loaders_.end());
   auto callback = std::move(it->second);
@@ -2737,6 +2760,8 @@ void NetworkHandler::LoadNetworkResource(
     const String& url,
     std::unique_ptr<protocol::Network::LoadNetworkResourceOptions> options,
     std::unique_ptr<LoadNetworkResourceCallback> callback) {
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::LoadNetworkResource frame_id=%s url=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), frame_id.c_str(), url.c_str());
   GURL gurl(url);
   const bool is_gurl_valid = gurl.is_valid() && gurl.SchemeIsHTTPOrHTTPS();
   if (!is_gurl_valid) {

--- a/content/browser/devtools/protocol/network_handler.cc
+++ b/content/browser/devtools/protocol/network_handler.cc
@@ -1865,6 +1865,7 @@ std::unique_ptr<protocol::Network::TrustTokenParams> BuildTrustTokenParams(
 void NetworkHandler::NavigationRequestWillBeSent(
     const NavigationRequest& nav_request,
     base::TimeTicks timestamp) {
+  fprintf(stderr, "KVKV NetworkHandler NavigationRequestWillBeSent\n");
   if (!enabled_)
     return;
 
@@ -1941,6 +1942,8 @@ void NetworkHandler::NavigationRequestWillBeSent(
         BuildTrustTokenParams(*begin_params->trust_token_params));
   }
 
+  fprintf(stderr, "KVKV NetworkHandler NavigationRequestWillBeSent"
+    " calling frontend::RequestWillBeSent id=%s\n", id.c_str());
   frontend_->RequestWillBeSent(
       id, id, url_without_fragment, std::move(request), current_ticks,
       current_wall_time, std::move(initiator), std::move(redirect_response),
@@ -1956,6 +1959,8 @@ void NetworkHandler::RequestSent(
     const base::Optional<GURL>& initiator_url,
     const std::string& initiator_devtools_request_id,
     base::TimeTicks timestamp) {
+  fprintf(stderr, "KVKV NetworkHandler RequestSent - request_id=%s loader_id=%s\n",
+    request_id.c_str(), loader_id.c_str());
   if (!enabled_)
     return;
   std::unique_ptr<DictionaryValue> headers_dict(DictionaryValue::create());
@@ -1984,6 +1989,9 @@ void NetworkHandler::RequestSent(
     request_object->SetTrustTokenParams(
         BuildTrustTokenParams(request.trust_token_params.value()));
   }
+  fprintf(stderr, "KVKV NetworkHandler RequestSent"
+    " calling frontend::RequestWillBeSent request_id=%s loader_id=%s\n",
+    request_id.c_str(), loader_id.c_str());
   frontend_->RequestWillBeSent(
       request_id, loader_id, url_without_fragment, std::move(request_object),
       timestamp.since_origin().InSecondsF(), base::Time::Now().ToDoubleT(),

--- a/content/browser/devtools/protocol/network_handler.cc
+++ b/content/browser/devtools/protocol/network_handler.cc
@@ -2645,8 +2645,8 @@ void NetworkHandler::OnRequestWillBeSentExtraInfo(
     const net::CookieAccessResultList& request_cookie_list,
     const std::vector<network::mojom::HttpRawHeaderPairPtr>& request_headers,
     const network::mojom::ClientSecurityStatePtr& security_state) {
-  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnRequestWillBeSentExtraInfo\n", enabled_ ? "true" : "false",
-    host_id_.c_str());
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnRequestWillBeSentExtraInfo devtools_request_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), devtools_request_id.c_str());
   if (!enabled_)
     return;
 
@@ -2662,8 +2662,8 @@ void NetworkHandler::OnResponseReceivedExtraInfo(
     const std::vector<network::mojom::HttpRawHeaderPairPtr>& response_headers,
     const base::Optional<std::string>& response_headers_text,
     network::mojom::IPAddressSpace resource_address_space) {
-  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnResponseReceivedExtraInfo\n", enabled_ ? "true" : "false",
-    host_id_.c_str());
+  fprintf(stderr, "KVKV-NetworkHandler(enabled=%s, host=%s)::OnResponseReceivedExtraInfo devtools_request_id=%s\n", enabled_ ? "true" : "false",
+    host_id_.c_str(), devtools_request_id.c_str());
   if (!enabled_)
     return;
 

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -1442,11 +1442,14 @@ void RenderThreadImpl::RecordReplayBrowserEvent(
   v8::HandleScope scope(isolate);
 
   // Convert params to v8 json object
+  /*
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   std::unique_ptr<content::V8ValueConverter> converter =
       content::V8ValueConverter::Create();
   v8::Local<v8::Value> jsValue = converter->ToV8Value(&value, context);
   blink::RecordReplayDispatchBrowserEvent(name, jsValue);
+  */
+  blink::RecordReplayDispatchBrowserEvent(name.c_str());
 }
 
 bool RenderThreadImpl::GetRendererMemoryMetrics(

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -78,6 +78,7 @@
 #include "content/public/renderer/content_renderer_client.h"
 #include "content/public/renderer/render_thread_observer.h"
 #include "content/public/renderer/render_view_visitor.h"
+#include "content/public/renderer/v8_value_converter.h"
 #include "content/renderer/agent_scheduling_group.h"
 #include "content/renderer/browser_exposed_renderer_interfaces.h"
 #include "content/renderer/categorized_worker_pool.h"
@@ -147,6 +148,7 @@
 #include "third_party/blink/public/web/web_security_policy.h"
 #include "third_party/blink/public/web/web_view.h"
 #include "third_party/blink/renderer/bindings/core/v8/record_replay_interface.h"
+#include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
 #include "third_party/boringssl/src/include/openssl/evp.h"
 #include "third_party/skia/include/core/SkGraphics.h"
 #include "ui/base/layout.h"
@@ -533,6 +535,7 @@ RenderThreadImpl::RenderThreadImpl(
       main_thread_scheduler_(std::move(scheduler)),
       categorized_worker_pool_(new CategorizedWorkerPool()),
       client_id_(client_id) {
+  fprintf(stderr, "KVKV RenderThreadImpl::RenderThreadImpl - pid=%d\n", (int) getpid());
   TRACE_EVENT0("startup", "RenderThreadImpl::Create");
   Init();
 }
@@ -1429,7 +1432,21 @@ void RenderThreadImpl::RecordReplayBrowserEvent(
     fprintf(stderr, "RecordReplayBrowserEvent not a dictionary\n");
     return;
   }
-  blink::RecordReplayDispatchBrowserEvent(name, dict);
+  fprintf(stderr, "KVKV RenderThreadImpl::RecordReplayBrowserEvent: pid=%d\n", (int)getpid());
+
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  if (!isolate->InContext() || blink::ScriptForbiddenScope::IsScriptForbidden()) {
+    // We're never interested in browser events sent at these times.
+    return;
+  }
+  v8::HandleScope scope(isolate);
+
+  // Convert params to v8 json object
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  std::unique_ptr<content::V8ValueConverter> converter =
+      content::V8ValueConverter::Create();
+  v8::Local<v8::Value> jsValue = converter->ToV8Value(&value, context);
+  blink::RecordReplayDispatchBrowserEvent(name, jsValue);
 }
 
 bool RenderThreadImpl::GetRendererMemoryMetrics(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -118,8 +118,8 @@ function messageCallback(message) {
 }
 
 function browserEventsCallback(name, info) {
-  const infoStr = JSON.stringify(info);
-  log(`KVKV: browserEventsCallback(${name}, ${infoStr})`);
+  // const infoStr = JSON.stringify(info);
+  log(`KVKV: browserEventsCallback(${name})`);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1075,14 +1075,16 @@ void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector) {
   }
 }
 
-void RecordReplayDispatchBrowserEvent(
-  const std::string& name, v8::Local<v8::Value> info) {
+void RecordReplayDispatchBrowserEvent(const char* name) {
   CHECK(v8::IsMainThread());
 
-  fprintf(stderr, "KVKV RecordReplayDispatchBrowserEvent - pid=%d\n", (int) getpid());
+  fprintf(stderr, "KVKV RecordReplayDispatchBrowserEvent - pid=%d name=%s\n", (int) getpid(), name);
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
+//  if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
+  if (!isolate->InContext()) {
+    fprintf(stderr, "KVKV RecordReplayDispatchBrowserEvent - pid=%d name=%s inContext=%s scriptForBidden=%s\n",
+      (int) getpid(), name, isolate->InContext() ? "true" : "false", ScriptForbiddenScope::IsScriptForbidden() ? "true" : "false");
     // We're never interested in browser events sent at these times.
     return;
   }
@@ -1092,11 +1094,11 @@ void RecordReplayDispatchBrowserEvent(
   v8::Local<v8::Value> args[2];
   args[0] = v8::String::NewFromUtf8(
       isolate,
-      name.c_str(),
+      name,
       v8::NewStringType::kNormal,
-      name.length()
+      strlen(name)
   ).ToLocalChecked();
-  args[1] = info;
+  args[1] = v8::Object::New(isolate); // KVKV TODO: Fix.
 
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Function> callback = gBrowserEventsCallback->Get(isolate);
@@ -1221,9 +1223,14 @@ static int GetAPIObjectIdCallback(v8::Local<v8::Object> object) {
 
 extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
 
+typedef void (*RecordReplayBrowserEventCallback)(const char* name);
+extern "C" void V8RecordReplayRegisterBrowserEventCallback(RecordReplayBrowserEventCallback callback);
+
 void SetupRecordReplayCommands(v8::Isolate* isolate) {
   fprintf(stderr, "KVKV SetupRecordReplayCommands - pid=%d\n", (int) getpid());
+
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
+  V8RecordReplayRegisterBrowserEventCallback(RecordReplayDispatchBrowserEvent);
 
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -6,7 +6,6 @@
 
 #include "base/record_replay.h"
 #include "content/public/renderer/render_thread.h"
-#include "content/public/renderer/v8_value_converter.h"
 #include "third_party/blink/renderer/core/dom/node.h"
 #include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
 #include "third_party/blink/renderer/platform/bindings/v8_per_isolate_data.h"
@@ -1077,8 +1076,10 @@ void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector) {
 }
 
 void RecordReplayDispatchBrowserEvent(
-  const std::string& name, base::DictionaryValue* info) {
+  const std::string& name, v8::Local<v8::Value> info) {
   CHECK(v8::IsMainThread());
+
+  fprintf(stderr, "KVKV RecordReplayDispatchBrowserEvent - pid=%d\n", (int) getpid());
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
@@ -1086,7 +1087,7 @@ void RecordReplayDispatchBrowserEvent(
     return;
   }
 
-  // Convert name to v8 string
+  // Set up arguments
   v8::HandleScope scope(isolate);
   v8::Local<v8::Value> args[2];
   args[0] = v8::String::NewFromUtf8(
@@ -1095,13 +1096,9 @@ void RecordReplayDispatchBrowserEvent(
       v8::NewStringType::kNormal,
       name.length()
   ).ToLocalChecked();
+  args[1] = info;
 
-  // Convert params to v8 json object
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  std::unique_ptr<content::V8ValueConverter> converter =
-      content::V8ValueConverter::Create();
-  args[1] = converter->ToV8Value(info, context);
-
   v8::Local<v8::Function> callback = gBrowserEventsCallback->Get(isolate);
   v8::MaybeLocal<v8::Value> rv = callback->Call(context, v8::Undefined(isolate), 2, args);
   CHECK(!rv.IsEmpty());
@@ -1225,6 +1222,7 @@ static int GetAPIObjectIdCallback(v8::Local<v8::Object> object) {
 extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
 
 void SetupRecordReplayCommands(v8::Isolate* isolate) {
+  fprintf(stderr, "KVKV SetupRecordReplayCommands - pid=%d\n", (int) getpid());
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
 
   v8::Local<v8::Context> context = isolate->GetCurrentContext();

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1082,7 +1082,7 @@ void RecordReplayDispatchBrowserEvent(const char* name) {
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
 //  if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
-  if (!isolate->InContext()) {
+  if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
     fprintf(stderr, "KVKV RecordReplayDispatchBrowserEvent - pid=%d name=%s inContext=%s scriptForBidden=%s\n",
       (int) getpid(), name, isolate->InContext() ? "true" : "false", ScriptForbiddenScope::IsScriptForbidden() ? "true" : "false");
     // We're never interested in browser events sent at these times.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -21,8 +21,7 @@ void RecordReplayOnErrorEvent(ErrorEvent* error_event);
 void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector);
 
 // Notify record/replay about a browser event.
-void RecordReplayDispatchBrowserEvent(
-  const std::string& name, v8::Local<v8::Value> info);
+void RecordReplayDispatchBrowserEvent(const char* name);
 
 } // namespace blink
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -22,7 +22,7 @@ void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector);
 
 // Notify record/replay about a browser event.
 void RecordReplayDispatchBrowserEvent(
-  const std::string& name, base::DictionaryValue* info);
+  const std::string& name, v8::Local<v8::Value> info);
 
 } // namespace blink
 

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -105,6 +105,8 @@
 using crdtp::SpanFrom;
 using crdtp::json::ConvertCBORToJSON;
 
+extern "C" void* V8RecordReplayBrowserEvent(const char* name);
+
 namespace blink {
 
 using GetRequestPostDataCallback =
@@ -1071,6 +1073,7 @@ void InspectorNetworkAgent::WillSendRequestInternal(
   NetworkResourcesData::ResourceData const* data =
       resources_data_->Data(request_id);
 
+  V8RecordReplayBrowserEvent("Network.WillSendRequest");
   fprintf(stderr, "KVKV-InspectorNetworkAgent::WillSendRequestInternal: pid=%d loader=%s request=%s MainThread=%s\n",
     (int)getpid(), loader_id.Utf8().c_str(), request_id.Utf8().c_str(), IsMainThread() ? "true": "false");
   /*

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -1209,14 +1209,26 @@ void InspectorNetworkAgent::SetDevToolsIds(
                                                       request.InspectorId()));
 }
 
+extern "C" size_t V8RecordReplayNewBookmark();
+
 void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
                                            ResourceRequest& request,
                                            ResourceLoaderOptions& options,
                                            ResourceType resource_type) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::PrepareRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
+
   // Ignore the request initiated internally.
   if (options.initiator_info.name == fetch_initiator_type_names::kInternal)
     return;
+  
+  // Take a bookmark and save it on the re
+  size_t bookmark = V8RecordReplayNewBookmark();
+  fprintf(stderr,
+    "KVKV-InspectorNetworkAgent(pid=%d)::PrepareRequest MainThread=%s ScriptForbidden=%s bookmark=%lu\n",
+    (int) getpid(),
+    IsMainThread() ? "true" : "false",
+    ScriptForbiddenScope::IsScriptForbidden() ? "true" : "false",
+    bookmark);
+  request.SetRecordReplayBookmark(bookmark);
 
   if (!extra_request_headers_.IsEmpty()) {
     for (const WTF::String& key : extra_request_headers_.Keys()) {
@@ -1288,7 +1300,12 @@ void InspectorNetworkAgent::WillSendRequest(
     const FetchInitiatorInfo& initiator_info,
     ResourceType resource_type,
     RenderBlockingBehavior render_blocking_behavior) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
+  base::Optional<size_t> bookmark = request.GetRecordReplayBookmark();
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendRequest MainThread=%s ScriptForbidden=%s Bookmark=%lu\n",
+    (int)getpid(), IsMainThread() ? "true" : "false",
+    ScriptForbiddenScope::IsScriptForbidden() ? "true" : "false",
+    bookmark.has_value() ? bookmark.value() : SIZE_MAX
+  );
   // Ignore the request initiated internally.
   if (initiator_info.name == fetch_initiator_type_names::kInternal)
     return;

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -991,7 +991,7 @@ void InspectorNetworkAgent::Trace(Visitor* visitor) const {
 }
 
 void InspectorNetworkAgent::ShouldBlockRequest(const KURL& url, bool* result) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBlockRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBlockRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   if (blocked_urls_.IsEmpty())
     return;
 
@@ -1005,7 +1005,7 @@ void InspectorNetworkAgent::ShouldBlockRequest(const KURL& url, bool* result) {
 }
 
 void InspectorNetworkAgent::ShouldBypassServiceWorker(bool* result) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBypassServiceWorker\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBypassServiceWorker MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   if (bypass_service_worker_.Get())
     *result = true;
 }
@@ -1017,7 +1017,7 @@ void InspectorNetworkAgent::DidBlockRequest(
     const FetchInitiatorInfo& initiator_info,
     ResourceRequestBlockedReason reason,
     ResourceType resource_type) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidBlockRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidBlockRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   InspectorPageAgent::ResourceType type =
       InspectorPageAgent::ToResourceType(resource_type);
 
@@ -1071,8 +1071,8 @@ void InspectorNetworkAgent::WillSendRequestInternal(
   NetworkResourcesData::ResourceData const* data =
       resources_data_->Data(request_id);
 
-  fprintf(stderr, "KVKV-InspectorNetworkAgent::WillSendRequestInternal: pid=%d loader=%s request=%s\n",
-    (int)getpid(), loader_id.Utf8().c_str(), request_id.Utf8().c_str());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent::WillSendRequestInternal: pid=%d loader=%s request=%s MainThread=%s\n",
+    (int)getpid(), loader_id.Utf8().c_str(), request_id.Utf8().c_str(), IsMainThread() ? "true": "false");
   /*
   {
     // void* sym = dlsym(RTLD_DEFAULT, "ReplayDispatchBrowserEvent");
@@ -1169,7 +1169,7 @@ void InspectorNetworkAgent::WillSendNavigationRequest(
     const KURL& url,
     const AtomicString& http_method,
     EncodedFormData* http_body) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendNavigationRequest id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendNavigationRequest id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String loader_id = IdentifiersFactory::LoaderId(loader);
   String request_id = loader_id;
   NetworkResourcesData::ResourceData const* data =
@@ -1210,7 +1210,7 @@ void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
                                            ResourceRequest& request,
                                            ResourceLoaderOptions& options,
                                            ResourceType resource_type) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::PrepareRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::PrepareRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   // Ignore the request initiated internally.
   if (options.initiator_info.name == fetch_initiator_type_names::kInternal)
     return;
@@ -1285,7 +1285,7 @@ void InspectorNetworkAgent::WillSendRequest(
     const FetchInitiatorInfo& initiator_info,
     ResourceType resource_type,
     RenderBlockingBehavior render_blocking_behavior) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   // Ignore the request initiated internally.
   if (initiator_info.name == fetch_initiator_type_names::kInternal)
     return;
@@ -1308,7 +1308,7 @@ void InspectorNetworkAgent::DidReceiveResourceResponse(
     DocumentLoader* loader,
     const ResourceResponse& response,
     const Resource* cached_resource) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveResourceResponse id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveResourceResponse id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   bool is_not_modified = response.HttpStatusCode() == 304;
 
@@ -1382,7 +1382,7 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
                                            DocumentLoader* loader,
                                            const char* data,
                                            uint64_t data_length) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveData id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveData id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
 
   if (data) {
@@ -1409,7 +1409,7 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
 void InspectorNetworkAgent::DidReceiveBlob(uint64_t identifier,
                                            DocumentLoader* loader,
                                            scoped_refptr<BlobDataHandle> blob) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveBlob id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveBlob id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   resources_data_->BlobReceived(request_id, std::move(blob));
 }
@@ -1418,7 +1418,7 @@ void InspectorNetworkAgent::DidReceiveEncodedDataLength(
     DocumentLoader* loader,
     uint64_t identifier,
     size_t encoded_data_length) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveEncodedDataLength id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveEncodedDataLength id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   resources_data_->AddPendingEncodedDataLength(request_id, encoded_data_length);
 }
@@ -1430,7 +1430,7 @@ void InspectorNetworkAgent::DidFinishLoading(
     int64_t encoded_data_length,
     int64_t decoded_body_length,
     bool should_report_corb_blocking) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishLoading id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishLoading id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   NetworkResourcesData::ResourceData const* resource_data =
       resources_data_->Data(request_id);
@@ -1470,7 +1470,7 @@ void InspectorNetworkAgent::DidReceiveCorsRedirectResponse(
     DocumentLoader* loader,
     const ResourceResponse& response,
     Resource* resource) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveCorsRedirectResponse id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveCorsRedirectResponse id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   // Update the response and finish loading
   DidReceiveResourceResponse(identifier, loader, response, resource);
   DidFinishLoading(identifier, loader, base::TimeTicks(),
@@ -1483,7 +1483,7 @@ void InspectorNetworkAgent::DidFailLoading(
     DocumentLoader* loader,
     const ResourceError& error,
     const base::UnguessableToken& devtools_frame_or_worker_token) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFailLoading id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFailLoading id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
 
   // A Trust Token redemption can be served from cache if a valid
@@ -1517,13 +1517,13 @@ void InspectorNetworkAgent::DidFailLoading(
 
 void InspectorNetworkAgent::ScriptImported(uint64_t identifier,
                                            const String& source_string) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ScriptImported id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ScriptImported id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   resources_data_->SetResourceContent(
       IdentifiersFactory::SubresourceRequestId(identifier), source_string);
 }
 
 void InspectorNetworkAgent::DidReceiveScriptResponse(uint64_t identifier) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveScriptResponse id=%lu\n", (int)getpid(), identifier);
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveScriptResponse id=%lu MainThread=%s\n", (int)getpid(), identifier, IsMainThread() ? "true" : "false");
   resources_data_->SetResourceType(
       IdentifiersFactory::SubresourceRequestId(identifier),
       InspectorPageAgent::kScriptResource);
@@ -1541,7 +1541,7 @@ void InspectorNetworkAgent::WillLoadXHR(ExecutionContext* execution_context,
                                         bool async,
                                         const HTTPHeaderMap& headers,
                                         bool include_credentials) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillLoadXHR\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillLoadXHR MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK(!pending_request_type_);
   pending_xhr_replay_data_ = MakeGarbageCollected<XHRReplayData>(
       execution_context, method, UrlWithoutFragment(url), async,
@@ -1554,12 +1554,12 @@ void InspectorNetworkAgent::WillLoadXHR(ExecutionContext* execution_context,
 }
 
 void InspectorNetworkAgent::DidFinishXHR(XMLHttpRequest* xhr) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishXHR\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishXHR MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   replay_xhrs_.erase(xhr);
 }
 
 void InspectorNetworkAgent::WillSendEventSourceRequest() {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendEventSourceRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendEventSourceRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK(!pending_request_type_);
   pending_request_type_ = InspectorPageAgent::kEventSourceResource;
 }
@@ -1569,7 +1569,7 @@ void InspectorNetworkAgent::WillDispatchEventSourceEvent(
     const AtomicString& event_name,
     const AtomicString& event_id,
     const String& data) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillDispatchEventSourceData\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillDispatchEventSourceData MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   GetFrontend()->eventSourceMessageReceived(
       IdentifiersFactory::SubresourceRequestId(identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(),
@@ -1581,7 +1581,7 @@ InspectorNetworkAgent::BuildInitiatorObject(
     Document* document,
     const FetchInitiatorInfo& initiator_info,
     int max_async_depth) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::BuildInitiatorObject\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::BuildInitiatorObject MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   if (initiator_info.is_imported_module && !initiator_info.referrer.IsEmpty()) {
     std::unique_ptr<protocol::Network::Initiator> initiator_object =
         protocol::Network::Initiator::create()
@@ -1661,7 +1661,7 @@ void InspectorNetworkAgent::DidCreateWebSocket(
     uint64_t identifier,
     const KURL& request_url,
     const String&) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCreateWebSocket\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCreateWebSocket MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   std::unique_ptr<v8_inspector::protocol::Runtime::API::StackTrace>
       current_stack_trace =
           SourceLocation::Capture(execution_context)->BuildInspectorObject();
@@ -1686,7 +1686,7 @@ void InspectorNetworkAgent::WillSendWebSocketHandshakeRequest(
     ExecutionContext*,
     uint64_t identifier,
     network::mojom::blink::WebSocketHandshakeRequest* request) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendWebSocketHandshakeRequest\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendWebSocketHandshakeRequest MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK(request);
   HTTPHeaderMap headers;
   for (auto& header : request->headers)
@@ -1706,7 +1706,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketHandshakeResponse(
     uint64_t identifier,
     network::mojom::blink::WebSocketHandshakeRequest* request,
     network::mojom::blink::WebSocketHandshakeResponse* response) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketHandshakeResponse\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketHandshakeResponse MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK(response);
 
   HTTPHeaderMap response_headers;
@@ -1748,7 +1748,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketHandshakeResponse(
 
 void InspectorNetworkAgent::DidCloseWebSocket(ExecutionContext*,
                                               uint64_t identifier) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCloseWebSocket\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCloseWebSocket MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   GetFrontend()->webSocketClosed(
       IdentifiersFactory::SubresourceRequestId(identifier),
       base::TimeTicks::Now().since_origin().InSecondsF());
@@ -1759,7 +1759,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketMessage(
     int op_code,
     bool masked,
     const Vector<base::span<const char>>& data) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessage\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessage MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   size_t size = 0;
   for (const auto& span : data) {
     size += span.size();
@@ -1781,7 +1781,7 @@ void InspectorNetworkAgent::DidSendWebSocketMessage(uint64_t identifier,
                                                     bool masked,
                                                     const char* payload,
                                                     size_t payload_length) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidSendWebSocketMessage\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidSendWebSocketMessage MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   GetFrontend()->webSocketFrameSent(
       IdentifiersFactory::RequestId(nullptr, identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(),
@@ -1791,7 +1791,7 @@ void InspectorNetworkAgent::DidSendWebSocketMessage(uint64_t identifier,
 void InspectorNetworkAgent::DidReceiveWebSocketMessageError(
     uint64_t identifier,
     const String& error_message) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessageError\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessageError MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   GetFrontend()->webSocketFrameError(
       IdentifiersFactory::RequestId(nullptr, identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(), error_message);
@@ -1840,7 +1840,7 @@ void InspectorNetworkAgent::WebTransportClosed(uint64_t transport_id) {
 Response InspectorNetworkAgent::enable(Maybe<int> total_buffer_size,
                                        Maybe<int> resource_buffer_size,
                                        Maybe<int> max_post_data_size) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Enable\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Enable MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   total_buffer_size_.Set(total_buffer_size.fromMaybe(kDefaultTotalBufferSize));
   resource_buffer_size_.Set(
       resource_buffer_size.fromMaybe(kDefaultResourceBufferSize));
@@ -1859,7 +1859,7 @@ void InspectorNetworkAgent::Enable() {
 }
 
 Response InspectorNetworkAgent::disable() {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Disable\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Disable MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK(!pending_request_type_);
   if (IsMainThread())
     GetNetworkStateNotifier().ClearOverride();
@@ -2262,7 +2262,7 @@ InspectorNetworkAgent::InspectorNetworkAgent(
       max_post_data_size_(&agent_state_, /*default_value=*/0),
       accepted_encodings_(&agent_state_,
                           /*default_value=*/false) {
-  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::InspectorNetworkAgent\n", (int)getpid());
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::InspectorNetworkAgent MainThread=%s\n", (int)getpid(), IsMainThread() ? "true" : "false");
   DCHECK((IsMainThread() && !worker_global_scope_) ||
          (!IsMainThread() && worker_global_scope_));
 }

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -32,10 +32,13 @@
 
 #include <memory>
 #include <utility>
+#include <dlfcn.h>
 
 #include "base/containers/span.h"
 #include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
+#include "content/renderer/render_thread_impl.h"
+//#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "net/base/ip_address.h"
 #include "net/base/ip_endpoint.h"
@@ -1058,6 +1061,18 @@ void InspectorNetworkAgent::WillSendRequestInternal(
     const ResourceResponse& redirect_response,
     const FetchInitiatorInfo& initiator_info,
     InspectorPageAgent::ResourceType type) {
+
+  fprintf(stderr, "KVKV InspectorNetworkAgent::WillSendRequestInternal: pid=%d\n", (int)getpid());
+  /*
+  {
+    // void* sym = dlsym(RTLD_DEFAULT, "ReplayDispatchBrowserEvent");
+    content::RenderThreadImpl* render_thread = content::RenderThreadImpl::current();
+    fprintf(stderr,
+      "KVKV InspectorNetworkAgent::WillSendRequestInternal - rt: %p\n", render_thread);
+  }
+  */
+  // blink::RecordReplayDispatchBrowserEvent(name, dict);
+
   String loader_id = IdentifiersFactory::LoaderId(loader);
   String request_id =
       IdentifiersFactory::RequestId(loader, request.InspectorId());

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -991,6 +991,7 @@ void InspectorNetworkAgent::Trace(Visitor* visitor) const {
 }
 
 void InspectorNetworkAgent::ShouldBlockRequest(const KURL& url, bool* result) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBlockRequest\n", (int)getpid());
   if (blocked_urls_.IsEmpty())
     return;
 
@@ -1004,6 +1005,7 @@ void InspectorNetworkAgent::ShouldBlockRequest(const KURL& url, bool* result) {
 }
 
 void InspectorNetworkAgent::ShouldBypassServiceWorker(bool* result) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ShouldBypassServiceWorker\n", (int)getpid());
   if (bypass_service_worker_.Get())
     *result = true;
 }
@@ -1015,6 +1017,7 @@ void InspectorNetworkAgent::DidBlockRequest(
     const FetchInitiatorInfo& initiator_info,
     ResourceRequestBlockedReason reason,
     ResourceType resource_type) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidBlockRequest\n", (int)getpid());
   InspectorPageAgent::ResourceType type =
       InspectorPageAgent::ToResourceType(resource_type);
 
@@ -1062,7 +1065,14 @@ void InspectorNetworkAgent::WillSendRequestInternal(
     const FetchInitiatorInfo& initiator_info,
     InspectorPageAgent::ResourceType type) {
 
-  fprintf(stderr, "KVKV InspectorNetworkAgent::WillSendRequestInternal: pid=%d\n", (int)getpid());
+  String loader_id = IdentifiersFactory::LoaderId(loader);
+  String request_id =
+      IdentifiersFactory::RequestId(loader, request.InspectorId());
+  NetworkResourcesData::ResourceData const* data =
+      resources_data_->Data(request_id);
+
+  fprintf(stderr, "KVKV-InspectorNetworkAgent::WillSendRequestInternal: pid=%d loader=%s request=%s\n",
+    (int)getpid(), loader_id.Utf8().c_str(), request_id.Utf8().c_str());
   /*
   {
     // void* sym = dlsym(RTLD_DEFAULT, "ReplayDispatchBrowserEvent");
@@ -1073,11 +1083,6 @@ void InspectorNetworkAgent::WillSendRequestInternal(
   */
   // blink::RecordReplayDispatchBrowserEvent(name, dict);
 
-  String loader_id = IdentifiersFactory::LoaderId(loader);
-  String request_id =
-      IdentifiersFactory::RequestId(loader, request.InspectorId());
-  NetworkResourcesData::ResourceData const* data =
-      resources_data_->Data(request_id);
   // Support for POST request redirect.
   scoped_refptr<EncodedFormData> post_data;
   if (data &&
@@ -1164,6 +1169,7 @@ void InspectorNetworkAgent::WillSendNavigationRequest(
     const KURL& url,
     const AtomicString& http_method,
     EncodedFormData* http_body) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendNavigationRequest id=%lu\n", (int)getpid(), identifier);
   String loader_id = IdentifiersFactory::LoaderId(loader);
   String request_id = loader_id;
   NetworkResourcesData::ResourceData const* data =
@@ -1204,6 +1210,7 @@ void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
                                            ResourceRequest& request,
                                            ResourceLoaderOptions& options,
                                            ResourceType resource_type) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::PrepareRequest\n", (int)getpid());
   // Ignore the request initiated internally.
   if (options.initiator_info.name == fetch_initiator_type_names::kInternal)
     return;
@@ -1278,6 +1285,7 @@ void InspectorNetworkAgent::WillSendRequest(
     const FetchInitiatorInfo& initiator_info,
     ResourceType resource_type,
     RenderBlockingBehavior render_blocking_behavior) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendRequest\n", (int)getpid());
   // Ignore the request initiated internally.
   if (initiator_info.name == fetch_initiator_type_names::kInternal)
     return;
@@ -1300,6 +1308,7 @@ void InspectorNetworkAgent::DidReceiveResourceResponse(
     DocumentLoader* loader,
     const ResourceResponse& response,
     const Resource* cached_resource) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveResourceResponse id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   bool is_not_modified = response.HttpStatusCode() == 304;
 
@@ -1373,6 +1382,7 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
                                            DocumentLoader* loader,
                                            const char* data,
                                            uint64_t data_length) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveData id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
 
   if (data) {
@@ -1399,6 +1409,7 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
 void InspectorNetworkAgent::DidReceiveBlob(uint64_t identifier,
                                            DocumentLoader* loader,
                                            scoped_refptr<BlobDataHandle> blob) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveBlob id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   resources_data_->BlobReceived(request_id, std::move(blob));
 }
@@ -1407,6 +1418,7 @@ void InspectorNetworkAgent::DidReceiveEncodedDataLength(
     DocumentLoader* loader,
     uint64_t identifier,
     size_t encoded_data_length) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveEncodedDataLength id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   resources_data_->AddPendingEncodedDataLength(request_id, encoded_data_length);
 }
@@ -1418,6 +1430,7 @@ void InspectorNetworkAgent::DidFinishLoading(
     int64_t encoded_data_length,
     int64_t decoded_body_length,
     bool should_report_corb_blocking) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishLoading id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
   NetworkResourcesData::ResourceData const* resource_data =
       resources_data_->Data(request_id);
@@ -1457,6 +1470,7 @@ void InspectorNetworkAgent::DidReceiveCorsRedirectResponse(
     DocumentLoader* loader,
     const ResourceResponse& response,
     Resource* resource) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveCorsRedirectResponse id=%lu\n", (int)getpid(), identifier);
   // Update the response and finish loading
   DidReceiveResourceResponse(identifier, loader, response, resource);
   DidFinishLoading(identifier, loader, base::TimeTicks(),
@@ -1469,6 +1483,7 @@ void InspectorNetworkAgent::DidFailLoading(
     DocumentLoader* loader,
     const ResourceError& error,
     const base::UnguessableToken& devtools_frame_or_worker_token) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFailLoading id=%lu\n", (int)getpid(), identifier);
   String request_id = IdentifiersFactory::RequestId(loader, identifier);
 
   // A Trust Token redemption can be served from cache if a valid
@@ -1502,11 +1517,13 @@ void InspectorNetworkAgent::DidFailLoading(
 
 void InspectorNetworkAgent::ScriptImported(uint64_t identifier,
                                            const String& source_string) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::ScriptImported id=%lu\n", (int)getpid(), identifier);
   resources_data_->SetResourceContent(
       IdentifiersFactory::SubresourceRequestId(identifier), source_string);
 }
 
 void InspectorNetworkAgent::DidReceiveScriptResponse(uint64_t identifier) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveScriptResponse id=%lu\n", (int)getpid(), identifier);
   resources_data_->SetResourceType(
       IdentifiersFactory::SubresourceRequestId(identifier),
       InspectorPageAgent::kScriptResource);
@@ -1524,6 +1541,7 @@ void InspectorNetworkAgent::WillLoadXHR(ExecutionContext* execution_context,
                                         bool async,
                                         const HTTPHeaderMap& headers,
                                         bool include_credentials) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillLoadXHR\n", (int)getpid());
   DCHECK(!pending_request_type_);
   pending_xhr_replay_data_ = MakeGarbageCollected<XHRReplayData>(
       execution_context, method, UrlWithoutFragment(url), async,
@@ -1536,10 +1554,12 @@ void InspectorNetworkAgent::WillLoadXHR(ExecutionContext* execution_context,
 }
 
 void InspectorNetworkAgent::DidFinishXHR(XMLHttpRequest* xhr) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidFinishXHR\n", (int)getpid());
   replay_xhrs_.erase(xhr);
 }
 
 void InspectorNetworkAgent::WillSendEventSourceRequest() {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendEventSourceRequest\n", (int)getpid());
   DCHECK(!pending_request_type_);
   pending_request_type_ = InspectorPageAgent::kEventSourceResource;
 }
@@ -1549,6 +1569,7 @@ void InspectorNetworkAgent::WillDispatchEventSourceEvent(
     const AtomicString& event_name,
     const AtomicString& event_id,
     const String& data) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillDispatchEventSourceData\n", (int)getpid());
   GetFrontend()->eventSourceMessageReceived(
       IdentifiersFactory::SubresourceRequestId(identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(),
@@ -1560,6 +1581,7 @@ InspectorNetworkAgent::BuildInitiatorObject(
     Document* document,
     const FetchInitiatorInfo& initiator_info,
     int max_async_depth) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::BuildInitiatorObject\n", (int)getpid());
   if (initiator_info.is_imported_module && !initiator_info.referrer.IsEmpty()) {
     std::unique_ptr<protocol::Network::Initiator> initiator_object =
         protocol::Network::Initiator::create()
@@ -1639,6 +1661,7 @@ void InspectorNetworkAgent::DidCreateWebSocket(
     uint64_t identifier,
     const KURL& request_url,
     const String&) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCreateWebSocket\n", (int)getpid());
   std::unique_ptr<v8_inspector::protocol::Runtime::API::StackTrace>
       current_stack_trace =
           SourceLocation::Capture(execution_context)->BuildInspectorObject();
@@ -1663,6 +1686,7 @@ void InspectorNetworkAgent::WillSendWebSocketHandshakeRequest(
     ExecutionContext*,
     uint64_t identifier,
     network::mojom::blink::WebSocketHandshakeRequest* request) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::WillSendWebSocketHandshakeRequest\n", (int)getpid());
   DCHECK(request);
   HTTPHeaderMap headers;
   for (auto& header : request->headers)
@@ -1682,6 +1706,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketHandshakeResponse(
     uint64_t identifier,
     network::mojom::blink::WebSocketHandshakeRequest* request,
     network::mojom::blink::WebSocketHandshakeResponse* response) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketHandshakeResponse\n", (int)getpid());
   DCHECK(response);
 
   HTTPHeaderMap response_headers;
@@ -1723,6 +1748,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketHandshakeResponse(
 
 void InspectorNetworkAgent::DidCloseWebSocket(ExecutionContext*,
                                               uint64_t identifier) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidCloseWebSocket\n", (int)getpid());
   GetFrontend()->webSocketClosed(
       IdentifiersFactory::SubresourceRequestId(identifier),
       base::TimeTicks::Now().since_origin().InSecondsF());
@@ -1733,6 +1759,7 @@ void InspectorNetworkAgent::DidReceiveWebSocketMessage(
     int op_code,
     bool masked,
     const Vector<base::span<const char>>& data) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessage\n", (int)getpid());
   size_t size = 0;
   for (const auto& span : data) {
     size += span.size();
@@ -1754,6 +1781,7 @@ void InspectorNetworkAgent::DidSendWebSocketMessage(uint64_t identifier,
                                                     bool masked,
                                                     const char* payload,
                                                     size_t payload_length) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidSendWebSocketMessage\n", (int)getpid());
   GetFrontend()->webSocketFrameSent(
       IdentifiersFactory::RequestId(nullptr, identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(),
@@ -1763,6 +1791,7 @@ void InspectorNetworkAgent::DidSendWebSocketMessage(uint64_t identifier,
 void InspectorNetworkAgent::DidReceiveWebSocketMessageError(
     uint64_t identifier,
     const String& error_message) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::DidReceiveWebSocketMessageError\n", (int)getpid());
   GetFrontend()->webSocketFrameError(
       IdentifiersFactory::RequestId(nullptr, identifier),
       base::TimeTicks::Now().since_origin().InSecondsF(), error_message);
@@ -1811,6 +1840,7 @@ void InspectorNetworkAgent::WebTransportClosed(uint64_t transport_id) {
 Response InspectorNetworkAgent::enable(Maybe<int> total_buffer_size,
                                        Maybe<int> resource_buffer_size,
                                        Maybe<int> max_post_data_size) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Enable\n", (int)getpid());
   total_buffer_size_.Set(total_buffer_size.fromMaybe(kDefaultTotalBufferSize));
   resource_buffer_size_.Set(
       resource_buffer_size.fromMaybe(kDefaultResourceBufferSize));
@@ -1829,6 +1859,7 @@ void InspectorNetworkAgent::Enable() {
 }
 
 Response InspectorNetworkAgent::disable() {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::Disable\n", (int)getpid());
   DCHECK(!pending_request_type_);
   if (IsMainThread())
     GetNetworkStateNotifier().ClearOverride();
@@ -2231,6 +2262,7 @@ InspectorNetworkAgent::InspectorNetworkAgent(
       max_post_data_size_(&agent_state_, /*default_value=*/0),
       accepted_encodings_(&agent_state_,
                           /*default_value=*/false) {
+  fprintf(stderr, "KVKV-InspectorNetworkAgent(pid=%d)::InspectorNetworkAgent\n", (int)getpid());
   DCHECK((IsMainThread() && !worker_global_scope_) ||
          (!IsMainThread() && worker_global_scope_));
 }

--- a/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
+++ b/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
@@ -1000,6 +1000,9 @@ void XMLHttpRequest::ThrowForLoadFailureIfNeeded(
 
 void XMLHttpRequest::CreateRequest(scoped_refptr<EncodedFormData> http_body,
                                    ExceptionState& exception_state) {
+  fprintf(stderr, "KVKV - XMLHttpRequest::CreateRequest scriptForbidden=%s\n",
+    ScriptForbiddenScope::IsScriptForbidden() ? "true" : "false"
+  );
   // Only GET request is supported for blob URL.
   if (url_.ProtocolIs("blob") && method_ != http_names::kGET) {
     HandleNetworkError();

--- a/third_party/blink/renderer/platform/loader/fetch/resource_request.h
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_request.h
@@ -414,6 +414,13 @@ class PLATFORM_EXPORT ResourceRequestHead {
     devtools_accepted_stream_types_ = types;
   }
 
+  const base::Optional<size_t> GetRecordReplayBookmark() const {
+    return record_replay_bookmark_;
+  }
+  void SetRecordReplayBookmark(size_t bookmark) {
+    record_replay_bookmark_ = bookmark;
+  }
+
   const base::Optional<String>& GetDevToolsId() const { return devtools_id_; }
   void SetDevToolsId(const base::Optional<String>& devtools_id) {
     devtools_id_ = devtools_id;
@@ -658,6 +665,9 @@ class PLATFORM_EXPORT ResourceRequestHead {
   scoped_refptr<
       base::RefCountedData<base::flat_set<net::SourceStream::SourceType>>>
       devtools_accepted_stream_types_;
+  
+  // If present, the record-replay bookmark info associated with this request
+  base::Optional<size_t> record_replay_bookmark_;
 };
 
 class PLATFORM_EXPORT ResourceRequestBody {


### PR DESCRIPTION
Putting up the scratch draft patch I'm working with to figure out how network events are threaded.  We're in roughly the right place here.

Joel mentioned that `NetworkHandler` in the browser subdir would receive and dispatch all network events, but after playing around with this today it actually seems like the `NetworkAgentImpl` in the renderer process directly uses mojo in some way to emit the CDP events to receiving clients.

Specifically only navigation requests show up in the `NetworkHandler`.

@ariya heads up.  I made a "kannan/netmonitor-scratch" branch to work on and this PR is against that.