### PR TITLE
Don't run destructors for thread local values when recording/replaying

### DIFF
--- a/base/threading/thread_local_storage.cc
+++ b/base/threading/thread_local_storage.cc
@@ -12,6 +12,8 @@
 #include "base/synchronization/lock.h"
 #include "build/build_config.h"
 
+#include <dlfcn.h>
+
 using base::internal::PlatformThreadLocalStorage;
 
 // Chrome Thread Local Storage (TLS)
@@ -256,13 +258,18 @@ TlsVectorEntry* ConstructTlsVector() {
   return tls_data;
 }
 
-void OnThreadExitInternal(TlsVectorEntry* tls_data) {
+static bool IsRecordingOrReplaying() {
+  void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayAttach");
+  return !!fnptr;
+}
+
+  void OnThreadExitInternal(TlsVectorEntry* tls_data) {
   // Thread local value destructors do not run consistently when recording/replaying.
   // When recording the current thread is no longer known and calls/locks/etc.
   // made by the destructors cannot be recorded, and when replaying the destructor
   // does not run at all. To avoid these problems we skip running the destructors
   // for now and let associated resources leak.
-  if (recordreplay::IsRecordingOrReplaying("leak-references"))
+  if (IsRecordingOrReplaying())
     return;
 
   DCHECK(tls_data);

--- a/base/threading/thread_local_storage.cc
+++ b/base/threading/thread_local_storage.cc
@@ -257,6 +257,14 @@ TlsVectorEntry* ConstructTlsVector() {
 }
 
 void OnThreadExitInternal(TlsVectorEntry* tls_data) {
+  // Thread local value destructors do not run consistently when recording/replaying.
+  // When recording the current thread is no longer known and calls/locks/etc.
+  // made by the destructors cannot be recorded, and when replaying the destructor
+  // does not run at all. To avoid these problems we skip running the destructors
+  // for now and let associated resources leak.
+  if (recordreplay::IsRecordingOrReplaying("leak-references"))
+    return;
+
   DCHECK(tls_data);
   // Some allocators, such as TCMalloc, use TLS. As a result, when a thread
   // terminates, one of the destructor calls we make may be to shut down an


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-549