### PR TITLE
Add generic annotation hook

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -34,6 +34,7 @@ extern "C" void V8RecordReplayOrderedLock(int lock);
 extern "C" void V8RecordReplayOrderedUnlock(int lock);
 extern "C" void V8RecordReplayNewCheckpoint();
 extern "C" uint64_t V8RecordReplayNewBookmark();
+extern "C" void V8RecordReplayOnAnnotation(const char* kind, const char* contents);
 extern "C" void V8RecordReplayOnNetworkRequest(const char* id, const char* kind, uint64_t bookmark);
 extern "C" void V8RecordReplayOnNetworkRequestEvent(const char* id);
 extern "C" void V8RecordReplayOnNetworkStreamStart(const char* id, const char* kind, const char* parentId);
@@ -126,6 +127,10 @@ void NewCheckpoint() {
 
 uint64_t NewBookmark() {
   return OP(V8RecordReplayNewBookmark());
+}
+
+void OnAnnotation(const char* kind, const char* contents) {
+  OP(V8RecordReplayOnAnnotation(kind, contents));
 }
 
 void OnNetworkRequest(const char* id, const char* kind, uint64_t bookmark) {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -46,6 +46,7 @@ void InvalidateRecording(const char* why);
 void NewCheckpoint();
 
 uint64_t NewBookmark();
+void OnAnnotation(const char* kind, const char* contents);
 void OnNetworkRequest(const char* id, const char* kind, uint64_t bookmark);
 void OnNetworkRequestEvent(const char* id);
 void OnNetworkStreamStart(const char* id, const char* kind, const char* parentId);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -25,6 +25,8 @@ static const char DirectorySeparator = '/';
 static const char DirectorySeparator = '\\';
 #endif
 
+static const char *AnnotationHookJSName = "__RECORD_REPLAY_ANNOTATION_HOOK__";
+
 namespace v8 {
 
 extern void FunctionCallbackRecordReplaySetCommandCallback(const FunctionCallbackInfo<Value>& args);
@@ -1548,6 +1550,31 @@ static void HandleBrowserEvent(const char* name, const char* payload) {
   }
 }
 
+// Called from page page javascript.
+// `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
+// Since this function is called from userland JS, we avoid assertions.
+// We don't want flawed uses of the API to crash the recording.
+static void InvokeOnAnnotation(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (! (args.Length() >= 2 && args[0]->IsString())) {
+    recordreplay::Print("%s called with incorrect arguments",
+      AnnotationHookJSName);
+    return;
+  }
+  v8::Isolate* isolate = args.GetIsolate();
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::String> json;
+  if (!v8::JSON::Stringify(context, args[1]).ToLocal(&json)) {
+    recordreplay::Print("%s contents failed to json stringify",
+      AnnotationHookJSName);
+    return;
+  }
+
+  v8::String::Utf8Value kind(args.GetIsolate(), args[0]);
+  v8::String::Utf8Value contents(args.GetIsolate(), json);
+  recordreplay::OnAnnotation(*kind, *contents);
+}
+
 extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
 extern "C" void V8RecordReplayRegisterBrowserEventCallback(
   void (*callback)(const char* name, const char* payload)
@@ -1580,8 +1607,14 @@ void SetupRecordReplayCommands(v8::Isolate* isolate) {
   v8::Local<v8::String> args_name_string =
     ToV8String(isolate, "__RECORD_REPLAY_ARGUMENTS__");
 
+  // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
+  // the page window global.
+  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
+                      InvokeOnAnnotation);
+
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   context->Global()->Set(context, args_name_string, args).Check();
+
 
   SetFunctionProperty(isolate, args, "log",
                       LogCallback);


### PR DESCRIPTION
Exposes `__RECORD_REPLAY_ANNOTATION_HOOK__` to allow userland scripts to add annotations to replays