### PR TITLE
Handle redirects in network monitor impl.

### DIFF
--- a/content/browser/loader/navigation_url_loader_impl.cc
+++ b/content/browser/loader/navigation_url_loader_impl.cc
@@ -18,6 +18,7 @@
 #include "base/optional.h"
 #include "base/stl_util.h"
 #include "base/trace_event/trace_event.h"
+#include "base/values.h"
 #include "build/build_config.h"
 #include "components/download/public/common/download_stats.h"
 #include "content/browser/about_url_loader_factory.h"
@@ -340,6 +341,7 @@ void NavigationURLLoaderImpl::Start(
     mojo::PendingRemote<network::mojom::URLLoaderFactory> factory_for_webui,
     std::string accept_langs,
     bool needs_loader_factory_interceptor) {
+
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   DCHECK(!started_);
   DCHECK(!head_);
@@ -393,6 +395,35 @@ void NavigationURLLoaderImpl::Start(
   CreateInterceptors(appcache_handle, prefetched_signed_exchange_cache,
                      signed_exchange_prefetch_metric_recorder, accept_langs);
   Restart();
+
+
+  // Send a message to the render process to trigger network monitor
+  // events for RecordReplay to observe.  Content processes are
+  // not recorded so this event will be lost otherwise.
+  base::DictionaryValue dict;
+  char request_id[64];
+  snprintf(request_id, 64, "%d.%d",
+    global_request_id_.child_id,
+    global_request_id_.request_id
+  );
+  dict.SetString("requestId", request_id);
+  dict.SetString("requestMethod", resource_request_->method);
+  dict.SetString("requestUrl", url_.spec());
+
+  base::ListValue headers;
+  for (auto header_entry : resource_request_->headers.GetHeaderVector()) {
+    base::DictionaryValue header_obj;
+    header_obj.SetString("name", header_entry.key);
+    header_obj.SetString("value", header_entry.value);
+    headers.Append(std::move(header_obj));
+  }
+  dict.SetKey("requestHeaders", std::move(headers));
+
+  FrameTreeNode* frame_tree_node = FrameTreeNode::GloballyFindByID(frame_tree_node_id_);
+  RenderFrameHostImpl* render_frame_host = frame_tree_node->current_frame_host();
+  RenderProcessHost* render_process_host = render_frame_host->GetProcess();
+  mojom::Renderer* renderer = render_process_host->GetRendererInterface();
+  renderer->RecordReplayBrowserEvent("Network.Navigation", std::move(dict));
 }
 
 void NavigationURLLoaderImpl::CreateInterceptors(
@@ -880,6 +911,36 @@ void NavigationURLLoaderImpl::CallOnReceivedResponse(
 void NavigationURLLoaderImpl::OnReceiveRedirect(
     const net::RedirectInfo& redirect_info,
     network::mojom::URLResponseHeadPtr head) {
+  // Notify the render process about the redirect, to allow
+  // for RecordReplay network monitor to register it.
+  {
+    base::DictionaryValue dict;
+    char request_id[64];
+    snprintf(request_id, 64, "%d.%d",
+      (int) global_request_id_.child_id,
+      (int) global_request_id_.request_id
+    );
+    dict.SetString("requestId", request_id);
+    dict.SetString("originalUrl", url_chain_[0].spec());
+    dict.SetString("requestMethod", resource_request_->method);
+    dict.SetString("requestUrl", redirect_info.new_url.spec());
+
+    base::ListValue headers;
+    for (auto header_entry : resource_request_->headers.GetHeaderVector()) {
+      base::DictionaryValue header_obj;
+      header_obj.SetString("name", header_entry.key);
+      header_obj.SetString("value", header_entry.value);
+      headers.Append(std::move(header_obj));
+    }
+    dict.SetKey("requestHeaders", std::move(headers));
+
+    FrameTreeNode* frame_tree_node = FrameTreeNode::GloballyFindByID(frame_tree_node_id_);
+    RenderFrameHostImpl* render_frame_host = frame_tree_node->current_frame_host();
+    RenderProcessHost* render_process_host = render_frame_host->GetProcess();
+    mojom::Renderer* renderer = render_process_host->GetRendererInterface();
+    renderer->RecordReplayBrowserEvent("Network.NavigationRedirect", std::move(dict));
+  }
+
   net::Error error = net::OK;
   if (!bypass_redirect_checks_ &&
       !IsSafeRedirectTarget(url_, redirect_info.new_url)) {

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -1423,6 +1423,12 @@ extern "C" void V8RecordReplayBrowserEvent(const char* name, const char* payload
 void RenderThreadImpl::RecordReplayBrowserEvent(
     const std::string& name,
     base::Value value) {
+
+  // Do nothing if not in record/replay mode.
+  if (!recordreplay::IsRecordingOrReplaying("browser-event") || !v8::IsMainThread()) {
+    return;
+  }
+
   if (!value.GetAsDictionary(nullptr)) {
     fprintf(stderr, "RecordReplayBrowserEvent not a dictionary\n");
     return;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2987,9 +2987,13 @@ static void fromJsGetObjectByCdpId(
 struct NetworkRequestStatus {
   size_t response_data_received;
   size_t request_data_sent;
-  NetworkRequestStatus()
+  std::string method;
+  uint64_t bookmark;
+  NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
   : response_data_received(0),
-    request_data_sent(0)
+    request_data_sent(0),
+    method(method),
+    bookmark(bookmark)
   {}
 };
 // Map of active network requests.
@@ -3064,20 +3068,150 @@ static void GetCurrentNetworkStreamData(const v8::FunctionCallbackInfo<v8::Value
   args.GetReturnValue().Set(result);
 }
 
+static std::string MakeRequestIdentifier(uint64_t identifier) {
+  char request_id[64];
+  snprintf(request_id, 64, "%d.%lu", (int) getpid(), identifier);
+  return std::string(request_id);
+}
+
 static void HandleNetworkPrepareRequestEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
   std::string request_id = *info.FindPath("requestId")->GetIfString();
-  gActiveNetworkRequests->insert({ request_id, NetworkRequestStatus() });
+  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
+    // If the request already exists, this is a redirect.
+    // Chromium will send a "Network.ResourceRedirect" event which will
+    // be handled by `HandleNetworkPrepareRequestEvent` below.
+    return;
+  }
 
+  // Save request info in a global table.
+  // Associate with it the following info which may be needed later if
+  // the request is redirected:
+  //   - the request method
+  //   - the request bookmark
+  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+  uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
+  gActiveNetworkRequests->insert(
+    { request_id, NetworkRequestStatus(request_method, bookmark) }
+  );
+
+  // Register the request.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
+
+  // Package and emit a network request event with the appropriate info.
   base::DictionaryValue event;
   event.SetString("kind", "request");
   event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->DeepCopy()));
-  event.Set("requestMethod", std::unique_ptr<base::Value>(info.FindPath("requestMethod")->DeepCopy()));
+  event.SetString("requestMethod", request_method);
   event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->DeepCopy()));
   const base::Value* request_cause_value = info.FindPath("requestCause");
   if (request_cause_value) {
     event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->DeepCopy()));
   }
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkResourceRedirectEvent(const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Retreive the existing request data which should already have been
+  // registered by `HandleNetworkPrepareRequestEvent`.
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("No original request for navigation redirect: %s",
+      request_id.c_str());
+    return;
+  }
+
+  // Register a new network request with the same request id as the original
+  // for this redirect.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
+
+  // Package and emit a network request event.
+  // The request_method is obtained from the saved request info.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->DeepCopy()));
+  event.SetString("requestMethod", request_info->second.method);
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->DeepCopy()));
+  const base::Value* request_cause_value = info.FindPath("requestCause");
+  if (request_cause_value) {
+    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->DeepCopy()));
+  }
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Navigation events are network requests that are not resource requests.
+  // They are directed here (the renderer process) from the content process.
+  // They have no associated bookmark, as we can't take bookmarks in the
+  // content process.
+
+  // Ensure that a request with the same ID has not already been registered.
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
+    recordreplay::Print("Duplicate request id: %s", request_id.c_str());
+    return;
+  }
+  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+  gActiveNetworkRequests->insert({ request_id, NetworkRequestStatus(request_method) });
+
+  // A navigation event is a new network request, so call the `OnNetworkRequest` hook.
+  // Navigation events have no bookmarks associated with them.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", /* bookmark = */ 0);
+
+  // Package and emit a network request event.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->DeepCopy()));
+  event.SetString("requestMethod", request_method);
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->DeepCopy()));
+  event.SetString("requestCause", "document");
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkNavigationRedirectEvent(const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Navigation redirect events are, as with navigation events, sent from
+  // the content process to the renderer process.
+
+  // Ensure that a request with the same ID has not already been registered.
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  // This is a redirect, so an existing request should have been registered
+  // with the same id.
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("No original request for navigation redirect: %s",
+      request_id.c_str());
+    return;
+  }
+
+  // A navigation redirect event is a new network request.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
+
+  // Package and emit a network request event.
+  // The request method is obtained from the saved request info.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->DeepCopy()));
+  event.SetString("requestMethod", request_info->second.method);
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->DeepCopy()));
+  event.SetString("requestCause", "document");
 
   gCurrentNetworkRequestEvent = &event;
   recordreplay::OnNetworkRequestEvent(request_id.c_str());
@@ -3135,12 +3269,6 @@ static void HandleNetworkRequestDataFormEvent(const base::DictionaryValue& info)
     gCurrentNetworkStreamData->clear();
   }
   request_info->second.request_data_sent += length;
-}
-
-static std::string MakeRequestIdentifier(uint64_t identifier) {
-  char request_id[64];
-  snprintf(request_id, 64, "%d.%lu", (int) getpid(), identifier);
-  return std::string(request_id);
 }
 
 static void HandleNetworkDidReceiveResponseEvent(const base::DictionaryValue& info) {
@@ -3470,6 +3598,8 @@ static void HandleBrowserEvent(const char* name, const char* payload) {
   assert(!val.is_dict() && "Browser event JSON is not a dictionary");
   if (!strcmp(name, "Network.PrepareRequest")) {
     HandleNetworkPrepareRequestEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.ResourceRedirect")) {
+    HandleNetworkResourceRedirectEvent(base::Value::AsDictionaryValue(val));
   } else if (!strcmp(name, "Network.RequestData.Form")) {
     HandleNetworkRequestDataFormEvent(base::Value::AsDictionaryValue(val));
   } else if (!strcmp(name, "Network.DidReceiveResponse")) {
@@ -3480,6 +3610,12 @@ static void HandleBrowserEvent(const char* name, const char* payload) {
     HandleNetworkDidFailLoadingEvent(base::Value::AsDictionaryValue(val));
   } else if (!strcmp(name, "Network.DidReceiveData")) {
     HandleNetworkDidReceiveDataEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.Navigation")) {
+    HandleNetworkNavigationEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.NavigationRedirect")) {
+    HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
+  } else {
+    recordreplay::Print("HandleBrowserEvent received unrecognized event %s", name);
   }
 }
 

--- a/third_party/blink/renderer/core/loader/frame_fetch_context.cc
+++ b/third_party/blink/renderer/core/loader/frame_fetch_context.cc
@@ -497,6 +497,7 @@ void FrameFetchContext::PrepareRequest(
     uint64_t identifier = RecordReplayNetworkRequestId(request.InspectorId());
 
     String request_id = IdentifiersFactory::RequestId(document_loader_, identifier);
+    dict.SetDouble("bookmark", (double) bookmark);
     dict.SetString("requestUrl", url_string);
     dict.SetString("requestMethod", request.HttpMethod().Utf8());
     dict.SetString("requestId", request_id.Utf8());
@@ -514,7 +515,6 @@ void FrameFetchContext::PrepareRequest(
     }
     dict.SetKey("requestHeaders", std::move(headers));
 
-    recordreplay::OnNetworkRequest(request_id.Utf8().c_str(), "http", bookmark);
     recordreplay::BrowserEvent("Network.PrepareRequest", dict);
 
     // Check the request body for request data or stream.

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
@@ -901,6 +901,25 @@ bool ResourceLoader::WillFollowRedirect(
     return false;
   }
 
+  if (PermitRecordReplayBrowserEvents()) {
+    // The redirect has not been cancelled.  Notify RecordReplay netmonitor.
+    base::DictionaryValue dict;
+    dict.SetDouble("identifier",
+                   (double) RecordReplayNetworkRequestId(resource_->InspectorId()));
+    dict.SetString("requestUrl", new_request->Url().GetString().Utf8());
+
+    base::ListValue headers;
+    for (auto header : new_request->HttpHeaderFields()) {
+      base::DictionaryValue header_obj;
+      header_obj.SetString("name", header.key.Utf8());
+      header_obj.SetString("value", header.value.Utf8());
+      headers.Append(std::move(header_obj));
+    }
+    dict.SetKey("requestHeaders", std::move(headers));
+
+    recordreplay::BrowserEvent("Network.ResourceRedirect", dict);
+  }
+
   report_raw_headers = new_request->ReportRawHeaders();
   return true;
 }


### PR DESCRIPTION
Forwards redirect events (which occur in the content process) to the render process.

In the process of writing this I discovered I wasn't handling navigation requests at all, so that functionality has been added.