### PR TITLE
Don't invoke on-pending-tasks-changed for idle task posts.

### DIFF
--- a/third_party/blink/renderer/platform/scheduler/common/idle_helper.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/idle_helper.cc
@@ -294,11 +294,14 @@ void IdleHelper::OnIdleTaskPostedOnMainThread() {
                "OnIdleTaskPostedOnMainThread");
   if (is_shutdown_)
     return;
-  delegate_->OnPendingTasksChanged(true);
 
   // Avoid updating idle state non-deterministically.
   if (recordreplay::AreEventsDisallowed())
     return;
+
+  // RecordReplay issue RUN-1021
+  // Only call OnPendingTasksChanged when events aren't disallowed.
+  delegate_->OnPendingTasksChanged(true);
 
   if (state_.idle_period_state() == IdlePeriodState::kInLongIdlePeriodPaused) {
     // Restart long idle period ticks.


### PR DESCRIPTION
We don't want to notify of a change in pending tasks either when events are disallowed.