### PR TITLE
Move netmon event callbacks into main renderer code.

### DIFF
--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
@@ -1281,35 +1281,6 @@ void InspectorNetworkAgent::PrepareRequest(DocumentLoader* loader,
     }
     request.SetDevToolsAcceptedStreamTypes(std::move(accepted_stream_types));
   }
-
-  // Capture the record replay bookmark for the network request here,
-  // where the devtools stack id is taken.
-  if (PermitRecordReplayBrowserEvents()) {
-    // We must allow user agent scripts when taking a new bookmark.
-    ScriptForbiddenScope::AllowUserAgentScript allow_script;
-    std::string url_string = request.Url().GetString().Utf8().c_str();
-    uint64_t bookmark = recordreplay::NewBookmark();
-    request.SetRecordReplayBookmark(bookmark);
-    base::DictionaryValue dict;
-    String loader_id = IdentifiersFactory::LoaderId(loader);
-    uint64_t identifier = request.InspectorId();
-    String request_id = IdentifiersFactory::RequestId(loader, identifier);
-    dict.SetString("requestUrl", url_string);
-    dict.SetString("requestMethod", request.HttpMethod().Utf8());
-    dict.SetString("requestId", request_id.Utf8());
-
-    base::ListValue headers;
-    for (auto header : request.HttpHeaderFields()) {
-      base::DictionaryValue header_obj;
-      header_obj.SetString("name", header.key.Utf8());
-      header_obj.SetString("value", header.value.Utf8());
-      headers.Append(std::move(header_obj));
-    }
-    dict.SetKey("requestHeaders", std::move(headers));
-
-    recordreplay::OnNetworkRequest(request_id.Utf8().c_str(), "http", bookmark);
-    recordreplay::BrowserEvent("Network.PrepareRequest", dict);
-  }
 }
 
 void InspectorNetworkAgent::WillSendRequest(
@@ -1441,16 +1412,6 @@ void InspectorNetworkAgent::DidReceiveData(uint64_t identifier,
   }
 
   double timestamp = base::TimeTicks::Now().since_origin().InSecondsF();
-
-  if (PermitRecordReplayBrowserEvents()) {
-    base::DictionaryValue dict;
-    dict.SetString("request_id", request_id.Utf8());
-    dict.SetDouble("identifier", (double) identifier);
-    if (data) {
-      dict.SetString("data", base::StringPiece(data, data_length));
-    }
-    recordreplay::BrowserEvent("Network.DidReceiveData", dict);
-  }
 
   GetFrontend()->dataReceived(
       request_id, timestamp,

--- a/third_party/blink/renderer/core/loader/frame_fetch_context.cc
+++ b/third_party/blink/renderer/core/loader/frame_fetch_context.cc
@@ -181,6 +181,10 @@ mojom::FetchCacheMode DetermineFrameCacheMode(Frame* frame) {
 
 }  // namespace
 
+static bool PermitRecordReplayBrowserEvents() {
+  return recordreplay::IsRecordingOrReplaying() && v8::IsMainThread();
+}
+
 struct FrameFetchContext::FrozenState final : GarbageCollected<FrozenState> {
   FrozenState(const KURL& url,
               scoped_refptr<const SecurityOrigin> parent_security_origin,
@@ -386,6 +390,35 @@ void FrameFetchContext::PrepareRequest(
     virtual_time_pauser = frame_scheduler->CreateWebScopedVirtualTimePauser(
         request.Url().GetString(),
         WebScopedVirtualTimePauser::VirtualTaskDuration::kNonInstant);
+  }
+
+  // Capture the record replay bookmark for the network request here,
+  // where the devtools stack id is taken.
+  if (PermitRecordReplayBrowserEvents()) {
+    // We must allow user agent scripts when taking a new bookmark.
+    ScriptForbiddenScope::AllowUserAgentScript allow_script;
+    std::string url_string = request.Url().GetString().Utf8().c_str();
+    uint64_t bookmark = recordreplay::NewBookmark();
+    request.SetRecordReplayBookmark(bookmark);
+    base::DictionaryValue dict;
+    String loader_id = IdentifiersFactory::LoaderId(document_loader_);
+    uint64_t identifier = request.InspectorId();
+    String request_id = IdentifiersFactory::RequestId(document_loader_, identifier);
+    dict.SetString("requestUrl", url_string);
+    dict.SetString("requestMethod", request.HttpMethod().Utf8());
+    dict.SetString("requestId", request_id.Utf8());
+
+    base::ListValue headers;
+    for (auto header : request.HttpHeaderFields()) {
+      base::DictionaryValue header_obj;
+      header_obj.SetString("name", header.key.Utf8());
+      header_obj.SetString("value", header.value.Utf8());
+      headers.Append(std::move(header_obj));
+    }
+    dict.SetKey("requestHeaders", std::move(headers));
+
+    recordreplay::OnNetworkRequest(request_id.Utf8().c_str(), "http", bookmark);
+    recordreplay::BrowserEvent("Network.PrepareRequest", dict);
   }
 
   probe::PrepareRequest(Probe(), document_loader_, request, options,

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
@@ -211,6 +211,10 @@ void LogCnameAliasMetrics(const CnameAliasMetricInfo& info) {
 
 }  // namespace
 
+static bool PermitRecordReplayBrowserEvents() {
+  return recordreplay::IsRecordingOrReplaying() && v8::IsMainThread();
+}
+
 // CodeCacheRequest handles the requests to fetch data from code cache.
 // This owns WebCodeCacheLoader that actually loads the data from the
 // code cache. This class performs the necessary checks of matching the
@@ -1130,6 +1134,16 @@ void ResourceLoader::DidStartLoadingResponseBody(
 
 void ResourceLoader::DidReceiveData(const char* data, int length) {
   CHECK_GE(length, 0);
+
+  if (PermitRecordReplayBrowserEvents()) {
+    base::DictionaryValue dict;
+    dict.SetDouble("identifier", (double) resource_->InspectorId());
+    if (data) {
+      dict.SetString("data", base::StringPiece(data, length));
+    }
+    recordreplay::BrowserEvent("Network.DidReceiveData", dict);
+  }
+
 
   if (auto* observer = fetcher_->GetResourceLoadObserver()) {
     observer->DidReceiveData(resource_->InspectorId(),


### PR DESCRIPTION
This moves the initial network request callback and the `OpenNetworkRequest` event callback to be in the main renderer code.

For #RUN-680