### PR TITLE
Move recording assertion

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
@@ -154,11 +154,11 @@ void WindowProxy::SetGlobalProxy(v8::Local<v8::Object> global_proxy) {
 // If there are JS code holds a closure to the old inner window,
 // it won't be able to reach the outer window via its global object.
 void WindowProxy::InitializeIfNeeded() {
-  // https://linear.app/replay/issue/RUN-965
-  recordreplay::Assert("WindowProxy::InitializeIfNeeded %d", (int)lifecycle_);
-
   if (lifecycle_ == Lifecycle::kContextIsUninitialized ||
       lifecycle_ == Lifecycle::kGlobalObjectIsDetached) {
+    // https://linear.app/replay/issue/RUN-965
+    recordreplay::Assert("WindowProxy::InitializeIfNeeded #1 %d", (int)lifecycle_);
+
     Initialize();
   }
 }


### PR DESCRIPTION
This assert is causing problems as WindowProxy::InitializeIfNeeded is called in a bunch of places in non-deterministic ways when replaying, causing failures to be blamed on warnings/mismatches involving this.  We only care about the case when the window actually needs to be initialized, so we can move the assert to a better place.