### PR TITLE
Disable media playback when recording/replaying

### DIFF
--- a/content/renderer/media/media_factory.cc
+++ b/content/renderer/media/media_factory.cc
@@ -373,6 +373,10 @@ blink::WebMediaPlayer* MediaFactory::CreateMediaPlayer(
     const cc::LayerTreeSettings& settings,
     scoped_refptr<base::SingleThreadTaskRunner>
         main_thread_compositor_task_runner) {
+  // Media playback is not supported when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying())
+    return nullptr;
+
   blink::WebLocalFrame* web_frame = render_frame_->GetWebFrame();
   if (source.IsMediaStream()) {
     return CreateWebMediaPlayerForMediaStream(


### PR DESCRIPTION
I noticed some crashes in CI where recording processes were sending sync messages to the GPU process, which isn't supported when recording/replaying.  This happened while initializing some state for media playback, which we should just disable as we don't support it.