### PR TITLE
Fix a couple bugs

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1212,9 +1212,7 @@ static int GetAPIObjectIdCallback(v8::Local<v8::Object> object) {
   for (const WrapperTypeInfo* info : infos) {
     if (V8PerIsolateData::From(isolate)->HasInstance(info, object)) {
       ScriptWrappable* wrappable = ToScriptWrappable(object);
-      int id = recordreplay::PointerId(wrappable);
-      CHECK(id);
-      return id;
+      return wrappable->RecordReplayId();
     }
   }
   return 0;
@@ -1334,7 +1332,6 @@ static void HandleNetworkDidReceiveResponseEvent(const base::DictionaryValue& in
   if (requestInfo == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request received response: %s",
       request_id.c_str());
-    requestInfo->second.response_received = true;
     return;
   }
 


### PR DESCRIPTION
This fixes a couple problems I noticed while working on https://github.com/replayio/chromium/pull/189

1. We should use RecordReplayId instead of PointerId when getting object IDs for V8 (this only affects non-default configurations where we are asserting the values used by running scripts).
2. Fix a crash I was running into when dereferencing an iterator pointing at the end of a table.