### PR TITLE
Avoid changing webrtc channel observers non-deterministically

### DIFF
--- a/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc
+++ b/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.cc
@@ -157,7 +157,13 @@ RTCDataChannel::Observer::Observer(
     scoped_refptr<webrtc::DataChannelInterface> channel)
     : main_thread_(main_thread),
       blink_channel_(blink_channel),
-      webrtc_channel_(channel) {}
+      webrtc_channel_(channel) {
+  // Because we avoid unregistering this observer non-deterministically,
+  // we also leak a reference to the observer to ensure it isn't destroyed
+  // without having been unregistered first.
+  if (recordreplay::IsRecordingOrReplaying("leak-references"))
+    AddRef();
+}
 
 RTCDataChannel::Observer::~Observer() {
   DCHECK(!blink_channel_) << "Reference to blink channel hasn't been released.";
@@ -172,6 +178,11 @@ RTCDataChannel::Observer::channel() const {
 void RTCDataChannel::Observer::Unregister() {
   DCHECK(main_thread_->BelongsToCurrentThread());
   blink_channel_ = nullptr;
+
+  // Avoid changing channel observers non-deterministically.
+  if (recordreplay::AreEventsDisallowed())
+    (void)webrtc_channel_.release();
+
   if (webrtc_channel_.get()) {
     webrtc_channel_->UnregisterObserver();
     // Now that we're guaranteed to not get further OnStateChange callbacks,


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-850