### PR TITLE
Remove unused recording assertions

### DIFF
--- a/base/files/file_util_posix.cc
+++ b/base/files/file_util_posix.cc
@@ -62,25 +62,6 @@
 #include <grp.h>
 #endif
 
-#include <dlfcn.h>
-
-static void (*gRecordReplayAssertFn)(const char*, va_list);
-
-static void RecordReplayAssert(const char* aFormat, ...) {
-  if (!gRecordReplayAssertFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAssert");
-    if (!fnptr) {
-      return;
-    }
-    gRecordReplayAssertFn = reinterpret_cast<void(*)(const char*, va_list)>(fnptr);
-  }
-
-  va_list ap;
-  va_start(ap, aFormat);
-  gRecordReplayAssertFn(aFormat, ap);
-  va_end(ap);
-}
-
 // We need to do this on AIX due to some inconsistencies in how AIX
 // handles XOPEN_SOURCE and ALL_SOURCE.
 #if defined(OS_AIX)
@@ -848,7 +829,6 @@ FILE* OpenFile(const FilePath& filename, const char* mode) {
   const char* the_mode = mode_with_e.c_str();
 #endif
   do {
-    RecordReplayAssert("OpenFile %s", filename.value().c_str());
     result = fopen(filename.value().c_str(), the_mode);
   } while (!result && errno == EINTR);
 #if defined(OS_APPLE)

--- a/base/memory/discardable_shared_memory.cc
+++ b/base/memory/discardable_shared_memory.cc
@@ -225,8 +225,6 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
   DCHECK_EQ(AlignToPageSize(offset), offset);
   DCHECK_EQ(AlignToPageSize(length), length);
 
-  recordreplay::Assert("DiscardableSharedMemory::Lock Start");
-
   // Calls to this function must be synchronized properly.
   DFAKE_SCOPED_LOCK(thread_collision_warner_);
 
@@ -238,7 +236,6 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
     // Return false when instance has been purged or not initialized properly
     // by checking if |last_known_usage_| is NULL.
     if (last_known_usage_.is_null()) {
-      recordreplay::Assert("DiscardableSharedMemory::Lock #1");
       return FAILED;
     }
 
@@ -252,7 +249,6 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
       // Update |last_known_usage_| in case the above CAS failed because of
       // an incorrect timestamp.
       last_known_usage_ = result.GetTimestamp();
-      recordreplay::Assert("DiscardableSharedMemory::Lock #2");
       return FAILED;
     }
   }
@@ -280,7 +276,6 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
 
   // Always behave as if memory was purged when trying to lock a 0 byte segment.
   if (!length) {
-    recordreplay::Assert("DiscardableSharedMemory::Lock #3");
     return PURGED;
   }
 
@@ -305,7 +300,6 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
   madvise(static_cast<char*>(shared_memory_mapping_.memory()) +
               AlignToPageSize(sizeof(SharedState)),
           AlignToPageSize(mapped_size_), MADV_FREE_REUSE);
-  recordreplay::Assert("DiscardableSharedMemory::Lock #4");
   return DiscardableSharedMemory::SUCCESS;
 #else
   return DiscardableSharedMemory::SUCCESS;

--- a/base/message_loop/message_pump_kqueue.cc
+++ b/base/message_loop/message_pump_kqueue.cc
@@ -162,8 +162,6 @@ MessagePumpKqueue::~MessagePumpKqueue() {}
 void MessagePumpKqueue::Run(Delegate* delegate) {
   AutoReset<bool> reset_keep_running(&keep_running_, true);
 
-  recordreplay::Assert("MessagePumpKqueue::Run Start %d", keep_running_);
-
   while (keep_running_) {
     mac::ScopedNSAutoreleasePool pool;
 
@@ -172,12 +170,7 @@ void MessagePumpKqueue::Run(Delegate* delegate) {
       break;
 
     Delegate::NextWorkInfo next_work_info = delegate->DoWork();
-
-    recordreplay::Assert("MessagePumpKqueue::Run #2.0 %d", next_work_info.is_immediate());
-
     do_more_work |= next_work_info.is_immediate();
-
-    recordreplay::Assert("MessagePumpKqueue::Run #2.1 %d %d", do_more_work, keep_running_);
 
     if (!keep_running_)
       break;
@@ -186,8 +179,6 @@ void MessagePumpKqueue::Run(Delegate* delegate) {
       continue;
 
     do_more_work |= delegate->DoIdleWork();
-
-    recordreplay::Assert("MessagePumpKqueue::Run #2.2 %d %d", do_more_work, keep_running_);
 
     if (!keep_running_)
       break;
@@ -463,7 +454,6 @@ bool MessagePumpKqueue::ProcessEvents(Delegate* delegate, int count) {
       if (controller) {
         auto scoped_do_native_work = delegate->BeginNativeWork();
         controller->watcher()->OnMachMessageReceived(port);
-        recordreplay::Assert("MessagePumpKqueue::ProcessEvents #2");
       }
     } else if (event->filter == EVFILT_TIMER) {
       // The wakeup timer fired.
@@ -489,7 +479,6 @@ bool MessagePumpKqueue::ProcessEvents(Delegate* delegate, int count) {
     }
   }
 
-  recordreplay::Assert("MessagePumpKqueue::ProcessEvents Done %d", did_work);
   return did_work;
 }
 

--- a/base/message_loop/message_pump_mac.mm
+++ b/base/message_loop/message_pump_mac.mm
@@ -208,7 +208,6 @@ void MessagePumpCFRunLoopBase::ScheduleDelayedWorkImpl(TimeDelta delta) {
   } else {
     CFRunLoopTimerSetTolerance(delayed_work_timer_, 0);
   }
-  recordreplay::Assert("ScheduleDelayedWorkImpl %.2f", delta.InSecondsF());
   CFRunLoopTimerSetNextFireDate(
       delayed_work_timer_, CFAbsoluteTimeGetCurrent() + delta.InSecondsF());
 }
@@ -634,14 +633,11 @@ MessagePumpNSRunLoop::~MessagePumpNSRunLoop() {
 }
 
 void MessagePumpNSRunLoop::DoRun(Delegate* delegate) {
-  recordreplay::Assert("MessagePumpNSRunLoop::DoRun Start");
   while (keep_running()) {
     // NSRunLoop manages autorelease pools itself.
-    recordreplay::Assert("MessagePumpNSRunLoop::DoRun #1");
     [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                              beforeDate:[NSDate distantFuture]];
   }
-  recordreplay::Assert("MessagePumpNSRunLoop::Done");
 }
 
 bool MessagePumpNSRunLoop::DoQuit() {

--- a/base/synchronization/waitable_event_mac.cc
+++ b/base/synchronization/waitable_event_mac.cc
@@ -364,7 +364,6 @@ size_t WaitableEvent::WaitMany(WaitableEvent** raw_waitables, size_t count) {
 
 // static
 bool WaitableEvent::PeekPort(mach_port_t port, bool dequeue) {
-  recordreplay::Assert("WaitableEvent::PeekPort %d %d", port, dequeue);
   if (dequeue) {
     mach_msg_empty_rcv_t msg{};
     msg.header.msgh_local_port = port;

--- a/base/synchronization/waitable_event_posix.cc
+++ b/base/synchronization/waitable_event_posix.cc
@@ -98,24 +98,12 @@ bool WaitableEvent::IsSignaled() {
 class SyncWaiter : public WaitableEvent::Waiter {
  public:
   SyncWaiter()
-      : fired_(false), signaling_event_(nullptr), lock_("SyncWaiter.lock_"), cv_(&lock_) {
-    // https://linear.app/replay/issue/RUN-513
-    recordreplay::RegisterPointer(this);
-  }
+      : fired_(false), signaling_event_(nullptr), lock_("SyncWaiter.lock_"), cv_(&lock_) {}
 
-  ~SyncWaiter() override {
-    // https://linear.app/replay/issue/RUN-513
-    recordreplay::UnregisterPointer(this);
-  }
+  ~SyncWaiter() override {}
 
   bool Fire(WaitableEvent* signaling_event) override {
     base::AutoLock locked(lock_);
-
-    // https://linear.app/replay/issue/RUN-513
-    recordreplay::Assert("SyncWaiter::Fire %d %d %d",
-                        recordreplay::PointerId(this),
-                        recordreplay::PointerId(signaling_event),
-                        fired_);
 
     if (fired_)
       return false;
@@ -215,9 +203,6 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
     sw.cv()->declare_only_used_while_idle();
   sw.lock()->Acquire();
 
-  // https://linear.app/replay/issue/RUN-513
-  recordreplay::Assert("WaitableEvent::TimedWait #0.1 %d", recordreplay::PointerId(&sw));
-
   Enqueue(&sw);
   kernel_->lock_.Release();
   // We are violating locking order here by holding the SyncWaiter lock but not
@@ -232,12 +217,7 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
       wait_delta.is_max() ? TimeTicks::Max()
                           : subtle::TimeTicksNowIgnoringOverride() + wait_delta;
 
-  // https://linear.app/replay/issue/RUN-513
-  recordreplay::Assert("WaitableEvent::TimedWait #1 %ld", end_time.ToInternalValue());
-
   for (TimeDelta remaining = wait_delta; remaining > TimeDelta() && !sw.fired();) {
-    // https://linear.app/replay/issue/RUN-513
-    recordreplay::Assert("WaitableEvent::TimedWait #2 %d", end_time.is_max());
     if (end_time.is_max())
       sw.cv()->Wait();
     else
@@ -245,13 +225,7 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
     remaining = end_time.is_max()
                     ? TimeDelta::Max()
                     : end_time - subtle::TimeTicksNowIgnoringOverride();
-    // https://linear.app/replay/issue/RUN-513
-    recordreplay::Assert("WaitableEvent::TimedWait #2.1 %ld %d %d",
-                         remaining.ToInternalValue(), remaining > TimeDelta(), sw.fired());
   }
-
-  // https://linear.app/replay/issue/RUN-513
-  recordreplay::Assert("WaitableEvent::TimedWait #3");
 
   // Get the SyncWaiter signaled state before releasing the lock.
   const bool return_value = sw.fired();
@@ -329,9 +303,6 @@ size_t WaitableEvent::WaitMany(WaitableEvent** raw_waitables,
     // enqueued anywhere.
     return waitables[r].second;
   }
-
-  // https://linear.app/replay/issue/RUN-513
-  recordreplay::Assert("WaitableEvent::WaitMany #5 %d", recordreplay::PointerId(&sw));
 
   // At this point, we hold the locks on all the WaitableEvents and we have
   // enqueued our waiter in them all.

--- a/base/task/common/task_annotator.cc
+++ b/base/task/common/task_annotator.cc
@@ -118,8 +118,6 @@ void TaskAnnotator::WillQueueTask(const char* trace_event_name,
 
 void TaskAnnotator::RunTask(const char* trace_event_name,
                             PendingTask* pending_task) {
-  recordreplay::Assert("TaskAnnotator::RunTask Start");
-
   DCHECK(trace_event_name);
   DCHECK(pending_task);
 
@@ -185,8 +183,6 @@ void TaskAnnotator::RunTask(const char* trace_event_name,
   task_backtrace.front() = nullptr;
   task_backtrace.back() = nullptr;
   debug::Alias(&task_backtrace);
-
-  recordreplay::Assert("TaskAnnotator::RunTask Done");
 }
 
 uint64_t TaskAnnotator::GetTaskTraceID(const PendingTask& task) const {

--- a/base/task/post_job.cc
+++ b/base/task/post_job.cc
@@ -32,7 +32,6 @@ bool JobDelegate::ShouldYield() {
   // ShouldYield() shouldn't be called again after returning true.
   DCHECK(!last_should_yield_);
 #endif  // DCHECK_IS_ON()
-  recordreplay::Assert("JobDelegate::ShouldYield Start");
   const bool should_yield =
       task_source_->ShouldYield() ||
       (pooled_task_runner_delegate_ &&
@@ -41,10 +40,6 @@ bool JobDelegate::ShouldYield() {
 #if DCHECK_IS_ON()
   last_should_yield_ = should_yield;
 #endif  // DCHECK_IS_ON()
-  recordreplay::Assert("JobDelegate::ShouldYield Done %d %d %d",
-                       should_yield,
-                       task_source_->ShouldYield(),
-                       !!pooled_task_runner_delegate_);
   return should_yield;
 }
 
@@ -59,7 +54,6 @@ void JobDelegate::NotifyConcurrencyIncrease() {
 uint8_t JobDelegate::GetTaskId() {
   if (task_id_ == kInvalidTaskId)
     task_id_ = task_source_->AcquireTaskId();
-  recordreplay::Assert("JobDelegate::GetTaskId %lu %u", recordreplay::PointerId(this), task_id_);
   return task_id_;
 }
 

--- a/base/task/sequence_manager/atomic_flag_set.cc
+++ b/base/task/sequence_manager/atomic_flag_set.cc
@@ -46,10 +46,6 @@ void AtomicFlagSet::AtomicFlag::SetActive(bool active) {
   DCHECK(group_);
   recordreplay::AutoOrderedLock lock(outer_->ordered_lock_id_);
 
-  // https://linear.app/replay/issue/RUN-568
-  recordreplay::Assert("AtomicFlagSet::AtomicFlag::SetActive %d %d %d",
-                       outer_->ordered_lock_id_, flag_bit_, active);
-
   if (active) {
     // Release semantics are required to ensure that all memory accesses made on
     // this thread happen-before any others done on the thread running the
@@ -66,10 +62,6 @@ void AtomicFlagSet::AtomicFlag::SetActive(bool active) {
 void AtomicFlagSet::AtomicFlag::ReleaseAtomicFlag() {
   if (!group_)
     return;
-
-  // https://linear.app/replay/issue/RUN-568
-  recordreplay::Assert("AtomicFlagSet::AtomicFlag::ReleaseAtomicFlag %d %d",
-                       outer_->ordered_lock_id_, flag_bit_);
 
   DCHECK_CALLED_ON_VALID_THREAD(outer_->associated_thread_->thread_checker);
   SetActive(false);
@@ -114,19 +106,11 @@ AtomicFlagSet::AtomicFlag AtomicFlagSet::AddFlag(RepeatingClosure callback) {
   if (group->IsFull())
     RemoveFromPartiallyFreeList(group);
 
-  // https://linear.app/replay/issue/RUN-568
-  recordreplay::Assert("AtomicFlagSet::AddFlag %d %d",
-                       ordered_lock_id_, flag_bit);
-
   return AtomicFlag(this, group, flag_bit);
 }
 
 void AtomicFlagSet::RunActiveCallbacks() const {
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
-
-  // https://linear.app/replay/issue/RUN-568
-  recordreplay::Assert("AtomicFlagSet::RunActiveCallbacks Start %d",
-                       ordered_lock_id_);
 
   for (Group* iter = alloc_list_head_.get(); iter; iter = iter->next.get()) {
     // Acquire semantics are required to guarantee that all memory side-effects
@@ -139,9 +123,6 @@ void AtomicFlagSet::RunActiveCallbacks() const {
         &iter->flags, size_t{0}, std::memory_order_acquire);
     }
 
-    // https://linear.app/replay/issue/RUN-568
-    recordreplay::Assert("AtomicFlagSet::RunActiveCallbacks #1 %lu", active_flags);
-
     // This is O(number of bits set).
     while (active_flags) {
       int index = Group::IndexOfFirstFlagSet(active_flags);
@@ -149,9 +130,6 @@ void AtomicFlagSet::RunActiveCallbacks() const {
       active_flags ^= size_t{1} << index;
       iter->flag_callbacks[index].Run();
     }
-
-    // https://linear.app/replay/issue/RUN-568
-    recordreplay::Assert("AtomicFlagSet::RunActiveCallbacks #2");
   }
 }
 

--- a/base/task/sequence_manager/lazy_now.cc
+++ b/base/task/sequence_manager/lazy_now.cc
@@ -28,7 +28,6 @@ TimeTicks LazyNow::Now() {
   // but in some test environments clock intentionally starts from zero.
   if (!now_) {
     DCHECK(tick_clock_);  // It can fire only on use after std::move.
-    recordreplay::Assert("LazyNow::Now #1");
     now_ = tick_clock_->NowTicks();
   }
   return *now_;

--- a/base/task/sequence_manager/real_time_domain.cc
+++ b/base/task/sequence_manager/real_time_domain.cc
@@ -27,25 +27,20 @@ TimeTicks RealTimeDomain::Now() const {
 }
 
 Optional<TimeDelta> RealTimeDomain::DelayTillNextTask(LazyNow* lazy_now) {
-  recordreplay::Assert("RealTimeDomain::DelayTillNextTask Start");
-
   Optional<TimeTicks> next_run_time = NextScheduledRunTime();
   if (!next_run_time) {
-    recordreplay::Assert("RealTimeDomain::DelayTillNextTask #1");
     return nullopt;
   }
 
   TimeTicks now = lazy_now->Now();
   if (now >= next_run_time) {
     // Overdue work needs to be run immediately.
-    recordreplay::Assert("RealTimeDomain::DelayTillNextTask #2");
     return TimeDelta();
   }
 
   TimeDelta delay = *next_run_time - now;
   TRACE_EVENT1("sequence_manager", "RealTimeDomain::DelayTillNextTask",
                "delay_ms", delay.InMillisecondsF());
-  recordreplay::Assert("RealTimeDomain::DelayTillNextTask Done %.2f", delay.InSecondsF());
   return delay;
 }
 

--- a/base/task/sequence_manager/sequence_manager_impl.cc
+++ b/base/task/sequence_manager/sequence_manager_impl.cc
@@ -594,15 +594,11 @@ void SequenceManagerImpl::LogTaskDebugInfo(
 Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
   CHECK(Validate());
 
-  recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl Start");
-
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("sequence_manager"),
                "SequenceManagerImpl::SelectNextTask");
 
   ReloadEmptyWorkQueues();
-
-  recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #1");
 
   LazyNow lazy_now(controller_->GetClock());
   MoveReadyDelayedTasksToWorkQueues(&lazy_now);
@@ -615,12 +611,8 @@ Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
   }
 
   while (true) {
-    recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #2");
-
     internal::WorkQueue* work_queue =
         main_thread_only().selector.SelectWorkQueueToService(option);
-
-    recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #3");
 
     TRACE_EVENT_OBJECT_SNAPSHOT_WITH_ID(
         TRACE_DISABLED_BY_DEFAULT("sequence_manager.debug"), "SequenceManager",
@@ -629,13 +621,11 @@ Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
                                             /* force_verbose */ false));
 
     if (!work_queue) {
-      recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #4");
       return nullptr;
     }
 
     // If the head task was canceled, remove it and run the selector again.
     if (UNLIKELY(work_queue->RemoveAllCanceledTasksFromFront())) {
-      recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #5");
       continue;
     }
 
@@ -646,7 +636,6 @@ Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
       // the additional delay should not be a problem.
       // Note because we don't delete queues while nested, it's perfectly OK to
       // store the raw pointer for |queue| here.
-      recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #6");
       internal::TaskQueueImpl::DeferredNonNestableTask deferred_task{
           work_queue->TakeTaskFromWorkQueue(), work_queue->task_queue(),
           work_queue->queue_type()};
@@ -657,7 +646,6 @@ Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
 
     if (UNLIKELY(!ShouldRunTaskOfPriority(
             work_queue->task_queue()->GetQueuePriority()))) {
-      recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #7");
       TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("sequence_manager"),
                    "SequenceManager.YieldToNative");
       return nullptr;
@@ -666,8 +654,6 @@ Task* SequenceManagerImpl::SelectNextTaskImpl(SelectTaskOption option) {
 #if DCHECK_IS_ON() && !defined(OS_NACL)
     LogTaskDebugInfo(work_queue);
 #endif  // DCHECK_IS_ON() && !defined(OS_NACL)
-
-    recordreplay::Assert("SequenceManagerImpl::SelectNextTaskImpl #8");
 
     main_thread_only().task_execution_stack.emplace_back(
         work_queue->TakeTaskFromWorkQueue(), work_queue->task_queue(),
@@ -707,18 +693,14 @@ TimeDelta SequenceManagerImpl::DelayTillNextTask(
     SelectTaskOption option) const {
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
 
-  recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask Start");
-
   if (auto priority =
           main_thread_only().selector.GetHighestPendingPriority(option)) {
     // If the selector has non-empty queues we trivially know there is immediate
     // work to be done. However we may want to yield to native work if it is
     // more important.
     if (UNLIKELY(!ShouldRunTaskOfPriority(*priority))) {
-      recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask #1");
       return GetDelayTillNextDelayedTask(lazy_now, option);
     }
-    recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask #2");
     return TimeDelta();
   }
 
@@ -730,10 +712,8 @@ TimeDelta SequenceManagerImpl::DelayTillNextTask(
   if (auto priority =
           main_thread_only().selector.GetHighestPendingPriority(option)) {
     if (UNLIKELY(!ShouldRunTaskOfPriority(*priority))) {
-      recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask #3");
       return GetDelayTillNextDelayedTask(lazy_now, option);
     }
-    recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask #4");
     return TimeDelta();
   }
 
@@ -741,9 +721,7 @@ TimeDelta SequenceManagerImpl::DelayTillNextTask(
   // call MoveReadyDelayedTasksToWorkQueues because it's assumed
   // DelayTillNextTask will return TimeDelta>() if the delayed task is due to
   // run now.
-  TimeDelta rv = GetDelayTillNextDelayedTask(lazy_now, option);
-  recordreplay::Assert("SequenceManagerImpl::DelayTillNextTask #5 %.2f", rv.InSecondsF());
-  return rv;
+  return GetDelayTillNextDelayedTask(lazy_now, option);
 }
 
 TimeDelta SequenceManagerImpl::GetDelayTillNextDelayedTask(
@@ -1043,7 +1021,6 @@ void SequenceManagerImpl::MaybeReclaimMemory() {
 }
 
 void SequenceManagerImpl::ReclaimMemory() {
-  recordreplay::Assert("SequenceManagerImpl::ReclaimMemory %lu", recordreplay::PointerId(this));
   std::map<TimeDomain*, TimeTicks> time_domain_now;
   for (auto* const queue : main_thread_only().active_queues)
     ReclaimMemoryFromQueue(queue, &time_domain_now);

--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -73,18 +73,11 @@ bool TaskQueueImpl::GuardedTaskPoster::PostTask(PostedTask task) {
   // has to do this) as it can lead to a deadlock and defer it instead.
   ScopedDeferTaskPosting disallow_task_posting;
 
-  recordreplay::Assert("TaskQueueImpl::GuardedTaskPoster::PostTask Start");
-
   auto token = operations_controller_.TryBeginOperation();
-
-  recordreplay::Assert("TaskQueueImpl::GuardedTaskPoster::PostTask #1 %d", !!token);
-
   if (!token)
     return false;
 
   outer_->PostTask(std::move(task));
-
-  recordreplay::Assert("TaskQueueImpl::GuardedTaskPoster::PostTask Done");
   return true;
 }
 
@@ -299,7 +292,6 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
     LazyNow lazy_now = any_thread_.time_domain->CreateLazyNow();
     bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
     if (add_queue_time_to_tasks || delayed_fence_allowed_) {
-      recordreplay::Assert("TaskQueueImpl::PostImmediateTaskImpl #1");
       task.queue_time = lazy_now.Now();
     }
 
@@ -308,9 +300,6 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
     // risk breaking the assumption that sequence numbers increase monotonically
     // within a queue.
     EnqueueOrder sequence_number = sequence_manager_->GetNextSequenceNumber();
-
-    recordreplay::Assert("TaskQueueImpl::PostImmediateTaskImpl #2 %lu",
-                        (size_t)sequence_number);
 
     bool was_immediate_incoming_queue_empty =
         any_thread_.immediate_incoming_queue.empty();
@@ -383,9 +372,6 @@ void TaskQueueImpl::PostDelayedTaskImpl(PostedTask task,
     // Lock-free fast path for delayed tasks posted from the main thread.
     EnqueueOrder sequence_number = sequence_manager_->GetNextSequenceNumber();
 
-    recordreplay::Assert("TaskQueueImpl::PostDelayedTaskImpl #1 %lu",
-                        (size_t)sequence_number);
-
     TimeTicks time_domain_now = main_thread_only().time_domain->Now();
     TimeTicks time_domain_delayed_run_time = time_domain_now + task.delay;
     if (sequence_manager_->GetAddQueueTimeToTasks())
@@ -401,9 +387,6 @@ void TaskQueueImpl::PostDelayedTaskImpl(PostedTask task,
     // because it causes two main thread tasks to be run.  Should this
     // assumption prove to be false in future, we may need to revisit this.
     EnqueueOrder sequence_number = sequence_manager_->GetNextSequenceNumber();
-
-    recordreplay::Assert("TaskQueueImpl::PostDelayedTaskImpl #2 %lu",
-                        (size_t)sequence_number);
 
     TimeTicks time_domain_now;
     {
@@ -483,8 +466,6 @@ void TaskQueueImpl::ScheduleDelayedWorkTask(Task pending_task) {
 }
 
 void TaskQueueImpl::ReloadEmptyImmediateWorkQueue() {
-  recordreplay::Assert("TaskQueueImpl::ReloadEmptyImmediateWorkQueue");
-
   DCHECK(main_thread_only().immediate_work_queue->Empty());
   main_thread_only().immediate_work_queue->TakeImmediateIncomingQueueTasks();
 
@@ -599,9 +580,6 @@ Optional<TimeTicks> TaskQueueImpl::GetNextScheduledWakeUp() {
 }
 
 void TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue(LazyNow* lazy_now) {
-  recordreplay::Assert("TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue %lu",
-                       recordreplay::PointerId(this));
-
   // Enqueue all delayed tasks that should be running now, skipping any that
   // have been canceled.
   WorkQueue::TaskPusher delayed_work_queue_task_pusher(
@@ -626,9 +604,6 @@ void TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue(LazyNow* lazy_now) {
     ActivateDelayedFenceIfNeeded(GetTaskDesiredExecutionTime(*task));
     DCHECK(!task->enqueue_order_set());
     task->set_enqueue_order(sequence_manager_->GetNextSequenceNumber());
-
-    recordreplay::Assert("TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue %lu",
-                         task->enqueue_order());
 
     delayed_work_queue_task_pusher.Push(task);
     main_thread_only().delayed_incoming_queue.pop();
@@ -662,8 +637,6 @@ void TaskQueueImpl::TraceQueueSize() const {
 }
 
 void TaskQueueImpl::SetQueuePriority(TaskQueue::QueuePriority priority) {
-  recordreplay::Assert("TaskQueueImpl::SetQueuePriority %lu %d",
-                       recordreplay::PointerId(this), priority);
   const TaskQueue::QueuePriority previous_priority = GetQueuePriority();
   if (priority == previous_priority)
     return;
@@ -694,9 +667,6 @@ void TaskQueueImpl::SetQueuePriority(TaskQueue::QueuePriority priority) {
     main_thread_only()
         .enqueue_order_at_which_we_became_unblocked_with_normal_priority =
         sequence_manager_->GetNextSequenceNumber();
-
-    recordreplay::Assert("TaskQueueImpl::SetQueuePriority %lu",
-                         main_thread_only().enqueue_order_at_which_we_became_unblocked_with_normal_priority);
   }
 }
 
@@ -847,9 +817,6 @@ void TaskQueueImpl::InsertFence(TaskQueue::InsertFencePosition position) {
   EnqueueOrder current_fence = position == TaskQueue::InsertFencePosition::kNow
                                    ? sequence_manager_->GetNextSequenceNumber()
                                    : EnqueueOrder::blocking_fence();
-
-  recordreplay::Assert("TaskQueueImpl::InsertFence %d %lu",
-                       position, (size_t)current_fence);
 
   // Tasks posted after this point will have a strictly higher enqueue order
   // and will be blocked from running.
@@ -1375,9 +1342,6 @@ void TaskQueueImpl::OnQueueUnblocked() {
 
   main_thread_only().enqueue_order_at_which_we_became_unblocked =
       sequence_manager_->GetNextSequenceNumber();
-
-  recordreplay::Assert("TaskQueueImpl::OnQueueUnblocked %lu",
-                       main_thread_only().enqueue_order_at_which_we_became_unblocked);
 
   static_assert(TaskQueue::QueuePriority::kLowPriority >
                     TaskQueue::QueuePriority::kNormalPriority,

--- a/base/task/sequence_manager/task_queue_selector.cc
+++ b/base/task/sequence_manager/task_queue_selector.cc
@@ -61,8 +61,6 @@ void TaskQueueSelector::DisableQueue(internal::TaskQueueImpl* queue) {
 
 void TaskQueueSelector::SetQueuePriority(internal::TaskQueueImpl* queue,
                                          TaskQueue::QueuePriority priority) {
-  recordreplay::Assert("TaskQueueSelector::SetQueuePriority %lu %lu",
-                       recordreplay::PointerId(queue), priority);
   DCHECK_LT(priority, TaskQueue::kQueuePriorityCount);
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   if (queue->IsQueueEnabled()) {
@@ -174,11 +172,8 @@ WorkQueue* TaskQueueSelector::SelectWorkQueueToService(
     SelectTaskOption option) {
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
 
-  recordreplay::Assert("TaskQueueSelector::SelectWorkQueueToService Start");
-
   auto highest_priority = GetHighestPendingPriority(option);
   if (!highest_priority.has_value()) {
-    recordreplay::Assert("TaskQueueSelector::SelectWorkQueueToService #1");
     return nullptr;
   }
 
@@ -200,8 +195,6 @@ WorkQueue* TaskQueueSelector::SelectWorkQueueToService(
             :
 #endif
             ChooseImmediateOnlyWithPriority<SetOperationOldest>(priority);
-    recordreplay::Assert("TaskQueueSelector::SelectWorkQueueToService #2 %lu",
-                         recordreplay::PointerId(queue));
     return queue;
   }
 
@@ -221,8 +214,6 @@ WorkQueue* TaskQueueSelector::SelectWorkQueueToService(
     immediate_starvation_count_ = 0;
   }
 
-  recordreplay::Assert("TaskQueueSelector::SelectWorkQueueToService #3 %lu",
-                       recordreplay::PointerId(queue));
   return queue;
 }
 
@@ -239,18 +230,14 @@ void TaskQueueSelector::SetTaskQueueSelectorObserver(Observer* observer) {
 
 Optional<TaskQueue::QueuePriority> TaskQueueSelector::GetHighestPendingPriority(
     SelectTaskOption option) const {
-  recordreplay::Assert("TaskQueueSelector::GetHighestPendingPriority Start %d", option);
-
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   if (!active_priority_tracker_.HasActivePriority()) {
-    recordreplay::Assert("TaskQueueSelector::GetHighestPendingPriority #1");
     return nullopt;
   }
 
   TaskQueue::QueuePriority highest_priority =
       active_priority_tracker_.HighestActivePriority();
   if (option != SelectTaskOption::kSkipDelayedTask) {
-    recordreplay::Assert("TaskQueueSelector::GetHighestPendingPriority #2 %d", highest_priority);
     return highest_priority;
   }
 
@@ -258,12 +245,10 @@ Optional<TaskQueue::QueuePriority> TaskQueueSelector::GetHighestPendingPriority(
        highest_priority = NextPriority(highest_priority)) {
     if (active_priority_tracker_.IsActive(highest_priority) &&
         !immediate_work_queue_sets_.IsSetEmpty(highest_priority)) {
-      recordreplay::Assert("TaskQueueSelector::GetHighestPendingPriority #3 %d", highest_priority);
       return highest_priority;
     }
   }
 
-  recordreplay::Assert("TaskQueueSelector::GetHighestPendingPriority #4");
   return nullopt;
 }
 
@@ -283,8 +268,6 @@ TaskQueueSelector::ActivePriorityTracker::ActivePriorityTracker() = default;
 void TaskQueueSelector::ActivePriorityTracker::SetActive(
     TaskQueue::QueuePriority priority,
     bool is_active) {
-  recordreplay::Assert("ActivePriorityTracker::SetActive %d %d", priority, is_active);
-
   DCHECK_LT(priority, TaskQueue::QueuePriority::kQueuePriorityCount);
   DCHECK_NE(IsActive(priority), is_active);
   if (is_active) {

--- a/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc
+++ b/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc
@@ -259,8 +259,6 @@ void ThreadControllerWithMessagePumpImpl::BeforeWait() {
 
 MessagePump::Delegate::NextWorkInfo
 ThreadControllerWithMessagePumpImpl::DoWork() {
-  recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWork Start");
-
   MaybeStartHangWatchScopeEnabled();
 
   work_deduplicator_.OnWorkStarted();
@@ -274,7 +272,6 @@ ThreadControllerWithMessagePumpImpl::DoWork() {
       ShouldScheduleWork::kScheduleImmediate) {
     // Need to run new work immediately, but due to the contract of DoWork
     // we only need to return a null TimeTicks to ensure that happens.
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWork #1");
     return MessagePump::Delegate::NextWorkInfo();
   }
 
@@ -282,7 +279,6 @@ ThreadControllerWithMessagePumpImpl::DoWork() {
   // special-casing here avoids unnecessarily sampling Now() when out of work.
   if (delay_till_next_task.is_max()) {
     main_thread_only().next_delayed_do_work = TimeTicks::Max();
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWork #2");
     return {TimeTicks::Max()};
   }
 
@@ -300,12 +296,10 @@ ThreadControllerWithMessagePumpImpl::DoWork() {
         main_thread_only().quit_runloop_after;
     // If we've passed |quit_runloop_after| there's no more work to do.
     if (continuation_lazy_now.Now() >= main_thread_only().quit_runloop_after) {
-      recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWork #3");
       return {TimeTicks::Max()};
     }
   }
 
-  recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWork #4");
   return {CapAtOneDay(main_thread_only().next_delayed_do_work,
                       &continuation_lazy_now),
           continuation_lazy_now.Now()};
@@ -316,31 +310,25 @@ TimeDelta ThreadControllerWithMessagePumpImpl::DoWorkImpl(
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("sequence_manager"),
                "ThreadControllerImpl::DoWork");
 
-  recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl Start");
-
   if (!main_thread_only().task_execution_allowed) {
     // Broadcast in a trace event that application tasks were disallowed. This
     // helps spot nested loops that intentionally starve application tasks.
     TRACE_EVENT0("base", "ThreadController: application tasks disallowed");
     if (main_thread_only().quit_runloop_after == TimeTicks::Max()) {
-      recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #1");
       return TimeDelta::Max();
     }
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #2");
     return main_thread_only().quit_runloop_after - continuation_lazy_now->Now();
   }
 
   DCHECK(main_thread_only().task_source);
 
   for (int i = 0; i < main_thread_only().work_batch_size; i++) {
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #3");
     const SequencedTaskSource::SelectTaskOption select_task_option =
         power_monitor_.IsProcessInPowerSuspendState()
             ? SequencedTaskSource::SelectTaskOption::kSkipDelayedTask
             : SequencedTaskSource::SelectTaskOption::kDefault;
     Task* task =
         main_thread_only().task_source->SelectNextTask(select_task_option);
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #4 %d", !!task);
     if (!task)
       break;
 
@@ -362,16 +350,12 @@ TimeDelta ThreadControllerWithMessagePumpImpl::DoWorkImpl(
       // See https://crbug.com/681863 and https://crbug.com/874982
       TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "RunTask");
 
-      recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #5");
-
       {
         // Trace events should finish before we call DidRunTask to ensure that
         // SequenceManager trace events do not interfere with them.
         TRACE_TASK_EXECUTION("ThreadControllerImpl::RunTask", *task);
         task_annotator_.RunTask("SequenceManager RunTask", task);
       }
-
-      recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #6");
 
       // This processes microtasks, hence all scoped operations above must end
       // after it.
@@ -382,13 +366,11 @@ TimeDelta ThreadControllerWithMessagePumpImpl::DoWorkImpl(
     // When Quit() is called we must stop running the batch because the caller
     // expects per-task granularity.
     if (main_thread_only().quit_pending) {
-      recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #7");
       break;
     }
   }
 
   if (main_thread_only().quit_pending) {
-    recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl #8");
     return TimeDelta::Max();
   }
 
@@ -401,15 +383,10 @@ TimeDelta ThreadControllerWithMessagePumpImpl::DoWorkImpl(
           ? SequencedTaskSource::SelectTaskOption::kSkipDelayedTask
           : SequencedTaskSource::SelectTaskOption::kDefault;
 
-  recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl 8.1 %d",
-                       select_task_option);
-
   TimeDelta do_work_delay = main_thread_only().task_source->DelayTillNextTask(
       continuation_lazy_now, select_task_option);
   DCHECK_GE(do_work_delay, TimeDelta());
 
-  //recordreplay::Assert("ThreadControllerWithMessagePumpImpl::DoWorkImpl Done %.2f",
-  //                     do_work_delay.InSecondsF());
   return do_work_delay;
 }
 

--- a/base/task/sequence_manager/time_domain.cc
+++ b/base/task/sequence_manager/time_domain.cc
@@ -77,9 +77,6 @@ void TimeDomain::SetNextWakeUpForQueue(
 
   if (wake_up) {
     // Insert a new wake-up into the heap.
-    recordreplay::Assert("TimeDomain::SetNextWakeUpForQueue #1 %lu", recordreplay::PointerId(queue));
-    recordreplay::AssertBytes("TimeDomain::SetNextWakeUpForQueue #2",
-                              &wake_up.value(), sizeof(internal::DelayedWakeUp));
     if (queue->heap_handle().IsValid()) {
       // O(log n)
       delayed_wake_up_queue_.ChangeKey(queue->heap_handle(),
@@ -90,7 +87,6 @@ void TimeDomain::SetNextWakeUpForQueue(
     }
   } else {
     // Remove a wake-up from heap if present.
-    recordreplay::Assert("TimeDomain::SetNextWakeUpForQueue #3 %lu", recordreplay::PointerId(queue));
     if (queue->heap_handle().IsValid())
       delayed_wake_up_queue_.erase(queue->heap_handle());
   }
@@ -129,24 +125,20 @@ void TimeDomain::SetNextWakeUpForQueue(
 }
 
 void TimeDomain::MoveReadyDelayedTasksToWorkQueues(LazyNow* lazy_now) {
-  recordreplay::Assert("TimeDomain::MoveReadyDelayedTasksToWorkQueues Start");
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   // Wake up any queues with pending delayed work.  Note std::multimap stores
   // the elements sorted by key, so the begin() iterator points to the earliest
   // queue to wake-up.
   while (true) {
     if (delayed_wake_up_queue_.empty()) {
-      recordreplay::Assert("TimeDomain::MoveReadyDelayedTasksToWorkQueues #1");
       break;
     }
     if (delayed_wake_up_queue_.Min().wake_up.time > lazy_now->Now()) {
-      recordreplay::Assert("TimeDomain::MoveReadyDelayedTasksToWorkQueues #2");
       break;
     }
     internal::TaskQueueImpl* queue = delayed_wake_up_queue_.Min().queue;
     queue->MoveReadyDelayedTasksToWorkQueue(lazy_now);
   }
-  recordreplay::Assert("TimeDomain::MoveReadyDelayedTasksToWorkQueues Done");
 }
 
 Optional<TimeTicks> TimeDomain::NextScheduledRunTime() const {

--- a/base/task/sequence_manager/work_deduplicator.cc
+++ b/base/task/sequence_manager/work_deduplicator.cc
@@ -46,7 +46,6 @@ WorkDeduplicator::ShouldScheduleWork WorkDeduplicator::OnDelayedWorkRequested()
 }
 
 void WorkDeduplicator::OnWorkStarted() {
-  recordreplay::Assert("WorkDeduplicator::OnWorkStarted");
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   DCHECK_EQ(state_.load() & kBoundFlag, kBoundFlag);
   // Clear kPendingDoWorkFlag and mark us as in a DoWork.
@@ -55,7 +54,6 @@ void WorkDeduplicator::OnWorkStarted() {
 }
 
 void WorkDeduplicator::WillCheckForMoreWork() {
-  recordreplay::Assert("WorkDeduplicator::WillCheckForMoreWork");
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   DCHECK_EQ(state_.load() & kBoundFlag, kBoundFlag);
   // Clear kPendingDoWorkFlag if it was set.
@@ -67,8 +65,6 @@ WorkDeduplicator::ShouldScheduleWork WorkDeduplicator::DidCheckForMoreWork(
     NextTask next_task) {
   DCHECK_CALLED_ON_VALID_THREAD(associated_thread_->thread_checker);
   DCHECK_EQ(state_.load() & kBoundFlag, kBoundFlag);
-  recordreplay::Assert("WorkDeduplicator::DidCheckForMoreWork %d",
-                       next_task == NextTask::kIsImmediate);
   if (next_task == NextTask::kIsImmediate) {
     state_.store(State::kDoWorkPending);
     return ShouldScheduleWork::kScheduleImmediate;
@@ -78,9 +74,7 @@ WorkDeduplicator::ShouldScheduleWork WorkDeduplicator::DidCheckForMoreWork(
   // thread determined that the next task wasn't immediate. In that case, that
   // other thread relies on us to return kScheduleImmediate.
   recordreplay::AutoOrderedLock ordered(state_ordered_lock_id_);
-  bool v = (state_.fetch_and(~kInDoWorkFlag) & kPendingDoWorkFlag);
-  recordreplay::Assert("WorkDeduplicator::DidCheckForMoreWork #1 %d", v);
-  return v
+  return (state_.fetch_and(~kInDoWorkFlag) & kPendingDoWorkFlag)
              ? ShouldScheduleWork::kScheduleImmediate
              : ShouldScheduleWork::kNotNeeded;
 }

--- a/base/task/sequence_manager/work_queue.cc
+++ b/base/task/sequence_manager/work_queue.cc
@@ -19,7 +19,6 @@ WorkQueue::WorkQueue(TaskQueueImpl* task_queue,
                      QueueType queue_type)
     : task_queue_(task_queue), name_(name), queue_type_(queue_type) {
   recordreplay::RegisterPointer(this);
-  recordreplay::Assert("WorkQueue::WorkQueue %lu", recordreplay::PointerId(this));
 }
 
 Value WorkQueue::AsValue(TimeTicks now) const {
@@ -59,8 +58,6 @@ bool WorkQueue::BlockedByFence() const {
 
 bool WorkQueue::GetFrontTaskEnqueueOrder(EnqueueOrder* enqueue_order) const {
   if (tasks_.empty() || BlockedByFence()) {
-    recordreplay::Assert("WorkQueue::GetFrontTaskEnqueueOrder #1 %lu",
-                         recordreplay::PointerId(this));
     return false;
   }
   // Quick sanity check.
@@ -68,15 +65,10 @@ bool WorkQueue::GetFrontTaskEnqueueOrder(EnqueueOrder* enqueue_order) const {
       << task_queue_->GetName() << " : " << work_queue_sets_->GetName() << " : "
       << name_;
   *enqueue_order = tasks_.front().enqueue_order();
-  recordreplay::Assert("WorkQueue::GetFrontTaskEnqueueOrder #2 %lu %lu",
-                       recordreplay::PointerId(this), (size_t)*enqueue_order);
   return true;
 }
 
 void WorkQueue::Push(Task task) {
-  recordreplay::Assert("WorkQueue::Push %lu %lu",
-                       recordreplay::PointerId(this), (size_t)task.enqueue_order());
-
   bool was_empty = tasks_.empty();
 #ifndef NDEBUG
   DCHECK(task.enqueue_order_set());
@@ -105,10 +97,6 @@ WorkQueue::TaskPusher::TaskPusher(TaskPusher&& other)
 }
 
 void WorkQueue::TaskPusher::Push(Task* task) {
-  recordreplay::Assert("WorkQueue::TaskPusher::Push %lu %lu",
-                       recordreplay::PointerId(work_queue_),
-                       (size_t)task->enqueue_order());
-
   DCHECK(work_queue_);
 
 #ifndef NDEBUG
@@ -133,16 +121,10 @@ WorkQueue::TaskPusher::~TaskPusher() {
 }
 
 WorkQueue::TaskPusher WorkQueue::CreateTaskPusher() {
-  recordreplay::Assert("WorkQueue::CreateTaskPusher %lu",
-                       recordreplay::PointerId(this));
   return TaskPusher(this);
 }
 
 void WorkQueue::PushNonNestableTaskToFront(Task task) {
-  recordreplay::Assert("WorkQueue::PushNonNestableTaskToFront %lu %lu",
-                       recordreplay::PointerId(this),
-                       (size_t)task.enqueue_order());
-
   DCHECK(task.nestable == Nestable::kNonNestable);
 
   bool was_empty = tasks_.empty();
@@ -192,16 +174,11 @@ Task WorkQueue::TakeTaskFromWorkQueue() {
   DCHECK(work_queue_sets_);
   DCHECK(!tasks_.empty());
 
-  recordreplay::Assert("WorkQueue::TakeTaskFromWorkQueue Start %lu",
-                       recordreplay::PointerId(this));
-
   Task pending_task = std::move(tasks_.front());
   tasks_.pop_front();
   // NB immediate tasks have a different pipeline to delayed ones.
-  recordreplay::Assert("WorkQueue::TakeTaskFromWorkQueue #0 %d", tasks_.empty());
   if (tasks_.empty()) {
     // NB delayed tasks are inserted via Push, no don't need to reload those.
-    recordreplay::Assert("WorkQueue::TakeTaskFromWorkQueue #1 %d", queue_type_);
     if (queue_type_ == QueueType::kImmediate) {
       // Short-circuit the queue reload so that OnPopMinQueueInSet does the
       // right thing.
@@ -224,7 +201,6 @@ Task WorkQueue::TakeTaskFromWorkQueue() {
 #endif
   task_queue_->TraceQueueSize();
 
-  recordreplay::Assert("WorkQueue::TakeTaskFromWorkQueue Done");
   return pending_task;
 }
 
@@ -259,7 +235,6 @@ bool WorkQueue::RemoveAllCanceledTasksFromFront() {
       break;
     tasks_.pop_front();
     task_removed = true;
-    recordreplay::Assert("WorkQueue::RemoveAllCanceledTasksFromFront #1");
   }
   if (task_removed) {
     if (tasks_.empty()) {

--- a/base/task/sequence_manager/work_queue_sets.cc
+++ b/base/task/sequence_manager/work_queue_sets.cc
@@ -24,8 +24,6 @@ WorkQueueSets::WorkQueueSets(const char* name,
 WorkQueueSets::~WorkQueueSets() = default;
 
 void WorkQueueSets::AddQueue(WorkQueue* work_queue, size_t set_index) {
-  recordreplay::Assert("WorkQueueSets::AddQueue %lu %lu",
-                       recordreplay::PointerId(work_queue), set_index);
   DCHECK(!work_queue->work_queue_sets());
   DCHECK_LT(set_index, work_queue_heaps_.size());
   DCHECK(!work_queue->heap_handle().IsValid());
@@ -42,8 +40,6 @@ void WorkQueueSets::AddQueue(WorkQueue* work_queue, size_t set_index) {
 }
 
 void WorkQueueSets::RemoveQueue(WorkQueue* work_queue) {
-  recordreplay::Assert("WorkQueueSets::RemoveQueue %lu",
-                       recordreplay::PointerId(work_queue));
   DCHECK_EQ(this, work_queue->work_queue_sets());
   work_queue->AssignToWorkQueueSets(nullptr);
   if (!work_queue->heap_handle().IsValid())
@@ -57,8 +53,6 @@ void WorkQueueSets::RemoveQueue(WorkQueue* work_queue) {
 }
 
 void WorkQueueSets::ChangeSetIndex(WorkQueue* work_queue, size_t set_index) {
-  recordreplay::Assert("WorkQueueSets::ChangeSetIndex %lu %lu",
-                       recordreplay::PointerId(work_queue), set_index);
   DCHECK_EQ(this, work_queue->work_queue_sets());
   DCHECK_LT(set_index, work_queue_heaps_.size());
   EnqueueOrder enqueue_order;
@@ -80,8 +74,6 @@ void WorkQueueSets::ChangeSetIndex(WorkQueue* work_queue, size_t set_index) {
 }
 
 void WorkQueueSets::OnQueuesFrontTaskChanged(WorkQueue* work_queue) {
-  recordreplay::Assert("WorkQueueSets::OnQueuesFrontTaskChanged %lu",
-                       recordreplay::PointerId(work_queue));
   EnqueueOrder enqueue_order;
   size_t set_index = work_queue->work_queue_set_index();
   DCHECK_EQ(this, work_queue->work_queue_sets());
@@ -102,8 +94,6 @@ void WorkQueueSets::OnQueuesFrontTaskChanged(WorkQueue* work_queue) {
 }
 
 void WorkQueueSets::OnTaskPushedToEmptyQueue(WorkQueue* work_queue) {
-  recordreplay::Assert("WorkQueueSets::OnTaskPushedToEmptyQueue %lu",
-                       recordreplay::PointerId(work_queue));
   // NOTE if this function changes, we need to keep |WorkQueueSets::AddQueue| in
   // sync.
   DCHECK_EQ(this, work_queue->work_queue_sets());
@@ -122,8 +112,6 @@ void WorkQueueSets::OnTaskPushedToEmptyQueue(WorkQueue* work_queue) {
 }
 
 void WorkQueueSets::OnPopMinQueueInSet(WorkQueue* work_queue) {
-  recordreplay::Assert("WorkQueueSets::OnPopMinQueueInSet %lu",
-                       recordreplay::PointerId(work_queue));
   // Assume that |work_queue| contains the lowest enqueue_order.
   size_t set_index = work_queue->work_queue_set_index();
   DCHECK_EQ(this, work_queue->work_queue_sets());
@@ -149,8 +137,6 @@ void WorkQueueSets::OnPopMinQueueInSet(WorkQueue* work_queue) {
 }
 
 void WorkQueueSets::OnQueueBlocked(WorkQueue* work_queue) {
-  recordreplay::Assert("WorkQueueSets::OnQueueBlocked %lu",
-                       recordreplay::PointerId(work_queue));
   DCHECK_EQ(this, work_queue->work_queue_sets());
   base::internal::HeapHandle heap_handle = work_queue->heap_handle();
   if (!heap_handle.IsValid())
@@ -163,22 +149,18 @@ void WorkQueueSets::OnQueueBlocked(WorkQueue* work_queue) {
 }
 
 WorkQueue* WorkQueueSets::GetOldestQueueInSet(size_t set_index) const {
-  recordreplay::Assert("WorkQueueSets::GetOldestQueueInSet Start %lu", set_index);
   DCHECK_LT(set_index, work_queue_heaps_.size());
   if (work_queue_heaps_[set_index].empty())
     return nullptr;
   WorkQueue* queue = work_queue_heaps_[set_index].Min().value;
   DCHECK_EQ(set_index, queue->work_queue_set_index());
   DCHECK(queue->heap_handle().IsValid());
-  recordreplay::Assert("WorkQueueSets::GetOldestQueueInSet Done %lu",
-                       recordreplay::PointerId(queue));
   return queue;
 }
 
 WorkQueue* WorkQueueSets::GetOldestQueueAndEnqueueOrderInSet(
     size_t set_index,
     EnqueueOrder* out_enqueue_order) const {
-  recordreplay::Assert("WorkQueueSets::GetOldestQueueAndEnqueueOrderInSet Start %lu", set_index);
   DCHECK_LT(set_index, work_queue_heaps_.size());
   if (work_queue_heaps_[set_index].empty())
     return nullptr;
@@ -188,8 +170,6 @@ WorkQueue* WorkQueueSets::GetOldestQueueAndEnqueueOrderInSet(
   EnqueueOrder enqueue_order;
   DCHECK(oldest.value->GetFrontTaskEnqueueOrder(&enqueue_order) &&
          oldest.key == enqueue_order);
-  recordreplay::Assert("WorkQueueSets::GetOldestQueueAndEnqueueOrderInSet Done %lu",
-                       recordreplay::PointerId(oldest.value));
   return oldest.value;
 }
 
@@ -261,8 +241,6 @@ bool WorkQueueSets::ContainsWorkQueueForTest(
 void WorkQueueSets::CollectSkippedOverLowerPriorityTasks(
     const internal::WorkQueue* selected_work_queue,
     std::vector<const Task*>* result) const {
-  recordreplay::Assert("WorkQueueSets::CollectSkippedOverLowerPriorityTasks %lu",
-                       recordreplay::PointerId(selected_work_queue));
   EnqueueOrder selected_enqueue_order;
   CHECK(selected_work_queue->GetFrontTaskEnqueueOrder(&selected_enqueue_order));
   for (size_t priority = selected_work_queue->work_queue_set_index() + 1;

--- a/base/task/thread_pool/job_task_source.cc
+++ b/base/task/thread_pool/job_task_source.cc
@@ -214,10 +214,6 @@ TaskSource::RunStatus JobTaskSource::WillRunTask() {
   const size_t max_concurrency =
       GetMaxConcurrency(state_before_add.worker_count());
 
-  // https://github.com/RecordReplay/backend/issues/5661
-  recordreplay::Assert("JobTaskSource::WillRunTask #1 %lu %lu",
-                       max_concurrency, state_before_add.worker_count());
-
   if (state_before_add.worker_count() < max_concurrency)
     state_before_add = state_.IncrementWorkerCount();
   const size_t worker_count_before_add = state_before_add.worker_count();
@@ -235,16 +231,12 @@ size_t JobTaskSource::GetRemainingConcurrency() const {
   // It is safe to read |state_| without a lock since this variable is atomic,
   // and no other state is synchronized with GetRemainingConcurrency().
   const auto state = TS_UNCHECKED_READ(state_).Load();
-  recordreplay::Assert("JobTaskSource::GetRemainingConcurrency START %d %d",
-                       state.is_canceled(), state.worker_count());
   if (state.is_canceled())
     return 0;
   const size_t max_concurrency = GetMaxConcurrency(state.worker_count());
   // Avoid underflows.
   if (state.worker_count() > max_concurrency)
     return 0;
-  recordreplay::Assert("JobTaskSource::GetRemainingConcurrency #1 %lu %lu",
-                       max_concurrency, state.worker_count());
   return max_concurrency - state.worker_count();
 }
 
@@ -338,7 +330,6 @@ Task JobTaskSource::TakeTask(TaskSource::Transaction* transaction) {
 bool JobTaskSource::DidProcessTask(TaskSource::Transaction* /*transaction*/) {
   // Lock is needed to access |join_flag_| below and signal
   // |worker_released_condition_|.
-  recordreplay::Assert("JobTaskSource::DidProcessTask Start");
   CheckedAutoLock auto_lock(worker_lock_);
   const auto state_before_sub = state_.DecrementWorkerCount();
 
@@ -347,7 +338,6 @@ bool JobTaskSource::DidProcessTask(TaskSource::Transaction* /*transaction*/) {
 
   // A canceled task source should never get re-enqueued.
   if (state_before_sub.is_canceled()) {
-    recordreplay::Assert("JobTaskSource::DidProcessTask #1");
     return false;
   }
 
@@ -356,10 +346,8 @@ bool JobTaskSource::DidProcessTask(TaskSource::Transaction* /*transaction*/) {
   // Re-enqueue the TaskSource if the task ran and the worker count is below the
   // max concurrency.
   // |worker_count - 1| to exclude the returning thread.
-  bool rv = state_before_sub.worker_count() <=
-            GetMaxConcurrency(state_before_sub.worker_count() - 1);
-  recordreplay::Assert("JobTaskSource::DidProcessTask #2 %d", rv);
-  return rv;
+  return state_before_sub.worker_count() <=
+         GetMaxConcurrency(state_before_sub.worker_count() - 1);
 }
 
 TaskSourceSortKey JobTaskSource::GetSortKey(

--- a/base/task/thread_pool/pooled_sequenced_task_runner.cc
+++ b/base/task/thread_pool/pooled_sequenced_task_runner.cc
@@ -21,7 +21,6 @@ PooledSequencedTaskRunner::PooledSequencedTaskRunner(
 }
 
 PooledSequencedTaskRunner::~PooledSequencedTaskRunner() {
-  recordreplay::Assert("~PooledSequencedTaskRunner %lu", recordreplay::PointerId(this));
   recordreplay::UnregisterPointer(this);
 }
 

--- a/base/task/thread_pool/pooled_single_thread_task_runner_manager.cc
+++ b/base/task/thread_pool/pooled_single_thread_task_runner_manager.cc
@@ -408,9 +408,7 @@ class PooledSingleThreadTaskRunnerManager::PooledSingleThreadTaskRunner
   bool PostDelayedTask(const Location& from_here,
                        OnceClosure closure,
                        TimeDelta delay) override {
-    recordreplay::Assert("PooledSingleThreadTaskRunner::PostDelayedTask Start");
     if (!g_manager_is_alive) {
-      recordreplay::Assert("PooledSingleThreadTaskRunner::PostDelayedTask #1");
       return false;
     }
 
@@ -418,12 +416,10 @@ class PooledSingleThreadTaskRunnerManager::PooledSingleThreadTaskRunner
 
     if (!outer_->task_tracker_->WillPostTask(&task,
                                              sequence_->shutdown_behavior())) {
-      recordreplay::Assert("PooledSingleThreadTaskRunner::PostDelayedTask #2");
       return false;
     }
 
     if (task.delayed_run_time.is_null()) {
-      recordreplay::Assert("PooledSingleThreadTaskRunner::PostDelayedTask #3");
       return GetDelegate()->PostTaskNow(sequence_, std::move(task));
     }
 
@@ -435,7 +431,6 @@ class PooledSingleThreadTaskRunnerManager::PooledSingleThreadTaskRunner
                  Unretained(GetDelegate()), sequence_),
         this);
 
-    recordreplay::Assert("PooledSingleThreadTaskRunner::PostDelayedTask Done");
     return true;
   }
 
@@ -454,8 +449,6 @@ class PooledSingleThreadTaskRunnerManager::PooledSingleThreadTaskRunner
 
  private:
   ~PooledSingleThreadTaskRunner() override {
-    recordreplay::Assert("~PooledSingleThreadTaskRunner %lu", recordreplay::PointerId(this));
-
     // Only unregister if this is a DEDICATED SingleThreadTaskRunner. SHARED
     // task runner WorkerThreads are managed separately as they are reused.
     // |g_manager_is_alive| avoids a use-after-free should this
@@ -478,8 +471,6 @@ class PooledSingleThreadTaskRunnerManager::PooledSingleThreadTaskRunner
         thread_mode_ == SingleThreadTaskRunnerThreadMode::DEDICATED) {
       outer_->UnregisterWorkerThread(worker_);
     }
-
-    recordreplay::Assert("~PooledSingleThreadTaskRunner Done");
   }
 
   WorkerThreadDelegate* GetDelegate() const {

--- a/base/task/thread_pool/sequence.cc
+++ b/base/task/thread_pool/sequence.cc
@@ -92,7 +92,6 @@ Task Sequence::TakeTask(TaskSource::Transaction* transaction) {
 }
 
 bool Sequence::DidProcessTask(TaskSource::Transaction* transaction) {
-  recordreplay::Assert("Sequence::DidProcessTask Start");
   CheckedAutoLockMaybe auto_lock(transaction ? nullptr : &lock_);
   // There should never be a call to DidProcessTask without an associated
   // WillRunTask().
@@ -101,13 +100,11 @@ bool Sequence::DidProcessTask(TaskSource::Transaction* transaction) {
   // See comment on TaskSource::task_runner_ for lifetime management details.
   if (queue_.empty()) {
     ReleaseTaskRunner();
-    recordreplay::Assert("Sequence::DidProcessTask #1");
     return false;
   }
   // Let the caller re-enqueue this non-empty Sequence regardless of
   // |run_result| so it can continue churning through this Sequence's tasks and
   // skip/delete them in the proper scope.
-  recordreplay::Assert("Sequence::DidProcessTask #2");
   return true;
 }
 
@@ -133,22 +130,16 @@ Task Sequence::Clear(TaskSource::Transaction* transaction) {
 }
 
 void Sequence::ReleaseTaskRunner() {
-  recordreplay::Assert("Sequence::ReleaseTaskRunner Start");
   if (!task_runner()) {
-    recordreplay::Assert("Sequence::ReleaseTaskRunner #1");
     return;
   }
   if (execution_mode() == TaskSourceExecutionMode::kParallel) {
-    recordreplay::Assert("Sequence::ReleaseTaskRunner #2");
     static_cast<PooledParallelTaskRunner*>(task_runner())
         ->UnregisterSequence(this);
-    recordreplay::Assert("Sequence::ReleaseTaskRunner #3");
   }
   // No member access after this point, releasing |task_runner()| might delete
   // |this|.
-  recordreplay::Assert("Sequence::ReleaseTaskRunner #4");
   task_runner()->Release();
-  recordreplay::Assert("Sequence::ReleaseTaskRunner Done");
 }
 
 Sequence::Sequence(const TaskTraits& traits,

--- a/base/task/thread_pool/task_source.cc
+++ b/base/task/thread_pool/task_source.cc
@@ -91,9 +91,7 @@ RegisteredTaskSource::RegisteredTaskSource(
 }
 
 RegisteredTaskSource::~RegisteredTaskSource() {
-  recordreplay::Assert("~RegisteredTaskSource Start");
   Unregister();
-  recordreplay::Assert("~RegisteredTaskSource Done");
 }
 
 //  static
@@ -107,7 +105,6 @@ scoped_refptr<TaskSource> RegisteredTaskSource::Unregister() {
 #if DCHECK_IS_ON()
   DCHECK_EQ(run_step_, State::kInitial);
 #endif  // DCHECK_IS_ON()
-  recordreplay::Assert("RegisteredTaskSource::Unregister %d %d", !!task_source_, !!task_tracker_);
   if (task_source_ && task_tracker_)
     return task_tracker_->UnregisterTaskSource(std::move(task_source_));
   return std::move(task_source_);

--- a/base/task/thread_pool/task_tracker.cc
+++ b/base/task/thread_pool/task_tracker.cc
@@ -416,8 +416,6 @@ RegisteredTaskSource TaskTracker::RunAndPopNextTask(
     RegisteredTaskSource task_source) {
   DCHECK(task_source);
 
-  recordreplay::Assert("TaskTracker::RunAndPopNextTask Start");
-
   const bool should_run_tasks = BeforeRunTask(task_source->shutdown_behavior());
 
   // Run the next task in |task_source|.
@@ -438,8 +436,6 @@ RegisteredTaskSource TaskTracker::RunAndPopNextTask(
     AfterRunTask(task_source->shutdown_behavior());
   const bool task_source_must_be_queued = task_source.DidProcessTask();
   // |task_source| should be reenqueued iff requested by DidProcessTask().
-  recordreplay::Assert("TaskTracker::RunAndPopNextTask Done %d",
-                       task_source_must_be_queued);
   if (task_source_must_be_queued)
     return task_source;
   return nullptr;
@@ -628,35 +624,28 @@ scoped_refptr<TaskSource> TaskTracker::UnregisterTaskSource(
 }
 
 void TaskTracker::DecrementNumItemsBlockingShutdown() {
-  recordreplay::Assert("TaskTracker::DecrementNumItemsBlockingShutdown Start");
   const bool shutdown_started_and_no_items_block_shutdown =
       state_->DecrementNumItemsBlockingShutdown();
   if (!shutdown_started_and_no_items_block_shutdown) {
-    recordreplay::Assert("TaskTracker::DecrementNumItemsBlockingShutdown #1");
     return;
   }
 
   CheckedAutoLock auto_lock(shutdown_lock_);
   DCHECK(shutdown_event_);
   shutdown_event_->Signal();
-  recordreplay::Assert("TaskTracker::DecrementNumItemsBlockingShutdown Done");
 }
 
 void TaskTracker::DecrementNumIncompleteTaskSources() {
-  recordreplay::Assert("TaskTracker::DecrementNumIncompleteTaskSources Start");
   const auto prev_num_incomplete_task_sources =
       num_incomplete_task_sources_.fetch_sub(1);
   DCHECK_GE(prev_num_incomplete_task_sources, 1);
   if (prev_num_incomplete_task_sources == 1) {
-    recordreplay::Assert("TaskTracker::DecrementNumIncompleteTaskSources #1");
     {
       CheckedAutoLock auto_lock(flush_lock_);
       flush_cv_->Signal();
     }
-    recordreplay::Assert("TaskTracker::DecrementNumIncompleteTaskSources #2");
     CallFlushCallbackForTesting();
   }
-  recordreplay::Assert("TaskTracker::DecrementNumIncompleteTaskSources Done");
 }
 
 void TaskTracker::CallFlushCallbackForTesting() {

--- a/base/task/thread_pool/thread_group.cc
+++ b/base/task/thread_pool/thread_group.cc
@@ -138,7 +138,6 @@ ThreadGroup::GetNumAdditionalWorkersForForegroundTaskSourcesLockRequired()
                                 TaskPriority::USER_BLOCKING);
   if (num_queued == 0 ||
       !task_tracker_->CanRunPriority(TaskPriority::HIGHEST)) {
-    recordreplay::Assert("ThreadGroup::GetNumAdditionalWorkersForForegroundTaskSourcesLockRequired #1");
     return 0U;
   }
   auto priority = priority_queue_.PeekSortKey().priority();
@@ -146,15 +145,10 @@ ThreadGroup::GetNumAdditionalWorkersForForegroundTaskSourcesLockRequired()
       priority == TaskPriority::USER_BLOCKING) {
     // Assign the correct number of workers for the top TaskSource (-1 for the
     // worker that is already accounted for in |num_queued|).
-    recordreplay::Assert("ThreadGroup::GetNumAdditionalWorkersForForegroundTaskSourcesLockRequired #2 %lu %lu",
-                         num_queued,
-                         priority_queue_.PeekTaskSource()->GetRemainingConcurrency());
     return std::max<size_t>(
         1, num_queued +
                priority_queue_.PeekTaskSource()->GetRemainingConcurrency() - 1);
   }
-  recordreplay::Assert("ThreadGroup::GetNumAdditionalWorkersForForegroundTaskSourcesLockRequired #3 %lu",
-                       num_queued);
   return num_queued;
 }
 
@@ -206,15 +200,12 @@ RegisteredTaskSource ThreadGroup::TakeRegisteredTaskSource(
 
   auto run_status = priority_queue_.PeekTaskSource().WillRunTask();
 
-  recordreplay::Assert("ThreadGroup::TakeRegisteredTaskSource Start %d", run_status);
-
   if (run_status == TaskSource::RunStatus::kDisallowed) {
     executor->ScheduleReleaseTaskSource(priority_queue_.PopTaskSource());
     return nullptr;
   }
 
   if (run_status == TaskSource::RunStatus::kAllowedSaturated) {
-    recordreplay::Assert("ThreadGroup::TakeRegisteredTaskSource #1");
     return priority_queue_.PopTaskSource();
   }
 
@@ -229,10 +220,8 @@ RegisteredTaskSource ThreadGroup::TakeRegisteredTaskSource(
   RegisteredTaskSource task_source =
       task_tracker_->RegisterTaskSource(priority_queue_.PeekTaskSource().get());
   if (!task_source) {
-    recordreplay::Assert("ThreadGroup::TakeRegisteredTaskSource #2");
     return priority_queue_.PopTaskSource();
   }
-  recordreplay::Assert("ThreadGroup::TakeRegisteredTaskSource #3");
   // Replace the top task_source and then update the queue.
   std::swap(priority_queue_.PeekTaskSource(), task_source);
   if (!disable_fair_scheduling_) {
@@ -285,15 +274,7 @@ void ThreadGroup::InvalidateAndHandoffAllTaskSourcesToOtherThreadGroup(
 bool ThreadGroup::ShouldYield(TaskSourceSortKey sort_key) {
   DCHECK(TS_UNCHECKED_READ(max_allowed_sort_key_).is_lock_free());
 
-  // https://linear.app/replay/issue/RUN-574
-  recordreplay::Assert("ThreadGroup::ShouldYield Start %d %d %ld",
-                       sort_key.priority(),
-                       (int)sort_key.worker_count(),
-                       sort_key.ready_time().ToInternalValue());
-
   if (!task_tracker_->CanRunPriority(sort_key.priority())) {
-    // https://linear.app/replay/issue/RUN-574
-    recordreplay::Assert("ThreadGroup::ShouldYield #1");
     return true;
   }
   // It is safe to read |max_allowed_sort_key_| without a lock since this
@@ -302,15 +283,10 @@ bool ThreadGroup::ShouldYield(TaskSourceSortKey sort_key) {
   auto max_allowed_sort_key =
       TS_UNCHECKED_READ(max_allowed_sort_key_).load(std::memory_order_relaxed);
 
-  // https://linear.app/replay/issue/RUN-574
-  recordreplay::Assert("ThreadGroup::ShouldYield #2 %d", max_allowed_sort_key);
-
   // To reduce unnecessary yielding, a task will never yield to a BEST_EFFORT
   // task regardless of its worker_count.
   if (sort_key.priority() > max_allowed_sort_key.priority ||
       max_allowed_sort_key.priority == TaskPriority::BEST_EFFORT) {
-    // https://linear.app/replay/issue/RUN-574
-    recordreplay::Assert("ThreadGroup::ShouldYield #3");
     return false;
   }
   // Otherwise, a task only yields to a task of equal priority if its
@@ -318,8 +294,6 @@ bool ThreadGroup::ShouldYield(TaskSourceSortKey sort_key) {
   // worker doesn't yield to a job with 0 workers.
   if (sort_key.priority() == max_allowed_sort_key.priority &&
       sort_key.worker_count() <= max_allowed_sort_key.worker_count + 1) {
-    // https://linear.app/replay/issue/RUN-574
-    recordreplay::Assert("ThreadGroup::ShouldYield #4");
     return false;
   }
 
@@ -328,9 +302,6 @@ bool ThreadGroup::ShouldYield(TaskSourceSortKey sort_key) {
   max_allowed_sort_key =
       TS_UNCHECKED_READ(max_allowed_sort_key_)
           .exchange(kMaxYieldSortKey, std::memory_order_relaxed);
-
-  // https://linear.app/replay/issue/RUN-574
-  recordreplay::Assert("ThreadGroup::ShouldYield #5 %d", max_allowed_sort_key);
 
   // Another thread might have decided to yield and racily reset
   // |max_allowed_sort_key_|, in which case this thread doesn't yield.

--- a/base/task/thread_pool/thread_group_impl.cc
+++ b/base/task/thread_pool/thread_group_impl.cc
@@ -142,8 +142,6 @@ class ThreadGroupImpl::ScopedCommandsExecutor
     void AddWorker(scoped_refptr<WorkerThread> worker) {
       if (!worker)
         return;
-      recordreplay::Assert("WorkerContainer::AddWorker %lu",
-                           recordreplay::PointerId(worker.get()));
       if (!first_worker_)
         first_worker_ = std::move(worker);
       else
@@ -153,12 +151,8 @@ class ThreadGroupImpl::ScopedCommandsExecutor
     template <typename Action>
     void ForEachWorker(Action action) {
       if (first_worker_) {
-        recordreplay::Assert("WorkerContainer::ForEachWorker #1 %lu",
-                             recordreplay::PointerId(first_worker_.get()));
         action(first_worker_.get());
         for (scoped_refptr<WorkerThread> worker : additional_workers_) {
-          recordreplay::Assert("WorkerContainer::ForEachWorker #2 %lu",
-                               recordreplay::PointerId(worker.get()));
           action(worker.get());
         }
       } else {
@@ -589,8 +583,6 @@ void ThreadGroupImpl::WorkerThreadDelegateImpl::OnMainEntry(
 
 RegisteredTaskSource ThreadGroupImpl::WorkerThreadDelegateImpl::GetWork(
     WorkerThread* worker) {
-  recordreplay::Assert("WorkerThreadDelegateImpl::GetWork Start %lu", recordreplay::PointerId(this));
-
   DCHECK_CALLED_ON_VALID_THREAD(worker_thread_checker_);
   DCHECK(!worker_only().is_running_task);
 
@@ -600,7 +592,6 @@ RegisteredTaskSource ThreadGroupImpl::WorkerThreadDelegateImpl::GetWork(
   DCHECK(ContainsWorker(outer_->workers_, worker));
 
   if (!CanGetWorkLockRequired(&executor, worker)) {
-    recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #1");
     return nullptr;
   }
 
@@ -619,22 +610,18 @@ RegisteredTaskSource ThreadGroupImpl::WorkerThreadDelegateImpl::GetWork(
   while (!task_source && !outer_->priority_queue_.IsEmpty()) {
     // Enforce the CanRunPolicy and that no more than |max_best_effort_tasks_|
     // BEST_EFFORT tasks run concurrently.
-    recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #1.1");
     priority = outer_->priority_queue_.PeekSortKey().priority();
     if (!outer_->task_tracker_->CanRunPriority(priority) ||
         (priority == TaskPriority::BEST_EFFORT &&
          outer_->num_running_best_effort_tasks_ >=
              outer_->max_best_effort_tasks_)) {
-      recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #1.2");
       break;
     }
 
     task_source = outer_->TakeRegisteredTaskSource(&executor);
-    recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #1.3 %d", !!task_source);
   }
   if (!task_source) {
     OnWorkerBecomesIdleLockRequired(worker);
-    recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #2");
     return nullptr;
   }
 
@@ -647,11 +634,9 @@ RegisteredTaskSource ThreadGroupImpl::WorkerThreadDelegateImpl::GetWork(
   if (outer_->after_start().wakeup_after_getwork &&
       outer_->after_start().wakeup_strategy !=
           WakeUpStrategy::kCentralizedWakeUps) {
-    recordreplay::Assert("WorkerThreadDelegateImpl::GetWork #3");
     outer_->EnsureEnoughWorkersLockRequired(&executor);
   }
 
-  recordreplay::Assert("WorkerThreadDelegateImpl::GetWork Done %d", !!task_source);
   return task_source;
 }
 
@@ -1021,13 +1006,6 @@ size_t ThreadGroupImpl::GetDesiredNumAwakeWorkersLockRequired() const {
   const size_t workers_for_foreground_task_sources =
       num_running_or_queued_foreground_task_sources;
 
-  recordreplay::Assert("ThreadGroupImpl::GetDesiredNumAwakeWorkersLockRequired %lu %lu %lu %lu %lu",
-                       workers_for_best_effort_task_sources,
-                       workers_for_foreground_task_sources,
-                       max_tasks_,
-                       num_running_tasks_,
-                       num_running_best_effort_tasks_);
-
   return std::min({workers_for_best_effort_task_sources +
                        workers_for_foreground_task_sources,
                    max_tasks_, kMaxNumberOfWorkers});
@@ -1041,12 +1019,8 @@ void ThreadGroupImpl::DidUpdateCanRunPolicy() {
 
 void ThreadGroupImpl::EnsureEnoughWorkersLockRequired(
     BaseScopedCommandsExecutor* base_executor) {
-  recordreplay::Assert("ThreadGroupImpl::EnsureEnoughWorkersLockRequired Start %lu",
-                       max_tasks_);
-
   // Don't do anything if the thread group isn't started.
   if (max_tasks_ == 0 || UNLIKELY(join_for_testing_started_)) {
-    recordreplay::Assert("ThreadGroupImpl::EnsureEnoughWorkersLockRequired #1");
     return;
   }
 
@@ -1057,9 +1031,6 @@ void ThreadGroupImpl::EnsureEnoughWorkersLockRequired(
       GetDesiredNumAwakeWorkersLockRequired();
   const size_t num_awake_workers = GetNumAwakeWorkersLockRequired();
 
-  recordreplay::Assert("ThreadGroupImpl::EnsureEnoughWorkersLockRequired #1.1 %lu %lu",
-                       desired_num_awake_workers, num_awake_workers);
-
   size_t num_workers_to_wake_up =
       ClampSub(desired_num_awake_workers, num_awake_workers);
   if (after_start().wakeup_strategy == WakeUpStrategy::kExponentialWakeUps) {
@@ -1068,9 +1039,6 @@ void ThreadGroupImpl::EnsureEnoughWorkersLockRequired(
              WakeUpStrategy::kSerializedWakeUps) {
     num_workers_to_wake_up = std::min(num_workers_to_wake_up, size_t(1U));
   }
-
-  recordreplay::Assert("ThreadGroupImpl::EnsureEnoughWorkersLockRequired #2 %lu",
-                       num_workers_to_wake_up);
 
   // Wake up the appropriate number of workers.
   for (size_t i = 0; i < num_workers_to_wake_up; ++i) {
@@ -1093,8 +1061,6 @@ void ThreadGroupImpl::EnsureEnoughWorkersLockRequired(
 
   // Ensure that the number of workers is periodically adjusted if needed.
   MaybeScheduleAdjustMaxTasksLockRequired(executor);
-
-  recordreplay::Assert("ThreadGroupImpl::EnsureEnoughWorkersLockRequired Done");
 }
 
 void ThreadGroupImpl::AdjustMaxTasks() {

--- a/base/task/thread_pool/thread_group_native.cc
+++ b/base/task/thread_pool/thread_group_native.cc
@@ -115,8 +115,6 @@ void ThreadGroupNative::UpdateMinAllowedPriorityLockRequired() {
 }
 
 RegisteredTaskSource ThreadGroupNative::GetWork() {
-  recordreplay::Assert("ThreadGroupNative::GetWork Start");
-
   ScopedCommandsExecutor workers_executor(this);
   CheckedAutoLock auto_lock(lock_);
   DCHECK_GT(num_pending_threadpool_work_, 0U);
@@ -128,7 +126,6 @@ RegisteredTaskSource ThreadGroupNative::GetWork() {
     priority = priority_queue_.PeekSortKey().priority();
     // Enforce the CanRunPolicy.
     if (!task_tracker_->CanRunPriority(priority)) {
-      recordreplay::Assert("ThreadGroupNative::GetWork #1");
       return nullptr;
     }
 
@@ -136,7 +133,6 @@ RegisteredTaskSource ThreadGroupNative::GetWork() {
   }
   UpdateMinAllowedPriorityLockRequired();
 
-  recordreplay::Assert("ThreadGroupNative::GetWork Done %d", !!task_source);
   return task_source;
 }
 

--- a/base/task/thread_pool/thread_pool_impl.cc
+++ b/base/task/thread_pool/thread_pool_impl.cc
@@ -429,22 +429,17 @@ bool ThreadPoolImpl::PostTaskWithSequenceNow(Task task,
 
 bool ThreadPoolImpl::PostTaskWithSequence(Task task,
                                           scoped_refptr<Sequence> sequence) {
-  recordreplay::Assert("ThreadPoolImpl::PostTaskWithSequence Start");
-
   // Use CHECK instead of DCHECK to crash earlier. See http://crbug.com/711167
   // for details.
   CHECK(task.task);
   DCHECK(sequence);
 
   if (!task_tracker_->WillPostTask(&task, sequence->shutdown_behavior())) {
-    recordreplay::Assert("ThreadPoolImpl::PostTaskWithSequence #1");
     return false;
   }
 
   if (task.delayed_run_time.is_null()) {
-    bool rv = PostTaskWithSequenceNow(std::move(task), std::move(sequence));
-    recordreplay::Assert("ThreadPoolImpl::PostTaskWithSequence #2 %d", rv);
-    return rv;
+    return PostTaskWithSequenceNow(std::move(task), std::move(sequence));
   } else {
     // It's safe to take a ref on this pointer since the caller must have a ref
     // to the TaskRunner in order to post.
@@ -461,14 +456,11 @@ bool ThreadPoolImpl::PostTaskWithSequence(Task task,
         std::move(task_runner));
   }
 
-  recordreplay::Assert("ThreadPoolImpl::PostTaskWithSequence Done");
   return true;
 }
 
 bool ThreadPoolImpl::ShouldYield(const TaskSource* task_source) {
-  recordreplay::Assert("ThreadPoolImpl::ShouldYield Start");
   if (disable_job_yield_) {
-    recordreplay::Assert("ThreadPoolImpl::ShouldYield #1");
     return false;
   }
   const TaskPriority priority = task_source->priority_racy();
@@ -477,7 +469,6 @@ bool ThreadPoolImpl::ShouldYield(const TaskSource* task_source) {
   // A task whose priority changed and is now running in the wrong thread group
   // should yield so it's rescheduled in the right one.
   if (!thread_group->IsBoundToCurrentThread()) {
-    recordreplay::Assert("ThreadPoolImpl::ShouldYield #2");
     return true;
   }
   return GetThreadGroupForTraits({priority, task_source->thread_policy()})

--- a/base/task/thread_pool/thread_pool_instance.cc
+++ b/base/task/thread_pool/thread_pool_instance.cc
@@ -53,10 +53,8 @@ ThreadPoolInstance::ScopedBestEffortExecutionFence::
 #if !defined(OS_NACL)
 // static
 void ThreadPoolInstance::CreateAndStartWithDefaultParams(StringPiece name) {
-  recordreplay::Assert("ThreadPoolInstance::CreateAndStartWithDefaultParams Start");
   Create(name);
   g_thread_pool->StartWithDefaultParams();
-  recordreplay::Assert("ThreadPoolInstance::CreateAndStartWithDefaultParams Done");
 }
 
 void ThreadPoolInstance::StartWithDefaultParams() {
@@ -73,9 +71,7 @@ void ThreadPoolInstance::StartWithDefaultParams() {
 #endif  // !defined(OS_NACL)
 
 void ThreadPoolInstance::Create(StringPiece name) {
-  recordreplay::Assert("ThreadPoolInstance::Create Start");
   Set(std::make_unique<internal::ThreadPoolImpl>(name));
-  recordreplay::Assert("ThreadPoolInstance::Create Done");
 }
 
 // static

--- a/base/task/thread_pool/worker_thread.cc
+++ b/base/task/thread_pool/worker_thread.cc
@@ -276,8 +276,6 @@ NOINLINE void WorkerThread::RunBackgroundDedicatedCOMWorker() {
 #endif  // defined(OS_WIN)
 
 void WorkerThread::RunWorker() {
-  recordreplay::Assert("WorkerThread::RunWorker Start");
-
   DCHECK_EQ(self_, this);
   TRACE_EVENT_INSTANT0("base", "WorkerThread born", TRACE_EVENT_SCOPE_THREAD);
   TRACE_EVENT_BEGIN0("base", "WorkerThread active");
@@ -285,11 +283,7 @@ void WorkerThread::RunWorker() {
   if (worker_thread_observer_)
     worker_thread_observer_->OnWorkerThreadMainEntry();
 
-  recordreplay::Assert("WorkerThread::RunWorker #1");
-
   delegate_->OnMainEntry(this);
-
-  recordreplay::Assert("WorkerThread::RunWorker #2");
 
   // Background threads can take an arbitrary amount of time to complete, do not
   // watch them for hangs. Ignore priority boosting for now.
@@ -306,11 +300,9 @@ void WorkerThread::RunWorker() {
 
   // A WorkerThread starts out waiting for work.
   {
-    recordreplay::Assert("WorkerThread::RunWorker #3");
     TRACE_EVENT_END0("base", "WorkerThread active");
     delegate_->WaitForWork(&wake_up_event_);
     TRACE_EVENT_BEGIN0("base", "WorkerThread active");
-    recordreplay::Assert("WorkerThread::RunWorker #4");
   }
 
   while (!ShouldExit()) {
@@ -327,8 +319,6 @@ void WorkerThread::RunWorker() {
     // Get the task source containing the next task to execute.
     RegisteredTaskSource task_source = delegate_->GetWork(this);
 
-    recordreplay::Assert("WorkerThread::RunWorker #4.1 %d", !!task_source);
-
     if (!task_source) {
       // Exit immediately if GetWork() resulted in detaching this worker.
       if (ShouldExit())
@@ -336,22 +326,14 @@ void WorkerThread::RunWorker() {
 
       TRACE_EVENT_END0("base", "WorkerThread active");
       hang_watch_scope.reset();
-      recordreplay::Assert("WorkerThread::RunWorker #5");
       delegate_->WaitForWork(&wake_up_event_);
-      recordreplay::Assert("WorkerThread::RunWorker #6");
       TRACE_EVENT_BEGIN0("base", "WorkerThread active");
       continue;
     }
 
-    recordreplay::Assert("WorkerThread::RunWorker #7");
-
     task_source = task_tracker_->RunAndPopNextTask(std::move(task_source));
 
-    recordreplay::Assert("WorkerThread::RunWorker #7.1");
-
     delegate_->DidProcessTask(std::move(task_source));
-
-    recordreplay::Assert("WorkerThread::RunWorker #7.2");
 
     // Calling WakeUp() guarantees that this WorkerThread will run Tasks from
     // TaskSources returned by the GetWork() method of |delegate_| until it

--- a/base/task_runner.cc
+++ b/base/task_runner.cc
@@ -14,24 +14,6 @@
 
 #include <dlfcn.h>
 
-// There are linker problems if we try to use recordreplay::Assert here.
-static void (*gRecordReplayAssertFn)(const char*, va_list);
-
-static void RecordReplayAssert(const char* aFormat, ...) {
-  if (!gRecordReplayAssertFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAssert");
-    if (!fnptr) {
-      return;
-    }
-    gRecordReplayAssertFn = reinterpret_cast<void(*)(const char*, va_list)>(fnptr);
-  }
-
-  va_list ap;
-  va_start(ap, aFormat);
-  gRecordReplayAssertFn(aFormat, ap);
-  va_end(ap);
-}
-
 static void (*gRecordReplayRegisterPointerFn)(void*);
 
 static bool RecordReplayRegisterPointer(void* ptr) {
@@ -106,10 +88,7 @@ bool PostTaskAndReplyTaskRunner::PostTask(const Location& from_here,
 }  // namespace
 
 bool TaskRunner::PostTask(const Location& from_here, OnceClosure task) {
-  RecordReplayAssert("TaskRunner::PostTask Start %lu", RecordReplayPointerId(this));
-  bool rv = PostDelayedTask(from_here, std::move(task), base::TimeDelta());
-  RecordReplayAssert("TaskRunner::PostTask Done %d", rv);
-  return rv;
+  return PostDelayedTask(from_here, std::move(task), base::TimeDelta());
 }
 
 bool TaskRunner::PostTaskAndReply(const Location& from_here,

--- a/base/third_party/libevent/epoll.c
+++ b/base/third_party/libevent/epoll.c
@@ -53,26 +53,6 @@
 #include "evsignal.h"
 #include "log.h"
 
-#include <dlfcn.h>
-
-static void (*gRecordReplayAssertFn)(const char*, va_list);
-
-static void RecordReplayAssertFromC(const char* aFormat, ...) {
-  if (!gRecordReplayAssertFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAssert");
-    if (!fnptr) {
-      return;
-    }
-    gRecordReplayAssertFn = fnptr;
-    //gRecordReplayAssertFn = reinterpret_cast<void(*)(const char*, va_list)>(fnptr);
-  }
-
-  va_list ap;
-  va_start(ap, aFormat);
-  gRecordReplayAssertFn(aFormat, ap);
-  va_end(ap);
-}
-
 /* due to limitations in the epoll interface, we need to keep track of
  * all file descriptors outself.
  */
@@ -214,8 +194,6 @@ epoll_dispatch(struct event_base *base, void *arg, struct timeval *tv)
 		 * see comment on MAX_EPOLL_TIMEOUT_MSEC. */
 		timeout = MAX_EPOLL_TIMEOUT_MSEC;
 	}
-
-	RecordReplayAssertFromC("epoll_dispatch %d %d %d", epollop->epfd, epollop->nevents, timeout);
 
 	res = epoll_wait(epollop->epfd, events, epollop->nevents, timeout);
 

--- a/base/third_party/libevent/event.c
+++ b/base/third_party/libevent/event.c
@@ -56,26 +56,6 @@
 #include "evutil.h"
 #include "log.h"
 
-#include <dlfcn.h>
-
-static void (*gRecordReplayAssertFn)(const char*, va_list);
-
-static void RecordReplayAssertFromC(const char* aFormat, ...) {
-  if (!gRecordReplayAssertFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAssert");
-    if (!fnptr) {
-      return;
-    }
-    gRecordReplayAssertFn = fnptr;
-    //gRecordReplayAssertFn = reinterpret_cast<void(*)(const char*, va_list)>(fnptr);
-  }
-
-  va_list ap;
-  va_start(ap, aFormat);
-  gRecordReplayAssertFn(aFormat, ap);
-  va_end(ap);
-}
-
 #ifdef HAVE_EVENT_PORTS
 extern const struct eventop evportops;
 #endif
@@ -143,8 +123,6 @@ static void	timeout_correct(struct event_base *, struct timeval *);
 static int
 gettime(struct event_base *base, struct timeval *tp)
 {
-  RecordReplayAssertFromC("gettime");
-
 	if (base->tv_cache.tv_sec) {
 		*tp = base->tv_cache;
 		return (0);

--- a/base/threading/sequence_local_storage_map.cc
+++ b/base/threading/sequence_local_storage_map.cc
@@ -24,8 +24,6 @@ SequenceLocalStorageMap::SequenceLocalStorageMap() {
 }
 
 SequenceLocalStorageMap::~SequenceLocalStorageMap() {
-  recordreplay::Assert("SequenceLocalStorageMap::~SequenceLocalStorageMap %lu",
-                       recordreplay::PointerId(this));
   recordreplay::UnregisterPointer(this);
 }
 

--- a/base/trace_event/memory_allocator_dump.cc
+++ b/base/trace_event/memory_allocator_dump.cc
@@ -17,25 +17,6 @@
 #include "third_party/perfetto/protos/perfetto/trace/memory_graph.pbzero.h"
 #include "third_party/perfetto/protos/perfetto/trace/trace_packet.pbzero.h"
 
-#include <dlfcn.h>
-
-static void (*gRecordReplayAssertFn)(const char*, va_list);
-
-static void RecordReplayAssert(const char* aFormat, ...) {
-  if (!gRecordReplayAssertFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAssert");
-    if (!fnptr) {
-      return;
-    }
-    gRecordReplayAssertFn = reinterpret_cast<void(*)(const char*, va_list)>(fnptr);
-  }
-
-  va_list ap;
-  va_start(ap, aFormat);
-  gRecordReplayAssertFn(aFormat, ap);
-  va_end(ap);
-}
-
 namespace base {
 namespace trace_event {
 
@@ -54,8 +35,6 @@ MemoryAllocatorDump::MemoryAllocatorDump(
       guid_(guid),
       level_of_detail_(level_of_detail),
       flags_(Flags::DEFAULT) {
-  RecordReplayAssert("MemoryAllocatorDump::MemoryAllocatorDump %s", absolute_name.c_str());
-
   // The |absolute_name| cannot be empty.
   DCHECK(!absolute_name.empty());
 

--- a/cc/base/tiling_data.cc
+++ b/cc/base/tiling_data.cc
@@ -251,6 +251,7 @@ gfx::Rect TilingData::TileBounds(int i, int j) const {
 }
 
 gfx::Rect TilingData::TileBoundsWithBorder(int i, int j) const {
+  // https://linear.app/replay/issue/RUN-465
   recordreplay::Assert("TilingData::TileBoundsWithBorder %d %d %d %d %d %d %d",
                        i, j,
                        max_texture_size_.width(), max_texture_size_.height(), border_texels_,

--- a/cc/input/scroll_snap_data.cc
+++ b/cc/input/scroll_snap_data.cc
@@ -112,9 +112,6 @@ SnapContainerData& SnapContainerData::operator=(SnapContainerData&& other) =
     default;
 
 void SnapContainerData::AddSnapAreaData(SnapAreaData snap_area_data) {
-  recordreplay::Assert("SnapContainerData::AddSnapAreaData %.2f %.2f %.2f %.2f",
-                       snap_area_data.rect.x(), snap_area_data.rect.y(),
-                       snap_area_data.rect.right(), snap_area_data.rect.bottom());
   snap_area_list_.push_back(snap_area_data);
 }
 
@@ -122,12 +119,6 @@ bool SnapContainerData::FindSnapPosition(
     const SnapSelectionStrategy& strategy,
     gfx::ScrollOffset* snap_position,
     TargetSnapAreaElementIds* target_element_ids) const {
-  recordreplay::Assert("SnapContainerData::FindSnapPosition Start %d %d %d %s %s",
-                       strategy.ShouldSnapOnX(), strategy.ShouldSnapOnY(),
-                       strategy.ShouldPrioritizeSnapTargets(),
-                       target_snap_area_element_ids_.x.ToString().c_str(),
-                       target_snap_area_element_ids_.y.ToString().c_str());
-
   *target_element_ids = TargetSnapAreaElementIds();
   if (scroll_snap_type_.is_none)
     return false;
@@ -156,8 +147,6 @@ bool SnapContainerData::FindSnapPosition(
       // instead.
       selected_x = GetTargetSnapAreaSearchResult(SearchAxis::kX);
       DCHECK(selected_x.has_value());
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #1 %.2f",
-                           selected_x.has_value() ? selected_x.value().snap_offset() : -1.0);
     } else {
       // Start from current position in the cross axis. The search algorithm
       // expects the cross axis position to be inside scroller bounds. But since
@@ -169,24 +158,18 @@ bool SnapContainerData::FindSnapPosition(
 
       selected_x = FindClosestValidArea(SearchAxis::kX, strategy,
                                         initial_snap_position_y);
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #2 %.2f",
-                           selected_x.has_value() ? selected_x.value().snap_offset() : -1.0);
     }
   }
   if (should_snap_on_y) {
     if (should_prioritize_y_target) {
       selected_y = GetTargetSnapAreaSearchResult(SearchAxis::kY);
       DCHECK(selected_y.has_value());
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #3 %.2f",
-                           selected_y.has_value() ? selected_y.value().snap_offset() : -1.0);
     } else {
       SnapSearchResult initial_snap_position_x = {
           base::ClampToRange(base_position.x(), 0.f, max_position_.x()),
           gfx::RangeF(0, max_position_.y())};
       selected_y = FindClosestValidArea(SearchAxis::kY, strategy,
                                         initial_snap_position_x);
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #4 %.2f",
-                           selected_y.has_value() ? selected_y.value().snap_offset() : -1.0);
     }
   }
 
@@ -211,19 +194,13 @@ bool SnapContainerData::FindSnapPosition(
     if (keep_candidate_on_x) {
       selected_y =
           FindClosestValidArea(SearchAxis::kY, strategy, selected_x.value());
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #5 %.2f",
-                           selected_y.has_value() ? selected_y.value().snap_offset() : -1.0);
     } else {
       selected_x =
           FindClosestValidArea(SearchAxis::kX, strategy, selected_y.value());
-      recordreplay::Assert("SnapContainerData::FindSnapPosition #6 %.2f",
-                           selected_x.has_value() ? selected_x.value().snap_offset() : -1.0);
     }
   }
 
   *snap_position = strategy.current_position();
-  recordreplay::Assert("SnapContainerData::FindSnapPosition #7 %.2f %.2f",
-                       snap_position->x(), snap_position->y());
 
   if (selected_x.has_value()) {
     snap_position->set_x(selected_x.value().snap_offset());
@@ -346,10 +323,6 @@ SnapContainerData::FindClosestValidAreaInternal(
   float smallest_distance =
       axis == SearchAxis::kX ? proximity_range_.x() : proximity_range_.y();
   for (const SnapAreaData& area : snap_area_list_) {
-    recordreplay::Assert("SnapContainerData::FindClosestValidAreaInternal #1 %.2f %.2f %.2f %.2f",
-                        area.rect.x(), area.rect.y(),
-                        area.rect.right(), area.rect.bottom());
-
     if (!strategy.IsValidSnapArea(axis, area))
       continue;
 
@@ -410,9 +383,6 @@ SnapContainerData::FindClosestValidAreaInternal(
 SnapSearchResult SnapContainerData::GetSnapSearchResult(
     SearchAxis axis,
     const SnapAreaData& area) const {
-  recordreplay::Assert("SnapContainerData::GetSnapSearchResult %.2f %.2f %.2f %.2f",
-                       area.rect.x(), area.rect.y(),
-                       area.rect.right(), area.rect.bottom());
   SnapSearchResult result;
   if (axis == SearchAxis::kX) {
     result.set_visible_range(gfx::RangeF(area.rect.y() - rect_.bottom(),

--- a/cc/layers/picture_layer.cc
+++ b/cc/layers/picture_layer.cc
@@ -51,8 +51,6 @@ std::unique_ptr<LayerImpl> PictureLayer::CreateLayerImpl(
 }
 
 void PictureLayer::PushPropertiesTo(LayerImpl* base_layer) {
-  recordreplay::Assert("PictureLayer::PushPropertiesTo %d", recordreplay::PointerId(base_layer));
-
   // TODO(enne): http://crbug.com/918126 debugging
   CHECK(this);
 
@@ -114,9 +112,6 @@ void PictureLayer::SetNeedsDisplayRect(const gfx::Rect& layer_rect) {
 }
 
 bool PictureLayer::Update() {
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("PictureLayer::Update");
-
   update_source_frame_number_ = layer_tree_host()->SourceFrameNumber();
   bool updated = Layer::Update();
 
@@ -143,12 +138,6 @@ bool PictureLayer::Update() {
   updated |= recording_source_->UpdateAndExpandInvalidation(
       &last_updated_invalidation_, layer_size, recorded_viewport);
 
-  // https://linear.app/replay/issue/RUN-467
-  for (gfx::Rect rect : last_updated_invalidation_) {
-    recordreplay::Assert("PictureLayer::Update #1 %d %d %d %d %d",
-                         updated, rect.x(), rect.y(), rect.width(), rect.height());
-  }
-
   if (updated) {
     {
       auto old_display_list = std::move(picture_layer_inputs_.display_list);
@@ -157,11 +146,6 @@ bool PictureLayer::Update() {
       if (old_display_list &&
           picture_layer_inputs_.display_list
               ->NeedsAdditionalInvalidationForLCDText(*old_display_list)) {
-
-        // https://linear.app/replay/issue/RUN-467
-        recordreplay::Assert("PictureLayer::Update #2 %d %d",
-                             bounds().width(), bounds().height());
-
         last_updated_invalidation_ = gfx::Rect(bounds());
       }
     }
@@ -190,9 +174,6 @@ bool PictureLayer::Update() {
     SetNeedsPushProperties();
     IncreasePaintCount();
   } else {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayer::Update #5");
-
     // If this invalidation did not affect the recording source, then it can be
     // cleared as an optimization.
     last_updated_invalidation_.Clear();

--- a/cc/layers/picture_layer_impl.cc
+++ b/cc/layers/picture_layer_impl.cc
@@ -724,13 +724,6 @@ void PictureLayerImpl::UpdateRasterSource(
     Region* new_invalidation,
     const PictureLayerTilingSet* pending_set,
     const PaintWorkletRecordMap* pending_paint_worklet_records) {
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("PictureLayerImpl::UpdateRasterSource");
-  for (gfx::Rect rect : *new_invalidation) {
-    recordreplay::Assert("PictureLayerImpl::UpdateRasterSource #1 %d %d %d %d",
-                         rect.x(), rect.y(), rect.width(), rect.height());
-  }
-
   // The bounds and the pile size may differ if the pile wasn't updated (ie.
   // PictureLayer::Update didn't happen). In that case the pile will be empty.
   DCHECK(raster_source->GetSize().IsEmpty() ||
@@ -782,12 +775,6 @@ void PictureLayerImpl::UpdateRasterSource(
                 new_display_item_list->discardable_image_map()
                     .content_color_usage());
 
-        // https://linear.app/replay/issue/RUN-467
-        recordreplay::Assert("PictureLayerImpl::UpdateRasterSource #4 %d %d %d",
-                             needs_full_invalidation,
-                             raster_source->GetSize().width(),
-                             raster_source->GetSize().height());
-
         if (needs_full_invalidation)
           new_invalidation->Union(gfx::Rect(raster_source->GetSize()));
       }
@@ -803,13 +790,6 @@ void PictureLayerImpl::UpdateRasterSource(
   // TODO(khushalsagar): UMA the number of animated images in layer?
   if (recording_updated)
     RegisterAnimatedImages();
-
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("PictureLayerImpl::UpdateRasterSource #5");
-  for (gfx::Rect rect : *new_invalidation) {
-    recordreplay::Assert("PictureLayerImpl::UpdateRasterSource #5.1 %d %d %d %d",
-                         rect.x(), rect.y(), rect.width(), rect.height());
-  }
 
   // The |new_invalidation| must be cleared before updating tilings since they
   // access the invalidation through the PictureLayerTilingClient interface.

--- a/cc/mojo_embedder/async_layer_tree_frame_sink.cc
+++ b/cc/mojo_embedder/async_layer_tree_frame_sink.cc
@@ -23,10 +23,6 @@
 #include "components/viz/common/quads/compositor_frame.h"
 #include "components/viz/service/display/record_replay_render.h"
 
-namespace viz {
-  extern void RecordReplayAssertSharedQuadContents(const SharedQuadState* state);
-}
-
 namespace cc {
 namespace mojo_embedder {
 
@@ -125,17 +121,6 @@ void AsyncLayerTreeFrameSink::SetLocalSurfaceId(
   local_surface_id_ = local_surface_id;
 }
 
-static void RecordReplayAssertCompositorFrameContents(const viz::CompositorFrame& frame) {
-  recordreplay::Assert("AssertCompositorFrameContents Start %lu", frame.render_pass_list.size());
-  for (const auto& render_pass : frame.render_pass_list) {
-    for (const viz::DrawQuad* quad : render_pass->quad_list) {
-      if (quad->shared_quad_state) {
-        RecordReplayAssertSharedQuadContents(quad->shared_quad_state);
-      }
-    }
-  }
-}
-
 void AsyncLayerTreeFrameSink::SubmitCompositorFrame(
     viz::CompositorFrame frame,
     bool hit_test_data_changed,
@@ -219,20 +204,12 @@ void AsyncLayerTreeFrameSink::SubmitCompositorFrame(
                          TRACE_EVENT_FLAG_FLOW_OUT, "step",
                          "SubmitHitTestData");
 
-  recordreplay::Assert("AsyncLayerTreeFrameSink::SubmitCompositorFrame #1");
-
   if (recordreplay::IsRecordingOrReplaying()) {
     RecordReplaySubmitCompositorFrame(local_surface_id_, frame);
   }
 
-  recordreplay::Assert("AsyncLayerTreeFrameSink::SubmitCompositorFrame #2");
-
-  RecordReplayAssertCompositorFrameContents(frame);
-
   compositor_frame_sink_ptr_->SubmitCompositorFrame(
       local_surface_id_, std::move(frame), std::move(hit_test_region_list), 0);
-
-  recordreplay::Assert("AsyncLayerTreeFrameSink::SubmitCompositorFrame Done");
 }
 
 void AsyncLayerTreeFrameSink::DidNotProduceFrame(

--- a/cc/paint/discardable_image_map.cc
+++ b/cc/paint/discardable_image_map.cc
@@ -357,12 +357,7 @@ DiscardableImageMap::TakeDecodingModeMap() {
 void DiscardableImageMap::GetDiscardableImagesInRect(
     const gfx::Rect& rect,
     std::vector<const DrawImage*>* images) const {
-  recordreplay::Assert("DiscardableImageMap::GetDiscardableImagesInRect %d %d %d %d %d",
-                       recordreplay::PointerId(this),
-                       rect.x(), rect.y(), rect.width(), rect.height());
   images_rtree_.SearchRefs(rect, images);
-  recordreplay::Assert("DiscardableImageMap::GetDiscardableImagesInRect Done %lu",
-                       images->size());
 }
 
 const DiscardableImageMap::Rects& DiscardableImageMap::GetRectsForImage(

--- a/cc/scheduler/scheduler.cc
+++ b/cc/scheduler/scheduler.cc
@@ -613,7 +613,6 @@ void Scheduler::BeginImplFrameSynchronous(const viz::BeginFrameArgs& args) {
 }
 
 void Scheduler::FinishImplFrame() {
-  recordreplay::Assert("Scheduler::FinishImplFrame Start");
   DCHECK(!needs_finish_frame_for_synchronous_compositor_);
   state_machine_.OnBeginImplFrameIdle();
 
@@ -644,7 +643,6 @@ void Scheduler::FinishImplFrame() {
 
   if (compositor_thread_pipeline_)
     compositor_thread_pipeline_->NotifyFrameFinished();
-  recordreplay::Assert("Scheduler::FinishImplFrame Done");
 }
 
 void Scheduler::SendDidNotProduceFrame(const viz::BeginFrameArgs& args,
@@ -762,8 +760,6 @@ void Scheduler::ScheduleBeginImplFrameDeadline() {
 }
 
 void Scheduler::OnBeginImplFrameDeadline() {
-  recordreplay::Assert("Scheduler::OnBeginImplFrameDeadline Start");
-
   TRACE_EVENT0("cc,benchmark", "Scheduler::OnBeginImplFrameDeadline");
   begin_impl_frame_deadline_task_.Cancel();
   // We split the deadline actions up into two phases so the state machine
@@ -785,8 +781,6 @@ void Scheduler::OnBeginImplFrameDeadline() {
     FinishImplFrameSynchronous();
   else
     FinishImplFrame();
-
-  recordreplay::Assert("Scheduler::OnBeginImplFrameDeadline Done");
 }
 
 void Scheduler::FinishImplFrameSynchronous() {

--- a/cc/tiles/picture_layer_tiling.cc
+++ b/cc/tiles/picture_layer_tiling.cc
@@ -111,18 +111,11 @@ void PictureLayerTiling::CreateMissingTilesInLiveTilesRect() {
     TileMapKey key(iter.index());
     auto find = tiles_.find(key);
 
-    // https://github.com/RecordReplay/backend/issues/5707
-    recordreplay::Assert("PictureLayerTiling::CreateMissingTilesInLiveTilesRect #1 %d %d %d",
-                         key.index_x, key.index_y, find != tiles_.end());
-
     if (find != tiles_.end())
       continue;
 
     Tile::CreateInfo info = CreateInfoForTile(key.index_x, key.index_y);
     if (ShouldCreateTileAt(info)) {
-      // https://github.com/RecordReplay/backend/issues/5707
-      recordreplay::Assert("PictureLayerTiling::CreateMissingTilesInLiveTilesRect #2");
-
       Tile* tile = CreateTile(info);
 
       // If this is the pending tree, then the active twin tiling may contain
@@ -151,9 +144,6 @@ void PictureLayerTiling::CreateMissingTilesInLiveTilesRect() {
         }
       }
     }
-
-    // https://github.com/RecordReplay/backend/issues/5707
-    recordreplay::Assert("PictureLayerTiling::CreateMissingTilesInLiveTilesRect #3");
   }
   VerifyLiveTilesRect();
 }
@@ -348,11 +338,7 @@ void PictureLayerTiling::RemoveTilesInRegion(const Region& layer_invalidation,
 }
 
 Tile::CreateInfo PictureLayerTiling::CreateInfoForTile(int i, int j) const {
-  recordreplay::Assert("PictureLayerTiling::CreateInfoForTile Start %d",
-                       recordreplay::PointerId(this));
   gfx::Rect tile_rect = tiling_data_.TileBoundsWithBorder(i, j);
-  recordreplay::Assert("PictureLayerTiling::CreateInfoForTile %d %d %d %d %d %d",
-                       i, j, tile_rect.x(), tile_rect.y(), tile_rect.width(), tile_rect.height());
   tile_rect.set_size(tiling_data_.max_texture_size());
   gfx::Rect enclosing_layer_rect =
       EnclosingLayerRectFromContentsRect(tile_rect);
@@ -377,8 +363,6 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   // creating tiles that are different from the current active tree, which is
   // represented by the logic in the rest of the function.
   if (tree_ == ACTIVE_TREE) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #1");
     return true;
   }
 
@@ -386,15 +370,11 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   const PictureLayerTiling* active_twin =
       client_->GetPendingOrActiveTwinTiling(this);
   if (!active_twin) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #2");
     return true;
   }
 
   // Pending tree will override the entire active tree if indices don't match.
   if (!TilingMatchesTileIndices(active_twin)) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #3");
     return true;
   }
 
@@ -404,8 +384,6 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   // PictureLayerTilingSet::CopyTilingsAndPropertiesFromPendingTwin.
   if (can_use_lcd_text() != active_twin->can_use_lcd_text() ||
       raster_transform() != active_twin->raster_transform()) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #4");
     return true;
   }
 
@@ -413,8 +391,6 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   // the pending tree should create one.
   if (!active_twin->raster_source()->IntersectsRect(info.enclosing_layer_rect,
                                                     *active_twin->client())) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #5");
     return true;
   }
 
@@ -424,16 +400,9 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   // Do the intersection test in content space to match the corresponding check
   // on the active tree and avoid floating point inconsistencies.
   for (gfx::Rect layer_rect : *layer_invalidation) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #5.1 %d %d %d %d",
-                         layer_rect.x(), layer_rect.y(),
-                         layer_rect.width(), layer_rect.height());
-
     gfx::Rect invalid_content_rect =
         EnclosingContentsRectFromLayerRect(layer_rect);
     if (invalid_content_rect.Intersects(info.content_rect)) {
-      // https://linear.app/replay/issue/RUN-467
-      recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #6");
       return true;
     }
   }
@@ -444,14 +413,10 @@ bool PictureLayerTiling::ShouldCreateTileAt(
   // display content, which will have to come from the pending tree.
   if (!active_twin->TileAt(i, j) &&
       current_visible_rect_.Intersects(info.content_rect)) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #7");
     return true;
   }
 
   // In all other cases, the pending tree doesn't need to create a tile.
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("PictureLayerTiling::ShouldCreateTileAt #8");
   return false;
 }
 

--- a/cc/tiles/picture_layer_tiling_set.cc
+++ b/cc/tiles/picture_layer_tiling_set.cc
@@ -176,9 +176,6 @@ void PictureLayerTilingSet::UpdateTilingsToCurrentRasterSourceForCommit(
     const Region& layer_invalidation,
     float minimum_contents_scale,
     float maximum_contents_scale) {
-  recordreplay::Assert("PictureLayerTilingSet::UpdateTilingsToCurrentRasterSourceForCommit %d",
-                       recordreplay::PointerId(this));
-
   RemoveTilingsBelowScaleKey(minimum_contents_scale);
   RemoveTilingsAboveScaleKey(maximum_contents_scale);
 

--- a/cc/tiles/software_image_decode_cache.cc
+++ b/cc/tiles/software_image_decode_cache.cc
@@ -184,8 +184,6 @@ SoftwareImageDecodeCache::GetTaskForImageAndRefInternal(
     const DrawImage& image,
     const TracingInfo& tracing_info,
     DecodeTaskType task_type) {
-  recordreplay::Assert("SoftwareImageDecodeCache::GetTaskForImageAndRefInternal Start");
-
   CacheKey key = CacheKey::FromDrawImage(
       image, GetColorTypeForPaintImage(image.target_color_space(),
                                        image.paint_image()));
@@ -196,13 +194,11 @@ SoftwareImageDecodeCache::GetTaskForImageAndRefInternal(
   // If the target size is empty, we can skip this image during draw (and thus
   // we don't need to decode it or ref it).
   if (key.target_size().IsEmpty()) {
-    recordreplay::Assert("SoftwareImageDecodeCache::GetTaskForImageAndRefInternal #1");
     return TaskResult(/*need_unref=*/false, /*is_at_raster_decode=*/false,
                       /*can_do_hardware_accelerated_decode=*/false);
   }
 
   if (!UseCacheForDrawImage(image)) {
-    recordreplay::Assert("SoftwareImageDecodeCache::GetTaskForImageAndRefInternal #2");
     return TaskResult(/*need_unref=*/false, /*is_at_raster_decode=*/false,
                       /*can_do_hardware_accelerated_decode=*/false);
   }
@@ -246,7 +242,6 @@ SoftwareImageDecodeCache::GetTaskForImageAndRefInternal(
   // If we already have a locked entry, then we can just use that. Otherwise
   // we'll have to create a task.
   if (cache_entry->is_locked) {
-    recordreplay::Assert("SoftwareImageDecodeCache::GetTaskForImageAndRefInternal #3");
     return TaskResult(/*need_unref=*/true, /*is_at_raster_decode=*/false,
                       /*can_do_hardware_accelerated_decode=*/false);
   }
@@ -262,7 +257,6 @@ SoftwareImageDecodeCache::GetTaskForImageAndRefInternal(
         this, key, image.paint_image(), task_type, tracing_info);
   }
 
-  recordreplay::Assert("SoftwareImageDecodeCache::GetTaskForImageAndRefInternal Done");
   return TaskResult(task, /*can_do_hardware_accelerated_decode=*/false);
 }
 
@@ -340,7 +334,6 @@ SoftwareImageDecodeCache::TaskProcessingResult
 SoftwareImageDecodeCache::DecodeImageIfNecessary(const CacheKey& key,
                                                  const PaintImage& paint_image,
                                                  CacheEntry* entry) {
-  recordreplay::Assert("SoftwareImageDecodeCache::DecodeImageIfNecessary Start");
   TRACE_EVENT1(TRACE_DISABLED_BY_DEFAULT("cc.debug"),
                "SoftwareImageDecodeCache::DecodeImageIfNecessary", "key",
                key.ToString());
@@ -365,14 +358,12 @@ SoftwareImageDecodeCache::DecodeImageIfNecessary(const CacheKey& key,
   // If we can use the original decode, we'll definitely need a decode.
   if (key.type() == CacheKey::kOriginal) {
     base::AutoUnlock release(lock_);
-    recordreplay::Assert("SoftwareImageDecodeCache::DecodeImageIfNecessary #1");
     local_cache_entry = Utils::DoDecodeImage(
         key, paint_image,
         GetColorTypeForPaintImage(key.target_color_space(), paint_image),
         generator_client_id_,
         base::BindOnce(&SoftwareImageDecodeCache::ClearCache,
                        base::Unretained(this)));
-    recordreplay::Assert("SoftwareImageDecodeCache::DecodeImageIfNecessary #2");
   } else {
     // Attempt to find a cached decode to generate a scaled/subrected decode
     // from.
@@ -461,7 +452,6 @@ SoftwareImageDecodeCache::DecodeImageIfNecessary(const CacheKey& key,
   }
 
   if (!local_cache_entry) {
-    recordreplay::Assert("SoftwareImageDecodeCache::DecodeImageIfNecessary #3");
     entry->decode_failed = true;
     return TaskProcessingResult::kCancelled;
   }
@@ -482,7 +472,6 @@ SoftwareImageDecodeCache::DecodeImageIfNecessary(const CacheKey& key,
     DCHECK(entry->is_locked);
   }
 
-  recordreplay::Assert("SoftwareImageDecodeCache::DecodeImageIfNecessary Done");
   return TaskProcessingResult::kFullDecode;
 }
 
@@ -626,7 +615,6 @@ void SoftwareImageDecodeCache::ReduceCacheUsageUntilWithinLimit(size_t limit) {
 }
 
 void SoftwareImageDecodeCache::ReduceCacheUsage() {
-  recordreplay::Assert("SoftwareImageDecodeCache::ReduceCacheUsage");
   base::AutoLock lock(lock_);
   ReduceCacheUsageUntilWithinLimit(max_items_in_cache_);
 }

--- a/cc/tiles/tile.cc
+++ b/cc/tiles/tile.cc
@@ -42,9 +42,6 @@ Tile::Tile(TileManager* tile_manager,
       raster_task_scheduled_with_checker_images_(false),
       id_(tile_manager->GetUniqueTileId()) {
   recordreplay::RegisterPointer(this);
-  recordreplay::Assert("Tile::Tile %d %d %d %d",
-                       enclosing_layer_rect_.x(), enclosing_layer_rect_.y(),
-                       enclosing_layer_rect_.width(), enclosing_layer_rect_.height());
   raster_rects_.emplace_back(info.content_rect, info.raster_transform);
 }
 

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -350,11 +350,9 @@ class DidFinishRunningAllTilesTask : public TileTask {
   void RunOnWorkerThread() override {
     TRACE_EVENT0("cc", "TaskSetFinishedTaskImpl::RunOnWorkerThread");
     bool has_pending_queries = false;
-    recordreplay::Assert("DidFinishRunningAllTilesTask::RunOnWorkerThread Start %d", !!pending_raster_queries_);
     if (pending_raster_queries_) {
       has_pending_queries =
           pending_raster_queries_->CheckRasterFinishedQueries();
-      recordreplay::Assert("DidFinishRunningAllTilesTask::RunOnWorkerThread #1 %d", has_pending_queries);
     }
     task_runner_->PostTask(FROM_HERE, base::BindOnce(std::move(completion_cb_),
                                                      has_pending_queries));
@@ -522,8 +520,6 @@ void TileManager::DidFinishRunningAllTileTasks(bool has_pending_queries) {
   TRACE_EVENT_NESTABLE_ASYNC_END0("cc", "ScheduledTasks", TRACE_ID_LOCAL(this));
   DCHECK(resource_pool_);
   DCHECK(tile_task_manager_);
-
-  recordreplay::Assert("TileManager::DidFinishRunningAllTileTasks %d", has_pending_queries);
 
   has_scheduled_tile_tasks_ = false;
   has_pending_queries_ = has_pending_queries;
@@ -695,8 +691,6 @@ bool TileManager::TilePriorityViolatesMemoryPolicy(
 }
 
 TileManager::PrioritizedWorkToSchedule TileManager::AssignGpuMemoryToTiles() {
-  recordreplay::Assert("TileManager::AssignGpuMemoryToTiles Start");
-
   TRACE_EVENT_BEGIN0("cc", "TileManager::AssignGpuMemoryToTiles");
 
   DCHECK(resource_pool_);
@@ -721,8 +715,6 @@ TileManager::PrioritizedWorkToSchedule TileManager::AssignGpuMemoryToTiles() {
   std::unique_ptr<EvictionTilePriorityQueue> eviction_priority_queue;
   PrioritizedWorkToSchedule work_to_schedule;
   for (; !raster_priority_queue->IsEmpty(); raster_priority_queue->Pop()) {
-    recordreplay::Assert("TileManager::AssignGpuMemoryToTiles #1");
-
     const PrioritizedTile& prioritized_tile = raster_priority_queue->Top();
     Tile* tile = prioritized_tile.tile();
     TilePriority priority = prioritized_tile.priority();
@@ -841,7 +833,6 @@ TileManager::PrioritizedWorkToSchedule TileManager::AssignGpuMemoryToTiles() {
     } else {
       // Creating the raster task here will acquire resources, but
       // this resource usage has already been accounted for above.
-      recordreplay::Assert("TileManager::AssignGpuMemoryToTiles #10");
       auto raster_task = CreateRasterTask(prioritized_tile, raster_color_space,
                                           sdr_white_level, &work_to_schedule);
       if (!raster_task) {
@@ -855,8 +846,6 @@ TileManager::PrioritizedWorkToSchedule TileManager::AssignGpuMemoryToTiles() {
     memory_usage += memory_required_by_tile_to_be_scheduled;
     work_to_schedule.tiles_to_raster.push_back(prioritized_tile);
   }
-
-  recordreplay::Assert("TileManager::AssignGpuMemoryToTiles #11");
 
   // Note that we should try and further reduce memory in case the above loop
   // didn't reduce memory. This ensures that we always release as many resources
@@ -947,19 +936,10 @@ void TileManager::PartitionImagesForCheckering(
     std::vector<PaintImage>* checkered_images,
     const gfx::Rect* invalidated_rect,
     base::flat_map<PaintImage::Id, size_t>* image_to_frame_index) {
-  recordreplay::Assert("TileManager::PartitionImagesForCheckering Start");
-
   Tile* tile = prioritized_tile.tile();
   std::vector<const DrawImage*> images_in_tile;
   gfx::Rect enclosing_rect = tile->enclosing_layer_rect();
-  recordreplay::Assert("TileManager::PartitionImagesForCheckering #0.1 %d %d %d %d %d",
-                       recordreplay::PointerId(tile),
-                       enclosing_rect.x(), enclosing_rect.y(),
-                       enclosing_rect.width(), enclosing_rect.height());
   if (invalidated_rect) {
-    recordreplay::Assert("TileManager::PartitionImagesForCheckering #0.2 %d %d %d %d",
-                         invalidated_rect->x(), invalidated_rect->y(),
-                         invalidated_rect->width(), invalidated_rect->height());
     enclosing_rect = ToEnclosingRect(
         tile->raster_transform().InverseMapRect(gfx::RectF(*invalidated_rect)));
   }
@@ -968,8 +948,6 @@ void TileManager::PartitionImagesForCheckering(
   WhichTree tree = tile->tiling()->tree();
 
   for (const auto* original_draw_image : images_in_tile) {
-    recordreplay::Assert("TileManager::PartitionImagesForCheckering #1");
-
     const auto& image = original_draw_image->paint_image();
     size_t frame_index = client_->GetFrameIndexForImage(image, tree);
     if (image_to_frame_index)
@@ -978,15 +956,11 @@ void TileManager::PartitionImagesForCheckering(
     DrawImage draw_image(*original_draw_image, tile->raster_transform().scale(),
                          frame_index, raster_color_space, sdr_white_level);
     if (checker_image_tracker_.ShouldCheckerImage(draw_image, tree)) {
-      recordreplay::Assert("TileManager::PartitionImagesForCheckering #2");
       checkered_images->push_back(draw_image.paint_image());
     } else {
-      recordreplay::Assert("TileManager::PartitionImagesForCheckering #3");
       sync_decoded_images->push_back(std::move(draw_image));
     }
   }
-
-  recordreplay::Assert("TileManager::PartitionImagesForCheckering Done");
 }
 
 void TileManager::AddCheckeredImagesToDecodeQueue(
@@ -1200,7 +1174,6 @@ scoped_refptr<TileTask> TileManager::CreateRasterTask(
     const gfx::ColorSpace& raster_color_space,
     float sdr_white_level,
     PrioritizedWorkToSchedule* work_to_schedule) {
-  recordreplay::Assert("TileManager::CreateRasterTask Start");
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("cc.debug"),
                "TileManager::CreateRasterTask");
   Tile* tile = prioritized_tile.tile();
@@ -1281,12 +1254,10 @@ scoped_refptr<TileTask> TileManager::CreateRasterTask(
   bool has_at_raster_images = false;
   bool has_hardware_accelerated_jpeg_candidates = false;
   bool has_hardware_accelerated_webp_candidates = false;
-  recordreplay::Assert("TileManager::CreateRasterTask #5 %u", sync_decoded_images.size());
   image_controller_.ConvertImagesToTasks(
       &sync_decoded_images, &decode_tasks, &has_at_raster_images,
       &has_hardware_accelerated_jpeg_candidates,
       &has_hardware_accelerated_webp_candidates, tracing_info);
-  recordreplay::Assert("TileManager::CreateRasterTask #6");
   // Notify |decoded_image_tracker_| after |image_controller_| to ensure we've
   // taken new refs on the images before releasing the predecode API refs.
   decoded_image_tracker_.OnImagesUsedInDraw(sync_decoded_images);
@@ -1325,13 +1296,11 @@ scoped_refptr<TileTask> TileManager::CreateRasterTask(
     }
   }
 
-  recordreplay::Assert("TileManager::CreateRasterTask #7");
   std::unique_ptr<RasterBuffer> raster_buffer =
       raster_buffer_provider_->AcquireBufferForRaster(
           resource, resource_content_id, tile->invalidated_id(),
           has_at_raster_images, has_hardware_accelerated_jpeg_candidates,
           has_hardware_accelerated_webp_candidates);
-  recordreplay::Assert("TileManager::CreateRasterTask #8");
 
   base::Optional<PlaybackImageProvider::Settings> settings;
   if (!skip_images) {
@@ -1502,10 +1471,7 @@ bool TileManager::IsReadyToDraw() const {
 void TileManager::ScheduleCheckRasterFinishedQueries() {
   DCHECK(has_pending_queries_);
 
-  recordreplay::Assert("TileManager::ScheduleCheckRasterFinishedQueries Start");
-
   if (!check_pending_tile_queries_callback_.IsCancelled()) {
-    recordreplay::Assert("TileManager::ScheduleCheckRasterFinishedQueries #1");
     return;
   }
 
@@ -1514,8 +1480,6 @@ void TileManager::ScheduleCheckRasterFinishedQueries() {
   task_runner_->PostDelayedTask(FROM_HERE,
                                 check_pending_tile_queries_callback_.callback(),
                                 base::TimeDelta::FromMilliseconds(100));
-
-  recordreplay::Assert("TileManager::ScheduleCheckRasterFinishedQueries Done");
 }
 
 void TileManager::CheckRasterFinishedQueries() {
@@ -1534,8 +1498,6 @@ void TileManager::CheckRasterFinishedQueries() {
         pending_raster_queries_->CheckRasterFinishedQueries();
   }
 
-  recordreplay::Assert("TileManager::CheckRasterFinishedQueries #1 %d", has_pending_queries_);
-
   if (has_pending_queries_)
     ScheduleCheckRasterFinishedQueries();
 }
@@ -1550,8 +1512,6 @@ void TileManager::FlushAndIssueSignals() {
 }
 
 void TileManager::IssueSignals() {
-  recordreplay::Assert("TileManager::IssueSignals Start");
-
   // Ready to activate.
   if (signals_.activate_tile_tasks_completed &&
       signals_.activate_gpu_work_completed &&
@@ -1575,19 +1535,13 @@ void TileManager::IssueSignals() {
     }
   }
 
-  recordreplay::Assert("TileManager::IssueSignals #1 %d %d",
-                       signals_.all_tile_tasks_completed,
-                       signals_.did_notify_all_tile_tasks_completed);
-
   // All tile tasks completed.
   if (signals_.all_tile_tasks_completed &&
       !signals_.did_notify_all_tile_tasks_completed) {
-    recordreplay::Assert("TileManager::IssueSignals #2 %d", has_scheduled_tile_tasks_);
     if (!has_scheduled_tile_tasks_) {
       TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("cc.debug"),
                    "TileManager::IssueSignals - all tile tasks completed");
 
-      recordreplay::Assert("TileManager::IssueSignals #3 %d", has_pending_queries_);
       if (has_pending_queries_)
         ScheduleCheckRasterFinishedQueries();
 
@@ -1608,8 +1562,6 @@ void TileManager::IssueSignals() {
     checker_image_tracker_.SetMaxDecodePriorityAllowed(
         CheckerImageTracker::DecodeType::kRaster);
   }
-
-  recordreplay::Assert("TileManager::IssueSignals Done");
 }
 
 void TileManager::CheckIfMoreTilesNeedToBePrepared() {

--- a/cc/trees/layer_tree_host.cc
+++ b/cc/trees/layer_tree_host.cc
@@ -619,15 +619,9 @@ void LayerTreeHost::OnDeferCommitsChanged(bool defer_status) {
 
 DISABLE_CFI_PERF
 void LayerTreeHost::SetNeedsAnimate() {
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("LayerTreeHost::SetNeedsAnimate Start");
-
   proxy_->SetNeedsAnimate();
   swap_promise_manager_.NotifySwapPromiseMonitorsOfSetNeedsCommit();
   events_metrics_manager_.SaveActiveEventMetrics();
-
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("LayerTreeHost::SetNeedsAnimate Done");
 }
 
 void LayerTreeHost::SetNeedsAnimateIfNotInsideMainFrame() {
@@ -726,15 +720,11 @@ void LayerTreeHost::CompositeForTest(base::TimeTicks frame_begin_time,
 }
 
 bool LayerTreeHost::UpdateLayers() {
-  recordreplay::Assert("LayerTreeHost::UpdateLayers Start");
-
   if (!root_layer()) {
     property_trees_.clear();
     viewport_property_ids_ = ViewportPropertyIds();
     return false;
   }
-
-  recordreplay::Assert("LayerTreeHost::UpdateLayers #1");
 
   DCHECK(!root_layer()->parent());
   base::ElapsedTimer timer;

--- a/cc/trees/proxy_main.cc
+++ b/cc/trees/proxy_main.cc
@@ -122,8 +122,6 @@ void ProxyMain::DidCompletePageScaleAnimation() {
 
 void ProxyMain::BeginMainFrame(
     std::unique_ptr<BeginMainFrameAndCommitState> begin_main_frame_state) {
-  recordreplay::Assert("ProxyMain::BeginMainFrame Start");
-
   DCHECK(IsMainThread());
   DCHECK_EQ(NO_PIPELINE_STAGE, current_pipeline_stage_);
 
@@ -168,7 +166,6 @@ void ProxyMain::BeginMainFrame(
                                   CommitEarlyOutReason::ABORTED_NOT_VISIBLE,
                                   begin_main_frame_start_time,
                                   std::move(empty_swap_promises)));
-    recordreplay::Assert("ProxyMain::BeginMainFrame #1");
     return;
   }
 
@@ -208,7 +205,6 @@ void ProxyMain::BeginMainFrame(
     // previously requested pipeline stages.
     deferred_final_pipeline_stage_ =
         std::max(final_pipeline_stage_, deferred_final_pipeline_stage_);
-    recordreplay::Assert("ProxyMain::BeginMainFrame #2");
     return;
   }
 
@@ -296,7 +292,6 @@ void ProxyMain::BeginMainFrame(
     // When we stop deferring commits, we should resume any previously requested
     // pipeline stages.
     deferred_final_pipeline_stage_ = final_pipeline_stage_;
-    recordreplay::Assert("ProxyMain::BeginMainFrame #3");
     return;
   }
 
@@ -316,14 +311,12 @@ void ProxyMain::BeginMainFrame(
   // list in advance, and "painting" amounts to copying the Blink display list
   // to corresponding  cc display list. An exception is for painted scrollbars,
   // which paint eagerly during layer update.
-  recordreplay::Assert("ProxyMain::BeginMainFrame #4 %d", should_update_layers);
   bool updated = should_update_layers && layer_tree_host_->UpdateLayers();
 
   // If updating the layers resulted in a content update, we need a commit.
   if (updated)
     final_pipeline_stage_ = COMMIT_PIPELINE_STAGE;
 
-  recordreplay::Assert("ProxyMain::BeginMainFrame #5");
   layer_tree_host_->WillCommit();
   devtools_instrumentation::ScopedCommitTrace commit_task(
       layer_tree_host_->GetId());
@@ -355,7 +348,6 @@ void ProxyMain::BeginMainFrame(
     layer_tree_host_->RecordEndOfFrameMetrics(
         begin_main_frame_start_time,
         begin_main_frame_state->active_sequence_trackers);
-    recordreplay::Assert("ProxyMain::BeginMainFrame #4");
     return;
   }
 
@@ -397,8 +389,6 @@ void ProxyMain::BeginMainFrame(
   layer_tree_host_->RecordEndOfFrameMetrics(
       begin_main_frame_start_time,
       begin_main_frame_state->active_sequence_trackers);
-
-  recordreplay::Assert("ProxyMain::BeginMainFrame Done");
 }
 
 void ProxyMain::DidPresentCompositorFrame(

--- a/chrome/browser/web_applications/components/file_handler_manager.cc
+++ b/chrome/browser/web_applications/components/file_handler_manager.cc
@@ -238,9 +238,6 @@ void FileHandlerManager::DisableAutomaticFileHandlerCleanupForTesting() {
 }
 
 int FileHandlerManager::CleanupAfterOriginTrials() {
-  recordreplay::Assert("FileHandlerManager::CleanupAfterOriginTrials Start %lu",
-                       recordreplay::PointerId(this));
-
   int cleaned_up_count = 0;
   for (const AppId& app_id : registrar_->GetAppIds()) {
     if (!AreFileHandlersEnabled(app_id))
@@ -255,7 +252,6 @@ int FileHandlerManager::CleanupAfterOriginTrials() {
     cleaned_up_count++;
   }
 
-  recordreplay::Assert("FileHandlerManager::CleanupAfterOriginTrials Done");
   return cleaned_up_count;
 }
 

--- a/chrome/services/sharing/webrtc/ipc_packet_socket_factory.cc
+++ b/chrome/services/sharing/webrtc/ipc_packet_socket_factory.cc
@@ -494,10 +494,6 @@ void IpcPacketSocket::SetError(int error) {
 
 void IpcPacketSocket::OnOpen(const net::IPEndPoint& local_address,
                              const net::IPEndPoint& remote_address) {
-  recordreplay::Assert("IpcPacketSocket::OnOpen %s %s",
-                       local_address.ToString().c_str(),
-                       remote_address.ToString().c_str());
-
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 
   if (!jingle_glue::IPEndPointToSocketAddress(local_address, &local_address_)) {

--- a/components/autofill/content/renderer/autofill_agent.cc
+++ b/components/autofill/content/renderer/autofill_agent.cc
@@ -1316,14 +1316,10 @@ void AutofillAgent::ReplaceElementIfNowInvalid(const FormData& original_form) {
 
 const mojo::AssociatedRemote<mojom::AutofillDriver>&
 AutofillAgent::GetAutofillDriver() {
-  recordreplay::Assert("AutofillAgent::GetAutofillDriver Start %d", !!autofill_driver_);
-
   if (!autofill_driver_) {
     render_frame()->GetRemoteAssociatedInterfaces()->GetInterface(
         &autofill_driver_);
   }
-
-  recordreplay::Assert("AutofillAgent::GetAutofillDriver Done");
   return autofill_driver_;
 }
 

--- a/components/discardable_memory/client/client_discardable_shared_memory_manager.cc
+++ b/components/discardable_memory/client/client_discardable_shared_memory_manager.cc
@@ -250,7 +250,6 @@ void ClientDiscardableSharedMemoryManager::OnBackgrounded() {
 std::unique_ptr<base::DiscardableMemory>
 ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
     size_t size) {
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory Start");
   base::AutoLock lock(lock_);
 
   if (may_schedule_periodic_purge_ && !is_purge_scheduled_) {
@@ -260,7 +259,6 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
                        this),
         kScheduledPurgeInterval);
     is_purge_scheduled_ = true;
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #1");
   }
 
   DCHECK_NE(size, 0u);
@@ -296,19 +294,16 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
     // Search free lists for suitable span.
     std::unique_ptr<DiscardableSharedMemoryHeap::Span> free_span =
         heap_->SearchFreeLists(pages, slack);
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #2");
     if (!free_span)
       break;
 
     // Attempt to lock |free_span|. Delete span and search free lists again
     // if locking failed.
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #3");
     if (free_span->shared_memory()->Lock(
             free_span->start() * base::GetPageSize() -
                 reinterpret_cast<size_t>(free_span->shared_memory()->memory()),
             free_span->length() * base::GetPageSize()) ==
         base::DiscardableSharedMemory::FAILED) {
-      recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #4");
       DCHECK(!free_span->shared_memory()->IsMemoryResident());
       // We have to release purged memory before |free_span| can be destroyed.
       heap_->ReleasePurgedMemory();
@@ -316,7 +311,6 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
       continue;
     }
 
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #5");
     free_span->set_is_locked(true);
 
     if (pages >= allocation_pages) {
@@ -331,11 +325,8 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
     auto discardable_memory =
         std::make_unique<DiscardableMemoryImpl>(this, std::move(free_span));
     allocated_memory_.insert(discardable_memory.get());
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #6");
     return std::move(discardable_memory);
   }
-
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory #7");
 
   // Release purged memory to free up the address space before we attempt to
   // allocate more memory.
@@ -393,8 +384,6 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
 
   MemoryUsageChanged(heap_->GetSize(), heap_->GetFreelistSize());
 
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory Done");
-
   auto discardable_memory =
       std::make_unique<DiscardableMemoryImpl>(this, std::move(new_span));
   allocated_memory_.insert(discardable_memory.get());
@@ -405,10 +394,8 @@ bool ClientDiscardableSharedMemoryManager::OnMemoryDump(
     const base::trace_event::MemoryDumpArgs& args,
     base::trace_event::ProcessMemoryDump* pmd) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::OnMemoryDump Start");
   base::AutoLock lock(lock_);
   if (foregrounded_) {
-    recordreplay::Assert("ClientDiscardableSharedMemoryManager::OnMemoryDump #1");
     const size_t total_size = heap_->GetSize() / 1024;                // in KiB
     const size_t freelist_size = heap_->GetFreelistSize() / 1024;     // in KiB
 
@@ -419,10 +406,7 @@ bool ClientDiscardableSharedMemoryManager::OnMemoryDump(
     base::UmaHistogramCounts1M("Memory.Discardable.Size.Foreground",
                                total_size - freelist_size);
   }
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::OnMemoryDump #2");
-  bool rv = heap_->OnMemoryDump(args, pmd);
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::OnMemoryDump Done %d", rv);
-  return rv;
+  return heap_->OnMemoryDump(args, pmd);
 }
 
 size_t ClientDiscardableSharedMemoryManager::GetBytesAllocated() const {
@@ -648,7 +632,6 @@ void ClientDiscardableSharedMemoryManager::AllocateCompletedOnIO(
 
 void ClientDiscardableSharedMemoryManager::DeletedDiscardableSharedMemory(
     int32_t id) {
-  recordreplay::Assert("ClientDiscardableSharedMemoryManager::DeletedDiscardableSharedMemory %d", id);
   io_task_runner_->PostTask(FROM_HERE,
                             base::BindOnce(&DeletedDiscardableSharedMemoryOnIO,
                                            manager_mojo_.get(), id));

--- a/components/discardable_memory/common/discardable_shared_memory_heap.cc
+++ b/components/discardable_memory/common/discardable_shared_memory_heap.cc
@@ -260,15 +260,12 @@ void DiscardableSharedMemoryHeap::ReleaseFreeMemory() {
 void DiscardableSharedMemoryHeap::ReleasePurgedMemory() {
   // Erase all purged segments after rearranging the segments in such a way
   // that resident segments precede all purged segments.
-  recordreplay::Assert("DiscardableSharedMemoryHeap::ReleasePurgedMemory Start %lu", memory_segments_.size());
   memory_segments_.erase(
       std::partition(memory_segments_.begin(), memory_segments_.end(),
                      [](const std::unique_ptr<ScopedMemorySegment>& segment) {
-                       recordreplay::Assert("DiscardableSharedMemoryHeap::ReleasePurgedMemory partition %d", segment->IsResident());
                        return segment->IsResident();
                      }),
       memory_segments_.end());
-  recordreplay::Assert("DiscardableSharedMemoryHeap::ReleasePurgedMemory Done");
 }
 
 size_t DiscardableSharedMemoryHeap::GetSize() const {

--- a/components/page_load_metrics/renderer/page_resource_data_use.cc
+++ b/components/page_load_metrics/renderer/page_resource_data_use.cc
@@ -122,7 +122,6 @@ int PageResourceDataUse::CalculateNewlyReceivedBytes() {
 }
 
 mojom::ResourceDataUpdatePtr PageResourceDataUse::GetResourceDataUpdate() {
-  recordreplay::Assert("PageResourceDataUse::GetResourceDataUpdate %s", mime_type_.c_str());
   DCHECK(cache_type_ == mojom::CacheType::kMemory ? is_complete_ : true);
   mojom::ResourceDataUpdatePtr resource_data_update =
       mojom::ResourceDataUpdate::New();

--- a/components/safe_browsing/content/browser/mojo_safe_browsing_impl.cc
+++ b/components/safe_browsing/content/browser/mojo_safe_browsing_impl.cc
@@ -134,8 +134,6 @@ void MojoSafeBrowsingImpl::CreateCheckerAndCheck(
     CreateCheckerAndCheckCallback callback) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
 
-  recordreplay::Assert("MojoSafeBrowsingImpl::CreateCheckerAndCheck %s", url.spec().c_str());
-
   if (delegate_->ShouldSkipRequestCheck(url, -1 /* frame_tree_node_id */,
                                         render_process_id_, render_frame_id,
                                         originated_from_service_worker)) {

--- a/components/variations/child_process_field_trial_syncer.cc
+++ b/components/variations/child_process_field_trial_syncer.cc
@@ -22,8 +22,6 @@ ChildProcessFieldTrialSyncer::~ChildProcessFieldTrialSyncer() {}
 
 void ChildProcessFieldTrialSyncer::InitFieldTrialObserving(
     const base::CommandLine& command_line) {
-  recordreplay::Assert("ChildProcessFieldTrialSyncer::InitFieldTrialObserving Start");
-
   // Set up initial set of crash dump data for field trials in this process.
   variations::InitCrashKeys();
 
@@ -38,23 +36,16 @@ void ChildProcessFieldTrialSyncer::InitFieldTrialObserving(
                                                       &initially_active_trials);
   std::set<std::string> initially_active_trials_set;
   for (const auto& entry : initially_active_trials) {
-    recordreplay::Assert("ChildProcessFieldTrialSyncer::InitFieldTrialObserving #1 %s",
-                         entry.trial_name.c_str());
     initially_active_trials_set.insert(std::move(entry.trial_name));
   }
 
   base::FieldTrial::ActiveGroups current_active_trials;
   base::FieldTrialList::GetActiveFieldTrialGroups(&current_active_trials);
   for (const auto& trial : current_active_trials) {
-    recordreplay::Assert("ChildProcessFieldTrialSyncer::InitFieldTrialObserving #2 %s",
-                         trial.trial_name.c_str());
     if (!base::Contains(initially_active_trials_set, trial.trial_name)) {
-      recordreplay::Assert("ChildProcessFieldTrialSyncer::InitFieldTrialObserving #3");
       observer_->OnFieldTrialGroupFinalized(trial.trial_name, trial.group_name);
     }
   }
-
-  recordreplay::Assert("ChildProcessFieldTrialSyncer::InitFieldTrialObserving Done");
 }
 
 void ChildProcessFieldTrialSyncer::OnSetFieldTrialGroup(

--- a/components/viz/common/quads/shared_quad_state.cc
+++ b/components/viz/common/quads/shared_quad_state.cc
@@ -21,20 +21,6 @@ SharedQuadState::~SharedQuadState() {
                                      "viz::SharedQuadState", this);
 }
 
-void RecordReplayAssertSharedQuadContents(const SharedQuadState* state) {
-  /*
-  recordreplay::Assert("SharedQuadContents #1 %d %d %.2f %d %d",
-                       state->is_clipped, state->are_contents_opaque, state->opacity,
-                       state->blend_mode, state->sorting_context_id);
-  recordreplay::Assert("SharedQuadContents #2 %s",
-                       state->quad_to_target_transform.ToString().c_str());
-  recordreplay::Assert("SharedQuadContents #3 %s", state->quad_layer_rect.ToString().c_str());
-  recordreplay::Assert("SharedQuadContents #4 %s", state->visible_quad_layer_rect.ToString().c_str());
-  recordreplay::Assert("SharedQuadContents #5 %s", state->clip_rect.ToString().c_str());
-  recordreplay::Assert("SharedQuadContents #6 %s", state->mask_filter_info.ToString().c_str());
-  */
-}
-
 void SharedQuadState::SetAll(const gfx::Transform& quad_to_target_transform,
                              const gfx::Rect& quad_layer_rect,
                              const gfx::Rect& visible_quad_layer_rect,
@@ -55,7 +41,6 @@ void SharedQuadState::SetAll(const gfx::Transform& quad_to_target_transform,
   this->opacity = opacity;
   this->blend_mode = blend_mode;
   this->sorting_context_id = sorting_context_id;
-  RecordReplayAssertSharedQuadContents(this);
 }
 
 void SharedQuadState::AsValueInto(base::trace_event::TracedValue* value) const {

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -209,7 +209,6 @@ void RecordReplayPaintFinished(const SkPixmap& pixmap) {
   }
 
   size_t bookmark = gLastCommitBookmark;
-  recordreplay::Assert("RecordReplayPaintFinished %lu", bookmark);
 
   if (bookmark) {
     gCurrentPixmap = &pixmap;

--- a/components/viz/service/display/software_output_device.cc
+++ b/components/viz/service/display/software_output_device.cc
@@ -51,15 +51,12 @@ SkCanvas* SoftwareOutputDevice::BeginPaint(const gfx::Rect& damage_rect) {
 }
 
 void SoftwareOutputDevice::EndPaint() {
-  recordreplay::Assert("SoftwareOutputDevice::EndPaint Start %d", !!surface_);
   if (recordreplay::IsRecordingOrReplaying()) {
     SkPixmap pixmap;
     if (surface_ && surface_->peekPixels(&pixmap)) {
-      recordreplay::Assert("SoftwareOutputDevice::EndPaint #1");
       RecordReplayPaintFinished(pixmap);
     }
   }
-  recordreplay::Assert("SoftwareOutputDevice::EndPaint Done");
 }
 
 gfx::VSyncProvider* SoftwareOutputDevice::GetVSyncProvider() {

--- a/components/viz/service/display/software_renderer.cc
+++ b/components/viz/service/display/software_renderer.cc
@@ -101,7 +101,6 @@ void SoftwareRenderer::BeginDrawingFrame() {
 }
 
 void SoftwareRenderer::FinishDrawingFrame() {
-  recordreplay::Assert("SoftwareRenderer::FinishDrawingFrame Start");
   TRACE_EVENT0("viz", "SoftwareRenderer::FinishDrawingFrame");
   current_framebuffer_canvas_.reset();
   current_canvas_ = nullptr;
@@ -109,7 +108,6 @@ void SoftwareRenderer::FinishDrawingFrame() {
   if (root_canvas_)
     output_device_->EndPaint();
   root_canvas_ = nullptr;
-  recordreplay::Assert("SoftwareRenderer::FinishDrawingFrame Done");
 }
 
 void SoftwareRenderer::SwapBuffers(SwapFrameData swap_frame_data) {

--- a/content/app/content_main.cc
+++ b/content/app/content_main.cc
@@ -160,14 +160,11 @@ void CommonSubprocessInit() {
 }
 
 void InitializeMojo(mojo::core::Configuration* config) {
-  recordreplay::Assert("InitializeMojo Start");
-
   // If this is the browser process and there's no Mojo invitation pipe on the
   // command line, we will serve as the global Mojo broker.
   const auto& command_line = *base::CommandLine::ForCurrentProcess();
   const bool is_browser = !command_line.HasSwitch(switches::kProcessType);
   if (is_browser) {
-    recordreplay::Assert("InitializeMojo #1");
     if (mojo::PlatformChannel::CommandLineHasPassedEndpoint(command_line)) {
       config->is_broker_process = false;
       config->force_direct_shared_memory_allocation = true;
@@ -186,7 +183,6 @@ void InitializeMojo(mojo::core::Configuration* config) {
   }
 
   if (!IsMojoCoreSharedLibraryEnabled()) {
-    recordreplay::Assert("InitializeMojo #2");
     mojo::core::Init(*config);
     return;
   }
@@ -195,7 +191,6 @@ void InitializeMojo(mojo::core::Configuration* config) {
     // Note that when dynamic Mojo Core is used, initialization for child
     // processes happens elsewhere. See ContentMainRunnerImpl::Run() and
     // ChildProcess construction.
-    recordreplay::Assert("InitializeMojo #3");
     return;
   }
 
@@ -207,8 +202,6 @@ void InitializeMojo(mojo::core::Configuration* config) {
   MojoResult result =
       mojo::LoadAndInitializeCoreLibrary(GetMojoCoreSharedLibraryPath(), flags);
   CHECK_EQ(MOJO_RESULT_OK, result);
-
-  recordreplay::Assert("InitializeMojo Done");
 }
 
 }  // namespace
@@ -312,22 +305,14 @@ int RunContentProcess(const ContentMainParams& params,
     InitializeMac();
 #endif
 
-    recordreplay::Assert("RunContentProcess #10");
-
     mojo::core::Configuration mojo_config;
     mojo_config.max_message_num_bytes = kMaximumMojoMessageSize;
     InitializeMojo(&mojo_config);
 
-    recordreplay::Assert("RunContentProcess #11");
-
     ui::RegisterPathProvider();
     tracker = base::debug::GlobalActivityTracker::Get();
 
-    recordreplay::Assert("RunContentProcess #12");
-
     exit_code = content_main_runner->Initialize(content_main_params);
-
-    recordreplay::Assert("RunContentProcess #13");
 
     if (exit_code >= 0) {
       if (tracker) {

--- a/content/child/child_thread_impl.cc
+++ b/content/child/child_thread_impl.cc
@@ -561,8 +561,6 @@ void ChildThreadImpl::OnFieldTrialGroupFinalized(
 }
 
 void ChildThreadImpl::Init(const Options& options) {
-  recordreplay::Assert("ChildThreadImpl::Init Start");
-
   TRACE_EVENT0("startup", "ChildThreadImpl::Init");
   g_lazy_child_thread_impl_tls.Pointer()->Set(this);
   on_channel_error_called_ = false;
@@ -705,14 +703,11 @@ void ChildThreadImpl::Init(const Options& options) {
   // In single-process mode, there is no need to synchronize trials to the
   // browser process (because it's the same process).
   if (!IsInBrowserProcess()) {
-    recordreplay::Assert("ChildThreadImpl::Init #1");
     field_trial_syncer_.reset(
         new variations::ChildProcessFieldTrialSyncer(this));
     field_trial_syncer_->InitFieldTrialObserving(
         *base::CommandLine::ForCurrentProcess());
   }
-
-  recordreplay::Assert("ChildThreadImpl::Init Done");
 }
 
 ChildThreadImpl::~ChildThreadImpl() {

--- a/content/child/field_trial.cc
+++ b/content/child/field_trial.cc
@@ -18,8 +18,6 @@
 namespace content {
 
 void InitializeFieldTrialAndFeatureList() {
-  recordreplay::Assert("InitializeFieldTrialAndFeatureList Start");
-
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
 
@@ -62,8 +60,6 @@ void InitializeFieldTrialAndFeatureList() {
   feature_list->RegisterExtraFeatureOverrides(
       GetSwitchDependentFeatureOverrides(command_line));
   base::FeatureList::SetInstance(std::move(feature_list));
-
-  recordreplay::Assert("InitializeFieldTrialAndFeatureList Done");
 }
 
 }  // namespace content

--- a/content/renderer/loader/navigation_body_loader.cc
+++ b/content/renderer/loader/navigation_body_loader.cc
@@ -295,8 +295,6 @@ void NavigationBodyLoader::ReadFromDataPipe() {
     uint32_t available = 0;
     MojoResult result =
         handle_->BeginReadData(&buffer, &available, MOJO_READ_DATA_FLAG_NONE);
-    recordreplay::Assert("NavigationBodyLoader::ReadFromDataPipe %u %u",
-                         available, available ? ((const char*)buffer)[0] : 0);
     if (result == MOJO_RESULT_SHOULD_WAIT) {
       handle_watcher_.ArmOrNotify();
       return;

--- a/content/renderer/media/batching_media_log.cc
+++ b/content/renderer/media/batching_media_log.cc
@@ -135,8 +135,6 @@ void BatchingMediaLog::AddLogRecordLocked(
     if (ipc_send_pending_)
       return;
 
-    recordreplay::Assert("BatchingMediaLog::AddLogRecordLocked #5");
-
     ipc_send_pending_ = true;
     delay_for_next_ipc_send = base::TimeDelta::FromSeconds(1) -
                               (tick_clock_->NowTicks() - last_ipc_send_time_);
@@ -258,8 +256,6 @@ void BatchingMediaLog::MaybeQueueEvent_Locked(
                  base::NumberToString(media::MediaLog::kLogLimit) +
                  " messages per second. Futher entries will be dropped.";
   DLOG(WARNING) << message;
-
-  recordreplay::Assert("BatchingMediaLog::MaybeQueueEvent_Locked #1");
 
   queued_media_events_.emplace_back();
   queued_media_events_.back().id = event->id;

--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -2767,7 +2767,6 @@ void RenderFrameImpl::NotifyResourceResponseReceived(
     network::mojom::URLResponseHeadPtr response_head,
     network::mojom::RequestDestination request_destination,
     int32_t previews_state) {
-  recordreplay::Assert("RenderFrameImpl::NotifyResourceResponseReceived");
   if (!blink::IsRequestDestinationFrame(request_destination)) {
     GetFrameHost()->SubresourceResponseStarted(response_url,
                                                response_head->cert_status);
@@ -3771,9 +3770,6 @@ blink::WebLocalFrame* RenderFrameImpl::CreateChildFrame(
   mojo::PendingRemote<blink::mojom::BrowserInterfaceBroker>
       browser_interface_broker;
 
-  recordreplay::Assert("RenderFrameImpl::CreateChildFrame #1 %s %s",
-                       name.Utf8().c_str(), frame_unique_name.c_str());
-
   // Now create the child frame in the browser via an asynchronous call.
   GetFrameHost()->CreateChildFrame(
       child_routing_id,
@@ -4530,7 +4526,6 @@ void RenderFrameImpl::DidObserveLazyLoadBehavior(
 
 void RenderFrameImpl::DidCreateScriptContext(v8::Local<v8::Context> context,
                                              int world_id) {
-  recordreplay::Assert("RenderFrameImpl::DidCreateScriptContext Start");
   if (((enabled_bindings_ & BINDINGS_POLICY_MOJO_WEB_UI) ||
        enable_mojo_js_bindings_) &&
       IsMainFrame() && world_id == ISOLATED_WORLD_ID_GLOBAL) {
@@ -4540,11 +4535,8 @@ void RenderFrameImpl::DidCreateScriptContext(v8::Local<v8::Context> context,
   }
 
   for (auto& observer : observers_) {
-    recordreplay::Assert("RenderFrameImpl::DidCreateScriptContext #1");
     observer.DidCreateScriptContext(context, world_id);
   }
-
-  recordreplay::Assert("RenderFrameImpl::DidCreateScriptContext Done");
 }
 
 void RenderFrameImpl::WillReleaseScriptContext(v8::Local<v8::Context> context,

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -885,7 +885,6 @@ void RenderThreadImpl::SetResourceRequestSenderDelegate(
 }
 
 void RenderThreadImpl::InitializeCompositorThread() {
-  recordreplay::Assert("RenderThreadImpl::InitializeCompositorThread START");
   blink_platform_impl_->CreateAndSetCompositorThread();
   compositor_task_runner_ = blink_platform_impl_->CompositorThreadTaskRunner();
 
@@ -895,7 +894,6 @@ void RenderThreadImpl::InitializeCompositorThread() {
                      false));
   GetContentClient()->renderer()->PostCompositorThreadCreated(
       compositor_task_runner_.get());
-  recordreplay::Assert("RenderThreadImpl::InitializeCompositorThread DONE");
 }
 
 scoped_refptr<base::SingleThreadTaskRunner>

--- a/content/renderer/theme_helper_mac.mm
+++ b/content/renderer/theme_helper_mac.mm
@@ -18,9 +18,6 @@ namespace content {
 void SystemColorsDidChange(int aqua_color_variant,
                            const std::string& highlight_text_color,
                            const std::string& highlight_color) {
-  recordreplay::Assert("SystemColorsDidChange %s %s",
-                       highlight_text_color.c_str(), highlight_color.c_str());
-
   NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
 
   // Register the defaults in the NSArgumentDomain, which is considered

--- a/extensions/common/extensions_client.cc
+++ b/extensions/common/extensions_client.cc
@@ -118,8 +118,6 @@ void ExtensionsClient::DoInitialize() {
   DCHECK(!ManifestHandler::IsRegistrationFinalized());
   PermissionsInfo* permissions_info = PermissionsInfo::GetInstance();
 
-  recordreplay::Assert("ExtensionsClient::DoInitialize");
-
   const base::ElapsedTimer timer;
   for (const auto& provider : api_providers_) {
     provider->RegisterManifestHandlers();

--- a/gin/v8_platform.cc
+++ b/gin/v8_platform.cc
@@ -539,8 +539,6 @@ std::unique_ptr<v8::JobHandle> V8Platform::PostJob(
                     base::BindRepeating(
                         [](const std::unique_ptr<v8::JobTask>& job_task,
                            base::JobDelegate* delegate) {
-                          recordreplay::Assert("V8Platform::PostJob callback %lu",
-                                               recordreplay::PointerId(delegate));
                           JobDelegateImpl delegate_impl(delegate);
                           job_task->Run(&delegate_impl);
                         },

--- a/gpu/ipc/client/gpu_channel_host.cc
+++ b/gpu/ipc/client/gpu_channel_host.cc
@@ -151,11 +151,8 @@ uint32_t GpuChannelHost::EnqueueDeferredMessage(
 }
 
 void GpuChannelHost::EnsureFlush(uint32_t deferred_message_id) {
-  recordreplay::Assert("GpuChannelHost::EnsureFlush Start");
   AutoLock lock(context_lock_);
-  recordreplay::Assert("GpuChannelHost::EnsureFlush #1");
   InternalFlush(deferred_message_id);
-  recordreplay::Assert("GpuChannelHost::EnsureFlush Done");
 }
 
 void GpuChannelHost::VerifyFlush(uint32_t deferred_message_id) {
@@ -191,9 +188,6 @@ void GpuChannelHost::EnqueuePendingOrderingBarrier() {
 
 void GpuChannelHost::InternalFlush(uint32_t deferred_message_id) {
   context_lock_.AssertAcquired();
-
-  recordreplay::Assert("GpuChannelHost::InternalFlush Start %d %u %u",
-                       deferred_messages_.empty(), deferred_message_id, flushed_deferred_message_id_);
 
   EnqueuePendingOrderingBarrier();
   if (!deferred_messages_.empty() &&

--- a/ipc/ipc_channel_proxy.cc
+++ b/ipc/ipc_channel_proxy.cc
@@ -124,8 +124,6 @@ void ChannelProxy::Context::FlushChannel() {
 // Called on the IPC::Channel thread
 bool ChannelProxy::Context::OnMessageReceived(const Message& message) {
   // First give a chance to the filters to process this message.
-  recordreplay::Assert("ChannelProxy::Context::OnMessageReceived %lu %d",
-                       recordreplay::PointerId(this), message.routing_id());
   if (!TryFilters(message))
     OnMessageReceivedNoFilter(message);
   return true;
@@ -133,8 +131,6 @@ bool ChannelProxy::Context::OnMessageReceived(const Message& message) {
 
 // Called on the IPC::Channel thread
 bool ChannelProxy::Context::OnMessageReceivedNoFilter(const Message& message) {
-  recordreplay::Assert("ChannelProxy::Context::OnMessageReceivedNoFilter %lu %d",
-                       recordreplay::PointerId(this), message.routing_id());
   GetTaskRunner(message.routing_id())
       ->PostTask(FROM_HERE,
                  base::BindOnce(&Context::OnDispatchMessage, this, message));
@@ -307,12 +303,10 @@ void ChannelProxy::Context::OnRemoveFilter(MessageFilter* filter) {
 
 // Called on the listener's thread
 void ChannelProxy::Context::AddFilter(MessageFilter* filter) {
-  recordreplay::Assert("ChannelProxy::Context::AddFilter Start");
   base::AutoLock auto_lock(pending_filters_lock_);
   pending_filters_.push_back(base::WrapRefCounted(filter));
   ipc_task_runner_->PostTask(FROM_HERE,
                              base::BindOnce(&Context::OnAddFilter, this));
-  recordreplay::Assert("ChannelProxy::Context::AddFilter Done");
 }
 
 // Called on the listener's thread
@@ -407,10 +401,8 @@ void ChannelProxy::Context::OnDispatchBadMessage(const Message& message) {
 void ChannelProxy::Context::OnDispatchAssociatedInterfaceRequest(
     const std::string& interface_name,
     mojo::ScopedInterfaceEndpointHandle handle) {
-  recordreplay::Assert("ChannelProxy::Context::OnDispatchAssociatedInterfaceRequest Start");
   if (listener_)
     listener_->OnAssociatedInterfaceRequest(interface_name, std::move(handle));
-  recordreplay::Assert("ChannelProxy::Context::OnDispatchAssociatedInterfaceRequest Done");
 }
 
 void ChannelProxy::Context::ClearChannel() {

--- a/ipc/ipc_message_pipe_reader.cc
+++ b/ipc/ipc_message_pipe_reader.cc
@@ -87,7 +87,6 @@ void MessagePipeReader::SetPeerPid(int32_t peer_pid) {
 }
 
 void MessagePipeReader::Receive(MessageView message_view) {
-  recordreplay::Assert("MessagePipeReader::Receive %lu", recordreplay::PointerId(this));
   if (message_view.bytes().empty()) {
     delegate_->OnBrokenDataReceived();
     return;

--- a/ipc/ipc_mojo_bootstrap.cc
+++ b/ipc/ipc_mojo_bootstrap.cc
@@ -774,8 +774,6 @@ class ChannelAssociatedGroupController
   }
 
   void NotifyEndpointOfError(Endpoint* endpoint, bool force_async) {
-    recordreplay::Assert("NotifyEndpointOfError Start");
-
     lock_.AssertAcquired();
     DCHECK(endpoint->task_runner() && endpoint->client());
     if (endpoint->task_runner()->RunsTasksInCurrentSequence() && !force_async) {
@@ -792,8 +790,6 @@ class ChannelAssociatedGroupController
                              NotifyEndpointOfErrorOnEndpointThread,
                          this, endpoint->id(), base::Unretained(endpoint)));
     }
-
-    recordreplay::Assert("NotifyEndpointOfError Done");
   }
 
   void NotifyEndpointOfErrorOnEndpointThread(mojo::InterfaceId id,
@@ -921,8 +917,6 @@ class ChannelAssociatedGroupController
   }
 
   void AcceptOnProxyThread(mojo::Message message) {
-    recordreplay::Assert("AcceptOnProxyThread Start");
-
     DCHECK(proxy_task_runner_->BelongsToCurrentThread());
     TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("mojom"),
                  "ChannelAssociatedGroupController::AcceptOnProxyThread");
@@ -933,13 +927,11 @@ class ChannelAssociatedGroupController
     base::AutoLock locker(lock_);
     Endpoint* endpoint = FindEndpoint(id);
     if (!endpoint) {
-      recordreplay::Assert("AcceptOnProxyThread #1");
       return;
     }
 
     mojo::InterfaceEndpointClient* client = endpoint->client();
     if (!client) {
-      recordreplay::Assert("AcceptOnProxyThread #2");
       return;
     }
 
@@ -959,8 +951,6 @@ class ChannelAssociatedGroupController
 
     if (!result)
       RaiseError();
-
-    recordreplay::Assert("AcceptOnProxyThread Done");
   }
 
   void AcceptSyncMessage(mojo::InterfaceId interface_id, uint32_t message_id) {

--- a/ipc/ipc_sync_channel.cc
+++ b/ipc/ipc_sync_channel.cc
@@ -398,9 +398,6 @@ void SyncChannel::SyncContext::Clear() {
 }
 
 bool SyncChannel::SyncContext::OnMessageReceived(const Message& msg) {
-  recordreplay::Assert("SyncChannel::SyncContext::OnMessageReceived %lu %d",
-                       recordreplay::PointerId(this), msg.routing_id());
-
   // Give the filters a chance at processing this message.
   if (TryFilters(msg))
     return true;

--- a/media/base/media_log.cc
+++ b/media/base/media_log.cc
@@ -73,15 +73,12 @@ void MediaLog::NotifyError(Status status) {
 
 void MediaLog::OnWebMediaPlayerDestroyedLocked() {}
 void MediaLog::OnWebMediaPlayerDestroyed() {
-  recordreplay::Assert("MediaLog::OnWebMediaPlayerDestroyed Start");
   AddEvent<MediaLogEvent::kWebMediaPlayerDestroyed>();
   base::AutoLock auto_lock(parent_log_record_->lock);
   // Forward to the parent log's implementation.
   if (parent_log_record_->media_log) {
-    recordreplay::Assert("MediaLog::OnWebMediaPlayerDestroyed #1");
     parent_log_record_->media_log->OnWebMediaPlayerDestroyedLocked();
   }
-  recordreplay::Assert("MediaLog::OnWebMediaPlayerDestroyed Done");
 }
 
 std::string MediaLog::GetErrorMessage() {
@@ -107,7 +104,6 @@ void MediaLog::AddLogRecord(std::unique_ptr<MediaLogRecord> record) {
 
 std::unique_ptr<MediaLogRecord> MediaLog::CreateRecord(
     MediaLogRecord::Type type) {
-  recordreplay::Assert("MediaLog::CreateRecord");
   auto record = std::make_unique<MediaLogRecord>();
   record->id = id();
   record->type = type;

--- a/media/blink/buffered_data_source_host_impl.cc
+++ b/media/blink/buffered_data_source_host_impl.cc
@@ -57,8 +57,6 @@ int64_t BufferedDataSourceHostImpl::UnloadedBytesInInterval(
 
 void BufferedDataSourceHostImpl::AddBufferedByteRange(int64_t start,
                                                       int64_t end) {
-  recordreplay::Assert("BufferedDataSourceHostImpl::AddBufferedByteRange");
-
   int64_t new_bytes = UnloadedBytesInInterval(Interval<int64_t>(start, end));
   if (new_bytes > 0)
     did_loading_progress_ = true;

--- a/media/blink/resource_multibuffer_data_provider.cc
+++ b/media/blink/resource_multibuffer_data_provider.cc
@@ -233,8 +233,6 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
 #endif
   DCHECK(active_loader_);
 
-  recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse Start");
-
   scoped_refptr<UrlData> destination_url_data(url_data_);
 
   if (!redirects_to_.is_empty()) {
@@ -273,8 +271,6 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
   // successful (in particular range request). So we only verify the partial
   // response for HTTP and HTTPS protocol.
   if (destination_url_data->url().SchemeIsHTTPOrHTTPS()) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #1");
-
     bool partial_response = (response.HttpStatusCode() == kHttpPartialContent);
     bool ok_response = (response.HttpStatusCode() == kHttpOK);
 
@@ -284,20 +280,16 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
     if (accept_ranges.find("bytes") != std::string::npos)
       destination_url_data->set_range_supported();
 
-    recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #2 %d", partial_response);
-
     // If we have verified the partial response and it is correct.
     // It's also possible for a server to support range requests
     // without advertising "Accept-Ranges: bytes".
     if (partial_response &&
         VerifyPartialResponse(response, destination_url_data)) {
-      recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #2");
       destination_url_data->set_range_supported();
     } else if (ok_response) {
       // We accept a 200 response for a Range:0- request, trusting the
       // Accept-Ranges header, because Apache thinks that's a reasonable thing
       // to return.
-      recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #3");
       destination_url_data->set_length(content_length);
       bytes_to_discard_ = byte_pos();
     } else if (response.HttpStatusCode() == kHttpRangeNotSatisfiable) {
@@ -306,10 +298,8 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
       // if we do, let's handle it in a sane way.
       // Note, we can't just call OnDataProviderEvent() here, because
       // url_data_ hasn't been updated to the final destination yet.
-      recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #4");
       end_of_file = true;
     } else {
-      recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #5");
       active_loader_.reset();
       // Can't call fail until readers have been migrated to the new
       // url data below.
@@ -365,7 +355,6 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
   }
 
   if (do_fail) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #10");
     destination_url_data->Fail();
     return;  // "this" may be deleted now.
   }
@@ -383,7 +372,6 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
 
   // This test is vital for security!
   if (!url_data_->ValidateDataOrigin(response_url.GetOrigin())) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse #11");
     active_loader_.reset();
     url_data_->Fail();
     return;  // "this" may be deleted now.
@@ -393,8 +381,6 @@ void ResourceMultiBufferDataProvider::DidReceiveResponse(
     fifo_.push_back(DataBuffer::CreateEOSBuffer());
     url_data_->multibuffer()->OnDataProviderEvent(this);
   }
-
-  recordreplay::Assert("ResourceMultiBufferDataProvider::DidReceiveResponse Done");
 }
 
 void ResourceMultiBufferDataProvider::DidReceiveData(const char* data,
@@ -507,12 +493,9 @@ bool ResourceMultiBufferDataProvider::ParseContentRange(
     int64_t* first_byte_position,
     int64_t* last_byte_position,
     int64_t* instance_size) {
-  recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange Start");
-
   const char kUpThroughBytesUnit[] = "bytes ";
   if (!base::StartsWith(content_range_str, kUpThroughBytesUnit,
                         base::CompareCase::SENSITIVE)) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange #1");
     return false;
   }
   std::string range_spec =
@@ -522,7 +505,6 @@ bool ResourceMultiBufferDataProvider::ParseContentRange(
 
   if (dash_offset == std::string::npos || slash_offset == std::string::npos ||
       slash_offset < dash_offset || slash_offset + 1 == range_spec.length()) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange #2");
     return false;
   }
   if (!base::StringToInt64(range_spec.substr(0, dash_offset),
@@ -530,7 +512,6 @@ bool ResourceMultiBufferDataProvider::ParseContentRange(
       !base::StringToInt64(
           range_spec.substr(dash_offset + 1, slash_offset - dash_offset - 1),
           last_byte_position)) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange #3");
     return false;
   }
   if (slash_offset == range_spec.length() - 2 &&
@@ -539,18 +520,15 @@ bool ResourceMultiBufferDataProvider::ParseContentRange(
   } else {
     if (!base::StringToInt64(range_spec.substr(slash_offset + 1),
                              instance_size)) {
-      recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange #4");
       return false;
     }
   }
   if (*last_byte_position < *first_byte_position ||
       (*instance_size != kPositionNotSpecified &&
        *last_byte_position >= *instance_size)) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange #5");
     return false;
   }
 
-  recordreplay::Assert("ResourceMultiBufferDataProvider::ParseContentRange Done");
   return true;
 }
 
@@ -577,14 +555,10 @@ int64_t ResourceMultiBufferDataProvider::block_size() const {
 bool ResourceMultiBufferDataProvider::VerifyPartialResponse(
     const WebURLResponse& response,
     const scoped_refptr<UrlData>& url_data) {
-  recordreplay::Assert("ResourceMultiBufferDataProvider::VerifyPartialResponse Start %s",
-                       response.HttpHeaderField("Content-Range").Utf8().c_str());
-
   int64_t first_byte_position, last_byte_position, instance_size;
   if (!ParseContentRange(response.HttpHeaderField("Content-Range").Utf8(),
                          &first_byte_position, &last_byte_position,
                          &instance_size)) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::VerifyPartialResponse #1");
     return false;
   }
 
@@ -593,16 +567,13 @@ bool ResourceMultiBufferDataProvider::VerifyPartialResponse(
   }
 
   if (first_byte_position > byte_pos()) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::VerifyPartialResponse #2");
     return false;
   }
   if (last_byte_position + 1 < byte_pos()) {
-    recordreplay::Assert("ResourceMultiBufferDataProvider::VerifyPartialResponse #3");
     return false;
   }
   bytes_to_discard_ = byte_pos() - first_byte_position;
 
-  recordreplay::Assert("ResourceMultiBufferDataProvider::VerifyPartialResponse Done");
   return true;
 }
 

--- a/media/filters/ffmpeg_demuxer.cc
+++ b/media/filters/ffmpeg_demuxer.cc
@@ -938,8 +938,6 @@ FFmpegDemuxer::FFmpegDemuxer(
 }
 
 FFmpegDemuxer::~FFmpegDemuxer() {
-  recordreplay::Assert("FFmpegDemuxer::~FFmpegDemuxer Start");
-
   DCHECK(!init_cb_);
   DCHECK(!pending_seek_cb_);
 
@@ -952,8 +950,6 @@ FFmpegDemuxer::~FFmpegDemuxer() {
   // earlier call to Abort() on |data_source_| prevents further access to it.
   blocking_task_runner_->DeleteSoon(FROM_HERE, url_protocol_.release());
   blocking_task_runner_->DeleteSoon(FROM_HERE, glue_.release());
-
-  recordreplay::Assert("FFmpegDemuxer::~FFmpegDemuxer Done");
 }
 
 std::string FFmpegDemuxer::GetDisplayName() const {

--- a/media/renderers/audio_renderer_impl.cc
+++ b/media/renderers/audio_renderer_impl.cc
@@ -197,14 +197,12 @@ void AudioRendererImpl::SetMediaTime(base::TimeDelta time) {
 }
 
 base::TimeDelta AudioRendererImpl::CurrentMediaTime() {
-  recordreplay::Assert("AudioRendererImpl::CurrentMediaTime");
   base::AutoLock auto_lock(lock_);
 
   // Return the current time based on the known extents of the rendered audio
   // data plus an estimate based on the last time those values were calculated.
   base::TimeDelta current_media_time = audio_clock_->front_timestamp();
   if (!last_render_time_.is_null()) {
-    recordreplay::Assert("AudioRendererImpl::CurrentMediaTime #1");
     current_media_time +=
         (tick_clock_->NowTicks() - last_render_time_) * playback_rate_;
     if (current_media_time > audio_clock_->back_timestamp())

--- a/mojo/core/channel_mac.cc
+++ b/mojo/core/channel_mac.cc
@@ -228,10 +228,6 @@ class ChannelMac : public Channel,
   bool RequestSendDeadNameNotification() {
     base::mac::ScopedMachSendRight previous;
 
-    recordreplay::Assert("RequestSendDeadNameNotification %d %d %d %d",
-                         send_port_.get(), MACH_NOTIFY_DEAD_NAME,
-                         receive_port_.get(), MACH_MSG_TYPE_MAKE_SEND_ONCE);
-
     kern_return_t kr = mach_port_request_notification(
         mach_task_self(), send_port_.get(), MACH_NOTIFY_DEAD_NAME, 0,
         receive_port_.get(), MACH_MSG_TYPE_MAKE_SEND_ONCE,
@@ -346,8 +342,6 @@ class ChannelMac : public Channel,
   }
 
   bool SendMessageLocked(MessagePtr message) {
-    recordreplay::Assert("ChannelMac::SendMessageLocked Start %lu", message->data_num_bytes());
-
     DCHECK(!send_buffer_contains_message_);
     base::BufferIterator<char> buffer(
         reinterpret_cast<char*>(send_buffer_.address()), send_buffer_.size());
@@ -421,8 +415,6 @@ class ChannelMac : public Channel,
       }
     }
 
-    recordreplay::Assert("ChannelMac::SendMessageLocked #1 %lu %d", buffer.position(), transfer_message_ool);
-
     if (transfer_message_ool) {
       auto* descriptor = buffer.MutableObject<mach_msg_ool_descriptor_t>();
       descriptor->address = const_cast<void*>(message->data());
@@ -440,14 +432,11 @@ class ChannelMac : public Channel,
       memcpy(data.data(), message->data(), message->data_num_bytes());
     }
 
-    recordreplay::Assert("ChannelMac::SendMessageLocked #2 %lu", buffer.position());
-
     header->msgh_size = round_msg(buffer.position());
     return MachMessageSendLocked(header);
   }
 
   bool MachMessageSendLocked(mach_msg_header_t* header) {
-    recordreplay::Assert("MachMessageSendLocked %lu", header->msgh_size);
     kern_return_t kr = mach_msg(header, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
                                 header->msgh_size, 0, MACH_PORT_NULL,
                                 /*timeout=*/0, MACH_PORT_NULL);

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -67,7 +67,6 @@ class MessageView {
   MessageView& operator=(MessageView&& other) = default;
 
   ~MessageView() {
-    recordreplay::Assert("MessageView::~MessageView %d", !!message_);
     if (message_) {
       UMA_HISTOGRAM_TIMES("Mojo.Channel.WriteMessageLatency",
                           base::TimeTicks::Now() - start_time_);
@@ -365,10 +364,6 @@ void ChannelPosix::OnFileCanWriteWithoutBlocking(int fd) {
 // cannot be written, it's queued and a wait is initiated to write the message
 // ASAP on the I/O thread.
 bool ChannelPosix::WriteNoLock(MessageView message_view) {
-  recordreplay::Assert("ChannelPosix::WriteNoLock %d %lu",
-                       socket_.get(),
-                       message_view.data_num_bytes());
-
   if (server_.is_valid()) {
     outgoing_messages_.emplace_front(std::move(message_view));
     return true;

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -237,15 +237,12 @@ void Core::RequestShutdown(base::OnceClosure callback) {
 }
 
 MojoHandle Core::ExtractMessagePipeFromInvitation(const std::string& name) {
-  recordreplay::Assert("Core::ExtractMessagePipeFromInvitation Overload Start");
   RequestContext request_context;
   ports::PortRef port0, port1;
   GetNodeController()->node()->CreatePortPair(&port0, &port1);
   MojoHandle handle = AddDispatcher(new MessagePipeDispatcher(
       GetNodeController(), port0, kUnknownPipeIdForDebug, 1));
-  recordreplay::Assert("Core::ExtractMessagePipeFromInvitation Overload #1");
   GetNodeController()->MergePortIntoInviter(name, port1);
-  recordreplay::Assert("Core::ExtractMessagePipeFromInvitation Overload Done");
   return handle;
 }
 
@@ -337,21 +334,16 @@ MojoResult Core::ArmTrap(MojoHandle trap_handle,
                          const MojoArmTrapOptions* options,
                          uint32_t* num_blocking_events,
                          MojoTrapEvent* blocking_events) {
-  recordreplay::Assert("Core::ArmTrap Start");
   if (options && options->struct_size < sizeof(*options)) {
-    recordreplay::Assert("Core::ArmTrap #1");
     return MOJO_RESULT_INVALID_ARGUMENT;
   }
 
   RequestContext request_context;
   scoped_refptr<Dispatcher> watcher = GetDispatcher(trap_handle);
   if (!watcher || watcher->GetType() != Dispatcher::Type::WATCHER) {
-    recordreplay::Assert("Core::ArmTrap #2");
     return MOJO_RESULT_INVALID_ARGUMENT;
   }
-  MojoResult rv = watcher->Arm(num_blocking_events, blocking_events);
-  recordreplay::Assert("Core::ArmTrap Done %d", rv);
-  return rv;
+  return watcher->Arm(num_blocking_events, blocking_events);
 }
 
 MojoResult Core::CreateMessage(const MojoCreateMessageOptions* options,
@@ -368,16 +360,13 @@ MojoResult Core::CreateMessage(const MojoCreateMessageOptions* options,
 }
 
 MojoResult Core::DestroyMessage(MojoMessageHandle message_handle) {
-  recordreplay::Assert("Core::DestroyMessage Start");
   if (!message_handle) {
-    recordreplay::Assert("Core::DestroyMessage #1");
     return MOJO_RESULT_INVALID_ARGUMENT;
   }
 
   RequestContext request_context;
   delete reinterpret_cast<ports::UserMessageEvent*>(message_handle);
 
-  recordreplay::Assert("Core::DestroyMessage Done");
   return MOJO_RESULT_OK;
 }
 
@@ -513,10 +502,6 @@ MojoResult Core::CreateMessagePipe(const MojoCreateMessagePipeOptions* options,
   ports::PortRef port0, port1;
   GetNodeController()->node()->CreatePortPair(&port0, &port1);
 
-  recordreplay::Assert("Core::CreateMessagePipe %lu %lu %lu %lu",
-                       port0.name().v1, port0.name().v2,
-                       port1.name().v1, port1.name().v2);
-
   DCHECK(message_pipe_handle0);
   DCHECK(message_pipe_handle1);
 
@@ -609,9 +594,6 @@ MojoResult Core::FuseMessagePipes(MojoHandle handle0,
       static_cast<MessagePipeDispatcher*>(dispatcher0.get());
   MessagePipeDispatcher* mpd1 =
       static_cast<MessagePipeDispatcher*>(dispatcher1.get());
-
-  recordreplay::Assert("Core::FuseMessagePipes %lu %lu",
-                       recordreplay::PointerId(mpd0), recordreplay::PointerId(mpd1));
 
   if (!mpd0->Fuse(mpd1))
     return MOJO_RESULT_FAILED_PRECONDITION;
@@ -1238,8 +1220,6 @@ MojoResult Core::ExtractMessagePipeFromInvitation(
     uint32_t name_num_bytes,
     const MojoExtractMessagePipeFromInvitationOptions* options,
     MojoHandle* message_pipe_handle) {
-  recordreplay::Assert("Core::ExtractMessagePipeFromInvitation Start");
-
   if (options && options->struct_size < sizeof(*options))
     return MOJO_RESULT_INVALID_ARGUMENT;
   if (!message_pipe_handle)

--- a/mojo/core/handle_table.cc
+++ b/mojo/core/handle_table.cc
@@ -89,13 +89,10 @@ bool HandleTable::AddDispatchersFromTransit(
 }
 
 scoped_refptr<Dispatcher> HandleTable::GetDispatcher(MojoHandle handle) const {
-  recordreplay::Assert("HandleTable::GetDispatcher Start %u", handle);
   auto it = handles_.find(handle);
   if (it == handles_.end()) {
-    recordreplay::Assert("HandleTable::GetDispatcher #1");
     return nullptr;
   }
-  recordreplay::Assert("HandleTable::GetDispatcher Done %u", handle);
   return it->second.dispatcher;
 }
 

--- a/mojo/core/message_pipe_dispatcher.cc
+++ b/mojo/core/message_pipe_dispatcher.cc
@@ -102,16 +102,9 @@ MessagePipeDispatcher::MessagePipeDispatcher(NodeController* node_controller,
       port_, base::MakeRefCounted<PortObserverThunk>(this));
 
   recordreplay::RegisterPointer(this);
-  recordreplay::Assert("MessagePipeDispatcher %lu %lu %lu",
-                       recordreplay::PointerId(this),
-                       port_.name().v1, port_.name().v2);
 }
 
 bool MessagePipeDispatcher::Fuse(MessagePipeDispatcher* other) {
-  recordreplay::Assert("MessagePipeDispatcher::Fuse %lu %lu %lu %lu",
-                       port_.name().v1, port_.name().v2,
-                       other->port_.name().v1, other->port_.name().v2);
-
   node_controller_->SetPortObserver(port_, nullptr);
   node_controller_->SetPortObserver(other->port_, nullptr);
 

--- a/mojo/core/node_channel.cc
+++ b/mojo/core/node_channel.cc
@@ -421,7 +421,6 @@ void NodeChannel::AcceptBrokerClient(const ports::NodeName& broker_name,
 
 void NodeChannel::RequestPortMerge(const ports::PortName& connector_port_name,
                                    const std::string& token) {
-  recordreplay::Assert("NodeChannel::RequestPortMerge Start");
   RequestPortMergeData* data;
   Channel::MessagePtr message =
       CreateMessage(MessageType::REQUEST_PORT_MERGE,
@@ -429,7 +428,6 @@ void NodeChannel::RequestPortMerge(const ports::PortName& connector_port_name,
   data->connector_port_name = connector_port_name;
   memcpy(data + 1, token.data(), token.size());
   WriteChannelMessage(std::move(message));
-  recordreplay::Assert("NodeChannel::RequestPortMerge Done");
 }
 
 void NodeChannel::RequestIntroduction(const ports::NodeName& name) {
@@ -458,9 +456,7 @@ void NodeChannel::Introduce(const ports::NodeName& name,
 }
 
 void NodeChannel::SendChannelMessage(Channel::MessagePtr message) {
-  recordreplay::Assert("NodeChannel::SendChannelMessage Start");
   WriteChannelMessage(std::move(message));
-  recordreplay::Assert("NodeChannel::SendChannelMessage Done");
 }
 
 void NodeChannel::Broadcast(Channel::MessagePtr message) {
@@ -574,18 +570,14 @@ void NodeChannel::OnChannelMessage(const void* payload,
                                    std::vector<PlatformHandle> handles) {
   DCHECK(owning_task_runner()->RunsTasksInCurrentSequence());
 
-  recordreplay::Assert("NodeChannel::OnChannelMessage Start");
-
   RequestContext request_context(RequestContext::Source::SYSTEM);
 
   if (payload_size <= sizeof(Header)) {
-    recordreplay::Assert("NodeChannel::OnChannelMessage #1");
     delegate_->OnChannelError(remote_node_name_, this);
     return;
   }
 
   const Header* header = static_cast<const Header*>(payload);
-  recordreplay::Assert("NodeChannel::OnChannelMessage #2 %d", header->type);
   switch (header->type) {
     case MessageType::ACCEPT_INVITEE: {
       AcceptInviteeData data;
@@ -711,7 +703,6 @@ void NodeChannel::OnChannelMessage(const void* payload,
     }
 
     case MessageType::INTRODUCE: {
-      recordreplay::Assert("NodeChannel::OnChannelMessage #3");
       IntroductionData data;
       if (GetMessagePayloadMinimumSized<IntroductionData, IntroductionDataV0>(
               payload, payload_size, &data)) {
@@ -730,7 +721,6 @@ void NodeChannel::OnChannelMessage(const void* payload,
                                std::move(channel_handle), data.capabilities);
         return;
       }
-      recordreplay::Assert("NodeChannel::OnChannelMessage #6");
       break;
     }
 

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -59,8 +59,6 @@ ports::NodeName GetRandomNodeName() {
 }
 
 Channel::MessagePtr SerializeEventMessage(ports::ScopedEvent event) {
-  recordreplay::Assert("SerializeEventMessage Start %d", event->type());
-
   if (event->type() == ports::Event::Type::kUserMessage) {
     // User message events must already be partially serialized.
     return UserMessageImpl::FinalizeEventMessage(
@@ -72,7 +70,6 @@ Channel::MessagePtr SerializeEventMessage(ports::ScopedEvent event) {
   auto message = NodeChannel::CreateEventMessage(size, size, &data, 0);
   event->Serialize(data);
 
-  recordreplay::Assert("SerializeEventMessage Done %lu %lu", size, message->data_num_bytes());
   return message;
 }
 
@@ -277,8 +274,6 @@ int NodeController::SendUserMessage(
 
 void NodeController::MergePortIntoInviter(const std::string& name,
                                           const ports::PortRef& port) {
-  recordreplay::Assert("NodeController::MergePortIntoInviter Start");
-
   scoped_refptr<NodeChannel> inviter;
   bool reject_merge = false;
   {
@@ -288,8 +283,6 @@ void NodeController::MergePortIntoInviter(const std::string& name,
     // |pending_port_merges_|.
     base::AutoLock lock(pending_port_merges_lock_);
     inviter = GetInviterChannel();
-    recordreplay::Assert("NodeController::MergePortIntoInviter #1 %d %d",
-                         reject_pending_merges_, !!inviter);
     if (reject_pending_merges_) {
       reject_merge = true;
     } else if (!inviter) {
@@ -301,13 +294,10 @@ void NodeController::MergePortIntoInviter(const std::string& name,
     node_->ClosePort(port);
     DVLOG(2) << "Rejecting port merge for name " << name
              << " due to closed inviter channel.";
-    recordreplay::Assert("NodeController::MergePortIntoInviter #2");
     return;
   }
 
-  recordreplay::Assert("NodeController::MergePortIntoInviter #3");
   inviter->RequestPortMerge(port.name(), name);
-  recordreplay::Assert("NodeController::MergePortIntoInviter Done");
 }
 
 int NodeController::MergeLocalPorts(const ports::PortRef& port0,
@@ -769,11 +759,6 @@ void NodeController::ForwardEvent(const ports::NodeName& node,
                                   ports::ScopedEvent event) {
   DCHECK(event);
 
-  recordreplay::Assert("NodeController::ForwardEvent %d %lu %lu %lu %lu",
-                       node == name_,
-                       name_.v1, name_.v2,
-                       node.v1, node.v2);
-
   if (node == name_)
     node_->AcceptEvent(std::move(event));
   else
@@ -794,8 +779,6 @@ void NodeController::BroadcastEvent(ports::ScopedEvent event) {
 }
 
 void NodeController::PortStatusChanged(const ports::PortRef& port) {
-  recordreplay::Assert("NodeController::PortStatusChanged Start");
-
   scoped_refptr<ports::UserData> user_data;
   node_->GetUserData(port, &user_data);
 
@@ -806,8 +789,6 @@ void NodeController::PortStatusChanged(const ports::PortRef& port) {
     DVLOG(2) << "Ignoring status change for " << port.name() << " because it "
              << "doesn't have an observer.";
   }
-
-  recordreplay::Assert("NodeController::PortStatusChanged Done");
 }
 
 void NodeController::OnAcceptInvitee(const ports::NodeName& from_node,
@@ -1059,13 +1040,10 @@ void NodeController::OnEventMessage(const ports::NodeName& from_node,
                                     Channel::MessagePtr channel_message) {
   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
 
-  recordreplay::Assert("NodeController::OnEventMessage Start");
-
   auto event = DeserializeEventMessage(from_node, std::move(channel_message));
   if (!event) {
     // We silently ignore unparseable events, as they may come from a process
     // running a newer version of Mojo.
-    recordreplay::Assert("NodeController::OnEventMessage #1");
     DVLOG(1) << "Ignoring invalid or unknown event from " << from_node;
     return;
   }
@@ -1073,8 +1051,6 @@ void NodeController::OnEventMessage(const ports::NodeName& from_node,
   node_->AcceptEvent(std::move(event));
 
   AttemptShutdownIfRequested();
-
-  recordreplay::Assert("NodeController::OnEventMessage Done");
 }
 
 void NodeController::OnRequestPortMerge(

--- a/mojo/core/ports/node.cc
+++ b/mojo/core/ports/node.cc
@@ -99,15 +99,12 @@ bool CanAcceptMoreMessages(const Port* port) {
 
 void GenerateRandomPortName(PortName* name) {
   *name = g_name_generator.Get().GenerateRandomPortName();
-  recordreplay::Assert("GenerateRandomPortName %lu %lu", name->v1, name->v2);
 }
 
 }  // namespace
 
 Node::Node(const NodeName& name, NodeDelegate* delegate)
-    : name_(name), delegate_(this, delegate), ports_lock_("Node.ports_lock_") {
-  recordreplay::Assert("Node::Node %lu %lu", name_.v1, name_.v2);
-}
+    : name_(name), delegate_(this, delegate), ports_lock_("Node.ports_lock_") {}
 
 Node::~Node() {
   if (!ports_.empty())
@@ -209,8 +206,6 @@ int Node::InitializePort(const PortRef& port_ref,
 
 int Node::CreatePortPair(PortRef* port0_ref, PortRef* port1_ref) {
   int rv;
-
-  recordreplay::Assert("Node::CreatePortPair %lu %lu", name_.v1, name_.v2);
 
   rv = CreateUninitializedPort(port0_ref);
   if (rv != OK)
@@ -408,7 +403,6 @@ int Node::GetMessage(const PortRef& port_ref,
 
 int Node::SendUserMessage(const PortRef& port_ref,
                           std::unique_ptr<UserMessageEvent> message) {
-  recordreplay::Assert("Node::SendUserMessage Start");
   int rv = SendUserMessageInternal(port_ref, &message);
   if (rv != OK) {
     // If send failed, close all carried ports. Note that we're careful not to
@@ -423,7 +417,6 @@ int Node::SendUserMessage(const PortRef& port_ref,
         ClosePort(port);
     }
   }
-  recordreplay::Assert("Node::SendUserMessage Done %d", rv);
   return rv;
 }
 
@@ -457,7 +450,6 @@ int Node::SetAcknowledgeRequestInterval(
 }
 
 int Node::AcceptEvent(ScopedEvent event) {
-  recordreplay::Assert("Node::AcceptEvent %d", event->type());
   switch (event->type()) {
     case Event::Type::kUserMessage:
       return OnUserMessage(Event::Cast<UserMessageEvent>(&event));
@@ -627,12 +619,8 @@ int Node::OnUserMessage(std::unique_ptr<UserMessageEvent> message) {
 }
 
 int Node::OnPortAccepted(std::unique_ptr<PortAcceptedEvent> event) {
-  recordreplay::Assert("Node::OnPortAccepted Start %lu %lu",
-                       event->port_name().v1, event->port_name().v2);
-
   PortRef port_ref;
   if (GetPort(event->port_name(), &port_ref) != OK) {
-    recordreplay::Assert("Node::OnPortAccepted UnknownPort");
     return ERROR_PORT_UNKNOWN;
   }
 
@@ -649,8 +637,6 @@ int Node::OnPortAccepted(std::unique_ptr<PortAcceptedEvent> event) {
 }
 
 int Node::OnObserveProxy(std::unique_ptr<ObserveProxyEvent> event) {
-  recordreplay::Assert("Node::OnObserveProxy Start");
-
   if (event->port_name() == kInvalidPortName) {
     // An ObserveProxy with an invalid target port name is a broadcast used to
     // inform ports when their peer (which was itself a proxy) has become
@@ -662,7 +648,6 @@ int Node::OnObserveProxy(std::unique_ptr<ObserveProxyEvent> event) {
     DCHECK_EQ(event->proxy_target_node_name(), kInvalidNodeName);
     DCHECK_EQ(event->proxy_target_port_name(), kInvalidPortName);
     DestroyAllPortsWithPeer(event->proxy_node_name(), event->proxy_port_name());
-    recordreplay::Assert("Node::OnObserveProxy #1");
     return OK;
   }
 
@@ -673,7 +658,6 @@ int Node::OnObserveProxy(std::unique_ptr<ObserveProxyEvent> event) {
   if (GetPort(event->port_name(), &port_ref) != OK) {
     DVLOG(1) << "ObserveProxy: " << event->port_name() << "@" << name_
              << " not found";
-    recordreplay::Assert("Node::OnObserveProxy #2");
     return OK;
   }
 
@@ -735,12 +719,8 @@ int Node::OnObserveProxy(std::unique_ptr<ObserveProxyEvent> event) {
     }
   }
 
-  recordreplay::Assert("Node::OnObserveProxy ForwardEvent #3 %d", !!event_to_forward);
-
   if (event_to_forward) {
-    recordreplay::Assert("Node::OnObserveProxy ForwardEvent #1");
     delegate_->ForwardEvent(event_target_node, std::move(event_to_forward));
-    recordreplay::Assert("Node::OnObserveProxy ForwardEvent #2");
   }
 
   if (peer_changed) {
@@ -752,7 +732,6 @@ int Node::OnObserveProxy(std::unique_ptr<ObserveProxyEvent> event) {
     delegate_->PortStatusChanged(port_ref);
   }
 
-  recordreplay::Assert("Node::OnObserveProxy Done");
   return OK;
 }
 
@@ -1110,33 +1089,16 @@ int Node::SendUserMessageInternal(const PortRef& port_ref,
 int Node::MergePortsInternal(const PortRef& port0_ref,
                              const PortRef& port1_ref,
                              bool allow_close_on_bad_state) {
-  recordreplay::Assert("Node::MergePortsInternal %lu %lu %lu %lu",
-                       port0_ref.name().v1, port0_ref.name().v2,
-                       port1_ref.name().v1, port1_ref.name().v2);
-
   const PortRef* port_refs[2] = {&port0_ref, &port1_ref};
   {
     // Needed to swap peer map entries below.
     PortLocker::AssertNoPortsLockedOnCurrentThread();
     base::ReleasableAutoLock ports_locker(&ports_lock_);
 
-    recordreplay::Assert("Node::MergePortsInternal #0.0 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
-
     base::Optional<PortLocker> locker(base::in_place, port_refs, 2);
 
-    recordreplay::Assert("Node::MergePortsInternal #0.01 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
-
     auto* port0 = locker->GetPort(port0_ref);
-
-    recordreplay::Assert("Node::MergePortsInternal #0.02 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
-
     auto* port1 = locker->GetPort(port1_ref);
-
-    recordreplay::Assert("Node::MergePortsInternal #0.03 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
 
     // There are several conditions which must be met before we'll consider
     // merging two ports:
@@ -1153,7 +1115,6 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
          port1->peer_port_name == port0_ref.name()) ||
         port0->next_sequence_num_to_send != kInitialSequenceNum ||
         port1->next_sequence_num_to_send != kInitialSequenceNum) {
-      recordreplay::Assert("Node::MergePortsInternal #1");
       // On failure, we only close a port if it was at least properly in the
       // |kReceiving| state. This avoids getting the system in an inconsistent
       // state by e.g. closing a proxy abruptly.
@@ -1172,9 +1133,6 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
       return ERROR_PORT_STATE_UNEXPECTED;
     }
 
-    recordreplay::Assert("Node::MergePortsInternal #0.1 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
-
     // Swap the ports' peer information and switch them both to proxying mode.
     SwapPortPeers(port0_ref.name(), port0, port1_ref.name(), port1);
     port0->state = Port::kProxying;
@@ -1183,19 +1141,13 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
       port0->remove_proxy_on_last_message = true;
     if (port1->peer_closed)
       port1->remove_proxy_on_last_message = true;
-
-    recordreplay::Assert("Node::MergePortsInternal #0.2 %lu %lu",
-                          port_refs[0]->name().v1, port_refs[0]->name().v2);
   }
 
   // Flush any queued messages from the new proxies and, if successful, complete
   // the merge by initiating proxy removals.
   if (ForwardUserMessagesFromProxy(port0_ref) == OK &&
       ForwardUserMessagesFromProxy(port1_ref) == OK) {
-    recordreplay::Assert("Node::MergePortsInternal #2");
     for (size_t i = 0; i < 2; ++i) {
-      recordreplay::Assert("Node::MergePortsInternal #2.1 %lu %lu %lu", i,
-                           port_refs[i]->name().v1, port_refs[i]->name().v2);
       bool try_remove_proxy_immediately = false;
       ScopedEvent closure_event;
       NodeName closure_event_target_node;
@@ -1212,7 +1164,6 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
               port->peer_port_name, port->last_sequence_num_to_receive);
         }
       }
-      recordreplay::Assert("Node::MergePortsInternal #3 %d", try_remove_proxy_immediately);
       if (try_remove_proxy_immediately)
         TryRemoveProxy(*port_refs[i]);
       else
@@ -1224,7 +1175,6 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
       }
     }
 
-    recordreplay::Assert("Node::MergePortsInternal Done");
     return OK;
   }
 
@@ -1245,7 +1195,6 @@ int Node::MergePortsInternal(const PortRef& port0_ref,
     port1->state = Port::kReceiving;
   }
 
-  recordreplay::Assert("Node::MergePortsInternal #4");
   ClosePort(port0_ref);
   ClosePort(port1_ref);
   return ERROR_PORT_STATE_UNEXPECTED;
@@ -1461,13 +1410,10 @@ int Node::PrepareToForwardUserMessage(const PortRef& forwarding_port_ref,
 }
 
 int Node::BeginProxying(const PortRef& port_ref) {
-  recordreplay::Assert("Node::BeginProxying Start");
-
   {
     SinglePortLocker locker(&port_ref);
     auto* port = locker.port();
     if (port->state != Port::kBuffering) {
-      recordreplay::Assert("Node::BeginProxying OOPS #1");
       return OOPS(ERROR_PORT_STATE_UNEXPECTED);
     }
     port->state = Port::kProxying;
@@ -1475,7 +1421,6 @@ int Node::BeginProxying(const PortRef& port_ref) {
 
   int rv = ForwardUserMessagesFromProxy(port_ref);
   if (rv != OK) {
-    recordreplay::Assert("Node::BeginProxying #1");
     return rv;
   }
 
@@ -1489,7 +1434,6 @@ int Node::BeginProxying(const PortRef& port_ref) {
     SinglePortLocker locker(&port_ref);
     auto* port = locker.port();
     if (port->state != Port::kProxying) {
-      recordreplay::Assert("Node::BeginProxying OOPS #2");
       return OOPS(ERROR_PORT_STATE_UNEXPECTED);
     }
 
@@ -1509,13 +1453,10 @@ int Node::BeginProxying(const PortRef& port_ref) {
     InitiateProxyRemoval(port_ref);
   }
 
-  recordreplay::Assert("Node::BeginProxying Done");
   return OK;
 }
 
 int Node::ForwardUserMessagesFromProxy(const PortRef& port_ref) {
-  recordreplay::Assert("Node::ForwardUserMessagesFromProxy Start");
-
   for (;;) {
     // NOTE: We forward messages in sequential order here so that we maintain
     // the message queue's notion of next sequence number. That's useful for the
@@ -1525,7 +1466,6 @@ int Node::ForwardUserMessagesFromProxy(const PortRef& port_ref) {
     {
       SinglePortLocker locker(&port_ref);
       locker.port()->message_queue.GetNextMessage(&message, nullptr);
-      recordreplay::Assert("Node::ForwardUserMessagesFromProxy #1 %d", !!message);
       if (!message)
         break;
     }
@@ -1535,20 +1475,15 @@ int Node::ForwardUserMessagesFromProxy(const PortRef& port_ref) {
                                          true /* ignore_closed_peer */,
                                          message.get(), &target_node);
     if (rv != OK) {
-      recordreplay::Assert("Node::ForwardUserMessagesFromProxy #2");
       return rv;
     }
 
     delegate_->ForwardEvent(target_node, std::move(message));
   }
-  recordreplay::Assert("Node::ForwardUserMessagesFromProxy Done");
   return OK;
 }
 
 void Node::InitiateProxyRemoval(const PortRef& port_ref) {
-  recordreplay::Assert("Node::InitiateProxyRemoval Start %lu %lu",
-                       port_ref.name().v1, port_ref.name().v2);
-
   NodeName peer_node_name;
   PortName peer_port_name;
   {
@@ -1566,8 +1501,6 @@ void Node::InitiateProxyRemoval(const PortRef& port_ref) {
                           std::make_unique<ObserveProxyEvent>(
                               peer_port_name, name_, port_ref.name(),
                               peer_node_name, peer_port_name));
-
-  recordreplay::Assert("Node::InitiateProxyRemoval Done");
 }
 
 void Node::TryRemoveProxy(const PortRef& port_ref) {

--- a/mojo/core/request_context.cc
+++ b/mojo/core/request_context.cc
@@ -30,11 +30,7 @@ RequestContext::RequestContext(Source source)
 }
 
 RequestContext::~RequestContext() {
-  recordreplay::Assert("RequestContext::~RequestContext Start");
-
   if (IsCurrent()) {
-    recordreplay::Assert("RequestContext::~RequestContext #1");
-
     // NOTE: Callbacks invoked by this destructor are allowed to initiate new
     // EDK requests on this thread, so we need to reset the thread-local context
     // pointer before calling them. We persist the original notification source
@@ -68,25 +64,19 @@ RequestContext::~RequestContext() {
       // treating all nested trap events as if they originated from a local API
       // call even if this is a system RequestContext.
       RequestContext inner_context(Source::LOCAL_API_CALL);
-      recordreplay::Assert("RequestContext::~RequestContext #2");
       watch->InvokeCallback(MOJO_RESULT_CANCELLED, closed_state, flags);
-      recordreplay::Assert("RequestContext::~RequestContext #3");
     }
 
     for (const WatchNotifyFinalizer& watch :
          watch_notify_finalizers_.container()) {
       RequestContext inner_context(source_);
-      recordreplay::Assert("RequestContext::~RequestContext #4");
       watch.watch->InvokeCallback(watch.result, watch.state, flags);
-      recordreplay::Assert("RequestContext::~RequestContext #5");
     }
   } else {
     // It should be impossible for nested contexts to have finalizers.
     DCHECK(watch_notify_finalizers_.container().empty());
     DCHECK(watch_cancel_finalizers_.container().empty());
   }
-
-  recordreplay::Assert("RequestContext::~RequestContext Done");
 }
 
 // static
@@ -98,7 +88,6 @@ RequestContext* RequestContext::current() {
 void RequestContext::AddWatchNotifyFinalizer(scoped_refptr<Watch> watch,
                                              MojoResult result,
                                              const HandleSignalsState& state) {
-  recordreplay::Assert("RequestContext::AddWatchNotifyFinalizer");
   DCHECK(IsCurrent());
   watch_notify_finalizers_->push_back(
       WatchNotifyFinalizer(std::move(watch), result, state));

--- a/mojo/core/user_message_impl.cc
+++ b/mojo/core/user_message_impl.cc
@@ -406,8 +406,6 @@ Channel::MessagePtr UserMessageImpl::FinalizeEventMessage(
   auto* message = message_event->GetMessage<UserMessageImpl>();
   DCHECK(message->IsSerialized());
 
-  recordreplay::Assert("UserMessageImpl::FinalizeEventMessage %lu", message->user_payload_size());
-
   if (!message->is_committed_)
     return nullptr;
 
@@ -695,7 +693,6 @@ UserMessageImpl::UserMessageImpl(ports::UserMessageEvent* message_event,
       header_size_(header_size),
       user_payload_(user_payload),
       user_payload_size_(user_payload_size) {
-  recordreplay::Assert("UserMessageImpl::UserMessageImpl %lu", user_payload_size_);
   EnsureMemoryDumpProviderExists();
   IncrementMessageCount();
 }

--- a/mojo/core/watch.cc
+++ b/mojo/core/watch.cc
@@ -30,8 +30,6 @@ bool Watch::NotifyState(const HandleSignalsState& state,
                         bool allowed_to_call_callback) {
   AssertWatcherLockAcquired();
 
-  recordreplay::Assert("Watch::NotifyState %lu %d", recordreplay::PointerId(this), allowed_to_call_callback);
-
   // NOTE: This method must NEVER call into |dispatcher_| directly, because it
   // may be called while |dispatcher_| holds a lock.
   MojoResult rv = MOJO_RESULT_SHOULD_WAIT;
@@ -43,8 +41,6 @@ bool Watch::NotifyState(const HandleSignalsState& state,
        condition_ == MOJO_TRIGGER_CONDITION_SIGNALS_UNSATISFIED);
   if (notify_success) {
     rv = MOJO_RESULT_OK;
-    recordreplay::Assert("Watch::NotifyState #0 %d %d",
-                         allowed_to_call_callback, last_known_result_);
     if (allowed_to_call_callback && rv != last_known_result_) {
       request_context->AddWatchNotifyFinalizer(this, MOJO_RESULT_OK, state);
     }
@@ -52,7 +48,6 @@ bool Watch::NotifyState(const HandleSignalsState& state,
              !state.can_satisfy_any(signals_)) {
     rv = MOJO_RESULT_FAILED_PRECONDITION;
     if (allowed_to_call_callback && rv != last_known_result_) {
-      recordreplay::Assert("Watch::NotifyState #1 %lu", recordreplay::PointerId(this));
       request_context->AddWatchNotifyFinalizer(
           this, MOJO_RESULT_FAILED_PRECONDITION, state);
     }
@@ -65,7 +60,6 @@ bool Watch::NotifyState(const HandleSignalsState& state,
 }
 
 void Watch::Cancel() {
-  recordreplay::Assert("Watch::Cancel %lu", recordreplay::PointerId(this));
   RequestContext::current()->AddWatchCancelFinalizer(this);
 }
 

--- a/mojo/core/watcher_dispatcher.cc
+++ b/mojo/core/watcher_dispatcher.cc
@@ -26,7 +26,6 @@ WatcherDispatcher::WatcherDispatcher(MojoTrapEventHandler handler)
 
 void WatcherDispatcher::NotifyHandleState(Dispatcher* dispatcher,
                                           const HandleSignalsState& state) {
-  recordreplay::Assert("WatcherDispatcher::NotifyHandleState %lu", recordreplay::PointerId(this));
   base::AutoLock lock(lock_);
   auto it = watched_handles_.find(dispatcher);
   if (it == watched_handles_.end())
@@ -72,8 +71,6 @@ void WatcherDispatcher::InvokeWatchCallback(uintptr_t context,
                                             MojoResult result,
                                             const HandleSignalsState& state,
                                             MojoTrapEventFlags flags) {
-  recordreplay::Assert("WatcherDispatcher::InvokeWatchCallback Start");
-
   MojoTrapEvent event;
   event.struct_size = sizeof(event);
   event.trigger_context = context;
@@ -96,14 +93,11 @@ void WatcherDispatcher::InvokeWatchCallback(uintptr_t context,
     // state management possible in user code.
     base::AutoLock lock(lock_);
     if (closed_ && result != MOJO_RESULT_CANCELLED) {
-      recordreplay::Assert("WatcherDispatcher::InvokeWatchCallback #1");
       return;
     }
   }
 
   handler_(&event);
-
-  recordreplay::Assert("WatcherDispatcher::InvokeWatchCallback Done");
 }
 
 Dispatcher::Type WatcherDispatcher::GetType() const {
@@ -222,26 +216,21 @@ MojoResult WatcherDispatcher::CancelWatch(uintptr_t context) {
 
 MojoResult WatcherDispatcher::Arm(uint32_t* num_blocking_events,
                                   MojoTrapEvent* blocking_events) {
-  recordreplay::Assert("WatcherDispatcher::Arm Start");
   base::AutoLock lock(lock_);
   if (num_blocking_events && !blocking_events) {
-    recordreplay::Assert("WatcherDispatcher::Arm #1");
     return MOJO_RESULT_INVALID_ARGUMENT;
   }
   if (closed_) {
-    recordreplay::Assert("WatcherDispatcher::Arm #2");
     return MOJO_RESULT_INVALID_ARGUMENT;
   }
 
   if (watched_handles_.empty()) {
-    recordreplay::Assert("WatcherDispatcher::Arm #3");
     return MOJO_RESULT_NOT_FOUND;
   }
 
   if (ready_watches_.empty()) {
     // Fast path: No watches are ready to notify, so we're done.
     armed_ = true;
-    recordreplay::Assert("WatcherDispatcher::Arm #4");
     return MOJO_RESULT_OK;
   }
 
@@ -295,7 +284,6 @@ MojoResult WatcherDispatcher::Arm(uint32_t* num_blocking_events,
     }
   }
 
-  recordreplay::Assert("WatcherDispatcher::Arm Done");
   return MOJO_RESULT_FAILED_PRECONDITION;
 }
 

--- a/mojo/core/watcher_set.cc
+++ b/mojo/core/watcher_set.cc
@@ -19,20 +19,13 @@ WatcherSet::~WatcherSet() {
 
 void WatcherSet::NotifyState(const HandleSignalsState& state) {
   // Avoid notifying watchers if they have already seen this state.
-  recordreplay::Assert("WatcherSet::NotifyState Start %lu %u %u",
-                       recordreplay::PointerId(this),
-                       state.satisfied_signals, state.satisfiable_signals);
   if (last_known_state_.has_value() && state.equals(last_known_state_.value())) {
-    recordreplay::Assert("WatcherSet::NotifyState #1");
     return;
   }
-  recordreplay::Assert("WatcherSet::NotifyState #2");
   last_known_state_ = state;
   for (const auto& entry : watchers_) {
-    recordreplay::Assert("WatcherSet::NotifyState #3");
     entry.first->NotifyHandleState(owner_, state);
   }
-  recordreplay::Assert("WatcherSet::NotifyState Done");
 }
 
 void WatcherSet::NotifyClosed() {
@@ -43,10 +36,6 @@ void WatcherSet::NotifyClosed() {
 MojoResult WatcherSet::Add(const scoped_refptr<WatcherDispatcher>& watcher,
                            uintptr_t context,
                            const HandleSignalsState& current_state) {
-  recordreplay::Assert("WatcherSet::Add Start %lu %u %u",
-                       recordreplay::PointerId(this),
-                       current_state.satisfied_signals, current_state.satisfiable_signals);
-
   auto it = watchers_.find(watcher.get());
   if (it == watchers_.end()) {
     auto result =
@@ -70,10 +59,6 @@ MojoResult WatcherSet::Add(const scoped_refptr<WatcherDispatcher>& watcher,
 }
 
 MojoResult WatcherSet::Remove(WatcherDispatcher* watcher, uintptr_t context) {
-  recordreplay::Assert("WatcherSet::Remove Start %lu %lu",
-                       recordreplay::PointerId(this),
-                       recordreplay::PointerId(watcher));
-
   auto it = watchers_.find(watcher);
   if (it == watchers_.end())
     return MOJO_RESULT_NOT_FOUND;

--- a/mojo/public/cpp/bindings/lib/buffer.cc
+++ b/mojo/public/cpp/bindings/lib/buffer.cc
@@ -52,6 +52,8 @@ Buffer& Buffer::operator=(Buffer&& other) {
 }
 
 size_t Buffer::Allocate(size_t num_bytes) {
+  // Make sure that mojo buffers have the same size when replaying, as sending
+  // different messages can cause behavior to diverge in more complex ways later on.
   recordreplay::Assert("Buffer::Allocate %lu", num_bytes);
 
   const size_t aligned_num_bytes = Align(num_bytes);

--- a/mojo/public/cpp/bindings/lib/connector.cc
+++ b/mojo/public/cpp/bindings/lib/connector.cc
@@ -222,8 +222,6 @@ ScopedMessagePipeHandle Connector::PassMessagePipe() {
 }
 
 void Connector::RaiseError() {
-  recordreplay::Assert("Connector::RaiseError");
-
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   HandleError(true, true);
@@ -238,8 +236,6 @@ void Connector::SetConnectionGroup(ConnectionGroup::Ref ref) {
 }
 
 bool Connector::WaitForIncomingMessage() {
-  recordreplay::Assert("Connector::WaitForIncomingMessage Start");
-
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   if (error_)
@@ -394,9 +390,6 @@ void Connector::OnSyncHandleWatcherHandleReady(MojoResult result) {
 }
 
 void Connector::OnHandleReadyInternal(MojoResult result) {
-  recordreplay::Assert("Connector::OnHandleReadyInternal Start %lu %u",
-                       recordreplay::PointerId(this), result);
-
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   if (result == MOJO_RESULT_FAILED_PRECONDITION) {
@@ -483,8 +476,6 @@ MojoResult Connector::ReadMessage(Message* message) {
 }
 
 bool Connector::DispatchMessage(Message message) {
-  recordreplay::Assert("Connector::DispatchMessage Start");
-
   DCHECK(!paused_);
 
   base::WeakPtr<Connector> weak_self = weak_self_;
@@ -563,28 +554,20 @@ void Connector::ScheduleDispatchOfPendingMessagesOrWaitForMore(
 }
 
 void Connector::ReadAllAvailableMessages() {
-  recordreplay::Assert("Connector::ReadAllAvailableMessages Start");
-
   if (paused_ || error_) {
-    recordreplay::Assert("Connector::ReadAllAvailableMessages #1");
     return;
   }
 
   base::WeakPtr<Connector> weak_self = weak_self_;
 
   do {
-    recordreplay::Assert("Connector::ReadAllAvailableMessages #2");
-
     Message message;
     MojoResult rv = ReadMessage(&message);
-
-    recordreplay::Assert("Connector::ReadAllAvailableMessages #3 %d", rv);
 
     switch (rv) {
       case MOJO_RESULT_OK:
         DCHECK(!message.IsNull());
         if (!DispatchMessage(std::move(message)) || !weak_self || paused_) {
-          recordreplay::Assert("Connector::ReadAllAvailableMessages #4");
           return;
         }
         break;
@@ -608,32 +591,22 @@ void Connector::ReadAllAvailableMessages() {
                     false /* force_async_handler */);
         return;
     }
-
-    recordreplay::Assert("Connector::ReadAllAvailableMessages #5");
   } while (weak_self && should_dispatch_messages_immediately());
-
-  recordreplay::Assert("Connector::ReadAllAvailableMessages #6 %d", !!weak_self);
 
   if (weak_self) {
     const auto pending_message_count = QueryPendingMessageCount();
     ScheduleDispatchOfPendingMessagesOrWaitForMore(pending_message_count);
   }
-
-  recordreplay::Assert("Connector::ReadAllAvailableMessages Done");
 }
 
 void Connector::CancelWait() {
-  recordreplay::Assert("Connector::CancelWait %lu", recordreplay::PointerId(this));
   peer_remoteness_tracker_.reset();
   handle_watcher_.reset();
   sync_watcher_.reset();
 }
 
 void Connector::HandleError(bool force_pipe_reset, bool force_async_handler) {
-  recordreplay::Assert("Connector::HandleError Start");
-
   if (error_ || !message_pipe_.is_valid()) {
-    recordreplay::Assert("Connector::HandleError #1");
     return;
   }
 
@@ -648,19 +621,14 @@ void Connector::HandleError(bool force_pipe_reset, bool force_async_handler) {
     force_pipe_reset = true;
 
   if (force_pipe_reset) {
-    recordreplay::Assert("Connector::HandleError #2");
     CancelWait();
-    recordreplay::Assert("Connector::HandleError #3");
     internal::MayAutoLock locker(&lock_);
     message_pipe_.reset();
     MessagePipe dummy_pipe;
     message_pipe_ = std::move(dummy_pipe.handle0);
   } else {
-    recordreplay::Assert("Connector::HandleError #4");
     CancelWait();
   }
-
-  recordreplay::Assert("Connector::HandleError #5");
 
   if (force_async_handler) {
     if (!paused_)
@@ -670,8 +638,6 @@ void Connector::HandleError(bool force_pipe_reset, bool force_async_handler) {
     if (connection_error_handler_)
       std::move(connection_error_handler_).Run();
   }
-
-  recordreplay::Assert("Connector::HandleError Done");
 }
 
 void Connector::EnsureSyncWatcherExists() {

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -241,7 +241,6 @@ void InterfaceEndpointClient::SendControlMessageWithResponder(
 }
 
 bool InterfaceEndpointClient::Accept(Message* message) {
-  recordreplay::Assert("InterfaceEndpointClient::Accept %lu", recordreplay::PointerId(this));
   return SendMessage(message, false /* is_control_message */);
 }
 
@@ -504,9 +503,6 @@ void InterfaceEndpointClient::OnAssociationEvent(
 bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
   DCHECK_EQ(handle_.id(), message->interface_id());
 
-  recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage Start %lu",
-                       recordreplay::PointerId(this));
-
   if (encountered_error_) {
     // This message is received after error has been encountered. For associated
     // interfaces, this means the remote side sends a
@@ -514,7 +510,6 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
     // for the same interface. Close the pipe because this shouldn't happen.
     DVLOG(1) << "A message is received for an interface after it has been "
              << "disconnected. Closing the pipe.";
-    recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #1");
     return false;
   }
 
@@ -526,10 +521,8 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
     auto responder = std::make_unique<ResponderThunk>(
         weak_ptr_factory_.GetWeakPtr(), task_runner_);
     if (mojo::internal::ControlMessageHandler::IsControlMessage(message)) {
-      bool rv = control_message_handler_.AcceptWithResponder(message,
-                                                             std::move(responder));
-      recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #2 %d", rv);
-      return rv;
+      return control_message_handler_.AcceptWithResponder(message,
+                                                          std::move(responder));
     } else {
       if (idle_tracking_connection_group_)
         responder->set_connection_group(idle_tracking_connection_group_);
@@ -543,18 +536,15 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
         !force_outgoing_messages_async_) {
       auto it = sync_responses_.find(request_id);
       if (it == sync_responses_.end()) {
-        recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #3");
         return false;
       }
       it->second->response = std::move(*message);
       *it->second->response_received = true;
-      recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #4");
       return true;
     }
 
     auto it = async_responders_.find(request_id);
     if (it == async_responders_.end()) {
-      recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #5");
       return false;
     }
     std::unique_ptr<MessageReceiver> responder = std::move(it->second);
@@ -564,9 +554,7 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
     return responder->Accept(message);
   } else {
     if (mojo::internal::ControlMessageHandler::IsControlMessage(message)) {
-      bool rv = control_message_handler_.Accept(message);
-      recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage #7 %d", rv);
-      return rv;
+      return control_message_handler_.Accept(message);
     }
 
     accepted_interface_message = incoming_receiver_->Accept(message);
@@ -579,8 +567,6 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
       MaybeStartIdleTimer();
   }
 
-  recordreplay::Assert("InterfaceEndpointClient::HandleValidatedMessage Done %d",
-                       accepted_interface_message);
   return accepted_interface_message;
 }
 

--- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
+++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
@@ -369,7 +369,6 @@ MultiplexRouter::MultiplexRouter(
 }
 
 MultiplexRouter::~MultiplexRouter() {
-  recordreplay::Assert("MultiplexRouter::~MultiplexRouter Start %lu", recordreplay::PointerId(this));
   recordreplay::UnregisterPointer(this);
 
   MayAutoLock locker(&lock_);
@@ -379,7 +378,6 @@ MultiplexRouter::~MultiplexRouter() {
   sync_message_tasks_.clear();
   tasks_.clear();
   endpoints_.clear();
-  recordreplay::Assert("MultiplexRouter::~MultiplexRouter Done");
 }
 
 void MultiplexRouter::SetIncomingMessageFilter(
@@ -899,8 +897,6 @@ bool MultiplexRouter::ProcessIncomingMessage(
     MessageWrapper* message_wrapper,
     ClientCallBehavior client_call_behavior,
     base::SequencedTaskRunner* current_task_runner) {
-  recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage Start");
-
   DCHECK(!current_task_runner ||
          current_task_runner->RunsTasksInCurrentSequence());
   DCHECK(!paused_);
@@ -911,7 +907,6 @@ bool MultiplexRouter::ProcessIncomingMessage(
   if (message->IsNull()) {
     // This is a sync message and has been processed during sync handle
     // watching.
-    recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage #1");
     return true;
   }
 
@@ -929,7 +924,6 @@ bool MultiplexRouter::ProcessIncomingMessage(
     if (!result)
       RaiseErrorInNonTestingMode();
 
-    recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage #2");
     return true;
   }
 
@@ -938,14 +932,12 @@ bool MultiplexRouter::ProcessIncomingMessage(
 
   InterfaceEndpoint* endpoint = FindEndpoint(id);
   if (!endpoint || endpoint->closed()) {
-    recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage #3");
     return true;
   }
 
   if (!endpoint->client()) {
     // We need to wait until a client is attached in order to dispatch further
     // messages.
-    recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage #4");
     return false;
   }
 
@@ -960,7 +952,6 @@ bool MultiplexRouter::ProcessIncomingMessage(
 
   if (!can_direct_call) {
     MaybePostToProcessTasks(endpoint->task_runner());
-    recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage #5");
     return false;
   }
 
@@ -983,7 +974,6 @@ bool MultiplexRouter::ProcessIncomingMessage(
   if (!result)
     RaiseErrorInNonTestingMode();
 
-  recordreplay::Assert("MultiplexRouter::ProcessIncomingMessage Done");
   return true;
 }
 

--- a/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
+++ b/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
@@ -181,8 +181,6 @@ class ScopedInterfaceEndpointHandle::State
     {
       internal::MayAutoLock locker(&lock_);
 
-      recordreplay::Assert("ScopedInterfaceEndpointHandle Start");
-
       // There may be race between Close() of endpoint A and
       // NotifyPeerAssociation() of endpoint A_peer on different sequences.
       // Therefore, it is possible that endpoint A has been closed but it
@@ -196,28 +194,20 @@ class ScopedInterfaceEndpointHandle::State
       group_controller_ = std::move(group_controller);
 
       if (!association_event_handler_.is_null()) {
-        recordreplay::Assert("ScopedInterfaceEndpointHandle #1");
         if (runner_->RunsTasksInCurrentSequence()) {
-          recordreplay::Assert("ScopedInterfaceEndpointHandle #1.1");
           handler = std::move(association_event_handler_);
           runner_ = nullptr;
         } else {
-          recordreplay::Assert("ScopedInterfaceEndpointHandle #2");
           runner_->PostTask(
               FROM_HERE, base::BindOnce(&ScopedInterfaceEndpointHandle::State::
                                             RunAssociationEventHandler,
                                         this, runner_, ASSOCIATED));
-          recordreplay::Assert("ScopedInterfaceEndpointHandle #3");
         }
       }
     }
 
-    recordreplay::Assert("ScopedInterfaceEndpointHandle #4");
-
     if (!handler.is_null())
       std::move(handler).Run(ASSOCIATED);
-
-    recordreplay::Assert("ScopedInterfaceEndpointHandle Done");
   }
 
   // Called by the peer, maybe from a different sequence.

--- a/mojo/public/cpp/bindings/lib/sequence_local_sync_event_watcher.cc
+++ b/mojo/public/cpp/bindings/lib/sequence_local_sync_event_watcher.cc
@@ -204,7 +204,6 @@ class SequenceLocalSyncEventWatcher::SequenceLocalState {
 };
 
 void SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled() {
-  recordreplay::Assert("SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled Start");
   for (;;) {
     base::flat_set<const SequenceLocalSyncEventWatcher*> ready_watchers;
     {
@@ -213,7 +212,6 @@ void SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled() {
     }
     if (ready_watchers.empty()) {
       event_.Reset();
-      recordreplay::Assert("SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled #1");
       return;
     }
 
@@ -224,7 +222,6 @@ void SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled() {
 
         // The callback may have deleted |this|.
         if (!weak_self) {
-          recordreplay::Assert("SequenceLocalSyncEventWatcher::SequenceLocalState::OnEventSignaled #2");
           return;
         }
       }

--- a/mojo/public/cpp/bindings/lib/string_serialization.h
+++ b/mojo/public/cpp/bindings/lib/string_serialization.h
@@ -27,14 +27,11 @@ struct Serializer<StringDataView, MaybeConstUserType> {
 
   static void Serialize(MaybeConstUserType& input,
                         MessageFragment<String_Data>& fragment) {
-    recordreplay::Assert("Serializer<StringDataView>::Serialize Start");
     if (CallIsNullIfExists<Traits>(input)) {
-      recordreplay::Assert("Serializer<StringDataView>::Serialize #1");
       return;
     }
 
     auto r = Traits::GetUTF8(input);
-    recordreplay::Assert("Serializer<StringDataView>::Serialize #2 %lu", r.size());
     fragment.AllocateArrayData(r.size());
     memcpy(fragment->storage(), r.data(), r.size());
   }

--- a/mojo/public/cpp/bindings/lib/sync_event_watcher.cc
+++ b/mojo/public/cpp/bindings/lib/sync_event_watcher.cc
@@ -31,8 +31,6 @@ void SyncEventWatcher::AllowWokenUpBySyncWatchOnSameThread() {
 
 bool SyncEventWatcher::SyncWatch(const bool** stop_flags,
                                  size_t num_stop_flags) {
-  recordreplay::Assert("SyncEventWatcher::SyncWatch Start");
-
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   IncrementRegisterCount();
 
@@ -50,13 +48,10 @@ bool SyncEventWatcher::SyncWatch(const bool** stop_flags,
 
   // This object has been destroyed.
   if (destroyed->data) {
-    recordreplay::Assert("SyncEventWatcher::SyncWatch #1");
     return false;
   }
 
   DecrementRegisterCount();
-
-  recordreplay::Assert("SyncEventWatcher::SyncWatch Done %d", result);
   return result;
 }
 

--- a/mojo/public/cpp/bindings/lib/sync_handle_registry.cc
+++ b/mojo/public/cpp/bindings/lib/sync_handle_registry.cc
@@ -117,7 +117,6 @@ SyncHandleRegistry::EventCallbackSubscription SyncHandleRegistry::RegisterEvent(
 }
 
 bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
-  recordreplay::Assert("SyncHandleRegistry::Wait Start %lu", recordreplay::PointerId(this));
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   size_t num_ready_handles;
@@ -126,13 +125,10 @@ bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
 
   scoped_refptr<SyncHandleRegistry> preserver(this);
   while (true) {
-    recordreplay::Assert("SyncHandleRegistry::Wait #1");
     V8RecordReplayMaybeTerminate(nullptr, nullptr);
 
     for (size_t i = 0; i < count; ++i) {
-      recordreplay::Assert("SyncHandleRegistry::Wait #2");
       if (*should_stop[i]) {
-        recordreplay::Assert("SyncHandleRegistry::Wait #3");
         return true;
       }
     }
@@ -143,16 +139,11 @@ bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
     num_ready_handles = 1;
     wait_set_.Wait(&ready_event, &num_ready_handles, &ready_handle,
                    &ready_handle_result);
-    recordreplay::Assert("SyncHandleRegistry::Wait #3.1 %lu", num_ready_handles);
     if (num_ready_handles) {
       DCHECK_EQ(1u, num_ready_handles);
       const auto iter = handles_.find(ready_handle);
-      recordreplay::Assert("SyncHandleRegistry::Wait #3.2 %u", ready_handle.value());
       iter->second.Run(ready_handle_result);
-      recordreplay::Assert("SyncHandleRegistry::Wait #3.3");
     }
-
-    recordreplay::Assert("SyncHandleRegistry::Wait #4 %lu", recordreplay::PointerId(ready_event));
 
     if (ready_event) {
       const auto iter = events_.find(ready_event);
@@ -160,9 +151,7 @@ bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
 
       {
         base::AutoReset<bool> in_nested_wait(&in_nested_wait_, true);
-        recordreplay::Assert("SyncHandleRegistry::Wait #4.1");
         iter->second->Notify();
-        recordreplay::Assert("SyncHandleRegistry::Wait #4.2");
       }
 
       // Notify() above may have both added and removed event registrations, for

--- a/mojo/public/cpp/system/handle_signal_tracker.cc
+++ b/mojo/public/cpp/system/handle_signal_tracker.cc
@@ -67,14 +67,10 @@ void HandleSignalTracker::Arm() {
 
 void HandleSignalTracker::OnNotify(MojoResult result,
                                    const HandleSignalsState& state) {
-  recordreplay::Assert("HandleSignalTracker::OnNotify Start");
-
   last_known_state_ = state;
   Arm();
   if (notification_callback_)
     notification_callback_.Run(state);
-
-  recordreplay::Assert("HandleSignalTracker::OnNotify Done");
 }
 
 }  // namespace mojo

--- a/mojo/public/cpp/system/wait_set.cc
+++ b/mojo/public/cpp/system/wait_set.cc
@@ -94,8 +94,6 @@ class WaitSet::State : public base::RefCountedThreadSafe<State> {
   }
 
   MojoResult RemoveHandle(Handle handle) {
-    recordreplay::Assert("WaitSet::State::RemoveHandle %u", handle.value());
-
     DCHECK(trap_handle_.is_valid());
 
     scoped_refptr<Context> context;
@@ -116,7 +114,6 @@ class WaitSet::State : public base::RefCountedThreadSafe<State> {
       // Ensure that we never return this handle as a ready result again. Note
       // that it's removal from |handle_to_context_| above ensures it will never
       // be added back to this map.
-      recordreplay::Assert("WaitSet::State::RemoveHandle #1");
       ready_handles_.erase(handle);
     }
 
@@ -215,7 +212,6 @@ class WaitSet::State : public base::RefCountedThreadSafe<State> {
 
     size_t index = base::WaitableEvent::WaitMany(events.container().data(),
                                                  events.container().size());
-    recordreplay::Assert("WaitSet::State::Wait #9 %lu", index);
     base::AutoLock lock(lock_);
 
     // Pop as many handles as we can out of the ready set and return them. Note
@@ -229,17 +225,14 @@ class WaitSet::State : public base::RefCountedThreadSafe<State> {
       if (signals_states)
         signals_states[i] = it->second.signals_state;
       ready_handles_.erase(it);
-      recordreplay::Assert("WaitSet::State::Wait #10 %u %u", ready_handles[i].value(), ready_results[i]);
     }
 
     // If the caller cares, let them know which user event unblocked us, if any.
     if (ready_event) {
       if (events.container()[index] == &handle_event_) {
-        recordreplay::Assert("WaitSet::State::Wait #11");
         *ready_event = nullptr;
       } else {
         *ready_event = events.container()[index];
-        recordreplay::Assert("WaitSet::State::Wait #12 %lu", recordreplay::PointerId(*ready_event));
       }
     }
   }
@@ -284,15 +277,11 @@ class WaitSet::State : public base::RefCountedThreadSafe<State> {
               MojoResult result,
               MojoHandleSignalsState signals_state,
               Context* context) {
-    recordreplay::Assert("WaitSet::State::Notify %u %u %u",
-                         handle.value(), result, signals_state);
-
     base::AutoLock lock(lock_);
 
     // This notification may have raced with RemoveHandle() from another
     // sequence. We only signal the WaitSet if that's not the case.
     if (handle_to_context_.count(handle)) {
-      recordreplay::Assert("WaitSet::State::Notify #1");
       ready_handles_[handle] = {result, signals_state};
       handle_event_.Signal();
     }

--- a/net/http/http_response_headers.cc
+++ b/net/http/http_response_headers.cc
@@ -730,9 +730,6 @@ void HttpResponseHeaders::ParseStatusLine(
   response_code_ = recordreplay::RecordReplayValue("HttpResponseHeaders::ParseStatusLine response code",
                                                    response_code_);
 
-  recordreplay::Assert("HttpResponseHeaders::ParseStatusLine #5 %s %d",
-                       base::MakeStringPiece(code, p).as_string().c_str(), response_code_);
-
   // Skip whitespace.
   while (p < line_end && *p == ' ')
     ++p;

--- a/services/metrics/public/cpp/mojo_ukm_recorder.cc
+++ b/services/metrics/public/cpp/mojo_ukm_recorder.cc
@@ -37,13 +37,7 @@ void MojoUkmRecorder::RecordNavigation(
 }
 
 void MojoUkmRecorder::AddEntry(mojom::UkmEntryPtr entry) {
-  // https://github.com/RecordReplay/backend/issues/5663
-  recordreplay::Assert("MojoUkmRecorder::AddEntry Start");
-
   interface_->AddEntry(std::move(entry));
-
-  // https://github.com/RecordReplay/backend/issues/5663
-  recordreplay::Assert("MojoUkmRecorder::AddEntry Done");
 }
 
 void MojoUkmRecorder::MarkSourceForDeletion(ukm::SourceId source_id) {

--- a/services/metrics/ukm_recorder_interface.cc
+++ b/services/metrics/ukm_recorder_interface.cc
@@ -32,7 +32,6 @@ void UkmRecorderInterface::Create(
 }
 
 void UkmRecorderInterface::AddEntry(ukm::mojom::UkmEntryPtr ukm_entry) {
-  recordreplay::Assert("UkmRecorderInterface::AddEntry %lu", recordreplay::PointerId(this));
   ukm_recorder_->AddEntry(std::move(ukm_entry));
 }
 

--- a/services/network/proxy_config_service_mojo.cc
+++ b/services/network/proxy_config_service_mojo.cc
@@ -53,8 +53,6 @@ void ProxyConfigServiceMojo::OnProxyConfigUpdated(
 
 void ProxyConfigServiceMojo::FlushProxyConfig(
     FlushProxyConfigCallback callback) {
-  recordreplay::Assert("ProxyConfigServiceMojo::FlushProxyConfig %lu",
-                       recordreplay::PointerId(this));
   std::move(callback).Run();
 }
 

--- a/services/network/restricted_cookie_manager.cc
+++ b/services/network/restricted_cookie_manager.cc
@@ -569,11 +569,9 @@ void RestrictedCookieManager::CookiesEnabledFor(
 }
 
 void RestrictedCookieManager::RemoveChangeListener(Listener* listener) {
-  recordreplay::Assert("RestrictedCookieManager::RemoveChangeListener Start");
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   listener->RemoveFromList();
   delete listener;
-  recordreplay::Assert("RestrictedCookieManager::RemoveChangeListener Done");
 }
 
 bool RestrictedCookieManager::ValidateAccessToCookiesAt(

--- a/third_party/blink/common/associated_interfaces/associated_interface_registry.cc
+++ b/third_party/blink/common/associated_interfaces/associated_interface_registry.cc
@@ -25,14 +25,11 @@ void AssociatedInterfaceRegistry::RemoveInterface(const std::string& name) {
 bool AssociatedInterfaceRegistry::TryBindInterface(
     const std::string& name,
     mojo::ScopedInterfaceEndpointHandle* handle) {
-  recordreplay::Assert("AssociatedInterfaceRegistry::TryBindInterface Start");
   auto it = interfaces_.find(name);
   if (it == interfaces_.end()) {
-    recordreplay::Assert("AssociatedInterfaceRegistry::TryBindInterface #1");
     return false;
   }
   it->second.Run(std::move(*handle));
-  recordreplay::Assert("AssociatedInterfaceRegistry::TryBindInterface Done");
   return true;
 }
 

--- a/third_party/blink/common/loader/throttling_url_loader.cc
+++ b/third_party/blink/common/loader/throttling_url_loader.cc
@@ -304,7 +304,6 @@ std::unique_ptr<ThrottlingURLLoader> ThrottlingURLLoader::CreateLoaderAndStart(
 }
 
 ThrottlingURLLoader::~ThrottlingURLLoader() {
-  recordreplay::Assert("ThrottlingURLLoader::~ThrottlingURLLoader %lu", recordreplay::PointerId(this));
   recordreplay::UnregisterPointer(this);
 
   if (inside_delegate_calls_ > 0) {

--- a/third_party/blink/renderer/bindings/core/v8/script_controller.cc
+++ b/third_party/blink/renderer/bindings/core/v8/script_controller.cc
@@ -297,12 +297,10 @@ bool ScriptController::CanExecuteScript(ExecuteScriptPolicy policy) {
 
 scoped_refptr<DOMWrapperWorld>
 ScriptController::CreateNewInspectorIsolatedWorld(const String& world_name) {
-  recordreplay::Assert("ScriptController::CreateNewInspectorIsolatedWorld Start");
   scoped_refptr<DOMWrapperWorld> world = DOMWrapperWorld::Create(
       GetIsolate(), DOMWrapperWorld::WorldType::kInspectorIsolated);
   // Bail out if we could not create an isolated world.
   if (!world) {
-    recordreplay::Assert("ScriptController::CreateNewInspectorIsolatedWorld #1");
     return nullptr;
   }
   if (!world_name.IsEmpty()) {
@@ -311,7 +309,6 @@ ScriptController::CreateNewInspectorIsolatedWorld(const String& world_name) {
   }
   // Make sure the execution context exists.
   WindowProxy(*world);
-  recordreplay::Assert("ScriptController::CreateNewInspectorIsolatedWorld Done");
   return world;
 }
 

--- a/third_party/blink/renderer/controller/performance_manager/renderer_resource_coordinator_impl.cc
+++ b/third_party/blink/renderer/controller/performance_manager/renderer_resource_coordinator_impl.cc
@@ -262,7 +262,6 @@ RendererResourceCoordinatorImpl::RendererResourceCoordinatorImpl(
 void RendererResourceCoordinatorImpl::DispatchOnV8ContextCreated(
     V8ContextDescriptionPtr v8_desc,
     IframeAttributionDataPtr iframe_attribution_data) {
-  recordreplay::Assert("RendererResourceCoordinatorImpl::DispatchOnV8ContextCreated Start");
   DCHECK(service_);
   // Calls to this can arrive on any thread (due to workers, etc), but the
   // interface itself is bound to the main thread. In this case, once we've
@@ -280,7 +279,6 @@ void RendererResourceCoordinatorImpl::DispatchOnV8ContextCreated(
     service_->OnV8ContextCreated(std::move(v8_desc),
                                  std::move(iframe_attribution_data));
   }
-  recordreplay::Assert("RendererResourceCoordinatorImpl::DispatchOnV8ContextCreated Done");
 }
 
 void RendererResourceCoordinatorImpl::DispatchOnV8ContextDetached(

--- a/third_party/blink/renderer/core/css/css_font_face.cc
+++ b/third_party/blink/renderer/core/css/css_font_face.cc
@@ -62,25 +62,17 @@ void CSSFontFace::DidBeginLoad() {
 }
 
 bool CSSFontFace::FontLoaded(CSSFontFaceSource* source) {
-  recordreplay::Assert("CSSFontFace::FontLoaded Start %lu %d",
-                       recordreplay::PointerId(font_face_.Get()), LoadStatus());
-
   if (!IsValid() || source != sources_.front()) {
-    recordreplay::Assert("CSSFontFace::FontLoaded #1");
     return false;
   }
 
   if (LoadStatus() == FontFace::kLoading) {
-    recordreplay::Assert("CSSFontFace::FontLoaded #2");
     if (source->IsValid()) {
-      recordreplay::Assert("CSSFontFace::FontLoaded #3");
       SetLoadStatus(FontFace::kLoaded);
     } else if (source->IsInFailurePeriod()) {
-      recordreplay::Assert("CSSFontFace::FontLoaded #4");
       sources_.clear();
       SetLoadStatus(FontFace::kError);
     } else {
-      recordreplay::Assert("CSSFontFace::FontLoaded #5");
       sources_.pop_front();
       Load();
     }
@@ -89,7 +81,6 @@ bool CSSFontFace::FontLoaded(CSSFontFaceSource* source) {
   for (CSSSegmentedFontFace* segmented_font_face : segmented_font_faces_)
     segmented_font_face->FontFaceInvalidated();
 
-  recordreplay::Assert("CSSFontFace::FontLoaded Done");
   return true;
 }
 

--- a/third_party/blink/renderer/core/css/font_face.cc
+++ b/third_party/blink/renderer/core/css/font_face.cc
@@ -511,8 +511,6 @@ String FontFace::status() const {
 }
 
 void FontFace::SetLoadStatus(LoadStatusType status) {
-  recordreplay::Assert("FontFace::SetLoadStatus Start %lu %d", recordreplay::PointerId(this), status);
-
   status_ = status;
   DCHECK(status_ != kError || error_);
 

--- a/third_party/blink/renderer/core/css/invalidation/pending_invalidations.cc
+++ b/third_party/blink/renderer/core/css/invalidation/pending_invalidations.cc
@@ -31,17 +31,9 @@ void PendingInvalidations::ScheduleInvalidationSetsForNode(
 
   if (node.GetStyleChangeType() < kSubtreeStyleChange) {
     for (auto& invalidation_set : invalidation_lists.descendants) {
-      // https://linear.app/replay/issue/RUN-556
-      recordreplay::Assert("PendingInvalidations::ScheduleInvalidationSetsForNode #4 %d",
-                           recordreplay::PointerId(invalidation_set.get()));
-
       if (invalidation_set->WholeSubtreeInvalid()) {
         auto* shadow_root = DynamicTo<ShadowRoot>(node);
         auto* subtree_root = shadow_root ? &shadow_root->host() : &node;
-
-        // https://linear.app/replay/issue/RUN-556
-        recordreplay::Assert("PendingInvalidations::ScheduleInvalidationSetsForNode #5 %d %d",
-                             !!shadow_root, recordreplay::PointerId(subtree_root));
 
         subtree_root->SetNeedsStyleRecalc(
             kSubtreeStyleChange, StyleChangeReasonForTracing::Create(
@@ -51,10 +43,6 @@ void PendingInvalidations::ScheduleInvalidationSetsForNode(
       }
 
       if (invalidation_set->InvalidatesSelf() && node.IsElementNode()) {
-        // https://linear.app/replay/issue/RUN-556
-        recordreplay::Assert("PendingInvalidations::ScheduleInvalidationSetsForNode #6 %d",
-                             recordreplay::PointerId(&node));
-
         node.SetNeedsStyleRecalc(kLocalStyleChange,
                                  StyleChangeReasonForTracing::Create(
                                      style_change_reason::kStyleInvalidator));
@@ -162,16 +150,10 @@ void PendingInvalidations::RescheduleSiblingInvalidationsAsDescendants(
 
   InvalidationLists invalidation_lists;
   for (const auto& invalidation_set : pending_invalidations.Siblings()) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("PendingInvalidations::RescheduleSiblingInvalidationsAsDescendants #5 %d",
-                         recordreplay::PointerId(invalidation_set.get()));
     invalidation_lists.descendants.push_back(invalidation_set);
     if (DescendantInvalidationSet* descendants =
             To<SiblingInvalidationSet>(*invalidation_set)
                 .SiblingDescendants()) {
-      // https://linear.app/replay/issue/RUN-556
-      recordreplay::Assert("PendingInvalidations::RescheduleSiblingInvalidationsAsDescendants #6 %d",
-                           recordreplay::PointerId(descendants));
       invalidation_lists.descendants.push_back(descendants);
     }
   }

--- a/third_party/blink/renderer/core/css/remote_font_face_source.cc
+++ b/third_party/blink/renderer/core/css/remote_font_face_source.cc
@@ -182,7 +182,6 @@ bool RemoteFontFaceSource::IsValid() const {
 }
 
 void RemoteFontFaceSource::NotifyFinished(Resource* resource) {
-  recordreplay::Assert("RemoteFontFaceSource::NotifyFinished %lu", recordreplay::PointerId(this));
   ExecutionContext* execution_context = font_selector_->GetExecutionContext();
   if (!execution_context)
     return;

--- a/third_party/blink/renderer/core/css/rule_feature_set.cc
+++ b/third_party/blink/renderer/core/css/rule_feature_set.cc
@@ -1166,10 +1166,6 @@ void RuleFeatureSet::CollectInvalidationSetsForClass(
   ExtractInvalidationSets(it->value.get(), descendants, siblings);
 
   if (descendants) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectInvalidationSetsForClass #5 %d",
-                         recordreplay::PointerId(descendants));
-
     TRACE_SCHEDULE_STYLE_INVALIDATION(element, *descendants, ClassChange,
                                       class_name);
     invalidation_lists.descendants.push_back(descendants);
@@ -1217,10 +1213,6 @@ void RuleFeatureSet::CollectInvalidationSetsForId(
   ExtractInvalidationSets(it->value.get(), descendants, siblings);
 
   if (descendants) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectInvalidationSetsForId #5 %d",
-                         recordreplay::PointerId(descendants));
-
     TRACE_SCHEDULE_STYLE_INVALIDATION(element, *descendants, IdChange, id);
     invalidation_lists.descendants.push_back(descendants);
   }
@@ -1265,10 +1257,6 @@ void RuleFeatureSet::CollectInvalidationSetsForAttribute(
   ExtractInvalidationSets(it->value.get(), descendants, siblings);
 
   if (descendants) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectInvalidationSetsForAttribute #5 %d",
-                         recordreplay::PointerId(descendants));
-
     TRACE_SCHEDULE_STYLE_INVALIDATION(element, *descendants, AttributeChange,
                                       attribute_name);
     invalidation_lists.descendants.push_back(descendants);
@@ -1317,10 +1305,6 @@ void RuleFeatureSet::CollectInvalidationSetsForPseudoClass(
   ExtractInvalidationSets(it->value.get(), descendants, siblings);
 
   if (descendants) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectInvalidationSetsForPseudoClass #5 %d",
-                         recordreplay::PointerId(descendants));
-
     TRACE_SCHEDULE_STYLE_INVALIDATION(element, *descendants, PseudoChange,
                                       pseudo);
     invalidation_lists.descendants.push_back(descendants);
@@ -1365,10 +1349,6 @@ NthSiblingInvalidationSet& RuleFeatureSet::EnsureNthInvalidationSet() {
 void RuleFeatureSet::CollectPartInvalidationSet(
     InvalidationLists& invalidation_lists) const {
   if (metadata_.invalidates_parts) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectPartInvalidationSet #5 %d",
-                         recordreplay::PointerId(InvalidationSet::PartInvalidationSet()));
-
     invalidation_lists.descendants.push_back(
         InvalidationSet::PartInvalidationSet());
   }
@@ -1378,10 +1358,6 @@ void RuleFeatureSet::CollectTypeRuleInvalidationSet(
     InvalidationLists& invalidation_lists,
     ContainerNode& root_node) const {
   if (type_rule_invalidation_set_) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("RuleFeatureSet::CollectTypeRuleInvalidationSet #5 %d",
-                         recordreplay::PointerId(type_rule_invalidation_set_.get()));
-
     invalidation_lists.descendants.push_back(type_rule_invalidation_set_);
     TRACE_SCHEDULE_STYLE_INVALIDATION(root_node, *type_rule_invalidation_set_,
                                       RuleSetInvalidation);

--- a/third_party/blink/renderer/core/css/style_engine.cc
+++ b/third_party/blink/renderer/core/css/style_engine.cc
@@ -1265,10 +1265,6 @@ void StyleEngine::ScheduleCustomElementInvalidations(
   }
   invalidation_set->SetTreeBoundaryCrossing();
 
-  // https://linear.app/replay/issue/RUN-556
-  recordreplay::Assert("StyleEngine::ScheduleCustomElementInvalidations %d",
-                       recordreplay::PointerId(invalidation_set.get()));
-
   InvalidationLists invalidation_lists;
   invalidation_lists.descendants.push_back(invalidation_set);
   pending_invalidations_.ScheduleInvalidationSetsForNode(invalidation_lists,
@@ -2145,14 +2141,11 @@ void StyleEngine::UpdateStyleAndLayoutTree() {
   // tree properly.
   DCHECK(!NeedsLayoutTreeRebuild());
 
-  recordreplay::Assert("StyleEngine::UpdateStyleAndLayoutTree");
-
   UpdateViewportStyle();
 
   if (Element* document_element = GetDocument().documentElement()) {
     NthIndexCache nth_index_cache(GetDocument());
     if (NeedsStyleRecalc()) {
-      recordreplay::Assert("StyleEngine::UpdateStyleAndLayoutTree #1");
       TRACE_EVENT0("blink,blink_style", "Document::recalcStyle");
       SCOPED_BLINK_UMA_HISTOGRAM_TIMER_HIGHRES("Style.RecalcTime");
       Element* viewport_defining = GetDocument().ViewportDefiningElement();
@@ -2162,7 +2155,6 @@ void StyleEngine::UpdateStyleAndLayoutTree() {
     }
     MarkForWhitespaceReattachment();
     if (NeedsLayoutTreeRebuild()) {
-      recordreplay::Assert("StyleEngine::UpdateStyleAndLayoutTree #2");
       TRACE_EVENT0("blink,blink_style", "Document::rebuildLayoutTree");
       SCOPED_BLINK_UMA_HISTOGRAM_TIMER_HIGHRES("Style.RebuildLayoutTreeTime");
       RebuildLayoutTree();

--- a/third_party/blink/renderer/core/dom/container_node.cc
+++ b/third_party/blink/renderer/core/dom/container_node.cc
@@ -1041,8 +1041,6 @@ void ContainerNode::ChildrenChanged(const ChildrenChange& change) {
     return;
   }
   if (inserted_node->IsContainerNode() || inserted_node->IsTextNode()) {
-    recordreplay::Assert("ContainerNode::ChildrenChanged #5 %d",
-                         recordreplay::PointerId(inserted_node));
     inserted_node->SetStyleChangeOnInsertion();
   }
 }

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -982,9 +982,6 @@ AtomicString Document::ConvertLocalName(const AtomicString& name) {
 // SVGElementFactory because they don't support prefixes correctly.
 Element* Document::CreateRawElement(const QualifiedName& qname,
                                     CreateElementFlags flags) {
-  recordreplay::Assert("Document::CreateRawElement %s %s",
-                       qname.NamespaceURI().Utf8().c_str(),
-                       qname.LocalName().Utf8().c_str());
   Element* element = nullptr;
   if (qname.NamespaceURI() == html_names::xhtmlNamespaceURI) {
     // https://html.spec.whatwg.org/C/#elements-in-the-dom:element-interface
@@ -1937,32 +1934,25 @@ bool Document::NeedsFullLayoutTreeUpdate() const {
   recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate Start");
 
   if (!IsActive() || !View()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #1");
     return false;
   }
   if (style_engine_->NeedsFullStyleUpdate()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #2");
     return true;
   }
   if (!use_elements_needing_update_.IsEmpty()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #3");
     return true;
   }
   // We have scheduled an invalidation set on the document node which means any
   // element may need a style recalc.
   if (NeedsStyleInvalidation()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #4");
     return true;
   }
   if (IsSlotAssignmentOrLegacyDistributionDirty()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #5");
     return true;
   }
   if (document_animations_->NeedsAnimationTimingUpdate()) {
-    recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #6");
     return true;
   }
-  recordreplay::Assert("Document::NeedsFullLayoutTreeUpdate #7");
   return false;
 }
 
@@ -2497,27 +2487,19 @@ bool Document::NeedsLayoutTreeUpdateForNode(const Node& node,
 bool Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked(
     const Node& node,
     bool ignore_adjacent_style) const {
-  recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked Start %d",
-                       recordreplay::PointerId(&node));
-
   if (node.IsShadowRoot()) {
-    recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #1");
     return false;
   }
   if (GetDisplayLockDocumentState().LockedDisplayLockCount() == 0 &&
       !NeedsLayoutTreeUpdate()) {
-    recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #2");
     return false;
   }
   if (!node.isConnected()) {
-    recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #3");
     return false;
   }
 
   if (NeedsFullLayoutTreeUpdate() || node.NeedsStyleRecalc() ||
       node.NeedsStyleInvalidation()) {
-    recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #4 %d %d",
-                         node.NeedsStyleRecalc(), node.NeedsStyleInvalidation());
     return true;
   }
   for (const ContainerNode* ancestor = LayoutTreeBuilderTraversal::Parent(node);
@@ -2525,13 +2507,11 @@ bool Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked(
     if (ShadowRoot* root = ancestor->GetShadowRoot()) {
       if (root->NeedsStyleRecalc() || root->NeedsStyleInvalidation() ||
           root->NeedsAdjacentStyleRecalc()) {
-        recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #5");
         return true;
       }
     }
     if (ancestor->NeedsStyleRecalc() || ancestor->NeedsStyleInvalidation() ||
         (ancestor->NeedsAdjacentStyleRecalc() && !ignore_adjacent_style)) {
-      recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #6");
       return true;
     }
     auto* element = DynamicTo<Element>(ancestor);
@@ -2541,39 +2521,30 @@ bool Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked(
       // Even if the ancestor is style-clean, we might've previously
       // blocked a style traversal going to the ancestor or its descendants.
       if (context->StyleTraversalWasBlocked()) {
-        recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #7");
         DCHECK(context->IsLocked());
         return true;
       }
     }
   }
-  recordreplay::Assert("Document::NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked #8");
   return false;
 }
 
 void Document::UpdateStyleAndLayoutTreeForNode(const Node* node) {
-  recordreplay::Assert("Document::UpdateStyleAndLayoutTreeForNode Start %d",
-                       recordreplay::PointerId(node));
-
   DCHECK(node);
   if (!node->InActiveDocument()) {
     // If |node| is not in the active document, we can't update its style or
     // layout tree.
     DCHECK_EQ(node->ownerDocument(), this);
-    recordreplay::Assert("Document::UpdateStyleAndLayoutTreeForNode #1");
     return;
   }
   DCHECK(!InStyleRecalc())
       << "UpdateStyleAndLayoutTreeForNode called from within style recalc";
   if (!NeedsLayoutTreeUpdateForNodeIncludingDisplayLocked(*node)) {
-    recordreplay::Assert("Document::UpdateStyleAndLayoutTreeForNode #2");
     return;
   }
 
   DisplayLockUtilities::ScopedForcedUpdate scoped_update_forced(node);
   UpdateStyleAndLayoutTree();
-
-  recordreplay::Assert("Document::UpdateStyleAndLayoutTreeForNode Done");
 }
 
 void Document::UpdateStyleAndLayoutTreeForSubtree(const Node* node) {
@@ -5516,7 +5487,6 @@ void Document::EnqueueUniqueAnimationFrameEvent(Event* event) {
 void Document::EnqueueScrollEventForNode(Node* target) {
   // Per the W3C CSSOM View Module only scroll events fired at the document
   // should bubble.
-  recordreplay::Assert("Document::EnqueueScrollEventForNode");
   overscroll_accumulated_delta_x_ = overscroll_accumulated_delta_y_ = 0;
   Event* scroll_event = target->IsDocumentNode()
                             ? Event::CreateBubble(event_type_names::kScroll)
@@ -7482,12 +7452,10 @@ void Document::CancelAnimationFrame(int id) {
 
 void Document::ServiceScriptedAnimations(
     base::TimeTicks monotonic_animation_start_time) {
-  recordreplay::Assert("Document::ServiceScriptedAnimations Start");
   auto start_time = base::TimeTicks::Now();
   scripted_animation_controller_->ServiceScriptedAnimations(
       monotonic_animation_start_time);
   if (GetFrame()) {
-    recordreplay::Assert("Document::ServiceScriptedAnimations #1");
     GetFrame()->GetFrameScheduler()->AddTaskTime(base::TimeTicks::Now() -
                                                  start_time);
   }
@@ -7722,18 +7690,15 @@ bool Document::HaveRenderBlockingResourcesLoaded() const {
 }
 
 Locale& Document::GetCachedLocale(const AtomicString& locale) {
-  recordreplay::Assert("Document::GetCachedLocale Start %s", locale.Utf8().c_str());
   AtomicString locale_key = locale;
   if (locale.IsEmpty() ||
       !RuntimeEnabledFeatures::LangAttributeAwareFormControlUIEnabled()) {
-    recordreplay::Assert("Document::GetCachedLocale #1");
     return Locale::DefaultLocale();
   }
   LocaleIdentifierToLocaleMap::AddResult result =
       locale_cache_.insert(locale_key, nullptr);
   if (result.is_new_entry)
     result.stored_value->value = Locale::Create(locale_key);
-  recordreplay::Assert("Document::GetCachedLocale Done");
   return *(result.stored_value->value);
 }
 

--- a/third_party/blink/renderer/core/dom/element.cc
+++ b/third_party/blink/renderer/core/dom/element.cc
@@ -687,7 +687,6 @@ Node* Element::Clone(Document& factory, CloneChildrenFlag flag) const {
 }
 
 Element& Element::CloneWithChildren(Document* nullable_factory) const {
-  recordreplay::Assert("Element::CloneWithChildren %lu", recordreplay::PointerId(this));
   Element& clone = CloneWithoutAttributesAndChildren(
       nullable_factory ? *nullable_factory : GetDocument());
   // This will catch HTML elements in the wrong namespace that are not correctly
@@ -1497,10 +1496,7 @@ LayoutBox* Element::GetLayoutBoxForScrolling() const {
 }
 
 double Element::scrollLeft() {
-  recordreplay::Assert("Element::scrollLeft Start");
-
   if (!InActiveDocument()) {
-    recordreplay::Assert("Element::scrollLeft #1");
     return 0;
   }
 
@@ -1509,16 +1505,13 @@ double Element::scrollLeft() {
 
   if (GetDocument().ScrollingElementNoLayout() == this) {
     if (GetDocument().domWindow()) {
-      recordreplay::Assert("Element::scrollLeft #2");
       return GetDocument().domWindow()->scrollX();
     }
-    recordreplay::Assert("Element::scrollLeft #3");
     return 0;
   }
 
   LayoutBox* box = GetLayoutBoxForScrolling();
   if (!box) {
-    recordreplay::Assert("Element::scrollLeft #4");
     return 0;
   }
   if (PaintLayerScrollableArea* scrollable_area = box->GetScrollableArea()) {
@@ -1535,7 +1528,6 @@ double Element::scrollLeft() {
         scrollable_area->GetScrollOffset().Width(), *GetLayoutBox());
   }
 
-  recordreplay::Assert("Element::scrollLeft Done");
   return 0;
 }
 
@@ -2872,8 +2864,6 @@ void Element::RecalcStyleForTraversalRootAncestor() {
 
 void Element::RecalcStyle(const StyleRecalcChange change,
                           const StyleRecalcContext& style_recalc_context) {
-  recordreplay::Assert("Element::RecalcStyle Start %lu", recordreplay::PointerId(this));
-
   DCHECK(InActiveDocument());
   DCHECK(GetDocument().InStyleRecalc());
   DCHECK(!GetDocument().Lifecycle().InDetach());
@@ -2919,7 +2909,6 @@ void Element::RecalcStyle(const StyleRecalcChange change,
     }
     if (HasCustomStyleCallbacks())
       DidRecalcStyle(child_change);
-    recordreplay::Assert("Element::RecalcStyle #1");
     return;
   }
 
@@ -2939,7 +2928,6 @@ void Element::RecalcStyle(const StyleRecalcChange change,
   if (child_change.TraverseChildren(*this)) {
     SelectorFilterParentScope filter_scope(*this);
     if (ShadowRoot* root = GetShadowRoot()) {
-      recordreplay::Assert("Element::RecalcStyle #2");
       root->RecalcDescendantStyles(child_change, child_recalc_context);
       // Sad panda. This is only to clear ensured ComputedStyles for elements
       // outside the flat tree for getComputedStyle() in the cases where we
@@ -2947,14 +2935,12 @@ void Element::RecalcStyle(const StyleRecalcChange change,
       // make sure we clear out-of-date ComputedStyles outside the flat tree
       // in Element::EnsureComputedStyle().
       if (child_change.RecalcDescendants()) {
-        recordreplay::Assert("Element::RecalcStyle #3");
         RecalcDescendantStyles(StyleRecalcChange::kClearEnsured,
                                child_recalc_context);
       }
     } else if (auto* slot = ToHTMLSlotElementIfSupportsAssignmentOrNull(this)) {
       slot->RecalcStyleForSlotChildren(child_change, child_recalc_context);
     } else {
-      recordreplay::Assert("Element::RecalcStyle #4");
       RecalcDescendantStyles(child_change, child_recalc_context);
     }
   }
@@ -2975,8 +2961,6 @@ void Element::RecalcStyle(const StyleRecalcChange change,
 
   if (HasCustomStyleCallbacks())
     DidRecalcStyle(child_change);
-
-  recordreplay::Assert("Element::RecalcStyle Done");
 }
 
 scoped_refptr<ComputedStyle> Element::PropagateInheritedProperties() {
@@ -3018,9 +3002,6 @@ static const StyleRecalcChange ApplyComputedStyleDiff(
 StyleRecalcChange Element::RecalcOwnStyle(
     const StyleRecalcChange change,
     const StyleRecalcContext& style_recalc_context) {
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("Element::RecalcOwnStyle %d", recordreplay::PointerId(this));
-
   DCHECK(GetDocument().InStyleRecalc());
   if (change.RecalcChildren() && HasRareData() && NeedsStyleRecalc()) {
     // This element needs recalc because its parent changed inherited

--- a/third_party/blink/renderer/core/dom/events/event.cc
+++ b/third_party/blink/renderer/core/dom/events/event.cc
@@ -246,9 +246,6 @@ void Event::preventDefault() {
 }
 
 void Event::SetTarget(EventTarget* target) {
-  recordreplay::Assert("Event::SetTarget %lu %lu",
-                       recordreplay::PointerId(this), recordreplay::PointerId(target));
-
   if (target_ == target)
     return;
 

--- a/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
+++ b/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
@@ -56,9 +56,6 @@
 namespace blink {
 
 DispatchEventResult EventDispatcher::DispatchEvent(Node& node, Event& event) {
-  recordreplay::Assert("EventDispatcher::DispatchEvent %lu %lu",
-                       recordreplay::PointerId(&node), recordreplay::PointerId(&event));
-
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("blink.debug"),
                "EventDispatcher::dispatchEvent");
 #if DCHECK_IS_ON()

--- a/third_party/blink/renderer/core/dom/events/event_target.cc
+++ b/third_party/blink/renderer/core/dom/events/event_target.cc
@@ -495,15 +495,11 @@ bool EventTarget::AddEventListenerInternal(
     const AtomicString& event_type,
     EventListener* listener,
     const AddEventListenerOptionsResolved* options) {
-  recordreplay::Assert("EventTarget::AddEventListenerInternal Start");
-
   if (!listener) {
-    recordreplay::Assert("EventTarget::AddEventListenerInternal #1");
     return false;
   }
 
   if (options->hasSignal() && options->signal()->aborted()) {
-    recordreplay::Assert("EventTarget::AddEventListenerInternal #2");
     return false;
   }
 
@@ -562,7 +558,6 @@ bool EventTarget::AddEventListenerInternal(
     }
   }
 
-  recordreplay::Assert("EventTarget::AddEventListenerInternal Done %d", added);
   return added;
 }
 
@@ -748,10 +743,6 @@ bool EventTarget::dispatchEventForBindings(Event* event,
 
   event->SetTrusted(false);
 
-  // https://linear.app/replay/issue/RUN-466
-  recordreplay::Assert("EventTarget::dispatchEventForBindings #5 %lu",
-                       recordreplay::PointerId(this));
-
   // Return whether the event was cancelled or not to JS not that it
   // might have actually been default handled; so check only against
   // CanceledByEventHandler.
@@ -760,12 +751,6 @@ bool EventTarget::dispatchEventForBindings(Event* event,
 }
 
 DispatchEventResult EventTarget::DispatchEvent(Event& event, const char* why) {
-  // https://linear.app/replay/issue/RUN-466
-  recordreplay::Assert("EventTarget::DispatchEvent %lu %s %s",
-                       recordreplay::PointerId(this),
-                       event.type().GetString().Ascii().c_str(),
-                       why);
-
   event.SetTrusted(true);
   return DispatchEventInternal(event);
 }
@@ -848,9 +833,6 @@ void EventTarget::CountLegacyEvents(
 }
 
 DispatchEventResult EventTarget::FireEventListeners(Event& event) {
-  recordreplay::Assert("EventTarget::FireEventListeners %lu",
-                       recordreplay::PointerId(this));
-
 #if DCHECK_IS_ON()
   DCHECK(!EventDispatchForbiddenScope::IsEventDispatchForbidden());
 #endif
@@ -1021,13 +1003,10 @@ void EventTarget::RemoveAllEventListeners() {
 }
 
 void EventTarget::EnqueueEvent(Event& event, TaskType task_type) {
-  recordreplay::Assert("EventTarget::EnqueueEvent %lu %lu",
-                       recordreplay::PointerId(this), recordreplay::PointerId(&event));
   ExecutionContext* context = GetExecutionContext();
   if (!context)
     return;
   probe::AsyncTaskScheduled(context, event.type(), event.async_task_id());
-  recordreplay::Assert("EventTarget::EnqueueEvent #1");
   context->GetTaskRunner(task_type)->PostTask(
       FROM_HERE,
       WTF::Bind(&EventTarget::DispatchEnqueuedEvent, WrapPersistent(this),
@@ -1036,8 +1015,6 @@ void EventTarget::EnqueueEvent(Event& event, TaskType task_type) {
 
 void EventTarget::DispatchEnqueuedEvent(Event* event,
                                         ExecutionContext* context) {
-  recordreplay::Assert("EventTarget::DispatchEnqueuedEvent %lu %lu",
-                       recordreplay::PointerId(this), recordreplay::PointerId(event));
   if (!GetExecutionContext()) {
     probe::AsyncTaskCanceled(context, event->async_task_id());
     return;

--- a/third_party/blink/renderer/core/dom/node.cc
+++ b/third_party/blink/renderer/core/dom/node.cc
@@ -1341,10 +1341,6 @@ void Node::SetNeedsStyleRecalc(StyleChangeType change_type,
   DCHECK(change_type != kNoStyleChange);
   DCHECK(IsElementNode() || IsTextNode());
 
-  // https://linear.app/replay/issue/RUN-556
-  recordreplay::Assert("Node::SetNeedsStyleRecalc Start %d",
-                       recordreplay::PointerId(this));
-
   if (!InActiveDocument())
     return;
   if (ShouldSkipMarkingStyleDirty())
@@ -1358,9 +1354,6 @@ void Node::SetNeedsStyleRecalc(StyleChangeType change_type,
 
   StyleChangeType existing_change_type = GetStyleChangeType();
   if (change_type > existing_change_type) {
-    // https://linear.app/replay/issue/RUN-556
-    recordreplay::Assert("Node::SetNeedsStyleRecalc #5 %d %d",
-                         recordreplay::PointerId(this), (int)change_type);
     SetStyleChange(change_type);
   }
 
@@ -2885,10 +2878,6 @@ void Node::DispatchScopedEvent(Event& event) {
 }
 
 DispatchEventResult Node::DispatchEventInternal(Event& event) {
-  // https://linear.app/replay/issue/RUN-466
-  recordreplay::Assert("Node::DispatchEventInternal %lu",
-                       recordreplay::PointerId(this));
-
   return EventDispatcher::DispatchEvent(*this, event);
 }
 
@@ -3276,10 +3265,6 @@ bool Node::HasMediaControlAncestor() const {
 }
 
 void Node::FlatTreeParentChanged() {
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("Node::FlatTreeParentChanged %d",
-                       recordreplay::PointerId(this));
-
   if (!isConnected())
     return;
   DCHECK(IsSlotable());

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -33,23 +33,18 @@ class IdleRequestCallbackWrapper
   static void IdleTaskFired(
       scoped_refptr<IdleRequestCallbackWrapper> callback_wrapper,
       base::TimeTicks deadline) {
-    recordreplay::Assert("IdleTaskFired Start");
     if (ScriptedIdleTaskController* controller =
             callback_wrapper->Controller()) {
       // If we are going to yield immediately, reschedule the callback for
       // later.
-      recordreplay::Assert("IdleTaskFired #1");
       if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
-        recordreplay::Assert("IdleTaskFired #2");
         controller->ScheduleCallback(std::move(callback_wrapper),
                                      /* timeout_millis */ 0);
         return;
       }
-      recordreplay::Assert("IdleTaskFired #3");
       controller->CallbackFired(callback_wrapper->Id(), deadline,
                                 IdleDeadline::CallbackType::kCalledWhenIdle);
     }
-    recordreplay::Assert("IdleTaskFired #4");
     callback_wrapper->Cancel();
   }
 
@@ -199,8 +194,6 @@ void ScriptedIdleTaskController::RunCallback(
     return;
   IdleTask* idle_task = idle_task_iter->value;
   DCHECK(idle_task);
-
-  recordreplay::Assert("ScriptedIdleTaskController::RunCallback #1");
 
   base::TimeDelta allotted_time =
       std::max(deadline - base::TimeTicks::Now(), base::TimeDelta());

--- a/third_party/blink/renderer/core/dom/slot_assignment.cc
+++ b/third_party/blink/renderer/core/dom/slot_assignment.cc
@@ -242,11 +242,6 @@ void SlotAssignment::SetNeedsAssignmentRecalc() {
 }
 
 void SlotAssignment::RecalcAssignment() {
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("SlotAssignment::RecalcAssignment %d %d",
-                       recordreplay::PointerId((void*)owner_),
-                       needs_assignment_recalc_);
-
   if (!needs_assignment_recalc_)
     return;
   {
@@ -410,16 +405,9 @@ void SlotAssignment::CollectSlots() {
   DCHECK(needs_collect_slots_);
   slots_.clear();
 
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("SlotAssignment::CollectSlots %d %d",
-                       recordreplay::PointerId((void*)owner_), slot_count_);
-
   slots_.ReserveCapacity(slot_count_);
   for (HTMLSlotElement& slot :
        Traversal<HTMLSlotElement>::DescendantsOf(*owner_)) {
-    // https://linear.app/replay/issue/RUN-493
-    recordreplay::Assert("SlotAssignment::CollectSlots #1 %d",
-                         recordreplay::PointerId(&slot));
     slots_.push_back(&slot);
   }
   needs_collect_slots_ = false;

--- a/third_party/blink/renderer/core/events/mouse_event.cc
+++ b/third_party/blink/renderer/core/events/mouse_event.cc
@@ -403,10 +403,6 @@ DispatchEventResult MouseEvent::DispatchEvent(EventDispatcher& dispatcher) {
   if (DefaultHandled())
     double_click_event.SetDefaultHandled();
 
-  // https://linear.app/replay/issue/RUN-466
-  recordreplay::Assert("MouseEvent::DispatchEvent #5 %lu",
-                       recordreplay::PointerId(&dispatcher.GetNode()));
-
   DispatchEventResult double_click_dispatch_result =
       EventDispatcher::DispatchEvent(dispatcher.GetNode(), double_click_event);
   if (double_click_dispatch_result != DispatchEventResult::kNotCanceled)

--- a/third_party/blink/renderer/core/exported/web_history_entry.cc
+++ b/third_party/blink/renderer/core/exported/web_history_entry.cc
@@ -59,7 +59,6 @@ WebVector<base::Optional<std::u16string>> ToOptionalString16Vector(
     WebVector<base::Optional<std::u16string>> output) {
   output.reserve(output.size() + input.size());
   for (const auto& i : input) {
-    recordreplay::Assert("ToOptionalString16Vector %d %lu", i.IsNull(), i.length());
     output.emplace_back(WebString::ToOptionalString16(i));
   }
   return output;

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -2383,7 +2383,6 @@ bool LocalFrame::ConsumeTransientUserActivation(
 void LocalFrame::NotifyUserActivation(
     mojom::blink::UserActivationNotificationType notification_type,
     bool need_browser_verification) {
-  recordreplay::Assert("LocalFrame::NotifyUserActivation Start");
   mojom::blink::UserActivationUpdateType update_type =
       need_browser_verification
           ? mojom::blink::UserActivationUpdateType::
@@ -2394,7 +2393,6 @@ void LocalFrame::NotifyUserActivation(
                                                       notification_type);
   Client()->NotifyUserActivation();
   NotifyUserActivationInFrameTree(notification_type);
-  recordreplay::Assert("LocalFrame::NotifyUserActivation Done");
 }
 
 bool LocalFrame::ConsumeTransientUserActivation(

--- a/third_party/blink/renderer/core/frame/local_frame_ukm_aggregator.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_ukm_aggregator.cc
@@ -25,9 +25,7 @@ LocalFrameUkmAggregator::ScopedUkmHierarchicalTimer::ScopedUkmHierarchicalTimer(
     : aggregator_(aggregator),
       metric_index_(metric_index),
       clock_(clock),
-      start_time_(clock_->NowTicks()) {
-  recordreplay::Assert("ScopedUkmHierarchicalTimer #1");
-}
+      start_time_(clock_->NowTicks()) {}
 
 LocalFrameUkmAggregator::ScopedUkmHierarchicalTimer::ScopedUkmHierarchicalTimer(
     ScopedUkmHierarchicalTimer&& other)
@@ -35,14 +33,12 @@ LocalFrameUkmAggregator::ScopedUkmHierarchicalTimer::ScopedUkmHierarchicalTimer(
       metric_index_(other.metric_index_),
       clock_(other.clock_),
       start_time_(other.start_time_) {
-  recordreplay::Assert("ScopedUkmHierarchicalTimer #2");
   other.aggregator_ = nullptr;
 }
 
 LocalFrameUkmAggregator::ScopedUkmHierarchicalTimer::
     ~ScopedUkmHierarchicalTimer() {
   if (aggregator_ && base::TimeTicks::IsHighResolution()) {
-    recordreplay::Assert("~ScopedUkmHierarchicalTimer #1");
     aggregator_->RecordSample(metric_index_, start_time_, clock_->NowTicks());
   }
 }
@@ -125,7 +121,6 @@ LocalFrameUkmAggregator::~LocalFrameUkmAggregator() {
 
 LocalFrameUkmAggregator::ScopedUkmHierarchicalTimer
 LocalFrameUkmAggregator::GetScopedTimer(size_t metric_index) {
-  recordreplay::Assert("LocalFrameUkmAggregator::GetScopedTimer");
   return ScopedUkmHierarchicalTimer(this, metric_index, clock_);
 }
 

--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
@@ -2713,15 +2713,12 @@ void LocalFrameView::ClearResizeObserverLimit() {
 
 bool LocalFrameView::RunStyleAndLayoutLifecyclePhases(
     DocumentLifecycle::LifecycleState target_state) {
-  recordreplay::Assert("LocalFrameView::RunStyleAndLayoutLifecyclePhases Start");
-
   TRACE_EVENT0("blink,benchmark",
                "LocalFrameView::RunStyleAndLayoutLifecyclePhases");
   UpdateStyleAndLayoutIfNeededRecursive();
   DCHECK(ShouldThrottleRendering() ||
          Lifecycle().GetState() >= DocumentLifecycle::kLayoutClean);
   if (Lifecycle().GetState() < DocumentLifecycle::kLayoutClean) {
-    recordreplay::Assert("LocalFrameView::RunStyleAndLayoutLifecyclePhases #1");
     return false;
   }
 
@@ -2742,7 +2739,6 @@ bool LocalFrameView::RunStyleAndLayoutLifecyclePhases(
   }
 
   if (target_state == DocumentLifecycle::kLayoutClean) {
-    recordreplay::Assert("LocalFrameView::RunStyleAndLayoutLifecyclePhases #2");
     return false;
   }
 
@@ -2763,13 +2759,11 @@ bool LocalFrameView::RunStyleAndLayoutLifecyclePhases(
     });
   }
 
-  recordreplay::Assert("LocalFrameView::RunStyleAndLayoutLifecyclePhases Done");
   return Lifecycle().GetState() >= DocumentLifecycle::kLayoutClean;
 }
 
 bool LocalFrameView::RunCompositingInputsLifecyclePhase(
     DocumentLifecycle::LifecycleState target_state) {
-  recordreplay::Assert("LocalFrameView::RunCompositingInputsLifecyclePhase Start");
   TRACE_EVENT0("blink,benchmark",
                "LocalFrameView::RunCompositingInputsLifecyclePhase");
   auto* layout_view = GetLayoutView();
@@ -2786,7 +2780,6 @@ bool LocalFrameView::RunCompositingInputsLifecyclePhase(
     });
   }
 
-  recordreplay::Assert("LocalFrameView::RunCompositingInputsLifecyclePhase Done");
   return target_state > DocumentLifecycle::kCompositingInputsClean;
 }
 

--- a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
+++ b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
@@ -2030,7 +2030,6 @@ void WebFrameWidgetImpl::BeginMainFrame(base::TimeTicks last_frame_time) {
 }
 
 void WebFrameWidgetImpl::BeginCommitCompositorFrame() {
-  recordreplay::Assert("WebFrameWidgetImpl::BeginCommitCompositorFrame");
   commit_compositor_frame_start_time_.emplace(base::TimeTicks::Now());
 }
 
@@ -2188,8 +2187,6 @@ void WebFrameWidgetImpl::RecordEndOfFrameMetrics(
     cc::ActiveFrameSequenceTrackers trackers) {
   if (!LocalRootImpl())
     return;
-
-  recordreplay::Assert("WebFrameWidgetImpl::RecordEndOfFrameMetrics");
 
   LocalRootImpl()
       ->GetFrame()

--- a/third_party/blink/renderer/core/html/forms/form_controller.cc
+++ b/third_party/blink/renderer/core/html/forms/form_controller.cc
@@ -91,10 +91,7 @@ bool IsDirtyControl(const ListedElement& control) {
 void FormControlState::SerializeTo(Vector<String>& state_vector) const {
   DCHECK(!IsFailure());
   state_vector.push_back(String::Number(values_.size()));
-  recordreplay::Assert("FormControlState::SerializeTo #1 %lu", values_.size());
   for (const auto& value : values_) {
-    recordreplay::Assert("FormControlState::SerializeTo #2 %d %s",
-                         value.IsNull(), value.Utf8().c_str());
     state_vector.push_back(value.IsNull() ? g_empty_string : value);
   }
 }
@@ -295,7 +292,6 @@ std::unique_ptr<SavedFormState> SavedFormState::Deserialize(
 
 void SavedFormState::SerializeTo(Vector<String>& state_vector) const {
   state_vector.push_back(String::Number(control_state_count_));
-  recordreplay::Assert("SavedFormState::SerializeTo #1 %lu", control_state_count_);
   std::vector<ControlKey> keys;
   for (const auto& form_control : state_for_new_controls_) {
     keys.push_back(form_control.key);
@@ -306,9 +302,6 @@ void SavedFormState::SerializeTo(Vector<String>& state_vector) const {
     CHECK(it != state_for_new_controls_.end());
     const Deque<FormControlState>& queue = it->value;
     for (const FormControlState& form_control_state : queue) {
-      recordreplay::Assert("SavedFormState::SerializeTo #2 %lu %lu",
-                           key.GetName()->length(),
-                           key.GetType()->length());
       state_vector.push_back(key.GetName());
       state_vector.push_back(key.GetType());
       form_control_state.SerializeTo(state_vector);
@@ -517,8 +510,6 @@ Vector<String> DocumentState::ToStateVector() {
   state_vector.ReserveInitialCapacity(GetControlList().size() * 4);
   state_vector.push_back(FormStateSignature());
   for (const auto& saved_form_state : *state_map) {
-    recordreplay::Assert("DocumentState::ToStateVector %s",
-                         saved_form_state.key.Utf8().c_str());
     state_vector.push_back(saved_form_state.key);
     saved_form_state.value->SerializeTo(state_vector);
   }

--- a/third_party/blink/renderer/core/html/html_image_loader.cc
+++ b/third_party/blink/renderer/core/html/html_image_loader.cc
@@ -67,8 +67,6 @@ void HTMLImageLoader::NoImageResourceToLoad() {
 }
 
 void HTMLImageLoader::ImageNotifyFinished(ImageResourceContent*) {
-  recordreplay::Assert("HTMLImageLoader::ImageNotifyFinished Start");
-
   ImageResourceContent* cached_image = GetContent();
   Element* element = GetElement();
   ImageLoader::ImageNotifyFinished(cached_image);
@@ -95,8 +93,6 @@ void HTMLImageLoader::ImageNotifyFinished(ImageResourceContent*) {
   if ((load_error || cached_image->GetResponse().HttpStatusCode() >= 400) &&
       html_image_element)
     html_image_element->RenderFallbackContent(nullptr);
-
-  recordreplay::Assert("HTMLImageLoader::ImageNotifyFinished Done");
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/html/html_link_element.cc
+++ b/third_party/blink/renderer/core/html/html_link_element.cc
@@ -358,7 +358,6 @@ void HTMLLinkElement::LinkLoaded() {
   if (rel_attribute_.IsLinkPrefetch()) {
     UseCounter::Count(GetDocument(), WebFeature::kLinkPrefetchLoadEvent);
   }
-  recordreplay::Assert("HTMLLinkElement::LinkLoaded");
   DispatchEvent(*Event::Create(event_type_names::kLoad), "HTMLLinkElement::LinkLoaded");
 }
 

--- a/third_party/blink/renderer/core/html/html_slot_element.cc
+++ b/third_party/blink/renderer/core/html/html_slot_element.cc
@@ -230,22 +230,12 @@ void HTMLSlotElement::assign(HeapVector<Member<Node>> nodes,
 }
 
 void HTMLSlotElement::AppendAssignedNode(Node& host_child) {
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("HTMLSlotElement::AppendAssignedNode %d",
-                       recordreplay::PointerId(&host_child));
-
   DCHECK(host_child.IsSlotable());
   assigned_nodes_.push_back(&host_child);
 }
 
 void HTMLSlotElement::UpdateManuallyAssignedNodesOrdering() {
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("HTMLSlotElement::UpdateManuallyAssignedNodesOrdering %d",
-                       recordreplay::PointerId(this));
-
   if (assigned_nodes_.IsEmpty() || assigned_nodes_candidates_.IsEmpty()) {
-    // https://linear.app/replay/issue/RUN-493
-    recordreplay::Assert("HTMLSlotElement::UpdateManuallyAssignedNodesOrdering #1");
     return;
   }
 
@@ -256,9 +246,6 @@ void HTMLSlotElement::UpdateManuallyAssignedNodesOrdering() {
   }
   assigned_nodes_.clear();
   for (auto& node : assigned_nodes_candidates_) {
-    // https://linear.app/replay/issue/RUN-493
-    recordreplay::Assert("HTMLSlotElement::UpdateManuallyAssignedNodesOrdering #2 %d %d",
-                         prev_nodes.Contains(node), recordreplay::PointerId((void*)node));
     if (prev_nodes.Contains(node))
       assigned_nodes_.push_back(node);
   }
@@ -277,9 +264,6 @@ void HTMLSlotElement::ClearAssignedNodesCandidates() {
 }
 
 void HTMLSlotElement::ClearAssignedNodes() {
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("HTMLSlotElement::ClearAssignedNodes %d",
-                       recordreplay::PointerId(this));
   assigned_nodes_.clear();
 }
 
@@ -316,20 +300,12 @@ void HTMLSlotElement::UpdateFlatTreeNodeDataForAssignedNodes() {
 void HTMLSlotElement::RecalcFlatTreeChildren() {
   DCHECK(SupportsAssignment());
 
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("HTMLSlotElement::RecalcFlatTreeChildren %d %d",
-                       recordreplay::PointerId(this),
-                       assigned_nodes_.IsEmpty());
-
   HeapVector<Member<Node>> old_flat_tree_children;
   old_flat_tree_children.swap(flat_tree_children_);
 
   if (assigned_nodes_.IsEmpty()) {
     // Use children as fallback
     for (auto& child : NodeTraversal::ChildrenOf(*this)) {
-      // https://linear.app/replay/issue/RUN-493
-      recordreplay::Assert("HTMLSlotElement::RecalcFlatTreeChildren #1 %d %d",
-                          recordreplay::PointerId(&child), child.IsSlotable());
       if (child.IsSlotable())
         flat_tree_children_.push_back(child);
     }
@@ -559,18 +535,6 @@ void HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange(
   if (old_slotted == new_slotted)
     return;
   probe::DidPerformSlotDistribution(this);
-
-  // https://linear.app/replay/issue/RUN-493
-  recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange %zu %zu",
-                       old_slotted.size(), new_slotted.size());
-  for (const auto& node : old_slotted) {
-    recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange OLD %d",
-                         recordreplay::PointerId(node));
-  }
-  for (const auto& node : new_slotted) {
-    recordreplay::Assert("HTMLSlotElement::NotifySlottedNodesOfFlatTreeChange NEW %d",
-                         recordreplay::PointerId(node));
-  }
 
   // It is very important to minimize the number of reattaching nodes in
   // |new_assigned_nodes| here. The following *works*, in terms of the

--- a/third_party/blink/renderer/core/html/parser/background_html_input_stream.cc
+++ b/third_party/blink/renderer/core/html/parser/background_html_input_stream.cc
@@ -35,8 +35,6 @@ BackgroundHTMLInputStream::BackgroundHTMLInputStream()
       total_checkpoint_token_count_(0) {}
 
 void BackgroundHTMLInputStream::Append(const String& input) {
-  recordreplay::Assert("BackgroundHTMLInputStream::Append %u %u", input.length(), input[0]);
-
   current_.Append(SegmentedString(input));
   segments_.push_back(input);
 }
@@ -119,8 +117,6 @@ void BackgroundHTMLInputStream::RewindTo(HTMLInputCheckpoint checkpoint_index,
   first_valid_segment_index_ = 0;
 
   UpdateTotalCheckpointTokenCount();
-
-  recordreplay::Assert("BackgroundHTMLInputStream::RewindTo %u", current_.length());
 }
 
 void BackgroundHTMLInputStream::UpdateTotalCheckpointTokenCount() {

--- a/third_party/blink/renderer/core/html/parser/background_html_parser.cc
+++ b/third_party/blink/renderer/core/html/parser/background_html_parser.cc
@@ -127,9 +127,6 @@ void BackgroundHTMLParser::Flush() {
 }
 
 void BackgroundHTMLParser::UpdateDocument(const String& decoded_data) {
-  recordreplay::Assert("BackgroundHTMLParser::UpdateDocument Start %u %u",
-                       decoded_data.length(), decoded_data[0]);
-
   DocumentEncodingData encoding_data(*decoder_.get());
   if (encoding_data != last_seen_encoding_data_) {
     last_seen_encoding_data_ = encoding_data;
@@ -137,12 +134,10 @@ void BackgroundHTMLParser::UpdateDocument(const String& decoded_data) {
       parser_->DidReceiveEncodingDataFromBackgroundParser(encoding_data);
   }
   if (decoded_data.IsEmpty()) {
-    recordreplay::Assert("BackgroundHTMLParser::UpdateDocument #1");
     return;
   }
 
   AppendDecodedBytes(decoded_data);
-  recordreplay::Assert("BackgroundHTMLParser::UpdateDocument Done");
 }
 
 void BackgroundHTMLParser::ResumeFrom(std::unique_ptr<Checkpoint> checkpoint) {
@@ -197,18 +192,12 @@ void BackgroundHTMLParser::PumpTokenizer() {
   HTMLTreeBuilderSimulator::SimulatedToken simulated_token =
       HTMLTreeBuilderSimulator::kOtherToken;
 
-  recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer Start %u",
-                       input_.Current().length());
-
   // No need to start speculating until the main thread has almost caught up.
   if (input_.TotalCheckpointTokenCount() > kOutstandingTokenLimit) {
-    recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #1");
     return;
   }
 
   while (tokenizer_->NextToken(input_.Current(), *token_)) {
-    recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #2");
-
     {
       TextPosition position = TextPosition(input_.Current().CurrentLine(),
                                            input_.Current().CurrentColumn());
@@ -225,7 +214,6 @@ void BackgroundHTMLParser::PumpTokenizer() {
       // starting a script so the main parser can decide if it should yield
       // before processing the chunk.
       if (simulated_token == HTMLTreeBuilderSimulator::kValidScriptStart) {
-        recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #3");
         EnqueueTokenizedChunk();
         starting_script_ = true;
       }
@@ -243,21 +231,17 @@ void BackgroundHTMLParser::PumpTokenizer() {
         simulated_token == HTMLTreeBuilderSimulator::kLink ||
         simulated_token == HTMLTreeBuilderSimulator::kCustomElementBegin ||
         pending_tokens_.size() >= kPendingTokenLimit) {
-      recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #4");
       EnqueueTokenizedChunk();
 
       // If we're far ahead of the main thread, yield for a bit to avoid
       // consuming too much memory.
       if (input_.TotalCheckpointTokenCount() > kOutstandingTokenLimit) {
-        recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #4.1");
         break;
       }
     }
   }
 
-  recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer #5");
   EnqueueTokenizedChunk();
-  recordreplay::Assert("BackgroundHTMLParser::PumpTokenizer Done");
 }
 
 void BackgroundHTMLParser::EnqueueTokenizedChunk() {

--- a/third_party/blink/renderer/core/html/parser/html_document_parser.cc
+++ b/third_party/blink/renderer/core/html/parser/html_document_parser.cc
@@ -691,13 +691,10 @@ void HTMLDocumentParser::EnqueueTokenizedChunk(
   DCHECK(!RuntimeEnabledFeatures::ForceSynchronousHTMLParsingEnabled());
   TRACE_EVENT0("blink", "HTMLDocumentParser::EnqueueTokenizedChunk");
 
-  recordreplay::Assert("HTMLDocumentParser::EnqueueTokenizedChunk Start");
-
   DCHECK(chunk);
   DCHECK(GetDocument());
 
   if (!IsParsing()) {
-    recordreplay::Assert("HTMLDocumentParser::EnqueueTokenizedChunk #1");
     return;
   }
 
@@ -739,8 +736,6 @@ void HTMLDocumentParser::EnqueueTokenizedChunk(
     // Delay sending some requests if meta tag based CSP is present or
     // if AppCache was used to fetch the HTML but was not yet initialized for
     // this document.
-    recordreplay::Assert("HTMLDocumentParser::EnqueueTokenizedChunk #2 %d",
-                         !!pending_csp_meta_token_);
     if (pending_csp_meta_token_ ||
         ((!base::FeatureList::IsEnabled(
               blink::features::kVerifyHTMLFetchedFromAppCacheBeforeDelay) ||
@@ -769,8 +764,6 @@ void HTMLDocumentParser::EnqueueTokenizedChunk(
 
   if (!IsPaused() && !IsScheduledForUnpause())
     parser_scheduler_->ScheduleForUnpause();
-
-  recordreplay::Assert("HTMLDocumentParser::EnqueueTokenizedChunk Done");
 }
 
 void HTMLDocumentParser::DidReceiveEncodingDataFromBackgroundParser(
@@ -856,7 +849,6 @@ void HTMLDocumentParser::DiscardSpeculationsAndResumeFrom(
       last_chunk_before_script->preload_scanner_checkpoint;
   checkpoint->unparsed_input = input_.Current().ToString().IsolatedCopy();
   // FIXME: This should be passed in instead of cleared.
-  recordreplay::Assert("HTMLDocumentParser::DiscardSpeculationsAndResumeFrom");
   input_.Current().Clear();
 
   DCHECK(checkpoint->unparsed_input.IsSafeToSendToAnotherThread());
@@ -1045,8 +1037,6 @@ bool HTMLDocumentParser::PumpTokenizer() {
   int budget = max_tokenization_budget_;
 
   while (!should_yield) {
-    recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #0");
-
     const auto next_token_status = CanTakeNextToken();
     if (next_token_status == NoTokens) {
       // No tokens left to process in this pump, so break
@@ -1066,27 +1056,21 @@ bool HTMLDocumentParser::PumpTokenizer() {
       RUNTIME_CALL_TIMER_SCOPE(
           V8PerIsolateData::MainThreadIsolate(),
           RuntimeCallStats::CounterId::kHTMLTokenizerNextToken);
-      recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #1 %u",
-                           input_.Current().length());
       if (!tokenizer_->NextToken(input_.Current(), Token()))
         break;
       budget--;
     }
     ConstructTreeFromHTMLToken();
     if (!should_run_until_completion && !IsPaused()) {
-      recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #2");
       DCHECK_EQ(task_runner_state_->GetMode(), kAllowDeferredParsing);
       should_yield = budget <= 0;
       should_yield |= scheduler_->ShouldYieldForHighPriorityWork();
       should_yield &= task_runner_state_->HaveExitedHeader();
-      recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #3");
     } else {
       should_yield = false;
     }
     DCHECK(IsStopped() || Token().IsUninitialized());
   }
-
-  recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #4");
 
   if (IsStopped())
     return false;
@@ -1104,8 +1088,6 @@ bool HTMLDocumentParser::PumpTokenizer() {
         preload_scanner_ = CreatePreloadScanner(
             TokenPreloadScanner::ScannerType::kMainDocument);
         preload_scanner_->AppendToEnd(input_.Current());
-        recordreplay::Assert("HTMLDocumentParser::PumpTokenizer #2 %u",
-                             input_.Current().length());
       }
       ScanAndPreload(preload_scanner_.get());
     }
@@ -1226,8 +1208,6 @@ void HTMLDocumentParser::insert(const String& sourceArg) {
     delete[] chars;
   }
 
-  recordreplay::Assert("HTMLDocumentParser::insert Start %u %d", source.length(), source.Is8Bit());
-
   if (IsStopped())
     return;
 
@@ -1244,9 +1224,6 @@ void HTMLDocumentParser::insert(const String& sourceArg) {
   SegmentedString excluded_line_number_source(source);
   excluded_line_number_source.SetExcludeLineNumbers();
   input_.InsertAtCurrentInsertionPoint(excluded_line_number_source);
-
-  recordreplay::Assert("HTMLDocumentParser::insert #1 %u",
-                        input_.Current().length());
 
   // Pump the the tokenizer to build the document from the given insert point.
   // Should process everything available and not defer anything.
@@ -1383,8 +1360,6 @@ void HTMLDocumentParser::Append(const String& input_source) {
   }
 
   input_.AppendToEnd(source);
-  recordreplay::Assert("HTMLDocumentParser::Append #1 %u",
-                        input_.Current().length());
 
   task_runner_state_->SetHaveSeenFirstByte();
 
@@ -1719,8 +1694,6 @@ void HTMLDocumentParser::ParseDocumentFragment(
 void HTMLDocumentParser::AppendBytes(const char* data, size_t length) {
   TRACE_EVENT2("blink", "HTMLDocumentParser::appendBytes", "size",
                (unsigned)length, "parser", (void*)this);
-
-  recordreplay::Assert("HTMLDocumentParser::AppendBytes %lu %u", length, data[0]);
 
   DCHECK(Thread::MainThread()->IsCurrentThread());
 

--- a/third_party/blink/renderer/core/html/parser/html_tokenizer.cc
+++ b/third_party/blink/renderer/core/html/parser/html_tokenizer.cc
@@ -136,10 +136,6 @@ bool HTMLTokenizer::FlushEmitAndResumeIn(SegmentedString& source,
 }
 
 bool HTMLTokenizer::NextToken(SegmentedString& source, HTMLToken& token) {
-  recordreplay::Assert("HTMLTokenizer::NextToken Start %lu %u %u",
-                       recordreplay::PointerId(this),
-                       source.length(), source.length() ? source.CurrentChar() : 0);
-
   // If we have a token in progress, then we're supposed to be called back
   // with the same token so we can finish it.
   DCHECK(!token_ || token_ == &token ||
@@ -155,18 +151,14 @@ bool HTMLTokenizer::NextToken(SegmentedString& source, HTMLToken& token) {
     temporary_buffer_.clear();
     if (state_ == HTMLTokenizer::kDataState) {
       // We're back in the data state, so we must be done with the tag.
-      recordreplay::Assert("HTMLTokenizer::NextToken #1");
       return true;
     }
   }
 
   if (source.IsEmpty() || !input_stream_preprocessor_.Peek(source)) {
-    recordreplay::Assert("HTMLTokenizer::NextToken #2");
     return HaveBufferedCharacterToken();
   }
   UChar cc = input_stream_preprocessor_.NextInputCharacter();
-
-  recordreplay::Assert("HTMLTokenizer::NextToken #3 %d", state_);
 
   // Source: http://www.whatwg.org/specs/web-apps/current-work/#tokenisation0
   switch (state_) {

--- a/third_party/blink/renderer/core/inspector/devtools_agent.cc
+++ b/third_party/blink/renderer/core/inspector/devtools_agent.cc
@@ -89,9 +89,7 @@ class DevToolsAgent::IOAgent : public mojom::blink::DevToolsAgent {
 
   void DeleteSoon() { io_task_runner_->DeleteSoon(FROM_HERE, this); }
 
-  ~IOAgent() override {
-    recordreplay::Assert("DevToolsAgent::IOAgent::~IOAgent");
-  }
+  ~IOAgent() override {}
 
   // mojom::blink::DevToolsAgent implementation.
   void AttachDevToolsSession(

--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -1138,7 +1138,6 @@ void InspectorNetworkAgent::WillSendRequestInternal(
     maybe_frame_id = frame_id;
 
   double wallTime = base::Time::Now().ToDoubleT();
-  recordreplay::Assert("InspectorNetworkAgent::WillSendRequestInternal %.2f", wallTime);
 
   if (PermitRecordReplayBrowserEvents()) {
     uint64_t bookmark = request.GetRecordReplayBookmark().value_or(0);
@@ -1442,7 +1441,6 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
   }
 
   double timestamp = base::TimeTicks::Now().since_origin().InSecondsF();
-  recordreplay::Assert("InspectorNetworkAgent::DidReceiveData %lf", timestamp);
 
   if (PermitRecordReplayBrowserEvents()) {
     base::DictionaryValue dict;
@@ -1498,7 +1496,6 @@ void InspectorNetworkAgent::DidFinishLoading(
       resources_data_->GetAndClearPendingEncodedDataLength(request_id));
   if (pending_encoded_data_length > 0) {
     double timestamp = base::TimeTicks::Now().since_origin().InSecondsF();
-    recordreplay::Assert("InspectorNetworkAgent::DidFinishLoading %lf", timestamp);
 
     GetFrontend()->dataReceived(
         request_id, timestamp, 0,

--- a/third_party/blink/renderer/core/intersection_observer/intersection_observation.cc
+++ b/third_party/blink/renderer/core/intersection_observer/intersection_observation.cc
@@ -47,9 +47,7 @@ IntersectionObservation::IntersectionObservation(IntersectionObserver& observer,
 void IntersectionObservation::ComputeIntersection(
     const IntersectionGeometry::RootGeometry& root_geometry,
     unsigned compute_flags) {
-  recordreplay::Assert("IntersectionObservation::ComputeIntersection Start %lu", recordreplay::PointerId(this));
   if (!ShouldCompute(compute_flags)) {
-    recordreplay::Assert("IntersectionObservation::ComputeIntersection #1");
     return;
   }
   DCHECK(observer_->root());
@@ -58,13 +56,10 @@ void IntersectionObservation::ComputeIntersection(
       root_geometry, *observer_->root(), *Target(), observer_->thresholds(),
       observer_->TargetMargin(), geometry_flags, cached_rects_.get());
   ProcessIntersectionGeometry(geometry);
-  recordreplay::Assert("IntersectionObservation::ComputeIntersection Done");
 }
 
 void IntersectionObservation::ComputeIntersection(unsigned compute_flags) {
-  recordreplay::Assert("IntersectionObservation::ComputeIntersection2 Start %lu", recordreplay::PointerId(this));
   if (!ShouldCompute(compute_flags)) {
-    recordreplay::Assert("IntersectionObservation::ComputeIntersection2 #1");
     return;
   }
   unsigned geometry_flags = GetIntersectionGeometryFlags(compute_flags);
@@ -72,7 +67,6 @@ void IntersectionObservation::ComputeIntersection(unsigned compute_flags) {
       observer_->root(), *Target(), observer_->RootMargin(),
       observer_->thresholds(), observer_->TargetMargin(), geometry_flags);
   ProcessIntersectionGeometry(geometry);
-  recordreplay::Assert("IntersectionObservation::ComputeIntersection2 Done");
 }
 
 void IntersectionObservation::TakeRecords(
@@ -223,7 +217,6 @@ void IntersectionObservation::ProcessIntersectionGeometry(
 
   if (last_threshold_index_ != geometry.ThresholdIndex() ||
       last_is_visible_ != geometry.IsVisible()) {
-    recordreplay::Assert("IntersectionObservation::ProcessIntersectionGeometry #1");
     entries_.push_back(MakeGarbageCollected<IntersectionObserverEntry>(
         geometry, last_run_time_, Target()));
     Observer()->SetNeedsDelivery();

--- a/third_party/blink/renderer/core/intersection_observer/intersection_observer.cc
+++ b/third_party/blink/renderer/core/intersection_observer/intersection_observer.cc
@@ -498,7 +498,6 @@ IntersectionObserver::GetDeliveryBehavior() const {
 }
 
 void IntersectionObserver::Deliver() {
-  recordreplay::Assert("IntersectionObserver::Deliver %lu", recordreplay::PointerId(this));
   if (!needs_delivery_)
     return;
   needs_delivery_ = 0;

--- a/third_party/blink/renderer/core/intersection_observer/intersection_observer_controller.cc
+++ b/third_party/blink/renderer/core/intersection_observer/intersection_observer_controller.cc
@@ -25,7 +25,6 @@ IntersectionObserverController::IntersectionObserverController(
 IntersectionObserverController::~IntersectionObserverController() = default;
 
 void IntersectionObserverController::PostTaskToDeliverNotifications() {
-  recordreplay::Assert("IntersectionObserverController::PostTaskToDeliverNotifications Start");
   DCHECK(GetExecutionContext());
   GetExecutionContext()
       ->GetTaskRunner(TaskType::kInternalIntersectionObserver)
@@ -34,7 +33,6 @@ void IntersectionObserverController::PostTaskToDeliverNotifications() {
           WTF::Bind(&IntersectionObserverController::DeliverNotifications,
                     WrapWeakPersistent(this),
                     IntersectionObserver::kPostTaskToDeliver));
-  recordreplay::Assert("IntersectionObserverController::PostTaskToDeliverNotifications Done");
 }
 
 void IntersectionObserverController::ScheduleIntersectionObserverForDelivery(
@@ -68,7 +66,6 @@ void IntersectionObserverController::DeliverNotifications(
 bool IntersectionObserverController::ComputeIntersections(
     unsigned flags,
     LocalFrameUkmAggregator& ukm_aggregator) {
-  recordreplay::Assert("IntersectionObserverController::ComputeIntersections Start");
   needs_occlusion_tracking_ = false;
   if (GetExecutionContext()) {
     TRACE_EVENT0("blink",
@@ -81,9 +78,7 @@ bool IntersectionObserverController::ComputeIntersections(
     for (auto& observer : observers_to_process) {
       if (observer->HasObservations()) {
         SCOPED_UMA_AND_UKM_TIMER(ukm_aggregator, observer->GetUkmMetricId());
-        recordreplay::Assert("IntersectionObserverController::ComputeIntersections #1");
         needs_occlusion_tracking_ |= observer->ComputeIntersections(flags);
-        recordreplay::Assert("IntersectionObserverController::ComputeIntersections #2");
       } else {
         tracked_explicit_root_observers_.erase(observer);
       }
@@ -95,13 +90,10 @@ bool IntersectionObserverController::ComputeIntersections(
     for (auto& observation : observations_to_process) {
       SCOPED_UMA_AND_UKM_TIMER(ukm_aggregator,
                                observation->Observer()->GetUkmMetricId());
-      recordreplay::Assert("IntersectionObserverController::ComputeIntersections #3");
       observation->ComputeIntersection(flags);
-      recordreplay::Assert("IntersectionObserverController::ComputeIntersections #4");
       needs_occlusion_tracking_ |= observation->Observer()->trackVisibility();
     }
   }
-  recordreplay::Assert("IntersectionObserverController::ComputeIntersections Done");
   return needs_occlusion_tracking_;
 }
 

--- a/third_party/blink/renderer/core/layout/layout_box.cc
+++ b/third_party/blink/renderer/core/layout/layout_box.cc
@@ -593,8 +593,6 @@ void LayoutBox::StyleWillChange(StyleDifference diff,
 
 void LayoutBox::StyleDidChange(StyleDifference diff,
                                const ComputedStyle* old_style) {
-  recordreplay::Assert("LayoutBox::StyleDidChange Start");
-
   NOT_DESTROYED();
   // Horizontal writing mode definition is updated in LayoutBoxModelObject::
   // updateFromStyle, (as part of the LayoutBoxModelObject::styleDidChange call
@@ -710,8 +708,6 @@ void LayoutBox::StyleDidChange(StyleDifference diff,
 
   // Non-atomic inlines should be LayoutInline or LayoutText, not LayoutBox.
   DCHECK(!IsInline() || IsAtomicInlineLevel());
-
-  recordreplay::Assert("LayoutBox::StyleDidChange Done");
 }
 
 void LayoutBox::UpdateBackgroundAttachmentFixedStatusAfterStyleChange() {

--- a/third_party/blink/renderer/core/layout/layout_object.cc
+++ b/third_party/blink/renderer/core/layout/layout_object.cc
@@ -4383,13 +4383,7 @@ void LayoutObject::
   // Only full invalidation reasons are allowed.
   DCHECK(IsFullPaintInvalidationReason(reason));
 
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal Start %d",
-                       recordreplay::PointerId(this));
-
   if (ShouldDoFullPaintInvalidation()) {
-    // https://linear.app/replay/issue/RUN-569
-    recordreplay::Assert("LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal #1");
     return;
   }
 
@@ -4400,9 +4394,6 @@ void LayoutObject::
   }
   full_paint_invalidation_reason_ = reason;
   bitfields_.SetShouldDelayFullPaintInvalidation(false);
-
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal Done");
 }
 
 void LayoutObject::SetShouldCheckForPaintInvalidation() {

--- a/third_party/blink/renderer/core/loader/modulescript/module_tree_linker.cc
+++ b/third_party/blink/renderer/core/loader/modulescript/module_tree_linker.cc
@@ -301,8 +301,6 @@ void ModuleTreeLinker::FetchRootInline(ModuleScript* module_script) {
 // #fetch-a-module-script-tree, #fetch-an-import()-module-script-graph, and
 // #fetch-a-module-worker-script-tree, and IMSGF.
 void ModuleTreeLinker::NotifyModuleLoadFinished(ModuleScript* module_script) {
-  recordreplay::Assert("ModuleTreeLinker::NotifyModuleLoadFinished Start");
-
   CHECK_GT(num_incomplete_fetches_, 0u);
   --num_incomplete_fetches_;
 
@@ -326,7 +324,6 @@ void ModuleTreeLinker::NotifyModuleLoadFinished(ModuleScript* module_script) {
   if (state_ != State::kFetchingDependencies) {
     // We may reach here if one of the descendant failed to load, and the other
     // descendants fetches were in flight.
-    recordreplay::Assert("ModuleTreeLinker::NotifyModuleLoadFinished #1");
     return;
   }
 
@@ -347,7 +344,6 @@ void ModuleTreeLinker::NotifyModuleLoadFinished(ModuleScript* module_script) {
   if (!module_script) {
     result_ = nullptr;
     AdvanceState(State::kFinished);
-    recordreplay::Assert("ModuleTreeLinker::NotifyModuleLoadFinished #2");
     return;
   }
 
@@ -364,8 +360,6 @@ void ModuleTreeLinker::NotifyModuleLoadFinished(ModuleScript* module_script) {
   // <spec label="IMSGF" step="5">Fetch the descendants of result given fetch
   // client settings object, destination, and visited set.</spec>
   FetchDescendants(module_script);
-
-  recordreplay::Assert("ModuleTreeLinker::NotifyModuleLoadFinished Done");
 }
 
 // <specdef

--- a/third_party/blink/renderer/core/loader/resource/image_resource.cc
+++ b/third_party/blink/renderer/core/loader/resource/image_resource.cc
@@ -512,7 +512,6 @@ void ImageResource::UpdateImage(
     scoped_refptr<SharedBuffer> shared_buffer,
     ImageResourceContent::UpdateImageOption update_image_option,
     bool all_data_received) {
-  recordreplay::Assert("ImageResource::UpdateImage Start");
   bool is_multipart = !!multipart_parser_;
   auto result = GetContent()->UpdateImage(std::move(shared_buffer), GetStatus(),
                                           update_image_option,
@@ -534,7 +533,6 @@ void ImageResource::UpdateImage(
     //    (b) after returning ImageResource::updateImage().
     DecodeError(all_data_received);
   }
-  recordreplay::Assert("ImageResource::UpdateImage Done");
 }
 
 void ImageResource::FlagAsUserAgentResource() {

--- a/third_party/blink/renderer/core/loader/web_associated_url_loader_impl.cc
+++ b/third_party/blink/renderer/core/loader/web_associated_url_loader_impl.cc
@@ -345,7 +345,6 @@ WebAssociatedURLLoaderImpl::WebAssociatedURLLoaderImpl(
       observer_(MakeGarbageCollected<Observer>(this, context)) {}
 
 WebAssociatedURLLoaderImpl::~WebAssociatedURLLoaderImpl() {
-  recordreplay::Assert("WebAssociatedURLLoaderImpl::~WebAssociatedURLLoaderImpl");
   Cancel();
 }
 

--- a/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.cc
+++ b/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.cc
@@ -1842,13 +1842,11 @@ base::Optional<FloatPoint>
 PaintLayerScrollableArea::GetSnapPositionAndSetTarget(
     const cc::SnapSelectionStrategy& strategy) {
   if (!RareData() || !RareData()->snap_container_data_) {
-    recordreplay::Assert("PaintLayerScrollableArea::GetSnapPositionAndSetTarget #1");
     return base::nullopt;
   }
 
   cc::SnapContainerData& data = RareData()->snap_container_data_.value();
   if (!data.size()) {
-    recordreplay::Assert("PaintLayerScrollableArea::GetSnapPositionAndSetTarget #2");
     return base::nullopt;
   }
 
@@ -1857,12 +1855,9 @@ PaintLayerScrollableArea::GetSnapPositionAndSetTarget(
   base::Optional<FloatPoint> snap_point;
   if (data.FindSnapPosition(strategy, &snap_position, &snap_targets)) {
     snap_point = FloatPoint(snap_position.x(), snap_position.y());
-    recordreplay::Assert("PaintLayerScrollableArea::GetSnapPositionAndSetTarget #3 %s",
-                         snap_point.value().ToString().Utf8().c_str());
   }
   if (data.SetTargetSnapAreaElementIds(snap_targets))
     GetLayoutBox()->SetNeedsPaintPropertyUpdate();
-  recordreplay::Assert("PaintLayerScrollableArea::GetSnapPositionAndSetTarget Done");
   return snap_point;
 }
 

--- a/third_party/blink/renderer/core/paint/paint_property_tree_builder.cc
+++ b/third_party/blink/renderer/core/paint/paint_property_tree_builder.cc
@@ -615,8 +615,6 @@ void FragmentPaintPropertyTreeBuilder::UpdatePaintOffsetTranslation(
         full_context_.direct_compositing_reasons &
         CompositingReason::kDirectReasonsForPaintOffsetTranslationProperty;
     state.rendering_context_id = context_.current.rendering_context_id;
-    recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdatePaintOffsetTranslation #1 %d",
-                         state.rendering_context_id);
     if (IsA<LayoutView>(object_)) {
       DCHECK(object_.GetFrame());
       state.flags.is_frame_paint_offset_translation = true;
@@ -987,8 +985,6 @@ void FragmentPaintPropertyTreeBuilder::UpdateTransform() {
         // does not exist in an existing rendering context, it establishes a
         // new one.
         state.rendering_context_id = context_.current.rendering_context_id;
-        recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdateTransform #1 %d",
-                             state.rendering_context_id);
         if (style.Preserves3D() && !state.rendering_context_id) {
           // When recording/replaying we need a consistent context ID, so use
           // the pointer ID of the object instead of its hash.
@@ -998,8 +994,6 @@ void FragmentPaintPropertyTreeBuilder::UpdateTransform() {
             state.rendering_context_id =
                 PtrHash<const LayoutObject>::GetHash(&object_);
           }
-          recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdateTransform #2 %d",
-                              state.rendering_context_id);
         }
 
         // TODO(crbug.com/1185254): Make this work correctly for block
@@ -1054,8 +1048,6 @@ void FragmentPaintPropertyTreeBuilder::UpdateTransform() {
     context_.current.transform = transform;
     if (object_.StyleRef().Preserves3D()) {
       context_.current.rendering_context_id = transform->RenderingContextId();
-      recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdateTransform #3 %d",
-                           context_.current.rendering_context_id);
       context_.current.should_flatten_inherited_transform = false;
     } else {
       context_.current.rendering_context_id = 0;
@@ -1900,8 +1892,6 @@ void FragmentPaintPropertyTreeBuilder::UpdatePerspective() {
       state.flags.flattens_inherited_transform =
           context_.current.should_flatten_inherited_transform;
       state.rendering_context_id = context_.current.rendering_context_id;
-      recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdatePerspective #1 %d",
-                           state.rendering_context_id);
       OnUpdate(properties_->UpdatePerspective(*context_.current.transform,
                                               std::move(state)));
     } else {
@@ -2110,8 +2100,6 @@ void FragmentPaintPropertyTreeBuilder::UpdateScrollAndScrollTranslation() {
           full_context_.direct_compositing_reasons &
           CompositingReason::kDirectReasonsForScrollTranslationProperty;
       state.rendering_context_id = context_.current.rendering_context_id;
-      recordreplay::Assert("FragmentPaintPropertyTreeBuilder::UpdateScrollAndScrollTranslation #1 %d",
-                           state.rendering_context_id);
       state.scroll = properties_->Scroll();
       // If scroll and transform are both present, we should use the
       // transform property tree node to determine visibility of the

--- a/third_party/blink/renderer/core/scroll/scrollable_area.cc
+++ b/third_party/blink/renderer/core/scroll/scrollable_area.cc
@@ -256,8 +256,6 @@ void ScrollableArea::SetScrollOffset(const ScrollOffset& offset,
                                      mojom::blink::ScrollType scroll_type,
                                      mojom::blink::ScrollBehavior behavior,
                                      ScrollCallback on_finish) {
-  recordreplay::Assert("ScrollableArea::SetScrollOffset Start");
-
   if (on_finish)
     RegisterScrollCompleteCallback(std::move(on_finish));
 
@@ -266,24 +264,15 @@ void ScrollableArea::SetScrollOffset(const ScrollOffset& offset,
 
   if (SmoothScrollSequencer* sequencer = GetSmoothScrollSequencer()) {
     if (sequencer->FilterNewScrollOrAbortCurrent(scroll_type)) {
-      recordreplay::Assert("ScrollableArea::SetScrollOffset #1");
       return;
     }
   }
 
   ScrollOffset clamped_offset = ClampScrollOffset(offset);
 
-  recordreplay::Assert("ScrollableArea::SetScrollOffset #1.1 %s %s %s",
-                       offset.ToString().Utf8().c_str(),
-                       clamped_offset.ToString().Utf8().c_str(),
-                       GetScrollOffset().ToString().Utf8().c_str());
-
   if (clamped_offset == GetScrollOffset()) {
-    recordreplay::Assert("ScrollableArea::SetScrollOffset #2");
     return;
   }
-
-  recordreplay::Assert("ScrollableArea::SetScrollOffset #3");
 
   TRACE_EVENT2("blink", "ScrollableArea::SetScrollOffset", "cur_x",
                GetScrollOffset().Width(), "cur_y", GetScrollOffset().Height());
@@ -321,8 +310,6 @@ void ScrollableArea::SetScrollOffset(const ScrollOffset& offset,
     default:
       NOTREACHED();
   }
-
-  recordreplay::Assert("ScrollableArea::SetScrollOffset Done");
 }
 
 void ScrollableArea::SetScrollOffset(const ScrollOffset& offset,
@@ -342,7 +329,6 @@ void ScrollableArea::ProgrammaticScrollHelper(
     mojom::blink::ScrollBehavior scroll_behavior,
     bool is_sequenced_scroll,
     ScrollCallback on_finish) {
-  recordreplay::Assert("ScrollableArea::ProgrammaticScrollHelper");
   CancelScrollAnimation();
 
   ScrollCallback callback = std::move(on_finish);
@@ -402,8 +388,6 @@ PhysicalRect ScrollableArea::ScrollIntoView(
 
 void ScrollableArea::ScrollOffsetChanged(const ScrollOffset& offset,
                                          mojom::blink::ScrollType scroll_type) {
-  recordreplay::Assert("ScrollableArea::ScrollOffsetChanged Start");
-
   TRACE_EVENT2("input", "ScrollableArea::scrollOffsetChanged", "x",
                offset.Width(), "y", offset.Height());
   TRACE_EVENT_INSTANT1("input", "Type", TRACE_EVENT_SCOPE_THREAD, "type",
@@ -420,7 +404,6 @@ void ScrollableArea::ScrollOffsetChanged(const ScrollOffset& offset,
   // If the layout object has been detached as a result of updating the scroll
   // this object will be cleaned up shortly.
   if (HasBeenDisposed()) {
-    recordreplay::Assert("ScrollableArea::ScrollOffsetChanged #1");
     return;
   }
 
@@ -459,7 +442,6 @@ void ScrollableArea::ScrollOffsetChanged(const ScrollOffset& offset,
   }
 
   GetScrollAnimator().SetCurrentOffset(offset);
-  recordreplay::Assert("ScrollableArea::ScrollOffsetChanged Done");
 }
 
 bool ScrollableArea::ScrollBehaviorFromString(
@@ -999,8 +981,6 @@ bool ScrollableArea::PerformSnapping(
   base::Optional<FloatPoint> snap_point = GetSnapPositionAndSetTarget(strategy);
   if (!snap_point)
     return false;
-  recordreplay::Assert("ScrollableArea::PerformSnapping #1 %s",
-                       snap_point.value().ToString().Utf8().c_str());
   CancelScrollAnimation();
   CancelProgrammaticScrollAnimation();
   SetScrollOffset(ScrollPositionToOffset(snap_point.value()),

--- a/third_party/blink/renderer/core/svg/animation/smil_animation_sandwich.cc
+++ b/third_party/blink/renderer/core/svg/animation/smil_animation_sandwich.cc
@@ -92,9 +92,6 @@ void SMILAnimationSandwich::UpdateActiveAnimationStack(
 }
 
 bool SMILAnimationSandwich::ApplyAnimationValues() {
-  recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues Start %d",
-                       recordreplay::PointerId(this));
-
   if (active_.IsEmpty())
     return false;
 
@@ -114,25 +111,17 @@ bool SMILAnimationSandwich::ApplyAnimationValues() {
   // element in the sandwich will do.
   SVGAnimationElement* animation = sandwich_.front();
 
-  recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues #1");
-
   // Only reset the animated type to the base value once for
   // the lowest priority animation that animates and
   // contributes to a particular element/attribute pair.
   SMILAnimationValue animation_value = animation->CreateAnimationValue();
 
-  recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues #2");
-
   for (auto* sandwich_it = sandwich_start; sandwich_it != active_.end();
        sandwich_it++) {
-    recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues #3");
     (*sandwich_it)->ApplyAnimation(animation_value);
-    recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues #4");
   }
 
   animation->ApplyResultsToTarget(animation_value);
-
-  recordreplay::Assert("SMILAnimationSandwich::ApplyAnimationValues Done");
   return true;
 }
 

--- a/third_party/blink/renderer/core/svg/animation/smil_time_container.cc
+++ b/third_party/blink/renderer/core/svg/animation/smil_time_container.cc
@@ -593,8 +593,6 @@ void SMILTimeContainer::UpdateTimedElements(TimingUpdate& update) {
 }
 
 void SMILTimeContainer::ApplyTimedEffects(SMILTime elapsed) {
-  recordreplay::Assert("SMILTimeContainer::ApplyTimedEffects Start");
-
   if (document_order_indexes_dirty_)
     UpdateDocumentOrderIndexes();
 
@@ -607,8 +605,6 @@ void SMILTimeContainer::ApplyTimedEffects(SMILTime elapsed) {
 
   bool did_apply_effects = false;
   for (auto& entry : animated_targets_vector) {
-    recordreplay::Assert("SMILTimeContainer::ApplyTimedEffects #1 %d",
-                         recordreplay::PointerId(entry.Get()));
     ElementSMILAnimations* animations = entry->GetSMILAnimations();
     if (animations && animations->Apply(elapsed))
       did_apply_effects = true;
@@ -618,8 +614,6 @@ void SMILTimeContainer::ApplyTimedEffects(SMILTime elapsed) {
     UseCounter::Count(&GetDocument(),
                       WebFeature::kSVGSMILAnimationAppliedEffect);
   }
-
-  recordreplay::Assert("SMILTimeContainer::ApplyTimedEffects Done");
 }
 
 void SMILTimeContainer::AdvanceFrameForTesting() {

--- a/third_party/blink/renderer/core/svg/svg_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_element.cc
@@ -522,13 +522,7 @@ void SVGElement::UpdateRelativeLengthsInformation(
 
 void SVGElement::InvalidateRelativeLengthClients(
     SubtreeLayoutScope* layout_scope) {
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("SVGElement::InvalidateRelativeLengthClients Start %d",
-                       recordreplay::PointerId(this));
-
   if (!isConnected()) {
-    // https://linear.app/replay/issue/RUN-569
-    recordreplay::Assert("SVGElement::InvalidateRelativeLengthClients #1");
     return;
   }
 

--- a/third_party/blink/renderer/core/svg/svg_use_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_use_element.cc
@@ -420,7 +420,6 @@ static void MoveChildrenToReplacementElement(ContainerNode& source_root,
 }
 
 SVGElement* SVGUseElement::CreateInstanceTree(SVGElement& target_root) const {
-  recordreplay::Assert("SVGUseElement::CreateInstanceTree %lu", recordreplay::PointerId(this));
   SVGElement* instance_root = &To<SVGElement>(target_root.CloneWithChildren());
   if (IsA<SVGSymbolElement>(target_root)) {
     // Spec: The referenced 'symbol' and its contents are deep-cloned into
@@ -596,10 +595,6 @@ void SVGUseElement::DispatchPendingEvent() {
 }
 
 void SVGUseElement::NotifyFinished(Resource* resource) {
-  // https://linear.app/replay/issue/RUN-466
-  recordreplay::Assert("SVGUseElement::NotifyFinished %d",
-                       recordreplay::PointerId(this));
-
   if (!isConnected())
     return;
 
@@ -613,9 +608,6 @@ void SVGUseElement::NotifyFinished(Resource* resource) {
       return;
     DCHECK(!have_fired_load_event_);
     have_fired_load_event_ = true;
-
-    // https://linear.app/replay/issue/RUN-466
-    recordreplay::Assert("SVGUseElement::NotifyFinished #2");
 
     GetDocument()
         .GetTaskRunner(TaskType::kDOMManipulation)

--- a/third_party/blink/renderer/core/timing/performance.cc
+++ b/third_party/blink/renderer/core/timing/performance.cc
@@ -923,14 +923,12 @@ ScriptPromise Performance::profile(ScriptState* script_state,
 }
 
 void Performance::RegisterPerformanceObserver(PerformanceObserver& observer) {
-  recordreplay::Assert("Performance::RegisterPerformanceObserver %lu", recordreplay::PointerId(this));
   observer_filter_options_ |= observer.FilterOptions();
   observers_.insert(&observer);
 }
 
 void Performance::UnregisterPerformanceObserver(
     PerformanceObserver& old_observer) {
-  recordreplay::Assert("Performance::UnregisterPerformanceObserver %lu", recordreplay::PointerId(this));
   observers_.erase(&old_observer);
   UpdatePerformanceObserverFilterOptions();
 }
@@ -943,23 +941,18 @@ void Performance::UpdatePerformanceObserverFilterOptions() {
 }
 
 void Performance::NotifyObserversOfEntry(PerformanceEntry& entry) const {
-  recordreplay::Assert("Performance::NotifyObserversOfEntry Start %lu",
-                       recordreplay::PointerId(this));
   DCHECK(entry.EntryTypeEnum() != PerformanceEntry::kEvent ||
          RuntimeEnabledFeatures::EventTimingEnabled(GetExecutionContext()));
   bool observer_found = false;
   for (auto& observer : observers_) {
-    recordreplay::Assert("Performance::NotifyObserversOfEntry #1");
     if (observer->FilterOptions() & entry.EntryTypeEnum() &&
         observer->CanObserve(entry)) {
-      recordreplay::Assert("Performance::NotifyObserversOfEntry #2");
       observer->EnqueuePerformanceEntry(entry);
       observer_found = true;
     }
   }
   if (observer_found && entry.EntryTypeEnum() == PerformanceEntry::kPaint)
     UseCounter::Count(GetExecutionContext(), WebFeature::kPaintTimingObserved);
-  recordreplay::Assert("Performance::NotifyObserversOfEntry Done");
 }
 
 bool Performance::HasObserverFor(
@@ -968,7 +961,6 @@ bool Performance::HasObserverFor(
 }
 
 void Performance::ActivateObserver(PerformanceObserver& observer) {
-  recordreplay::Assert("Performance::ActivateObserver %d", active_observers_.IsEmpty());
   if (active_observers_.IsEmpty())
     deliver_observations_timer_.StartOneShot(base::TimeDelta(), FROM_HERE);
 

--- a/third_party/blink/renderer/core/workers/dedicated_worker_object_proxy.cc
+++ b/third_party/blink/renderer/core/workers/dedicated_worker_object_proxy.cc
@@ -60,8 +60,6 @@ DedicatedWorkerObjectProxy::~DedicatedWorkerObjectProxy() {
 
 void DedicatedWorkerObjectProxy::PostMessageToWorkerObject(
     BlinkTransferableMessage message) {
-  recordreplay::Assert("DedicatedWorkerObjectProxy::PostMessageToWorkerObject %lu",
-                       recordreplay::PointerId(this));
   PostCrossThreadTask(
       *GetParentExecutionContextTaskRunners()->Get(TaskType::kPostedMessage),
       FROM_HERE,

--- a/third_party/blink/renderer/core/workers/worker_thread.cc
+++ b/third_party/blink/renderer/core/workers/worker_thread.cc
@@ -760,9 +760,6 @@ void WorkerThread::PrepareForShutdownOnWorkerThread() {
 }
 
 void WorkerThread::PerformShutdownOnWorkerThread() {
-  recordreplay::Assert("WorkerThread::PerformShutdownOnWorkerThread %lu",
-                       recordreplay::PointerId(this));
-
   DCHECK(IsCurrentThread());
   {
     MutexLocker lock(mutex_);
@@ -864,9 +861,6 @@ void WorkerThread::PauseOrFreeze(mojom::FrameLifecycleState state) {
 
 void WorkerThread::PauseOrFreezeOnWorkerThread(
     mojom::FrameLifecycleState state) {
-  recordreplay::Assert("WorkerThread::PauseOrFreezeOnWorkerThread %lu",
-                       recordreplay::PointerId(this));
-
   DCHECK(IsCurrentThread());
   DCHECK(state == mojom::FrameLifecycleState::kFrozen ||
          state == mojom::FrameLifecycleState::kPaused);

--- a/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
+++ b/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
@@ -563,9 +563,6 @@ void XMLHttpRequest::ChangeState(State new_state) {
 }
 
 void XMLHttpRequest::DispatchReadyStateChangeEvent() {
-  recordreplay::Assert("XMLHttpRequest::DispatchReadyStateChangeEvent %lu",
-                       recordreplay::PointerId(this));
-
   if (!GetExecutionContext())
     return;
 
@@ -1270,9 +1267,6 @@ void XMLHttpRequest::ClearResponse() {
   // be careful with this initialization.
   received_length_ = 0;
 
-  recordreplay::Assert("XMLHttpRequest::ClearResponse Start %lu",
-                       recordreplay::PointerId(this));
-
   response_ = ResourceResponse();
 
   response_text_.Clear();
@@ -1675,13 +1669,8 @@ bool XMLHttpRequest::ResponseIsHTML() const {
 }
 
 int XMLHttpRequest::status() const {
-  recordreplay::Assert("XMLHttpRequest::status %lu %d %d",
-                       recordreplay::PointerId(this), (int)state_, error_);
-
   if (state_ == kUnsent || state_ == kOpened || error_)
     return 0;
-
-  recordreplay::Assert("XMLHttpRequest::status #1 %d", response_.HttpStatusCode());
 
   if (response_.HttpStatusCode())
     return response_.HttpStatusCode();
@@ -1762,8 +1751,6 @@ void XMLHttpRequest::DidFinishLoading(uint64_t identifier) {
 }
 
 void XMLHttpRequest::DidFinishLoadingInternal() {
-  recordreplay::Assert("XMLHttpRequest::DidFinishLoadingInternal Start");
-
   if (response_document_parser_) {
     // |DocumentParser::finish()| tells the parser that we have reached end of
     // the data.  When using |HTMLDocumentParser|, which works asynchronously,
@@ -1772,7 +1759,6 @@ void XMLHttpRequest::DidFinishLoadingInternal() {
     // |notifyParserStopped| to progress state.
     response_document_parser_->Finish();
     DCHECK(response_document_);
-    recordreplay::Assert("XMLHttpRequest::DidFinishLoadingInternal #1");
     return;
   }
 
@@ -1794,8 +1780,6 @@ void XMLHttpRequest::DidFinishLoadingInternal() {
 
   ClearVariablesForLoading();
   EndLoading();
-
-  recordreplay::Assert("XMLHttpRequest::DidFinishLoadingInternal Done");
 }
 
 void XMLHttpRequest::DidFinishLoadingFromBlob() {
@@ -1836,7 +1820,6 @@ void XMLHttpRequest::NotifyParserStopped() {
 }
 
 void XMLHttpRequest::EndLoading() {
-  recordreplay::Assert("XMLHttpRequest::EndLoading Start");
   probe::DidFinishXHR(GetExecutionContext(), this);
 
   if (loader_) {
@@ -1851,14 +1834,10 @@ void XMLHttpRequest::EndLoading() {
 
   if (auto* window = DynamicTo<LocalDOMWindow>(GetExecutionContext())) {
     LocalFrame* frame = window->GetFrame();
-    recordreplay::Assert("XMLHttpRequest::EndLoading #0 %d %d", !!frame, cors::IsOkStatus(status()));
     if (frame && cors::IsOkStatus(status())) {
-      recordreplay::Assert("XMLHttpRequest::EndLoading #1");
       frame->GetPage()->GetChromeClient().AjaxSucceeded(frame);
     }
   }
-
-  recordreplay::Assert("XMLHttpRequest::EndLoading Done");
 }
 
 void XMLHttpRequest::DidSendData(uint64_t bytes_sent,
@@ -1886,9 +1865,6 @@ void XMLHttpRequest::DidReceiveResponse(uint64_t identifier,
                                         const ResourceResponse& response) {
   // TODO(yhirano): Remove this CHECK: see https://crbug.com/570946.
   CHECK(&response);
-
-  recordreplay::Assert("XMLHttpRequest::DidReceiveResponse Start %lu %d",
-                       recordreplay::PointerId(this), response.HttpStatusCode());
 
   DVLOG(1) << this << " didReceiveResponse(" << identifier << ")";
   ScopedEventDispatchProtect protect(&event_dispatch_recursion_level_);

--- a/third_party/blink/renderer/modules/crypto/crypto_result_impl.cc
+++ b/third_party/blink/renderer/modules/crypto/crypto_result_impl.cc
@@ -132,8 +132,6 @@ void CryptoResultImpl::ClearResolver() {
 
 void CryptoResultImpl::CompleteWithError(WebCryptoErrorType error_type,
                                          const WebString& error_details) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithError");
-
   if (!resolver_)
     return;
 
@@ -156,8 +154,6 @@ void CryptoResultImpl::CompleteWithError(WebCryptoErrorType error_type,
 
 void CryptoResultImpl::CompleteWithBuffer(const void* bytes,
                                           unsigned bytes_size) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithBuffer");
-
   if (!resolver_)
     return;
 
@@ -167,8 +163,6 @@ void CryptoResultImpl::CompleteWithBuffer(const void* bytes,
 
 void CryptoResultImpl::CompleteWithJson(const char* utf8_data,
                                         unsigned length) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithJson");
-
   if (!resolver_)
     return;
 
@@ -193,8 +187,6 @@ void CryptoResultImpl::CompleteWithJson(const char* utf8_data,
 }
 
 void CryptoResultImpl::CompleteWithBoolean(bool b) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithBoolean");
-
   if (!resolver_)
     return;
 
@@ -203,8 +195,6 @@ void CryptoResultImpl::CompleteWithBoolean(bool b) {
 }
 
 void CryptoResultImpl::CompleteWithKey(const WebCryptoKey& key) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithKey");
-
   if (!resolver_)
     return;
 
@@ -214,8 +204,6 @@ void CryptoResultImpl::CompleteWithKey(const WebCryptoKey& key) {
 
 void CryptoResultImpl::CompleteWithKeyPair(const WebCryptoKey& public_key,
                                            const WebCryptoKey& private_key) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithKeyPair");
-
   if (!resolver_)
     return;
 
@@ -236,8 +224,6 @@ void CryptoResultImpl::CompleteWithKeyPair(const WebCryptoKey& public_key,
 }
 
 void CryptoResultImpl::CompleteWithError(ExceptionState& exception_state) {
-  recordreplay::Assert("CryptoResultImpl::CompleteWithError #2");
-
   if (!resolver_)
     return;
 
@@ -246,8 +232,6 @@ void CryptoResultImpl::CompleteWithError(ExceptionState& exception_state) {
 }
 
 void CryptoResultImpl::Cancel() {
-  recordreplay::Assert("CryptoResultImpl::Cancel");
-
   DCHECK(cancel_);
   cancel_->Cancel();
   cancel_ = nullptr;

--- a/third_party/blink/renderer/modules/crypto/subtle_crypto.cc
+++ b/third_party/blink/renderer/modules/crypto/subtle_crypto.cc
@@ -300,8 +300,6 @@ ScriptPromise SubtleCrypto::digest(ScriptState* script_state,
                                    const AlgorithmIdentifier& raw_algorithm,
                                    const BufferSource& raw_data,
                                    ExceptionState& exception_state) {
-  recordreplay::Assert("SubtleCrypto::digest Start");
-
   // Method described by:
   // https://w3c.github.io/webcrypto/Overview.html#SubtleCrypto-method-digest
 
@@ -315,7 +313,6 @@ ScriptPromise SubtleCrypto::digest(ScriptState* script_state,
   if (!NormalizeAlgorithm(script_state->GetIsolate(), raw_algorithm,
                           kWebCryptoOperationDigest, normalized_algorithm,
                           exception_state)) {
-    recordreplay::Assert("SubtleCrypto::digest #1");
     return ScriptPromise();
   }
 
@@ -328,7 +325,6 @@ ScriptPromise SubtleCrypto::digest(ScriptState* script_state,
   Platform::Current()->Crypto()->Digest(normalized_algorithm, std::move(data),
                                         result->Result(),
                                         std::move(task_runner));
-  recordreplay::Assert("SubtleCrypto::digest Done");
   return result->Promise();
 }
 

--- a/third_party/blink/renderer/modules/websockets/dom_websocket.cc
+++ b/third_party/blink/renderer/modules/websockets/dom_websocket.cc
@@ -494,10 +494,6 @@ bool DOMWebSocket::HasPendingActivity() const {
 
 void DOMWebSocket::ContextLifecycleStateChanged(
     mojom::FrameLifecycleState state) {
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("DOMWebSocket::ContextLifecycleStateChanged Start %d",
-                       recordreplay::PointerId(this));
-
   if (state == mojom::FrameLifecycleState::kRunning) {
     event_queue_->Unpause();
 
@@ -508,9 +504,6 @@ void DOMWebSocket::ContextLifecycleStateChanged(
   } else {
     event_queue_->Pause();
   }
-
-  // https://linear.app/replay/issue/RUN-569
-  recordreplay::Assert("DOMWebSocket::ContextLifecycleStateChanged Done");
 }
 
 void DOMWebSocket::DidConnect(const String& subprotocol,

--- a/third_party/blink/renderer/platform/graphics/compositing/property_tree_manager.cc
+++ b/third_party/blink/renderer/platform/graphics/compositing/property_tree_manager.cc
@@ -427,8 +427,6 @@ int PropertyTreeManager::EnsureCompositorTransformNode(
   compositor_node.flattens_inherited_transform =
       transform_node.FlattensInheritedTransform();
   compositor_node.sorting_context_id = transform_node.RenderingContextId();
-  recordreplay::Assert("PropertyTreeManager::EnsureCompositorTransformNode #1 %d %u",
-                       id, compositor_node.sorting_context_id);
   compositor_node.delegates_to_parent_for_backface =
       transform_node.DelegatesToParentForBackface();
 

--- a/third_party/blink/renderer/platform/graphics/image_frame_generator.cc
+++ b/third_party/blink/renderer/platform/graphics/image_frame_generator.cc
@@ -110,12 +110,9 @@ bool ImageFrameGenerator::DecodeAndScale(
     size_t row_bytes,
     ImageDecoder::AlphaOption alpha_option,
     cc::PaintImage::GeneratorClientId client_id) {
-  recordreplay::Assert("ImageFrameGenerator::DecodeAndScale Start");
-
   {
     MutexLocker lock(generator_mutex_);
     if (decode_failed_) {
-      recordreplay::Assert("ImageFrameGenerator::DecodeAndScale #1");
       return false;
     }
   }
@@ -159,12 +156,10 @@ bool ImageFrameGenerator::DecodeAndScale(
   decode_failed_ = decode_failed;
   if (decode_failed_) {
     DCHECK(!current_decode_succeeded);
-    recordreplay::Assert("ImageFrameGenerator::DecodeAndScale #2");
     return false;
   }
 
   if (!current_decode_succeeded) {
-    recordreplay::Assert("ImageFrameGenerator::DecodeAndScale #3");
     return false;
   }
 
@@ -172,7 +167,6 @@ bool ImageFrameGenerator::DecodeAndScale(
   if (frame_count != 0u)
     frame_count_ = frame_count;
 
-  recordreplay::Assert("ImageFrameGenerator::DecodeAndScale Done");
   return true;
 }
 

--- a/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.cc
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator.cc
@@ -95,27 +95,10 @@ void DisplayItemRasterInvalidator::Generate() {
     }
   }
 
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("DisplayItemRasterInvalidator::Generate #5");
-
   for (const auto& item : clients_to_invalidate) {
-    // https://linear.app/replay/issue/RUN-467
-    recordreplay::Assert("DisplayItemRasterInvalidator::Generate #6 KEY %d OLD %d %d %d %d NEW %d %d %d %d",
-                         item.key,
-                         item.value.old_visual_rect.X(),
-                         item.value.old_visual_rect.Y(),
-                         item.value.old_visual_rect.Width(),
-                         item.value.old_visual_rect.Height(),
-                         item.value.new_visual_rect.X(),
-                         item.value.new_visual_rect.Y(),
-                         item.value.new_visual_rect.Width(),
-                         item.value.new_visual_rect.Height());
     GenerateRasterInvalidation(*item.value.client, item.value.old_visual_rect,
                                item.value.new_visual_rect, item.value.reason);
   }
-
-  // https://linear.app/replay/issue/RUN-467
-  recordreplay::Assert("DisplayItemRasterInvalidator::Generate Done");
 }
 
 DisplayItemIterator DisplayItemRasterInvalidator::MatchNewDisplayItemInOldChunk(

--- a/third_party/blink/renderer/platform/heap/impl/blink_gc_memory_dump_provider.cc
+++ b/third_party/blink/renderer/platform/heap/impl/blink_gc_memory_dump_provider.cc
@@ -57,8 +57,6 @@ BlinkGCMemoryDumpProvider::~BlinkGCMemoryDumpProvider() {
 bool BlinkGCMemoryDumpProvider::OnMemoryDump(
     const base::trace_event::MemoryDumpArgs& args,
     base::trace_event::ProcessMemoryDump* process_memory_dump) {
-  recordreplay::Assert("BlinkGCMemoryDumpProvider::OnMemoryDump Start");
-
   ThreadState::Statistics::DetailLevel detail_level =
       args.level_of_detail ==
               base::trace_event::MemoryDumpLevelOfDetail::DETAILED
@@ -78,7 +76,6 @@ bool BlinkGCMemoryDumpProvider::OnMemoryDump(
                        stats.used_size_bytes);
 
   if (detail_level == ThreadState::Statistics::kBrief) {
-    recordreplay::Assert("BlinkGCMemoryDumpProvider::OnMemoryDump #1");
     return true;
   }
 
@@ -142,7 +139,6 @@ bool BlinkGCMemoryDumpProvider::OnMemoryDump(
     }
   }
 
-  recordreplay::Assert("BlinkGCMemoryDumpProvider::OnMemoryDump Done");
   return true;
 }
 

--- a/third_party/blink/renderer/platform/loader/fetch/raw_resource.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/raw_resource.cc
@@ -241,8 +241,6 @@ void RawResource::Trace(Visitor* visitor) const {
 }
 
 void RawResource::ResponseReceived(const ResourceResponse& response) {
-  recordreplay::Assert("RawResource::ResponseReceived Start");
-
   if (response.WasFallbackRequiredByServiceWorker()) {
     // The ServiceWorker asked us to re-fetch the request. This resource must
     // not be reused.
@@ -258,8 +256,6 @@ void RawResource::ResponseReceived(const ResourceResponse& response) {
   while (RawResourceClient* c = w.Next()) {
     c->ResponseReceived(this, this->GetResponse());
   }
-
-  recordreplay::Assert("RawResource::ResponseReceived Done");
 }
 
 void RawResource::ResponseBodyReceived(

--- a/third_party/blink/renderer/platform/loader/fetch/resource.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource.cc
@@ -241,8 +241,6 @@ void Resource::CheckResourceIntegrity() {
 void Resource::NotifyFinished() {
   CHECK(IsLoaded());
 
-  recordreplay::Assert("Resource::NotifyFinished %lu", recordreplay::PointerId(this));
-
   ResourceClientWalker<ResourceClient> w(clients_);
   while (ResourceClient* c = w.Next()) {
     MarkClientFinished(c);

--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
@@ -992,8 +992,6 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
   resource_request.SetFromOriginDirtyStyleSheet(
       params.IsFromOriginDirtyStyleSheet());
 
-  recordreplay::Assert("ResourceFetcher::RequestResource #1");
-
   TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(
       TRACE_DISABLED_BY_DEFAULT("network"), "ResourceLoad",
       TRACE_ID_WITH_SCOPE("BlinkResourceID", TRACE_ID_LOCAL(identifier)), "url",

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
@@ -703,7 +703,6 @@ void ResourceLoader::DidChangePriority(ResourceLoadPriority load_priority,
 
 void ResourceLoader::ScheduleCancel() {
   if (!cancel_timer_.IsActive()) {
-    recordreplay::Assert("ResourceLoader::ScheduleCancel #1");
     cancel_timer_.StartOneShot(base::TimeDelta(), FROM_HERE);
   }
 }
@@ -924,9 +923,6 @@ void ResourceLoader::DidReceiveResponse(const WebURLResponse& response) {
 
 void ResourceLoader::DidReceiveResponseInternal(
     const ResourceResponse& response) {
-  recordreplay::Assert("ResourceLoader::DidReceiveResponseInternal %d",
-                       response.HttpStatusCode());
-
   const ResourceRequestHead& request = resource_->GetResourceRequest();
 
   if (request.IsAutomaticUpgrade()) {
@@ -1282,8 +1278,6 @@ void ResourceLoader::RequestSynchronously(const ResourceRequestHead& request) {
   DCHECK(loader_);
   DCHECK_EQ(request.Priority(), ResourceLoadPriority::kHighest);
 
-  recordreplay::Assert("ResourceLoader::RequestSynchronously Start");
-
   auto network_resource_request = std::make_unique<network::ResourceRequest>();
   scoped_refptr<EncodedFormData> form_body = request_body_.FormBody();
   PopulateResourceRequest(request, std::move(request_body_),
@@ -1296,8 +1290,6 @@ void ResourceLoader::RequestSynchronously(const ResourceRequestHead& request) {
   int64_t encoded_data_length = WebURLLoaderClient::kUnknownEncodedDataLength;
   int64_t encoded_body_length = 0;
   WebBlobInfo downloaded_blob;
-
-  recordreplay::Assert("ResourceLoader::RequestSynchronously #0");
 
   if (CanHandleDataURLRequestLocally(request)) {
     ResourceResponse response;
@@ -1319,31 +1311,26 @@ void ResourceLoader::RequestSynchronously(const ResourceRequestHead& request) {
     // Don't do mime sniffing for fetch (crbug.com/2016)
     bool no_mime_sniffing = request.GetRequestContext() ==
                             blink::mojom::blink::RequestContextType::FETCH;
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #0.1");
     loader_->LoadSynchronously(
         std::move(network_resource_request), request.GetURLRequestExtraData(),
         request.RequestorID(), request.DownloadToBlob(), no_mime_sniffing,
         request.TimeoutInterval(), this, response_out, error_out, data_out,
         encoded_data_length, encoded_body_length, downloaded_blob,
         Context().CreateResourceLoadInfoNotifierWrapper());
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #0.2");
   }
   // A message dispatched while synchronously fetching the resource
   // can bring about the cancellation of this load.
   if (!IsLoading()) {
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #1");
     return;
   }
   int64_t decoded_body_length = data_out.size();
   if (error_out) {
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #2");
     DidFail(*error_out, base::TimeTicks::Now(), encoded_data_length,
             encoded_body_length, decoded_body_length);
     return;
   }
   DidReceiveResponse(response_out);
   if (!IsLoading()) {
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #3");
     return;
   }
   DCHECK_GE(response_out.ToResourceResponse().EncodedBodyLength(), 0);
@@ -1353,10 +1340,8 @@ void ResourceLoader::RequestSynchronously(const ResourceRequestHead& request) {
   // empty buffer is a noop in most cases, but is destructive in the case of
   // a 304, where it will overwrite the cached data we should be reusing.
   if (data_out.size()) {
-    recordreplay::Assert("ResourceLoader::RequestSynchronously #4");
     data_out.ForEachSegment([this](const char* segment, size_t segment_size,
                                    size_t segment_offset) {
-      recordreplay::Assert("ResourceLoader::RequestSynchronously #5");
       DidReceiveData(segment, SafeCast<int>(segment_size));
       return true;
     });
@@ -1370,8 +1355,6 @@ void ResourceLoader::RequestSynchronously(const ResourceRequestHead& request) {
   }
   DidFinishLoading(base::TimeTicks::Now(), encoded_data_length,
                    encoded_body_length, decoded_body_length, false);
-
-  recordreplay::Assert("ResourceLoader::RequestSynchronously Done");
 }
 
 void ResourceLoader::RequestAsynchronously(const ResourceRequestHead& request) {

--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/mojo_url_loader_client.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/mojo_url_loader_client.cc
@@ -446,7 +446,6 @@ void MojoURLLoaderClient::OnStartLoadingResponseBody(
   has_received_response_body_ = true;
 
   if (!on_receive_response_time_.is_null()) {
-    recordreplay::Assert("MojoURLLoaderClient::OnStartLoadingResponseBody #1");
     UMA_HISTOGRAM_TIMES(
         "Renderer.OnReceiveResponseToOnStartLoadingResponseBody",
         base::TimeTicks::Now() - on_receive_response_time_);

--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/web_url_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/web_url_loader.cc
@@ -660,10 +660,7 @@ bool WebURLLoader::Context::OnReceivedRedirect(
 
 void WebURLLoader::Context::OnReceivedResponse(
     network::mojom::URLResponseHeadPtr head) {
-  recordreplay::Assert("WebURLLoader::Context::OnReceivedResponse Start");
-
   if (!client_) {
-    recordreplay::Assert("WebURLLoader::Context::OnReceivedResponse #1");
     return;
   }
 
@@ -681,8 +678,6 @@ void WebURLLoader::Context::OnReceivedResponse(
   PopulateURLResponse(url_, *head, &response, report_raw_headers_, request_id_);
 
   client_->DidReceiveResponse(response);
-
-  recordreplay::Assert("WebURLLoader::Context::OnReceivedResponse Done");
 
   // DidReceiveResponse() may have triggered a cancel, causing the |client_| to
   // go away.
@@ -784,7 +779,6 @@ WebURLLoader::WebURLLoader() {
 }
 
 WebURLLoader::~WebURLLoader() {
-  recordreplay::Assert("WebURLLoader::~WebURLLoader %lu", recordreplay::PointerId(this));
   recordreplay::UnregisterPointer(this);
   Cancel();
 }
@@ -911,9 +905,6 @@ void WebURLLoader::PopulateURLResponse(
   const net::HttpResponseHeaders* headers = head.headers.get();
   if (!headers)
     return;
-
-  recordreplay::Assert("WebURLLoader::PopulateURLResponse #5 %d",
-                       headers->response_code());
 
   WebURLResponse::HTTPVersion version = WebURLResponse::kHTTPVersionUnknown;
   if (headers->GetHttpVersion() == net::HttpVersion(0, 9))

--- a/third_party/blink/renderer/platform/p2p/ipc_socket_factory.cc
+++ b/third_party/blink/renderer/platform/p2p/ipc_socket_factory.cc
@@ -523,10 +523,6 @@ void IpcPacketSocket::SetError(int error) {
 
 void IpcPacketSocket::OnOpen(const net::IPEndPoint& local_address,
                              const net::IPEndPoint& remote_address) {
-  recordreplay::Assert("IpcPacketSocket::OnOpen %s %s",
-                       local_address.ToString().c_str(),
-                       remote_address.ToString().c_str());
-
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 
   if (!jingle_glue::IPEndPointToSocketAddress(local_address, &local_address_)) {
@@ -535,9 +531,6 @@ void IpcPacketSocket::OnOpen(const net::IPEndPoint& local_address,
     OnError();
     return;
   }
-
-  recordreplay::Assert("IpcPacketSocket::OnOpen #1 %d",
-                       local_address_.IsAnyIP());
 
   state_ = IS_OPEN;
   TraceSendThrottlingState();

--- a/third_party/blink/renderer/platform/p2p/mdns_responder_adapter.cc
+++ b/third_party/blink/renderer/platform/p2p/mdns_responder_adapter.cc
@@ -27,9 +27,7 @@ void OnNameCreatedForAddress(
     const String& name,
     bool announcement_scheduled) {
   // We currently ignore whether there is an announcement sent for the name.
-  recordreplay::Assert("OnNameCreatedForAddress Start");
   callback(addr, name.Utf8());
-  recordreplay::Assert("OnNameCreatedForAddress Done");
 }
 
 void OnNameRemovedForAddress(

--- a/third_party/blink/renderer/platform/scheduler/common/idle_helper.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/idle_helper.cc
@@ -196,8 +196,6 @@ void IdleHelper::StartIdlePeriod(IdlePeriodState new_state,
 }
 
 void IdleHelper::EndIdlePeriod() {
-  recordreplay::Assert("IdleHelper::EndIdlePeriod");
-
   if (is_shutdown_)
     return;
 
@@ -226,7 +224,6 @@ void IdleHelper::WillProcessTask(const base::PendingTask& pending_task,
 }
 
 void IdleHelper::DidProcessTask(const base::PendingTask& pending_task) {
-  recordreplay::Assert("IdleHelper::DidProcessTask Start");
   helper_->CheckOnValidThread();
   DCHECK(!is_shutdown_);
   DCHECK(IsInIdlePeriod(state_.idle_period_state()));
@@ -243,7 +240,6 @@ void IdleHelper::DidProcessTask(const base::PendingTask& pending_task) {
       EndIdlePeriod();
     }
   }
-  recordreplay::Assert("IdleHelper::DidProcessTask Done");
 }
 
 void IdleHelper::UpdateLongIdlePeriodStateAfterIdleTask() {

--- a/third_party/blink/renderer/platform/scheduler/common/throttling/throttled_time_domain.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/throttling/throttled_time_domain.cc
@@ -39,28 +39,22 @@ void ThrottledTimeDomain::SetNextTaskRunTime(base::TimeTicks run_time) {
 
 base::Optional<base::TimeDelta> ThrottledTimeDomain::DelayTillNextTask(
     base::sequence_manager::LazyNow* lazy_now) {
-  recordreplay::Assert("ThrottledTimeDomain::DelayTillNextTask Start");
-
   base::TimeTicks now = lazy_now->Now();
   if (next_task_run_time_ && next_task_run_time_ > now) {
-    recordreplay::Assert("ThrottledTimeDomain::DelayTillNextTask #1");
     return next_task_run_time_.value() - now;
   }
 
   base::Optional<base::TimeTicks> next_run_time = NextScheduledRunTime();
   if (!next_run_time) {
-    recordreplay::Assert("ThrottledTimeDomain::DelayTillNextTask #2");
     return base::nullopt;
   }
 
   if (now >= next_run_time) {
-    recordreplay::Assert("ThrottledTimeDomain::DelayTillNextTask #3");
     return base::TimeDelta();  // Makes DoWork post an immediate continuation.
   }
 
   // We assume the owner (i.e. TaskQueueThrottler) will manage wake-ups on our
   // behalf.
-  recordreplay::Assert("ThrottledTimeDomain::DelayTillNextTask Done");
   return base::nullopt;
 }
 

--- a/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.cc
@@ -855,8 +855,6 @@ void FrameSchedulerImpl::SetPageKeepActiveForTracing(bool keep_active) {
 }
 
 void FrameSchedulerImpl::UpdatePolicy() {
-  recordreplay::Assert("FrameSchedulerImpl::UpdatePolicy Start %lu", recordreplay::PointerId(this));
-
   bool task_queues_were_throttled = task_queues_throttled_;
   task_queues_throttled_ = ShouldThrottleTaskQueues();
 
@@ -880,8 +878,6 @@ void FrameSchedulerImpl::UpdatePolicy() {
 void FrameSchedulerImpl::UpdateQueuePolicy(
     MainThreadTaskQueue* queue,
     TaskQueue::QueueEnabledVoter* voter) {
-  recordreplay::Assert("FrameSchedulerImpl::UpdateQueuePolicy Start %lu %lu",
-                       recordreplay::PointerId(this), recordreplay::PointerId(queue));
   DCHECK(queue);
   UpdatePriority(queue);
   if (!voter)

--- a/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
@@ -953,12 +953,10 @@ void MainThreadSchedulerImpl::WillBeginFrame(const viz::BeginFrameArgs& args) {
 }
 
 void MainThreadSchedulerImpl::DidCommitFrameToCompositor() {
-  recordreplay::Assert("MainThreadSchedulerImpl::DidCommitFrameToCompositor Start");
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("renderer.scheduler"),
                "MainThreadSchedulerImpl::DidCommitFrameToCompositor");
   helper_.CheckOnValidThread();
   if (helper_.IsShutdown()) {
-    recordreplay::Assert("MainThreadSchedulerImpl::DidCommitFrameToCompositor #1");
     return;
   }
 
@@ -972,7 +970,6 @@ void MainThreadSchedulerImpl::DidCommitFrameToCompositor() {
   }
 
   main_thread_only().idle_time_estimator.DidCommitFrameToCompositor();
-  recordreplay::Assert("MainThreadSchedulerImpl::DidCommitFrameToCompositor Done");
 }
 
 void MainThreadSchedulerImpl::BeginFrameNotExpectedSoon() {
@@ -1471,17 +1468,12 @@ bool MainThreadSchedulerImpl::IsHighPriorityWorkAnticipated() {
 }
 
 bool MainThreadSchedulerImpl::ShouldYieldForHighPriorityWork() {
-  recordreplay::Assert("MainThreadSchedulerImpl::ShouldYieldForHighPriorityWork Start");
-
   helper_.CheckOnValidThread();
   if (helper_.IsShutdown()) {
-    recordreplay::Assert("MainThreadSchedulerImpl::ShouldYieldForHighPriorityWork #1");
     return false;
   }
 
   MaybeUpdatePolicy();
-
-  recordreplay::Assert("MainThreadSchedulerImpl::ShouldYieldForHighPriorityWork #2");
 
   // We only yield if there's a urgent task to be run now, or we are expecting
   // one soon (touch start).
@@ -1536,7 +1528,6 @@ void MainThreadSchedulerImpl::RunIdleTasksForTesting(
 void MainThreadSchedulerImpl::MaybeUpdatePolicy() {
   helper_.CheckOnValidThread();
   if (policy_may_need_update_.IsSet()) {
-    recordreplay::Assert("MainThreadSchedulerImpl::MaybeUpdatePolicy #1");
     UpdatePolicy();
   }
 }
@@ -1568,8 +1559,6 @@ void MainThreadSchedulerImpl::UpdatePolicyLocked(UpdateType update_type) {
   any_thread_lock_.AssertAcquired();
   if (helper_.IsShutdown())
     return;
-
-  recordreplay::Assert("MainThreadSchedulerImpl::UpdatePolicyLocked");
 
   base::TimeTicks now = helper_.NowTicks();
   policy_may_need_update_.SetWhileLocked(false);
@@ -1603,7 +1592,6 @@ void MainThreadSchedulerImpl::UpdatePolicyLocked(UpdateType update_type) {
   }
 
   if (new_policy_duration > base::TimeDelta()) {
-    recordreplay::Assert("MainThreadSchedulerImpl::UpdatePolicyLocked #3");
     main_thread_only().current_policy_expiration_time =
         now + new_policy_duration;
     delayed_update_policy_runner_.SetDeadline(FROM_HERE, new_policy_duration,
@@ -1733,7 +1721,6 @@ void MainThreadSchedulerImpl::UpdatePolicyLocked(UpdateType update_type) {
   Policy old_policy = main_thread_only().current_policy;
   main_thread_only().current_policy = new_policy;
 
-  recordreplay::Assert("MainThreadSchedulerImpl::UpdatePolicyLocked #10");
   UpdateCompositorTaskQueuePriority();
 
   UpdateStateForAllTaskQueues(old_policy);
@@ -2242,7 +2229,6 @@ void MainThreadSchedulerImpl::OnIdlePeriodStarted() {
 }
 
 void MainThreadSchedulerImpl::OnIdlePeriodEnded() {
-  recordreplay::Assert("MainThreadSchedulerImpl::OnIdlePeriodEnded");
   base::AutoLock lock(any_thread_lock_);
   any_thread().last_idle_period_end_time = helper_.NowTicks();
   any_thread().in_idle_period = false;
@@ -2739,10 +2725,6 @@ void MainThreadSchedulerImpl::OnTaskCompleted(
     const base::sequence_manager::Task& task,
     TaskQueue::TaskTiming* task_timing,
     base::sequence_manager::LazyNow* lazy_now) {
-  recordreplay::Assert("MainThreadSchedulerImpl::OnTaskCompleted %lu %lu",
-                       recordreplay::PointerId(this),
-                       recordreplay::PointerId(queue ? queue->GetFrameScheduler() : nullptr));
-
   // Microtasks may detach the task queue and invalidate |queue|.
   PerformMicrotaskCheckpoint();
 
@@ -2776,9 +2758,6 @@ void MainThreadSchedulerImpl::OnTaskCompleted(
   // Unset the state of |task_priority_for_tracing|.
   main_thread_only().task_priority_for_tracing = base::nullopt;
 
-  recordreplay::Assert("MainThreadSchedulerImpl::OnTaskCompleted #1 %lu",
-                       recordreplay::PointerId(queue ? queue->GetFrameScheduler() : nullptr));
-
   RecordTaskUkm(queue.get(), task, *task_timing);
 
   main_thread_only().compositor_priority_experiments.OnTaskCompleted(
@@ -2792,9 +2771,6 @@ void MainThreadSchedulerImpl::RecordTaskUkm(
     MainThreadTaskQueue* queue,
     const base::sequence_manager::Task& task,
     const TaskQueue::TaskTiming& task_timing) {
-  recordreplay::Assert("MainThreadSchedulerImpl::RecordTaskUkm %lu %lu",
-                       recordreplay::PointerId(this),
-                       recordreplay::PointerId(queue ? queue->GetFrameScheduler() : nullptr));
   if (!helper_.ShouldRecordTaskUkm(task_timing.has_thread_time()))
     return;
 
@@ -2830,9 +2806,6 @@ UkmRecordingStatus MainThreadSchedulerImpl::RecordTaskUkmImpl(
     const TaskQueue::TaskTiming& task_timing,
     FrameSchedulerImpl* frame_scheduler,
     bool precise_attribution) {
-  recordreplay::Assert("MainThreadSchedulerImpl::RecordTaskUkmImpl %lu",
-                       recordreplay::PointerId(frame_scheduler));
-
   // Skip tasks which have deleted the frame or the page scheduler.
   if (!frame_scheduler)
     return UkmRecordingStatus::kErrorMissingFrame;

--- a/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_task_queue.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_task_queue.cc
@@ -145,7 +145,6 @@ void MainThreadTaskQueue::OnTaskCompleted(
     const base::sequence_manager::Task& task,
     TaskQueue::TaskTiming* task_timing,
     base::sequence_manager::LazyNow* lazy_now) {
-  recordreplay::Assert("MainThreadTaskQueue::OnTaskCompleted %lu", recordreplay::PointerId(this));
   if (main_thread_scheduler_) {
     main_thread_scheduler_->OnTaskCompleted(weak_ptr_factory_.GetWeakPtr(),
                                             task, task_timing, lazy_now);

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
@@ -884,7 +884,6 @@ void PageSchedulerImpl::UpdateWakeUpBudgetPools(
 }
 
 void PageSchedulerImpl::NotifyFrames() {
-  recordreplay::Assert("PageSchedulerImpl::NotifyFrames %lu", recordreplay::PointerId(this));
   std::vector<FrameSchedulerImpl*> frame_scheduler_vector;
   for (FrameSchedulerImpl* frame_scheduler : frame_schedulers_) {
     frame_scheduler_vector.push_back(frame_scheduler);
@@ -1061,7 +1060,6 @@ PageSchedulerImpl::PageLifecycleStateTracker::
 }
 
 FrameSchedulerImpl* PageSchedulerImpl::SelectFrameForUkmAttribution() {
-  recordreplay::Assert("PageSchedulerImpl::SelectFrameForUkmAttribution %lu", recordreplay::PointerId(this));
   std::vector<FrameSchedulerImpl*> frame_scheduler_vector;
   for (FrameSchedulerImpl* frame_scheduler : frame_schedulers_) {
     frame_scheduler_vector.push_back(frame_scheduler);
@@ -1071,8 +1069,6 @@ FrameSchedulerImpl* PageSchedulerImpl::SelectFrameForUkmAttribution() {
 
   for (FrameSchedulerImpl* frame_scheduler : frame_scheduler_vector) {
     if (frame_scheduler->GetUkmRecorder()) {
-      recordreplay::Assert("PageSchedulerImpl::SelectFrameForUkmAttribution %lu",
-                           recordreplay::PointerId(frame_scheduler));
       return frame_scheduler;
     }
   }

--- a/third_party/blink/renderer/platform/text/locale_mac.mm
+++ b/third_party/blink/renderer/platform/text/locale_mac.mm
@@ -70,7 +70,6 @@ static NSLocale* DetermineLocale(const String& locale) {
 }
 
 std::unique_ptr<Locale> Locale::Create(const String& locale) {
-  recordreplay::Assert("Locale::Create %s", locale.Utf8().c_str());
   return LocaleMac::Create(DetermineLocale(locale));
 }
 
@@ -106,13 +105,11 @@ LocaleMac::LocaleMac(NSLocale* locale)
 LocaleMac::~LocaleMac() {}
 
 std::unique_ptr<LocaleMac> LocaleMac::Create(const String& locale_identifier) {
-  recordreplay::Assert("LocaleMac::Create #1");
   NSLocale* locale = [NSLocale localeWithLocaleIdentifier:locale_identifier];
   return LocaleMac::Create(locale);
 }
 
 std::unique_ptr<LocaleMac> LocaleMac::Create(NSLocale* locale) {
-  recordreplay::Assert("LocaleMac::Create #2");
   return base::WrapUnique(new LocaleMac(locale));
 }
 

--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
@@ -167,18 +167,13 @@ void LayerTreeView::DidUpdateLayers() {
 }
 
 void LayerTreeView::BeginMainFrame(const viz::BeginFrameArgs& args) {
-  recordreplay::Assert("LayerTreeView::BeginMainFrame Start");
   if (!delegate_) {
-    recordreplay::Assert("LayerTreeView::BeginMainFrame #1");
     return;
   }
   if (web_main_thread_scheduler_) {
-    recordreplay::Assert("LayerTreeView::BeginMainFrame #2");
     web_main_thread_scheduler_->WillBeginFrame(args);
-    recordreplay::Assert("LayerTreeView::BeginMainFrame #3");
   }
   delegate_->BeginMainFrame(args.frame_time);
-  recordreplay::Assert("LayerTreeView::BeginMainFrame Done");
 }
 
 void LayerTreeView::OnDeferMainFrameUpdatesChanged(bool status) {

--- a/third_party/blink/renderer/platform/widget/input/main_thread_event_queue.cc
+++ b/third_party/blink/renderer/platform/widget/input/main_thread_event_queue.cc
@@ -283,8 +283,6 @@ void MainThreadEventQueue::HandleEvent(
     const WebInputEventAttribution& attribution,
     std::unique_ptr<cc::EventMetrics> metrics,
     HandledEventCallback callback) {
-  recordreplay::Assert("MainThreadEventQueue::HandleEvent Start");
-
   TRACE_EVENT2("input", "MainThreadEventQueue::HandleEvent", "dispatch_type",
                original_dispatch_type, "event_type", event->Event().GetType());
   DCHECK(original_dispatch_type == DispatchType::kBlocking ||
@@ -363,10 +361,8 @@ void MainThreadEventQueue::HandleEvent(
               WebInputEvent::Type::kPointerRawUpdate,
               static_cast<const WebMouseEvent&>(event->Event())),
           event->latency_info());
-      recordreplay::Assert("MainThreadEventQueue::HandleEvent #1");
       QueueEvent(QueuedWebInputEvent::CreateForRawEvent(
           std::move(raw_event), attribution, metrics.get()));
-      recordreplay::Assert("MainThreadEventQueue::HandleEvent #2");
     } else if (event->Event().GetType() == WebInputEvent::Type::kTouchMove) {
       const WebTouchEvent& touch_event =
           static_cast<const WebTouchEvent&>(event->Event());
@@ -378,10 +374,8 @@ void MainThreadEventQueue::HandleEvent(
               event->latency_info());
           raw_event->EventPointer()->SetType(
               WebInputEvent::Type::kPointerRawUpdate);
-          recordreplay::Assert("MainThreadEventQueue::HandleEvent #3");
           QueueEvent(QueuedWebInputEvent::CreateForRawEvent(
               std::move(raw_event), attribution, metrics.get()));
-          recordreplay::Assert("MainThreadEventQueue::HandleEvent #4");
         }
       }
     }
@@ -398,16 +392,12 @@ void MainThreadEventQueue::HandleEvent(
       IsForwardedAndSchedulerKnown(ack_result), attribution,
       std::move(metrics));
 
-  recordreplay::Assert("MainThreadEventQueue::HandleEvent #5");
   QueueEvent(std::move(queued_event));
-  recordreplay::Assert("MainThreadEventQueue::HandleEvent #6");
 
   if (callback) {
     std::move(callback).Run(ack_result, cloned_latency_info, nullptr,
                             base::nullopt);
   }
-
-  recordreplay::Assert("MainThreadEventQueue::HandleEvent Done");
 }
 
 void MainThreadEventQueue::QueueClosure(base::OnceClosure closure) {

--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
@@ -725,7 +725,6 @@ void WidgetInputHandlerManager::DidHandleInputEventSentToCompositor(
     std::unique_ptr<InputHandlerProxy::DidOverscrollParams> overscroll_params,
     const WebInputEventAttribution& attribution,
     std::unique_ptr<cc::EventMetrics> metrics) {
-  recordreplay::Assert("WidgetInputHandlerManager::DidHandleInputEventSentToCompositor Start");
   TRACE_EVENT1("input",
                "WidgetInputHandlerManager::DidHandleInputEventSentToCompositor",
                "Disposition", event_disposition);
@@ -758,7 +757,6 @@ void WidgetInputHandlerManager::DidHandleInputEventSentToCompositor(
         FROM_HERE,
         base::BindOnce(&WidgetInputHandlerManager::FindScrollTargetOnMainThread,
                        this, event_position, std::move(result_callback)));
-    recordreplay::Assert("WidgetInputHandlerManager::DidHandleInputEventSentToCompositor #1");
     return;
   }
 
@@ -786,11 +784,9 @@ void WidgetInputHandlerManager::DidHandleInputEventSentToCompositor(
     HandledEventCallback handled_event = base::BindOnce(
         &WidgetInputHandlerManager::DidHandleInputEventSentToMain, this,
         std::move(callback));
-    recordreplay::Assert("WidgetInputHandlerManager::DidHandleInputEventSentToCompositor #1.1");
     input_event_queue_->HandleEvent(std::move(event), dispatch_type, ack_state,
                                     attribution, std::move(metrics),
                                     std::move(handled_event));
-    recordreplay::Assert("WidgetInputHandlerManager::DidHandleInputEventSentToCompositor #2");
     return;
   }
 
@@ -803,8 +799,6 @@ void WidgetInputHandlerManager::DidHandleInputEventSentToCompositor(
                                     allowed_touch_action_.value())
                               : nullptr);
   }
-
-  recordreplay::Assert("WidgetInputHandlerManager::DidHandleInputEventSentToCompositor Done");
 }
 
 void WidgetInputHandlerManager::DidHandleInputEventSentToMainFromWidgetBase(


### PR DESCRIPTION
This removes a bunch of unused recording assertions, we had over 1000 and now we have less than 100.  In general assertions should only be in the code base for issues that haven't been fixed yet, or have recently been fixed and we're verifying things are fixed.