### PR TITLE
Set `requestCause` on recordreplay network events.

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1450,6 +1450,10 @@ static void HandleNetworkPrepareRequestEvent(const base::DictionaryValue& info) 
   event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->DeepCopy()));
   event.Set("requestMethod", std::unique_ptr<base::Value>(info.FindPath("requestMethod")->DeepCopy()));
   event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->DeepCopy()));
+  const base::Value* request_cause_value = info.FindPath("requestCause");
+  if (request_cause_value) {
+    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->DeepCopy()));
+  }
 
   gCurrentNetworkRequestEvent = &event;
   recordreplay::OnNetworkRequestEvent(request_id.c_str());

--- a/third_party/blink/renderer/core/loader/frame_fetch_context.cc
+++ b/third_party/blink/renderer/core/loader/frame_fetch_context.cc
@@ -356,6 +356,91 @@ uint64_t RecordReplayNetworkRequestId(uint64_t inspector_id) {
   return recordreplay::RecordReplayValue("NetworkRequestId", inspector_id);
 }
 
+
+static const char* GetRequestCauseString(ResourceRequest& req) {
+  switch (req.GetRequestContext()) {
+    case mojom::blink::RequestContextType::SCRIPT:
+      return "script";
+    case mojom::blink::RequestContextType::STYLE:
+      return "stylesheet";
+    case mojom::blink::RequestContextType::OBJECT:
+      return "object";
+    case mojom::blink::RequestContextType::IMAGE:
+      return "img";
+    case mojom::blink::RequestContextType::XML_HTTP_REQUEST:
+      return "xhr";
+    case mojom::blink::RequestContextType::BEACON:
+      return "beacon";
+    case mojom::blink::RequestContextType::FETCH:
+      return "fetch";
+    case mojom::blink::RequestContextType::XSLT:
+      return "xslt";
+    case mojom::blink::RequestContextType::MANIFEST:
+      return "webManifest";
+    case mojom::blink::RequestContextType::FONT:
+      return "font";
+    case mojom::blink::RequestContextType::PING:
+      return "ping";
+    case mojom::blink::RequestContextType::IMAGE_SET:
+      return "imageset";
+    case mojom::blink::RequestContextType::CSP_REPORT:
+      return "csp";
+    // ReplayIO/Kannan
+    // Remaining are guesses, not quite sure if they're correct (kv).
+    case mojom::blink::RequestContextType::IFRAME:
+    case mojom::blink::RequestContextType::FRAME:
+      return "subdocument";
+    case mojom::blink::RequestContextType::HYPERLINK:
+    case mojom::blink::RequestContextType::PREFETCH:
+      return "document";
+    case mojom::blink::RequestContextType::SUBRESOURCE:
+      return "subdocument";
+    case mojom::blink::RequestContextType::VIDEO:
+      return "media";
+    // ReplayIO/Kannan
+    // The following doesn't have an equivalent in gecko-dev
+    case mojom::blink::RequestContextType::FAVICON:
+      return "favicon";
+    case mojom::blink::RequestContextType::AUDIO:
+      return "audio";
+    case mojom::blink::RequestContextType::DOWNLOAD:
+      return "download";
+    case mojom::blink::RequestContextType::EMBED:
+      return "embed";
+    case mojom::blink::RequestContextType::EVENT_SOURCE:
+      return "eventSource";
+    case mojom::blink::RequestContextType::FORM:
+      return "form";
+    case mojom::blink::RequestContextType::INTERNAL:
+      return "internal";
+    case mojom::blink::RequestContextType::LOCATION:
+      return "location";
+    case mojom::blink::RequestContextType::PLUGIN:
+      return "plugin";
+    case mojom::blink::RequestContextType::SERVICE_WORKER:
+      return "serviceWorker";
+    case mojom::blink::RequestContextType::SHARED_WORKER:
+      return "sharedWorker";
+    case mojom::blink::RequestContextType::SUBRESOURCE_WEBBUNDLE:
+      return "subresourceWebbundle";
+    case mojom::blink::RequestContextType::TRACK:
+      return "track";
+    case mojom::blink::RequestContextType::IMPORT:
+      return "import";
+    case mojom::blink::RequestContextType::WORKER:
+      return "worker";
+    case mojom::blink::RequestContextType::UNSPECIFIED:
+    default:
+      return nullptr;
+  }
+  /* ReplayIO/Kannan
+   * No mappings yet for the following gecko content policy types:
+   * [Ci.nsIContentPolicy.TYPE_OBJECT_SUBREQUEST]: "objectSubdoc",
+   * [Ci.nsIContentPolicy.TYPE_DTD]: "dtd",
+   * [Ci.nsIContentPolicy.TYPE_WEBSOCKET]: "websocket",
+   */
+}
+
 void FrameFetchContext::PrepareRequest(
     ResourceRequest& request,
     ResourceLoaderOptions& options,
@@ -415,6 +500,10 @@ void FrameFetchContext::PrepareRequest(
     dict.SetString("requestUrl", url_string);
     dict.SetString("requestMethod", request.HttpMethod().Utf8());
     dict.SetString("requestId", request_id.Utf8());
+    const char* requestCause = GetRequestCauseString(request);
+    if (requestCause) {
+      dict.SetString("requestCause", requestCause);
+    }
 
     base::ListValue headers;
     for (auto header : request.HttpHeaderFields()) {


### PR DESCRIPTION
Should fix the request cause issue (ping @jaril)

@loganfsmyth There are a few content policy mappings that I couldn't really figure out a good 1:1 for in chromium vs. what I see in gecko.  The closest chromium equivalent to that content policy mapping is here: https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/third_party/blink/public/mojom/fetch/fetch_api_request.mojom-shared.h;l=96;drc=0a0e17f61671bb8bfded92b311623256b9e912e7

There are also a whole bunch more `RequestContextType` enumeration members in chromium.  I just mapped those to appropriate strings that seemed reasonable, but they have no gecko equivalent.

If you could take a look at those and lemme know it'll be good.