### PR TITLE
Track bookmarks with renderer-initiated requests.

### DIFF
--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -1185,6 +1185,8 @@ void InspectorNetworkAgent::SetDevToolsIds(
                                                       request.InspectorId()));
 }
 
+extern "C" size_t V8RecordReplayNewBookmark();
+
 void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
                                            ResourceRequest& request,
                                            ResourceLoaderOptions& options,
@@ -1239,6 +1241,14 @@ void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
       request.SetDevToolsStackId(stack_id);
     }
   }
+
+  // Capture the record replay bookmark for the network request here,
+  // where the devtools stack id is taken.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    uint64_t bookmark = V8RecordReplayNewBookmark();
+    request.SetRecordReplayBookmark(bookmark);
+  }
+
   if (!accepted_encodings_.IsEmpty()) {
     scoped_refptr<
         base::RefCountedData<base::flat_set<net::SourceStream::SourceType>>>

--- a/third_party/blink/renderer/platform/loader/fetch/resource_request.h
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_request.h
@@ -443,6 +443,20 @@ class PLATFORM_EXPORT ResourceRequestHead {
     devtools_stack_id_ = devtools_stack_id;
   }
 
+  // If this request was initiated in the renderer during recording, the record
+  // replay bookmark id.  This behaves similarly to `devtools_stack_id_` in that
+  // if set, it needs to be set when the invoking JS is still on stack (i.e. within
+  // the dynamic scope of the call that initited the network request).  This
+  // variable is set from `InspectorNetworkAgent`, and also accessed from
+  // other event-handler methods within it.
+  const base::Optional<uint64_t>& GetRecordReplayBookmark() const {
+    return record_replay_bookmark_;
+  }
+  void SetRecordReplayBookmark(const base::Optional<uint64_t> &record_replay_bookmark) {
+    record_replay_bookmark_ = record_replay_bookmark;
+  }
+
+
   void SetUkmSourceId(ukm::SourceId ukm_source_id) {
     ukm_source_id_ = ukm_source_id;
   }
@@ -611,6 +625,8 @@ class PLATFORM_EXPORT ResourceRequestHead {
   String purpose_header_;
 
   base::Optional<String> devtools_stack_id_;
+
+  base::Optional<uint64_t> record_replay_bookmark_;
 
   ukm::SourceId ukm_source_id_ = ukm::kInvalidSourceId;
 


### PR DESCRIPTION
Take a bookmark during request initiation and track with resource requests.

I'll switch the `NewBookmark` to using the `recordreplay::` interface if @ariya's patch lands first.