### PR TITLE
Fixes RUN-981 (first version of CSS.getAppliedRules)

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -228,7 +228,7 @@ function messageCallback(message) {
       }
     }
   } catch (e) {
-    log(`Message callback exception: ${e}`);
+    log(`[RuntimeError] Message callback exception: ${e}`);
   }
 }
 
@@ -270,7 +270,7 @@ const CommandCallbacks = {
 
 function commandCallback(method, params) {
   if (!CommandCallbacks[method]) {
-    log(`[RuntimeError][Command ${method}] Missing command callback: ${method}`);
+    log(`[Command ${method}] Missing command callback: ${method}`);
     return {};
   }
 
@@ -381,7 +381,7 @@ function Target_getCurrentNetworkRequestEvent() {
     const obj = JSON.parse(getCurrentNetworkRequestEvent());
     return { data: obj };
   } catch (e) {
-    log(`Error: getCurrentNetworkRequestEvent exception: ${e}`);
+    log(`[RuntimeError] getCurrentNetworkRequestEvent exception: ${e}`);
   }
 }
 
@@ -390,7 +390,7 @@ function Target_getCurrentNetworkStreamData(params) {
   if (data) {
     return { data };
   } else {
-    log(`Error: getCurrentNetworkStreamData returned no data.`);
+    log(`[RuntimeError] getCurrentNetworkStreamData returned no data.`);
   }
 }
 
@@ -575,9 +575,11 @@ const gRrpIdByPlainObject = new Map();
 const gPlainObjectByRrpId = new Map();
 
 /**
+ * Some preview objects are best constructed at an earlier time and then cached for
+ * later use in this map.
  * @type {Map<string, Object>}
  */
-const gPreviewExtraByRrpId = new Map();
+const gObjectPreviewByRrpId = new Map();
 
 let gLastRrpId = 0;
 
@@ -598,13 +600,13 @@ function clearPauseDataCallback() {
     gRrpIdByCdpId.clear();
     gRrpIdByPlainObject.clear();
     gPlainObjectByRrpId.clear();
-    gPreviewExtraByRrpId.clear();
+    gObjectPreviewByRrpId.clear();
     gCdpScopesByRrpId.clear();
     gLastBoundingClientRectsByNodeRrpId.clear();
     gCssRulesByNodeRrpId.clear();
     gLastRrpId = 0;
   } catch (e) {
-    log(`Error: clearPauseDataCallback exception: ${e}`);
+    log(`[RuntimeError] clearPauseDataCallback exception: ${e}`);
   }
 }
 
@@ -702,7 +704,9 @@ function registerCdpObject(cdpObject) {
  */
 function getCdpObjectByRrpId(rrpId) {
   const cdpObject = gCdpObjectsByRrpId.get(rrpId);
-  assert(cdpObject);
+  if (!cdpObject) {
+    throw new Error(`getCdpObjectByRrpId failed - rrpId not found: "${rrpId}"`);
+  }
   return cdpObject;
 }
 
@@ -715,12 +719,12 @@ function getCdpObjectByRrpId(rrpId) {
  * its CDP representation.
  * 
  * 
- * @param {object} previewExtra Used in `getObjectPreview`.
+ * @param {object} rrpObjectPreview Used in `getObjectPreview`.
  * @return {number} rrpId
  * 
  * @see https://static.replay.io/protocol/tot/Pause/#type-ObjectPreview
  */
-function registergRrpPreviewExtra(previewExtra, plainObject) {
+function registerRrpPreview(rrpObjectPreview, plainObject) {
   let rrpId;
   if (plainObject) {
     rrpId = gRrpIdByPlainObject.get(plainObject);
@@ -728,14 +732,14 @@ function registergRrpPreviewExtra(previewExtra, plainObject) {
 
   // NOTE: there is no cdpObject because there is no `CDP.Runtime.RemoteObject`.
   const cdpObject = null;
-  return registerNewRrpObject(rrpId, cdpObject, previewExtra, plainObject);
+  return registerNewRrpObject(rrpId, cdpObject, rrpObjectPreview, plainObject);
 }
 
 /**
  * Generates `rrpId`, if it does not have one yet.
  * Associates `rrpId` with its related data.
  */
-function registerNewRrpObject(rrpId, cdpObject, previewExtra, plainObject) {
+function registerNewRrpObject(rrpId, cdpObject, rrpObjectPreview, plainObject) {
   // new RrpId
   const existingRrpId = rrpId;
   rrpId ||= ++gLastRrpId + '';  // coerce to string
@@ -745,9 +749,10 @@ function registerNewRrpObject(rrpId, cdpObject, previewExtra, plainObject) {
     const cdpId = cdpObject.objectId;
     registerRrpCpdId(rrpId, cdpId, cdpObject);
   }
-  if (previewExtra) {
+  if (rrpObjectPreview) {
     // preview objects, already built from specialized CDP objects
-    gPreviewExtraByRrpId.set(rrpId, previewExtra);
+    gObjectPreviewByRrpId.set(rrpId, rrpObjectPreview);
+    rrpObjectPreview.objectId = rrpId; // set `objectId`
   }
   if (plainObject && !existingRrpId) {
     gRrpIdByPlainObject.set(plainObject, rrpId);
@@ -879,21 +884,11 @@ function isCdpObjectProxy(cdpObj) {
  * @see https://static.replay.io/protocol/tot/Pause/#type-Object
  */
 function createPauseObject(rrpId, level) {
-  // TODO: need a better thing happening instead of `getCdpObjectByRrpId` to pick up on the pre-cached preview objects
-  //    (TODO2: ideally, create a unique id for CSS.Rule preview objects)
-  /**
-  {
-    "className": "CSSStyleRule",
-    "objectId": "329",
-    "preview": {
-      "overflow": true,
-      "prototypeId": "226",
-      "rule": {
-        // ...
-      }
-    }
+  const existingPreview = gObjectPreviewByRrpId.get(rrpId);
+  if (existingPreview) {
+    return existingPreview;
   }
-  */
+
   const cdpObj = getCdpObjectByRrpId(rrpId);
   // NOTE: `subtype` is not reliably available, due to a divergence check in V8 → `value-mirror.cc`
   const className = isCdpObjectProxy(cdpObj) ? "Proxy" : (cdpObj.className || "Function");
@@ -1154,23 +1149,25 @@ function previewBlinkObject(cdpObject, allProperties) {
       node: previewBlinkNode(plainObject)
     }
   }
+
+  // NOTE: we created and cached several of these previews in `getAppliedRules`, since 
+  //      its annoyingly difficult to do this more properly.
   if (isInstanceOfNative(plainObject, CSSStyleDeclaration)) {
     return {
       style: previewBlinkStyle(plainObject)
     }
   }
-  if (isInstanceOfNative(plainObject, CSSRule)) {
-    return {
-      // TODO
-      // rule: previewBlinkRule(plainObject)
-    }
-  }
-  if (isInstanceOfNative(plainObject, CSSStyleSheet)) {
-    return {
-      // TODO
-      // rule: previewBlinkStyleSheet(plainObject)
-    }
-  }
+  
+  // if (isInstanceOfNative(plainObject, CSSRule)) {
+  //   return {
+  //     rule: previewBlinkRule(plainObject)
+  //   }
+  // }
+  // if (isInstanceOfNative(plainObject, CSSStyleSheet)) {
+  //   return {
+  //     styleSheet: previewBlinkStyleSheet(plainObject)
+  //   }
+  // }
 
   // TODO: preview other blink objects
   // Issue: https://linear.app/replay/issue/RUN-861/add-dom-related-props-to-pausegetobjectpreview-and-fix-objectid
@@ -1191,8 +1188,8 @@ function previewBlinkNode(node) {
 
   let style;
   if (node.style) {
+    // TODO: get correct style preview id/object
     style = registerPlainObject(node.style);
-    // TODO: clean up when done w/ RUN-981
     log(`DDBG preview.node.style: ${style} (${typeof node.style})`);
   }
 
@@ -1244,24 +1241,26 @@ function previewBlinkNode(node) {
 }
 
 function previewBlinkStyle(style) {
-  let parentRule;
-  if (style.parentRule) {
-    parentRule = registerPlainObject(style.parentRule);
-  }
+  // NOTE: we currently only use these for inline styles, where there is no parentRule
+  let parentRule = undefined;
+  // if (style.parentRule) {
+  //   parentRule = registerPlainObject(style.parentRule);
+  // }
 
   const properties = [];
   for (let i = 0; i < style.length; i++) {
     const name = style.item(i);
     const value = style.getPropertyValue(name);
-    const important =
-      style.getPropertyPriority(name) == "important" ? true : undefined;
-    properties.push({ name, value, important });
+    if (value) {
+      const important = style.getPropertyPriority(name) == "important" ? true : undefined;
+      properties.push({ name, value, important });
+    }
   }
 
   return {
     cssText: style.cssText,
     parentRule,
-    properties,
+    properties
   };
 }
 
@@ -1811,21 +1810,6 @@ class CssRule {
   style;
 }
 
-/**
- * @see https://static.replay.io/protocol/tot/CSS/#type-StyleDeclaration
- * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
- * @see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-CSSStyle
- */
-function registerCssStyleDeclaration() {
-  // TODO!
-
-  const decl = {
-    cssText,
-    parentRule,
-    properties
-  };
-  return decl;
-}
 
 /**
  * 
@@ -1837,12 +1821,12 @@ function registerCssStyleDeclaration() {
 function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   // NOTE: type is deprecated -> don't care
   const type = 1;
-  const {
+  let {
+    selectorList = {},
+    styleSheetId: styleSheetCpdId,
     style: {
       cssText: styleCssText,
       // range: styleRange,
-      selectorList = {},
-      styleSheetId: styleSheetCpdId,
       cssProperties
     } = {},
     range: ruleRange,
@@ -1859,26 +1843,34 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
       //   -> The way to look these up is via `id_to_inspector_style_sheet_` 
       //        and `css_style_sheet_to_inspector_style_sheet_`
       const nativeSheet = fromJsCssGetStylesheetByCpdId(styleSheetCpdId);
+
+      // TODO: `nativeSheet` is always null
       log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
 
       // NOTE: `isSystem` is part of RRP from `gecko`.
       //    -> Chromium has a more diversified `StyleSheetOrigin` enum for this, 
-      //      but that is only accessible on the rule level here, for some reason.
+      //      (that is only accessible on the rule level in CDP, for some reason)
       const href = nativeSheet?.href;
       const isSystem = origin !== 'regular';
 
-      const styleSheetExtra = {
-        styleSheet: {
-          href,
-          isSystem
+      const styleSheetPreview = {
+        className: 'RRPStyleSheetPreview', // no pre-defined className
+        preview: {
+          overflow: true,
+          styleSheet: {
+            href,
+            isSystem
+          }
         }
       };
-      styleSheetRrpId = registergRrpPreviewExtra(styleSheetExtra, nativeSheet);
+      styleSheetRrpId = registerRrpPreview(styleSheetPreview, nativeSheet);
       registerRrpCpdId(styleSheetRrpId, styleSheetCpdId);
     }
   }
 
-  // styleExtra
+
+  // stylePreview
+
   const properties = cssProperties?.map(prop => {
     const { name, value, important } = prop;
     return {
@@ -1886,18 +1878,39 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
       value,
       important
     };
-  });
-  const styleExtra = {
-    style: {
-      cssText: styleCssText,
-      parentRule: 0, // filled in once we have it, below
-      properties
+  }) || [];
+  /**
+   * hackfix: for some reason, `user-agent` (and possibly other) styles don't have `cssText`.
+   *    So, for now, we cook up a simple css serialization algo here.
+   *    Native chromium has a better solution of course.
+   * @see https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/style_property_serializer.cc;l=251;drc=3decef66bc4c08b142a19db9628e9efe68973e64
+   * @see https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/style_property_serializer.cc;l=204;drc=3decef66bc4c08b142a19db9628e9efe68973e64
+   */
+  if (!styleCssText) {
+    styleCssText = '\n  ' + properties
+      .map(({ name, value, important }) => {
+        const suffix = important ? ' !important' : '';
+        return `${name}: ${value}${suffix};`;
+      })
+      .join('\n  ');
+  }
+  const stylePreview = {
+    className: 'CSS2Properties', // `gecko` naming convention
+    preview: {
+      overflow: true,
+      style: {
+        cssText: styleCssText,
+        parentRule: 0, // filled in once we have it, below
+        properties
+      }
     }
   };
   const nativeStlyeDeclaration = null;
-  const styleRrpId = registergRrpPreviewExtra(styleExtra, nativeStlyeDeclaration);
+  const styleRrpId = registerRrpPreview(stylePreview, nativeStlyeDeclaration);
 
-  // ruleExtra
+
+  // rulePreview
+
   const startLine = ruleRange?.startLine;
   const startColumn = ruleRange?.startColumn;
   // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
@@ -1907,18 +1920,23 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   /**
    * Based on `CSSStyleRule::cssText()`.
    * @see https://github.com/replayio/chromium/blob/052831f0220b79fe0c3343b49f6d2863ea6de05d/third_party/blink/renderer/core/css/css_style_rule.cc#L94
-   */  
-  const ruleCssText = `${selectorText} {${styleCssText}}`; 
-  const ruleExtra = {
-    rule: {
-      type,
-      cssText: ruleCssText,
-      parentStyleSheet: styleSheetRrpId,
-      startLine,
-      startColumn,
-      originalLocation,
-      selectorText,
-      style: styleRrpId
+   */
+  const ruleCssText = `${selectorText || ''} {${styleCssText}}`;
+  
+  const rulePreview = {
+    className: 'CSSRule',
+    preview: {
+      overflow: true,
+      rule: {
+        type,
+        cssText: ruleCssText,
+        parentStyleSheet: styleSheetRrpId,
+        startLine,
+        startColumn,
+        originalLocation,
+        selectorText,
+        style: styleRrpId
+      }
     }
   };
 
@@ -1927,10 +1945,10 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   //      store an id.
   // const nativeRule = lookupNativeCssRuleByCdpRule();
   const nativeRule = null;
-  const ruleRrpId = registergRrpPreviewExtra(ruleExtra, nativeRule);
+  const ruleRrpId = registerRrpPreview(rulePreview, nativeRule);
 
   // set ruleRrpId
-  styleExtra && (styleExtra.style.parentRule = ruleRrpId);
+  stylePreview && (stylePreview.preview.style.parentRule = ruleRrpId);
 
   return ruleRrpId;
 }
@@ -1949,6 +1967,8 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
  */
 function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
   const appliedRules = [];
+
+  log(`DDBG convertCdpToRrpCssRules - cdpMatchedStyles: ${JSON.stringify(cdpMatchedStyles)}`);
 
   const {
     matchedRules = [],
@@ -1986,7 +2006,7 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
     }
   }
 
-  return { rules: appliedRules, data: {} };
+  return appliedRules;
 }
 
 function CSS_getAppliedRules({ node: nodeRrpId }) {
@@ -2012,10 +2032,12 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
     //   }
     // }
     rules = convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles);
+    gCssRulesByNodeRrpId.set(nodeRrpId, rules);
   }
 
   return { rules, data };
 }
+
 
 
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1838,13 +1838,8 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   if (styleSheetCpdId) {
     styleSheetRrpId = gRrpIdByCdpId.get(styleSheetCpdId);
     if (!styleSheetRrpId) {
-      // What is `styleSheetCdpId`?
-      //   -> InspectorStyleSheet.Id()
-      //   -> The way to look these up is via `id_to_inspector_style_sheet_` 
-      //        and `css_style_sheet_to_inspector_style_sheet_`
       const nativeSheet = fromJsCssGetStylesheetByCpdId(styleSheetCpdId);
-
-      // TODO: `nativeSheet` is always null
+      
       log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
 
       // NOTE: `isSystem` is part of RRP from `gecko`.
@@ -1871,14 +1866,16 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
 
   // stylePreview
 
-  const properties = cssProperties?.map(prop => {
-    const { name, value, important } = prop;
-    return {
-      name,
-      value,
-      important
-    };
-  }) || [];
+  const properties = (cssProperties || [])
+    .filter(prop => !!prop.text) // ignore props without text presentation
+    .map(prop => {
+      const { name, value, important } = prop;
+      return {
+        name,
+        value,
+        important
+      };
+    });
   /**
    * hackfix: for some reason, `user-agent` (and possibly other) styles don't have `cssText`.
    *    So, for now, we cook up a simple css serialization algo here.
@@ -1915,13 +1912,13 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   const startColumn = ruleRange?.startColumn;
   // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
   const originalLocation = undefined; // TODO
-  const selectorText = selectorList?.text;
+  const selectorText = selectorList?.text || '';
 
   /**
    * Based on `CSSStyleRule::cssText()`.
    * @see https://github.com/replayio/chromium/blob/052831f0220b79fe0c3343b49f6d2863ea6de05d/third_party/blink/renderer/core/css/css_style_rule.cc#L94
    */
-  const ruleCssText = `${selectorText || ''} {${styleCssText}}`;
+  const ruleCssText = `${selectorText} {${styleCssText}}`;
   
   const rulePreview = {
     className: 'CSSRule',
@@ -1988,7 +1985,7 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
   }
 
   for (const cdpRule of matchedRules) {
-    addCdpRule(cdpRule);
+    addCdpRule(cdpRule.rule);
   }
 
   for (const cdpInheritedEntry of inheritedEntries) {
@@ -3585,10 +3582,6 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
       // hackfix: bind node here
       //   (if the DOMAgent was enabled, it would track DOM automatically)
       int nodeId = domAgent->BindDocumentNode(node);
-      
-      // TODO: clean up when done w/ RUN-981
-      P("DDBG fromJsGetNodeId %s -> %d", *cdpId, nodeId);
-
       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
       return;
     } else {
@@ -3738,18 +3731,20 @@ static void fromJsCssGetStylesheetByCpdId(
   auto sheetId = ToCoreString(args[0].As<v8::String>());
   auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
 
+  P("DDBG fromJsCssGetStylesheetByCpdId 1: %s", sheetId.Utf8().c_str());
   CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
   if (styleSheet) {
+    P("DDBG fromJsCssGetStylesheetByCpdId 2");
     v8::Local<v8::Value> jsStyleSheet;
     ScriptState* scriptState = ScriptState::Current(isolate);
     if (styleSheet->WrapV2(scriptState).ToLocal(&jsStyleSheet)) {
+      P("DDBG fromJsCssGetStylesheetByCpdId 3");
       args.GetReturnValue().Set(jsStyleSheet);
       return;
     }
   }
-  else {
-    args.GetReturnValue().SetNull();
-  }
+  P("DDBG fromJsCssGetStylesheetByCpdId 4");
+  args.GetReturnValue().SetNull();
 }
 
 /** ###########################################################################

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3822,10 +3822,10 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
                       fromJsCssGetStylesheetByCpdId);
 
-      // unsorted RR stuff
-      SetFunctionProperty(
-          isolate, args, "setClearPauseDataCallback",
-          v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+  // unsorted RR stuff
+  SetFunctionProperty(
+      isolate, args, "setClearPauseDataCallback",
+      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
   SetFunctionProperty(isolate, args, "getCurrentError",
                       GetCurrentError);
   SetFunctionProperty(isolate, args, "getRecordingId",

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -584,6 +584,7 @@ const gObjectPreviewByRrpId = new Map();
 let gLastRrpId = 0;
 
 // Map protocol ObjectId => Debugger.Scope
+// TODO: gCdpScopesByRrpId can probably be replaced with gCdpObjectsByRrpId
 const gCdpScopesByRrpId = new Map();
 
 // cheap cache for boundingClientRects
@@ -841,7 +842,6 @@ function buildRrpObjectFromCdpObject(cdpObject) {
  */
 function registerCdpScope(scope) {
   const rrpId = registerCdpObject(scope.object);
-  // TODO: we can probably get rid of gCdpScopesByRrpId
   gCdpScopesByRrpId.set(rrpId, scope);
   return rrpId;
 }
@@ -1040,8 +1040,6 @@ ProtocolObjectPreview.prototype = {
       return;
     }
 
-    // TODO: eval getter
-
     const value = buildRrpObjectFromCdpObject(cdpValue);
     this.getterValues.set(name, { name, ...value });
   },
@@ -1169,9 +1167,6 @@ function previewBlinkObject(cdpObject, allProperties) {
   //   }
   // }
 
-  // TODO: preview other blink objects
-  // Issue: https://linear.app/replay/issue/RUN-861/add-dom-related-props-to-pausegetobjectpreview-and-fix-objectid
-
 }
 
 function previewBlinkNode(node) {
@@ -1197,12 +1192,12 @@ function previewBlinkNode(node) {
   if (node.parentNode) {
     parentNode = registerPlainObject(node.parentNode);
   } else if (node.defaultView && node.defaultView.parent != node.defaultView && node.defaultView.parent.document) {
-    // TODO: properly handle `iframe`s and the case where `node.defaultView.parent.document` is missing
     /**
      * Nested documents use the parent element instead of null.
      * 
      * TODO: will need more work here to support multi-CSP iframes
-     * Issue: https://linear.app/replay/issue/RUN-954/dom-feature-support-multi-cspcross-origin-iframes
+     *   (properly handle `iframe`s and the case where `node.defaultView.parent.document` is missing)
+     *   Issue: https://linear.app/replay/issue/RUN-954/dom-feature-support-multi-cspcross-origin-iframes
      */
     const iframes = node.defaultView.parent.document.getElementsByTagName(
       "iframe"
@@ -1908,8 +1903,8 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
 
   // rulePreview
 
-  const startLine = ruleRange?.startLine;
-  const startColumn = ruleRange?.startColumn;
+  const startLine = (ruleRange || styleRange)?.startLine;
+  const startColumn = (ruleRange || styleRange)?.startColumn;
   // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
   const originalLocation = undefined; // TODO
   const selectorText = selectorList?.text || '';
@@ -3592,37 +3587,6 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   // auto response = domAgent->requestNode(cdpId, &nodeId);
   args.GetReturnValue().SetNull();
-
-  // TODO: clean up when done w/ RUN-981
-  // // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
-  // v8::String::Utf8Value cdpId(isolate, args[0]);
-  // const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
-  // v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
-  // v8::Local<v8::Object> plainObject;
-  // if (getObjectByCdpId(isolate, cdpIdV8, plainObject)) {
-  //   Node* node = V8Node::ToImpl(plainObject);
-  //   if (node) {
-  //     auto nodeId = DOMNodeIds::IdForNode(node);
-  //     auto* resultNode = DOMNodeIds::NodeForId(nodeId);
-  //     // assert(!!resultNode && "[RuntimeError] failed");
-  //     if (resultNode != node) {
-  //       recordreplay::Print(
-  //           "[RuntimeError] fromJsGetNodeId failed - node id lookup broken?
-  //           nodeId=%d, resultNode=%d", nodeId, !!resultNode);
-  //     }
-  //     else {
-  //       recordreplay::Print("DDBG fromJsGetNodeId success, nodeId=%d,
-  //       resultNode=%d", nodeId, !!resultNode);
-  //       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
-  //     }
-  //     return;
-  //   }
-  //   else {
-  //     recordreplay::Print("[RuntimeError] fromJsGetNodeId failed for cdpId
-  //     \"%s\"", *cdpId);
-  //   }
-  // }
-  // args.GetReturnValue().SetNull();
 }
 
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1108,7 +1108,7 @@ ProtocolObjectPreview.prototype = {
           // this.addGetterValue(prop.name, prop.value, this.cdpObj);
         }
         else if (prop.get) {
-          // TODO: call getter without side-effects?
+          // TODO: call getter without side-effects? - https://linear.app/replay/issue/RUN-1016
         }
       }
 
@@ -1148,8 +1148,6 @@ function previewBlinkObject(cdpObject, allProperties) {
     }
   }
 
-  // NOTE: we created and cached several of these previews in `getAppliedRules`, since 
-  //      its annoyingly difficult to do this more properly.
   if (isInstanceOfNative(plainObject, CSSStyleDeclaration)) {
     return {
       style: previewBlinkStyle(plainObject)
@@ -1176,16 +1174,13 @@ function previewBlinkNode(node) {
     for (const { name, value } of node.attributes) {
       attributes.push({ name, value });
     }
-    // TODO: We cannot access pseudo elements using the JS DOM API.
-    //   Issue: https://linear.app/replay/issue/RUN-953/dom-feature-add-pseudo-elements
+    // TODO: We cannot access pseudo elements using the JS DOM API - https://linear.app/replay/issue/RUN-953/
     // pseudoType = node.localName;
   }
 
   let style;
   if (node.style) {
-    // TODO: get correct style preview id/object
     style = registerPlainObject(node.style);
-    log(`DDBG preview.node.style: ${style} (${typeof node.style})`);
   }
 
   let parentNode;
@@ -1236,7 +1231,7 @@ function previewBlinkNode(node) {
 }
 
 function previewBlinkStyle(style) {
-  // NOTE: we currently only use these for inline styles, where there is no parentRule
+  // NOTE: this is for inline styles, where there is no parentRule
   let parentRule = undefined;
   // if (style.parentRule) {
   //   parentRule = registerPlainObject(style.parentRule);
@@ -1741,8 +1736,8 @@ function CSS_getComputedStyle({ node }) {
     // NOTE: tested successfully for same-CSP elements of different iframes
     const ownerGlobal = window;
 
-    // TODO: fix pseudoTypes
-    //   → Issue: https://linear.app/replay/issue/RUN-953/
+    // TODO: add pseudoType support - https://linear.app/replay/issue/RUN-953
+
     // const pseudoType = getPseudoType(node);
     // let styleInfo;
     // if (pseudoType) {
@@ -1968,8 +1963,7 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
   } = cdpMatchedStyles;
 
   function addCdpRule(cdpRule) {
-    // TODO: add pseudoElement support
-    //   Issue: https://linear.app/replay/issue/RUN-953
+    // TODO: add pseudoElement support - https://linear.app/replay/issue/RUN-953
     const pseudoElement = undefined;
     const rrpRuleId = registerCdpAsRrpCssRule(nodeObj, cdpRule);
     const appliedRule = {
@@ -1990,7 +1984,7 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
       matchedCSSRules  // inherited non-inline rules
     } = cdpInheritedEntry;
 
-    // TODO: convert/add inlineStyle
+    // TODO: maybe convert/add inlineStyle
 
     for (const matchedRule of matchedCSSRules) {
       // matchedRule.matchingSelectors
@@ -3225,7 +3219,7 @@ static void fromJsGetObjectByCdpId(
   auto context = isolate->GetCurrentContext();
 
   // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
-  // TODO: can this be improved?
+  // future-work: can this be improved?
   v8::String::Utf8Value cdpId(isolate, args[0]);
   const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
   v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
@@ -3774,9 +3768,7 @@ static void RunScript(v8::Isolate* isolate, v8::Local<v8::Context> context, cons
 
   v8::Local<v8::String> source = ToV8String(isolate, script);
 
-  // TODO: check for errors after `Compile` and `Run`
-  // Issue:
-  // https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
+  // TODO: check for errors after `Compile` and `Run` - https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
   v8::Local<v8::Script> compiled = v8::Script::Compile(context, source, &origin).ToLocalChecked();
   compiled->Run(context).ToLocalChecked();
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -584,7 +584,7 @@ const gObjectPreviewByRrpId = new Map();
 let gLastRrpId = 0;
 
 // Map protocol ObjectId => Debugger.Scope
-// TODO: gCdpScopesByRrpId can probably be replaced with gCdpObjectsByRrpId
+// TODO: gCdpScopesByRrpId can probably be removed (use gCdpObjectsByRrpId instead)
 const gCdpScopesByRrpId = new Map();
 
 // cheap cache for boundingClientRects
@@ -1816,7 +1816,7 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
     styleSheetId: styleSheetCpdId,
     style: {
       cssText: styleCssText,
-      // range: styleRange,
+      range: styleRange,
       cssProperties
     } = {},
     range: ruleRange,
@@ -1829,8 +1829,6 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
     styleSheetRrpId = gRrpIdByCdpId.get(styleSheetCpdId);
     if (!styleSheetRrpId) {
       const nativeSheet = fromJsCssGetStylesheetByCpdId(styleSheetCpdId);
-      
-      log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
 
       // NOTE: `isSystem` is part of RRP from `gecko`.
       //    -> Chromium has a more diversified `StyleSheetOrigin` enum for this, 
@@ -1955,8 +1953,6 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
 function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
   const appliedRules = [];
 
-  log(`DDBG convertCdpToRrpCssRules - cdpMatchedStyles: ${JSON.stringify(cdpMatchedStyles)}`);
-
   const {
     matchedRules = [],
     inheritedEntries = []
@@ -1983,8 +1979,6 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
       inlineStyle, // inherited inline style
       matchedCSSRules  // inherited non-inline rules
     } = cdpInheritedEntry;
-
-    // TODO: maybe convert/add inlineStyle
 
     for (const matchedRule of matchedCSSRules) {
       // matchedRule.matchingSelectors
@@ -3607,8 +3601,6 @@ static void fromJsGetBoxModel(
         nodeId, response.Code(), response.Message().c_str());
   } else {
     auto result = convertCborToJS(isolate, boxModel.get());
-    P("DDBG boxModel getContent()->size=%d not-empty=%d",
-      boxModel.get()->getContent()->size(), !result.IsEmpty());
     if (!result.IsEmpty()) {
       args.GetReturnValue().Set(result.ToLocalChecked());
       return;
@@ -3689,19 +3681,15 @@ static void fromJsCssGetStylesheetByCpdId(
   auto sheetId = ToCoreString(args[0].As<v8::String>());
   auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
 
-  P("DDBG fromJsCssGetStylesheetByCpdId 1: %s", sheetId.Utf8().c_str());
   CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
   if (styleSheet) {
-    P("DDBG fromJsCssGetStylesheetByCpdId 2");
     v8::Local<v8::Value> jsStyleSheet;
     ScriptState* scriptState = ScriptState::Current(isolate);
     if (styleSheet->WrapV2(scriptState).ToLocal(&jsStyleSheet)) {
-      P("DDBG fromJsCssGetStylesheetByCpdId 3");
       args.GetReturnValue().Set(jsStyleSheet);
       return;
     }
   }
-  P("DDBG fromJsCssGetStylesheetByCpdId 4");
   args.GetReturnValue().SetNull();
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -506,16 +506,62 @@ function Graphics_getDevicePixelRatio() {
 
 
 ///////////////////////////////////////////////////////////////////////////////
+// Utilities
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Check whether given object `x` is instance of class of given `target.name`,
+ * and also has a `native` constructor.
+ * NOTE: ideal solution is `x instanceof global[name]`, but we cannot do that.
+ * @see https://linear.app/replay/issue/RUN-1014/chromium-find-better-way-of-determining-dom-class-membership
+ */
+function isInstanceOfNative(x, target) {
+  /**
+   * NOTE: `instanceof` is implemented in `Object::InstanceOf` -> `JSReceiver::HasInPrototypeChain`
+   * @see https://github.com/replayio/gecko-dev/blob/592992ff7e15cb8ad1dd6fb109f19bd3523cd452/devtools/server/actors/replay/module.js#L1937
+   * @see https://github.com/replayio/chromium-v8/blob/51140a440949dbbeea7a4e6c2185ccdeb8b6276e/src/objects/objects.cc#L929
+   * @see https://github.com/replayio/chromium-v8/blob/51140a440949dbbeea7a4e6c2185ccdeb8b6276e/src/objects/js-objects.cc#170
+   */
+  // old sln: check assortment of props
+  // if (plainObject?.nodeType > 0 && plainObject.nodeType <= 11 && plainObject.appendChild && plainObject.cloneNode) {
+
+  // new sln (also a hackfix): check if its native, and has `name` in inheritance chain
+  const name = target?.name;
+  return name && 
+    x?.constructor?.toString()?.includes('() { [native code] }') && 
+    hasInProtoChain(x.constructor, name);
+}
+
+function hasInProtoChain(x, name) {
+  if (x.name === name) {
+    return true;
+  }
+  if (!x.__proto__) {
+    return false;
+  }
+  return hasInProtoChain(x.__proto__, name);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
 // object.js
 // Manage association between remote objects and protocol object IDs.
 ///////////////////////////////////////////////////////////////////////////////
 
 
-// Map protocol ObjectId => RemoteObject
 /**
- * @type {Map<CDP.Runtime.RemoteObject, string>}
+ * This is mostly standard CDP `RemoteObject`s.
+ * In some cases, CDP decided to have non-standard objects with
+ * a separate id space (e.g. `CSSStylesheet`). We do not store those.
+ * 
+ * @type {Map<string, CDP.Runtime.RemoteObject>}
  */
 const gCdpObjectsByRrpId = new Map();
+/**
+ * Special CDP objects that are not `CDP.Runtime.RemoteObject` and not plainObjects.
+ * @type {Map<string, Object>}
+ */
+const gOtherRrpObjectsByRrpId = new Map();
 
 /**
  * @type {Map<string, string>}
@@ -535,7 +581,7 @@ let gLastRrpId = 0;
 // Map protocol ObjectId => Debugger.Scope
 const gCdpScopesByRrpId = new Map();
 
-
+// cheap cache for boundingClientRects
 const gLastBoundingClientRectsByNodeRrpId = new Map();
 
 /**
@@ -578,7 +624,7 @@ function makeDebuggeeValue(plainObject) {
 function registerPlainObject(plainObject) {
   let rrpId = gRrpIdByPlainObject.get(plainObject);
   if (!rrpId) {
-    // → ask V8InspectorSession to wrap plainObject (gets CDP.RemoteObject)
+    // → ask V8InspectorSession to wrap plainObject (gets CDP.Runtime.RemoteObject)
     const cdpObject = makeDebuggeeValue(plainObject);
     if (cdpObject) {
       rrpId = registerCdpObject(cdpObject);
@@ -642,11 +688,58 @@ function registerCdpObject(cdpObject) {
     }
   }
 
+  return registerNewRrpObject(rrpId, cdpObject, plainObject);
+}
+
+
+/**
+ * 
+ * @return {CDP.Runtime.RemoteObject | Object}
+ */
+function getCdpObjectByRrpId(rrpId) {
+  const cdpObject = gCdpObjectsByRrpId.get(rrpId);
+  assert(cdpObject);
+  return cdpObject;
+}
+
+/**
+ * Edge case: CDP produces a custom object that does NOT have an `objectId`.
+ * Sometimes, they have a different id which refers back to some native plainObject 
+ *   (e.g. `CSSStylesheet`).
+ * Sometimes they do not map to a native plainObject (e.g. `CSSRule`).
+ * For such a CDP object, we only store its RRP representation and, for now, discard
+ * its CDP representation.
+ * 
+ * @param {object}
+ * @return {number} rrpId
+ */
+function registerOtherRrpObject(otherRrpObject, plainObject) {
+  assert(!cdpObject.objectId);
+
+  let rrpId;
+  if (plainObject) {
+    rrpId = gRrpIdByPlainObject.get(plainObject);
+  }
+
+  // NOTE: there is no cdpObject because there is no `CDP.Runtime.RemoteObject`.
+  const cdpObject = null;
+  return registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject);
+}
+
+function registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject) {
   // new RrpId
   const existingRrpId = rrpId;
   rrpId ||= ++gLastRrpId + '';  // coerce to string
-  gCdpObjectsByRrpId.set(rrpId, cdpObject);
-  gRrpIdByCdpId.set(cdpId, rrpId);
+  if (cdpObject) {
+    // CDP.Runtime.RemoteObject
+    assert(cdpObject.objectId);
+    const cdpId = cdpObject.objectId;
+    storeRrpId(rrpId, cdpId, cdpObject);
+  }
+  if (otherRrpObject) {
+    // specialized RRP objects, built from specialized CDP objects
+    gOtherRrpObjectsByRrpId.set(rrpId, otherRrpObject);
+  }
   if (plainObject && !existingRrpId) {
     gRrpIdByPlainObject.set(plainObject, rrpId);
     gPlainObjectByRrpId.set(rrpId, plainObject);
@@ -655,15 +748,14 @@ function registerCdpObject(cdpObject) {
   return rrpId;
 }
 
-/**
- * 
- * @return {CDP.Runtime.RemoteObject}
- */
-function getCdpObjectByRrpId(rrpId) {
-  const cdpObject = gCdpObjectsByRrpId.get(rrpId);
-  assert(cdpObject);
-  return cdpObject;
+function storeRrpId(rrpId, cdpId, cdpObject = null) {
+  gRrpIdByCdpId.set(cdpId, rrpId);
+  if (cdpObject) {
+    gCdpObjectsByRrpId.set(rrpId, cdpObject);
+  }
 }
+
+
 
 // Strings longer than this will be truncated when creating protocol values.
 const MaxStringLength = 10000;
@@ -714,20 +806,20 @@ function buildRrpObjectFromCdpObject(cdpObject) {
   }
 }
 
-/**
- * NOTE: This is called `createProtocolValueRaw` in gecko
- */
-function buildRrpObjectFromPlainValue(value) {
-  let cdpObject;
-  if (isNonNullObject(value)) {
-    const rrpId = registerPlainObject(value);
-    cdpObject = gCdpObjectsByRrpId.get(rrpId);
-  }
-  else {
-    cdpObject = makeDebuggeeValue(value);
-  }
-  return buildRrpObjectFromCdpObject(cdpObject);
-}
+// /**
+//  * NOTE: This is called `createProtocolValueRaw` in gecko
+//  */
+// function buildRrpObjectFromPlainValue(value) {
+//   let cdpObject;
+//   if (isNonNullObject(value)) {
+//     const rrpId = registerPlainObject(value);
+//     cdpObject = gCdpObjectsByRrpId.get(rrpId);
+//   }
+//   else {
+//     cdpObject = makeDebuggeeValue(value);
+//   }
+//   return buildRrpObjectFromCdpObject(cdpObject);
+// }
 
 /**
  * 
@@ -735,6 +827,7 @@ function buildRrpObjectFromPlainValue(value) {
  */
 function registerCdpScope(scope) {
   const rrpId = registerCdpObject(scope.object);
+  // TODO: we can probably get rid of gCdpScopesByRrpId
   gCdpScopesByRrpId.set(rrpId, scope);
   return rrpId;
 }
@@ -769,7 +862,7 @@ function getBlinkNodeIdByRrpId(nodeRrpId) {
 // Logic for creating object previews for the record/replay protocol.
 
 function isCdpObjectProxy(cdpObj) {
-  return cdpObj.subtype ==="proxy";
+  return cdpObj.subtype === "proxy";
 }
 
 /**
@@ -929,7 +1022,7 @@ ProtocolObjectPreview.prototype = {
     }
 
     // TODO: eval getter
-    
+
     const value = buildRrpObjectFromCdpObject(cdpValue);
     this.getterValues.set(name, { name, ...value });
   },
@@ -1032,29 +1125,23 @@ function previewBlinkObject(cdpObject, allProperties) {
   assert(rrpId);
   const plainObject = getPlainObjectByRrpId(rrpId);
 
-  /**
-   * @see https://github.com/replayio/gecko-dev/blob/592992ff7e15cb8ad1dd6fb109f19bd3523cd452/devtools/server/actors/replay/module.js#L1937
-   */
-  // TODO: figure out how to check for Node without using `instanceof`
-  // if (plainObject instanceof Node) {
-  // hackfix: check for random properties that nodes should have (can cause false positives)
-  if (plainObject?.nodeType > 0 && plainObject.nodeType <= 11 && plainObject.appendChild && plainObject.cloneNode) {
+  if (isInstanceOfNative(plainObject, Node)) {
     return {
       node: previewBlinkNode(plainObject)
     }
   }
-  if (plainObject instanceof CSSStyleDeclaration) {
+  if (isInstanceOfNative(plainObject, CSSStyleDeclaration)) {
     return {
       style: previewBlinkStyle(plainObject)
     }
   }
-  if (plainObject instanceof CSSRule) {
+  if (isInstanceOfNative(plainObject, CSSRule)) {
     return {
       // TODO
       // rule: previewBlinkRule(plainObject)
     }
   }
-  if (plainObject instanceof CSSStyleSheet) {
+  if (isInstanceOfNative(plainObject, CSSStyleSheet)) {
     return {
       // TODO
       // rule: previewBlinkStyleSheet(plainObject)
@@ -1068,10 +1155,7 @@ function previewBlinkObject(cdpObject, allProperties) {
 
 function previewBlinkNode(node) {
   let attributes, pseudoType;
-  // TODO: figure out how to check for Element without using `instanceof`
-  // if (node instanceof Element) {
-  // hackfix: (can cause false positives)
-  if (node.attributes?.length) {
+  if (isInstanceOfNative(node, Element)) {
     attributes = [];
     for (const { name, value } of node.attributes) {
       attributes.push({ name, value });
@@ -1548,7 +1632,7 @@ function DOM_getBoxModel({ node: nodeRrpId }) {
    */
   const cdpModel = fromJsGetBoxModel(nodeId);
 
-  const model = { 
+  const model = {
     node: nodeRrpId
   };
 
@@ -1560,9 +1644,9 @@ function DOM_getBoxModel({ node: nodeRrpId }) {
     Object.assign(
       model,
       {
-        content, 
-        padding, 
-        border, 
+        content,
+        padding,
+        border,
         margin
       }
     );
@@ -1635,7 +1719,7 @@ function CSS_getComputedStyle({ node }) {
   const nodeObj = getPlainObjectByRrpId(node);
 
   const computedStyle = [];
-  if (nodeObj instanceof Element) {
+  if (isInstanceOfNative(nodeObj, Element)) {
     // NOTE: tested successfully for same-CSP elements of different iframes
     const ownerGlobal = window;
 
@@ -1733,18 +1817,33 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
     cssText,
     range,
     selectorList = {},
-    styleSheetId: styleSheetAgentId
+    styleSheetId: styleSheetCpdId
   } = cdpRule.style || {};
-  
-  let parentStyleSheet;
-  if (styleSheetAgentId) {
-    // trace down `styleSheetCdpId`
-    //   -> InspectorStyleSheet.Id()
-    //   -> The way to look these up is via `id_to_inspector_style_sheet_` 
-    //        and `css_style_sheet_to_inspector_style_sheet_`
-    const styleSheetObj = getPlainObjectByCdpId(styleSheetCdpId);
-    log(`DDBG CdpAsRrpCssRule - styleSheetObj - ${styleSheetObj?.constructor?.name}: ${JSON.stringify(styleSheetObj)}`);
-    const parentStyleSheetRrpId = TODO;
+
+  let styleSheetRrpId;
+  if (styleSheetCpdId) {
+    styleSheetRrpId = gRrpIdByCdpId.get(styleSheetCpdId);
+    if (!styleSheetRrpId) {
+      // What is `styleSheetCdpId`?
+      //   -> InspectorStyleSheet.Id()
+      //   -> The way to look these up is via `id_to_inspector_style_sheet_` 
+      //        and `css_style_sheet_to_inspector_style_sheet_`
+      const nativeSheet = fromJsCssGetStylesheetByCpdId(styleSheetCpdId);
+      log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
+
+      const rrpSheet = {
+        type,
+        cssText,
+        parentStyleSheet,
+        startLine,
+        startColumn,
+        originalLocation,
+        selectorText,
+        style
+      };
+      styleSheetRrpId = registerOtherRrpObject(rrpSheet, nativeSheet);
+      storeRrpId(styleSheetRrpId, styleSheetCpdId);
+    }
   }
   const startLine = range?.startLine;
   const startColumn = range?.startColumn;
@@ -1756,14 +1855,22 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   const rrpRule = {
     type,
     cssText,
-    parentStyleSheet,
+    parentStyleSheet: styleSheetRrpId,
     startLine,
     startColumn,
     originalLocation,
     selectorText,
     style
   };
-  return rrpRuleId;
+
+  // NOTE: we cannot currently lookup the native `CSSRule` object because
+  //      InspectorCSSAgent::BuildObjectForRuleWithoutMedia does not 
+  //      store an id.
+  // const nativeRule = lookupNativeCssRuleByCdpRule();
+  const nativeRule = null;
+  const ruleRrrpId = registerOtherRrpObject(rrpRule, nativeRule);
+
+  return ruleRrrpId;
 }
 
 
@@ -1802,14 +1909,14 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
     addCdpRule(cdpRule);
   }
 
-  forst (const cdpInheritedEntry of inheritedEntries) {
+  for (const cdpInheritedEntry of inheritedEntries) {
     // see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-InheritedStyleEntry
     const {
       inlineStyle, // inherited inline style
       matchedCSSRules  // inherited non-inline rules from some stylesheet
     } = cdpInheritedEntry;
 
-    // TODO: convert/add inlineStyle?
+    // TODO: convert/add inlineStyle
 
     for (const matchedRule of matchedCSSRules) {
       // matchedRule.matchingSelectors
@@ -1825,18 +1932,33 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
 
   let rules = gCssRulesByNodeRrpId.get(nodeRrpId);
   const data = {};
-  if (!rules && nodeObj instanceof Element) {
+
+  // TODO: need to hackfix this, since 
+  if (!rules && isInstanceOfNative(nodeObj, Element)) {
     const nodeId = getBlinkNodeIdByRrpId(nodeRrpId);
 
     // NOTE: CSS domain commands are not accessible, so we have to get the data indirectly
     // const cdpMatchedStyles = sendMessage('CSS.getMatchedStylesForNode', { nodeId });
     const cdpMatchedStyles = fromJsGetMatchedStylesForNode(nodeId);
 
+
+    // NOTE: we don't seem to need `inlineStyle` for now, as its taken care of separately in 
+    //   `Pause.getObjectPreview`.
+    // if (inlineStyle.isJust()) {
+    //   auto rulesJs = convertCborToJS(isolate, inlineStyle.fromJust());
+    //   if (!rulesJs.IsEmpty()) {
+    //     SetDataProperty(isolate, result, "inlineStyle", rulesJs.ToLocalChecked());
+    //   }
+    // }
     rules = convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles);
   }
 
   return { rules, data };
 }
+
+
+
+
 
 
 
@@ -2912,7 +3034,8 @@ InspectorDOMAgent* getOrCreateInspectorDOMAgent(v8::Isolate* isolate) {
     InspectedFrames* inspectedFrames = getOrCreateInspectedFrames();
     gInspectorDomAgent = MakeGarbageCollected<InspectorDOMAgent>(
         isolate, inspectedFrames, gInspectorSession);
-    // gInspectorDomAgent->enable(); // NOTE: we cannot enable without a full session active
+    // NOTE: we cannot easily enable without a full session active
+    // gInspectorDomAgent->enable();
   }
   return gInspectorDomAgent;
 }
@@ -2940,12 +3063,12 @@ InspectorCSSAgent* getOrCreateInspectorCSSAgent(v8::Isolate* isolate) {
     gInspectorCssAgent = MakeGarbageCollected<InspectorCSSAgent>(
         domAgent, inspectedFrames, networkAgent, resource_content_loader,
         resource_container);
-
-    // // callback implementation example:
-    // // https://source.chromium.org/chromium/chromium/src/+/main:out/mac-Debug/gen/third_party/blink/renderer/core/inspector/protocol/css.cc;l=890?q=EnableCallbackImpl&ss=chromium%2Fchromium%2Fsrc
-    // std::unique_ptr<blink::protocol::CSS::Backend::EnableCallback> cb(nullptr);
-    // gInspectorCssAgent->enable(std::move(cb));
-
+    
+    // NOTE: we cannot easily enable without a full session active,
+    //      but if we wanted to, here is an example:
+    // https://source.chromium.org/chromium/chromium/src/+/main:out/mac-Debug/gen/third_party/blink/renderer/core/inspector/protocol/css.cc;l=890?q=EnableCallbackImpl&ss=chromium%2Fchromium%2Fsrc
+    // std::unique_ptr<blink::protocol::CSS::Backend::EnableCallback>
+    // cb(nullptr); gInspectorCssAgent->enable(std::move(cb));
   }
   return gInspectorCssAgent;
 }
@@ -3380,8 +3503,8 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
     Node* node = V8Node::ToImpl(nodeObj);
     if (node) {
-      // hackfix: bind node here (because the DOMAgent is not informed about the
-      // actual DOM)
+      // hackfix: bind node here
+      //   (if the DOMAgent was enabled, it would track DOM automatically)
       int nodeId = domAgent->BindDocumentNode(node);
       
       // TODO: clean up when done w/ RUN-981
@@ -3497,14 +3620,6 @@ static void fromJsGetMatchedStylesForNode(
     args.GetReturnValue().SetNull();
   } else {
     v8::Local<v8::Object> result = v8::Object::New(isolate);
-    // NOTE: we don't seem to need `inlineStyle` for now, as its taken care of separately in 
-    //   `Pause.getObjectPreview`.
-    // if (inlineStyle.isJust()) {
-    //   auto rulesJs = convertCborToJS(isolate, inlineStyle.fromJust());
-    //   if (!rulesJs.IsEmpty()) {
-    //     SetDataProperty(isolate, result, "inlineStyle", rulesJs.ToLocalChecked());
-    //   }
-    // }
     // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
     if (attributesStyle.isJust()) {
       auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
@@ -3530,6 +3645,31 @@ static void fromJsGetMatchedStylesForNode(
       SetDataProperty(isolate, result, "keyframesRules", rulesJs);
     }
     args.GetReturnValue().Set(result);
+  }
+}
+
+ 
+static void fromJsCssGetStylesheetByCpdId(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "[RuntimeError] must be called with a single number");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto sheetId = ToCoreString(args[0].As<v8::String>());
+  auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
+
+  CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
+  if (styleSheet) {
+    v8::Local<v8::Value> jsStyleSheet;
+    ScriptState* scriptState = ScriptState::Current(isolate);
+    if (styleSheet->WrapV2(scriptState).ToLocal(&jsStyleSheet)) {
+      args.GetReturnValue().Set(jsStyleSheet);
+      return;
+    }
+  }
+  else {
+    args.GetReturnValue().SetNull();
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -106,6 +106,7 @@ const {
   fromJsGetNodeId,
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForNode,
+  fromJsCssGetStylesheetByCpdId,
 
   // network
   getCurrentNetworkRequestEvent,
@@ -118,8 +119,6 @@ const {
 const gSourceMapData = new Map();
 
 try {
-
-
 
 
 
@@ -261,7 +260,7 @@ const CommandCallbacks = {
   "DOM.getEventListeners": DOM_getEventListeners,
   "DOM.querySelector": DOM_querySelector,
   "CSS.getComputedStyle": CSS_getComputedStyle,
-  "CSS.getAppliedRules": CSS_getAppliedRules,
+  // "CSS.getAppliedRules": CSS_getAppliedRules,
 };
 
 
@@ -737,6 +736,7 @@ function registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject) {
     storeRrpId(rrpId, cdpId, cdpObject);
   }
   if (otherRrpObject) {
+    // TODO: this cannot really work like this... need to find better solution for matching with getObjectPreview
     // specialized RRP objects, built from specialized CDP objects
     gOtherRrpObjectsByRrpId.set(rrpId, otherRrpObject);
   }
@@ -1832,14 +1832,7 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
       log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
 
       const rrpSheet = {
-        type,
-        cssText,
-        parentStyleSheet,
-        startLine,
-        startColumn,
-        originalLocation,
-        selectorText,
-        style
+        TODO
       };
       styleSheetRrpId = registerOtherRrpObject(rrpSheet, nativeSheet);
       storeRrpId(styleSheetRrpId, styleSheetCpdId);
@@ -1933,11 +1926,10 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
   let rules = gCssRulesByNodeRrpId.get(nodeRrpId);
   const data = {};
 
-  // TODO: need to hackfix this, since 
   if (!rules && isInstanceOfNative(nodeObj, Element)) {
     const nodeId = getBlinkNodeIdByRrpId(nodeRrpId);
 
-    // NOTE: CSS domain commands are not accessible, so we have to get the data indirectly
+    // NOTE: CSS domain commands are not accessible via `sendMessage`, so we have to get the data indirectly.
     // const cdpMatchedStyles = sendMessage('CSS.getMatchedStylesForNode', { nodeId });
     const cdpMatchedStyles = fromJsGetMatchedStylesForNode(nodeId);
 
@@ -1955,6 +1947,8 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
 
   return { rules, data };
 }
+
+
 
 
 
@@ -3801,11 +3795,13 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
   SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForNode",
                       fromJsGetMatchedStylesForNode);
+  SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
+                      fromJsCssGetStylesheetByCpdId);
 
-  // unsorted RR stuff
-  SetFunctionProperty(
-      isolate, args, "setClearPauseDataCallback",
-      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+      // unsorted RR stuff
+      SetFunctionProperty(
+          isolate, args, "setClearPauseDataCallback",
+          v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
   SetFunctionProperty(isolate, args, "getCurrentError",
                       GetCurrentError);
   SetFunctionProperty(isolate, args, "getRecordingId",

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -64,13 +64,10 @@ extern void RecordReplayConfirmObjectHasId(v8::Isolate* isolate, v8::Local<v8::C
                                            v8::Local<v8::Value> object);
 
 } // namespace internal
-
 } // namespace v8
 
 namespace blink {
-
 // using RemoteObjectIdTypeRaw = v8_inspector::String16;
-
 // The actual type for RemoteObjectId
 using RemoteObjectIdTypeRaw = std::u16string;
 
@@ -119,6 +116,13 @@ const {
 const gSourceMapData = new Map();
 
 try {
+
+
+
+
+
+
+
 
 
 
@@ -260,7 +264,7 @@ const CommandCallbacks = {
   "DOM.getEventListeners": DOM_getEventListeners,
   "DOM.querySelector": DOM_querySelector,
   "CSS.getComputedStyle": CSS_getComputedStyle,
-  // "CSS.getAppliedRules": CSS_getAppliedRules,
+  "CSS.getAppliedRules": CSS_getAppliedRules
 };
 
 
@@ -526,8 +530,8 @@ function isInstanceOfNative(x, target) {
 
   // new sln (also a hackfix): check if its native, and has `name` in inheritance chain
   const name = target?.name;
-  return name && 
-    x?.constructor?.toString()?.includes('() { [native code] }') && 
+  return name &&
+    x?.constructor?.toString()?.includes('() { [native code] }') &&
     hasInProtoChain(x.constructor, name);
 }
 
@@ -556,11 +560,6 @@ function hasInProtoChain(x, name) {
  * @type {Map<string, CDP.Runtime.RemoteObject>}
  */
 const gCdpObjectsByRrpId = new Map();
-/**
- * Special CDP objects that are not `CDP.Runtime.RemoteObject` and not plainObjects.
- * @type {Map<string, Object>}
- */
-const gOtherRrpObjectsByRrpId = new Map();
 
 /**
  * @type {Map<string, string>}
@@ -574,6 +573,11 @@ const gRrpIdByPlainObject = new Map();
  * @type {Map<string, Object>}
  */
 const gPlainObjectByRrpId = new Map();
+
+/**
+ * @type {Map<string, Object>}
+ */
+const gPreviewExtraByRrpId = new Map();
 
 let gLastRrpId = 0;
 
@@ -594,6 +598,7 @@ function clearPauseDataCallback() {
     gRrpIdByCdpId.clear();
     gRrpIdByPlainObject.clear();
     gPlainObjectByRrpId.clear();
+    gPreviewExtraByRrpId.clear();
     gCdpScopesByRrpId.clear();
     gLastBoundingClientRectsByNodeRrpId.clear();
     gCssRulesByNodeRrpId.clear();
@@ -687,7 +692,7 @@ function registerCdpObject(cdpObject) {
     }
   }
 
-  return registerNewRrpObject(rrpId, cdpObject, plainObject);
+  return registerNewRrpObject(rrpId, cdpObject, null, plainObject);
 }
 
 
@@ -702,19 +707,20 @@ function getCdpObjectByRrpId(rrpId) {
 }
 
 /**
- * Edge case: CDP produces a custom object that does NOT have an `objectId`.
- * Sometimes, they have a different id which refers back to some native plainObject 
+ * Edge case: CDP calls produce custom objects that do NOT have an `objectId`.
+ * Sometimes, they have their own id which refers back to some native plainObject 
  *   (e.g. `CSSStylesheet`).
  * Sometimes they do not map to a native plainObject (e.g. `CSSRule`).
- * For such a CDP object, we only store its RRP representation and, for now, discard
+ * For such a CDP object, we only store its RRP preview extra and, for now, discard
  * its CDP representation.
  * 
- * @param {object}
+ * 
+ * @param {object} previewExtra Used in `getObjectPreview`.
  * @return {number} rrpId
+ * 
+ * @see https://static.replay.io/protocol/tot/Pause/#type-ObjectPreview
  */
-function registerOtherRrpObject(otherRrpObject, plainObject) {
-  assert(!cdpObject.objectId);
-
+function registergRrpPreviewExtra(previewExtra, plainObject) {
   let rrpId;
   if (plainObject) {
     rrpId = gRrpIdByPlainObject.get(plainObject);
@@ -722,10 +728,14 @@ function registerOtherRrpObject(otherRrpObject, plainObject) {
 
   // NOTE: there is no cdpObject because there is no `CDP.Runtime.RemoteObject`.
   const cdpObject = null;
-  return registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject);
+  return registerNewRrpObject(rrpId, cdpObject, previewExtra, plainObject);
 }
 
-function registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject) {
+/**
+ * Generates `rrpId`, if it does not have one yet.
+ * Associates `rrpId` with its related data.
+ */
+function registerNewRrpObject(rrpId, cdpObject, previewExtra, plainObject) {
   // new RrpId
   const existingRrpId = rrpId;
   rrpId ||= ++gLastRrpId + '';  // coerce to string
@@ -733,12 +743,11 @@ function registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject) {
     // CDP.Runtime.RemoteObject
     assert(cdpObject.objectId);
     const cdpId = cdpObject.objectId;
-    storeRrpId(rrpId, cdpId, cdpObject);
+    registerRrpCpdId(rrpId, cdpId, cdpObject);
   }
-  if (otherRrpObject) {
-    // TODO: this cannot really work like this... need to find better solution for matching with getObjectPreview
-    // specialized RRP objects, built from specialized CDP objects
-    gOtherRrpObjectsByRrpId.set(rrpId, otherRrpObject);
+  if (previewExtra) {
+    // preview objects, already built from specialized CDP objects
+    gPreviewExtraByRrpId.set(rrpId, previewExtra);
   }
   if (plainObject && !existingRrpId) {
     gRrpIdByPlainObject.set(plainObject, rrpId);
@@ -748,7 +757,7 @@ function registerNewRrpObject(rrpId, cdpObject, otherRrpObject, plainObject) {
   return rrpId;
 }
 
-function storeRrpId(rrpId, cdpId, cdpObject = null) {
+function registerRrpCpdId(rrpId, cdpId, cdpObject = null) {
   gRrpIdByCdpId.set(cdpId, rrpId);
   if (cdpObject) {
     gCdpObjectsByRrpId.set(rrpId, cdpObject);
@@ -870,6 +879,21 @@ function isCdpObjectProxy(cdpObj) {
  * @see https://static.replay.io/protocol/tot/Pause/#type-Object
  */
 function createPauseObject(rrpId, level) {
+  // TODO: need a better thing happening instead of `getCdpObjectByRrpId` to pick up on the pre-cached preview objects
+  //    (TODO2: ideally, create a unique id for CSS.Rule preview objects)
+  /**
+  {
+    "className": "CSSStyleRule",
+    "objectId": "329",
+    "preview": {
+      "overflow": true,
+      "prototypeId": "226",
+      "rule": {
+        // ...
+      }
+    }
+  }
+  */
   const cdpObj = getCdpObjectByRrpId(rrpId);
   // NOTE: `subtype` is not reliably available, due to a divergence check in V8 → `value-mirror.cc`
   const className = isCdpObjectProxy(cdpObj) ? "Proxy" : (cdpObj.className || "Function");
@@ -1814,11 +1838,17 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   // NOTE: type is deprecated -> don't care
   const type = 1;
   const {
-    cssText,
-    range,
-    selectorList = {},
-    styleSheetId: styleSheetCpdId
-  } = cdpRule.style || {};
+    style: {
+      cssText: styleCssText,
+      // range: styleRange,
+      selectorList = {},
+      styleSheetId: styleSheetCpdId,
+      cssProperties
+    } = {},
+    range: ruleRange,
+    origin
+  } = cdpRule || {};
+
 
   let styleSheetRrpId;
   if (styleSheetCpdId) {
@@ -1831,29 +1861,65 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
       const nativeSheet = fromJsCssGetStylesheetByCpdId(styleSheetCpdId);
       log(`DDBG registerCdpAsRrpCssRule - styleSheetObj - ${nativeSheet?.constructor?.name}: ${JSON.stringify(nativeSheet)}`);
 
-      const rrpSheet = {
-        TODO
+      // NOTE: `isSystem` is part of RRP from `gecko`.
+      //    -> Chromium has a more diversified `StyleSheetOrigin` enum for this, 
+      //      but that is only accessible on the rule level here, for some reason.
+      const href = nativeSheet?.href;
+      const isSystem = origin !== 'regular';
+
+      const styleSheetExtra = {
+        styleSheet: {
+          href,
+          isSystem
+        }
       };
-      styleSheetRrpId = registerOtherRrpObject(rrpSheet, nativeSheet);
-      storeRrpId(styleSheetRrpId, styleSheetCpdId);
+      styleSheetRrpId = registergRrpPreviewExtra(styleSheetExtra, nativeSheet);
+      registerRrpCpdId(styleSheetRrpId, styleSheetCpdId);
     }
   }
-  const startLine = range?.startLine;
-  const startColumn = range?.startColumn;
-  // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
-  const originalLocation = null; // TODO
-  const selectorText = selectorList?.text;
-  const style = TODO;
 
-  const rrpRule = {
-    type,
-    cssText,
-    parentStyleSheet: styleSheetRrpId,
-    startLine,
-    startColumn,
-    originalLocation,
-    selectorText,
-    style
+  // styleExtra
+  const properties = cssProperties?.map(prop => {
+    const { name, value, important } = prop;
+    return {
+      name,
+      value,
+      important
+    };
+  });
+  const styleExtra = {
+    style: {
+      cssText: styleCssText,
+      parentRule: 0, // filled in once we have it, below
+      properties
+    }
+  };
+  const nativeStlyeDeclaration = null;
+  const styleRrpId = registergRrpPreviewExtra(styleExtra, nativeStlyeDeclaration);
+
+  // ruleExtra
+  const startLine = ruleRange?.startLine;
+  const startColumn = ruleRange?.startColumn;
+  // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
+  const originalLocation = undefined; // TODO
+  const selectorText = selectorList?.text;
+
+  /**
+   * Based on `CSSStyleRule::cssText()`.
+   * @see https://github.com/replayio/chromium/blob/052831f0220b79fe0c3343b49f6d2863ea6de05d/third_party/blink/renderer/core/css/css_style_rule.cc#L94
+   */  
+  const ruleCssText = `${selectorText} {${styleCssText}}`; 
+  const ruleExtra = {
+    rule: {
+      type,
+      cssText: ruleCssText,
+      parentStyleSheet: styleSheetRrpId,
+      startLine,
+      startColumn,
+      originalLocation,
+      selectorText,
+      style: styleRrpId
+    }
   };
 
   // NOTE: we cannot currently lookup the native `CSSRule` object because
@@ -1861,9 +1927,12 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
   //      store an id.
   // const nativeRule = lookupNativeCssRuleByCdpRule();
   const nativeRule = null;
-  const ruleRrrpId = registerOtherRrpObject(rrpRule, nativeRule);
+  const ruleRrpId = registergRrpPreviewExtra(ruleExtra, nativeRule);
 
-  return ruleRrrpId;
+  // set ruleRrpId
+  styleExtra && (styleExtra.style.parentRule = ruleRrpId);
+
+  return ruleRrpId;
 }
 
 
@@ -1906,7 +1975,7 @@ function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
     // see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-InheritedStyleEntry
     const {
       inlineStyle, // inherited inline style
-      matchedCSSRules  // inherited non-inline rules from some stylesheet
+      matchedCSSRules  // inherited non-inline rules
     } = cdpInheritedEntry;
 
     // TODO: convert/add inlineStyle
@@ -1947,12 +2016,6 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
 
   return { rules, data };
 }
-
-
-
-
-
-
 
 
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -261,7 +261,7 @@ const CommandCallbacks = {
   "DOM.getEventListeners": DOM_getEventListeners,
   "DOM.querySelector": DOM_querySelector,
   "CSS.getComputedStyle": CSS_getComputedStyle,
-  // "CSS.getAppliedRules": CSS_getAppliedRules,
+  "CSS.getAppliedRules": CSS_getAppliedRules,
 };
 
 
@@ -1685,9 +1685,14 @@ const PseudoElements = [
 ];
 
 /**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSRule
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule
  * @see https://static.replay.io/protocol/tot/CSS/#type-Rule
  */
 class CssRule {
+  /**
+   * @deprecated
+   */
   type;
   cssText;
   parentStyleSheet;
@@ -1699,17 +1704,71 @@ class CssRule {
 }
 
 /**
+ * @see https://static.replay.io/protocol/tot/CSS/#type-StyleDeclaration
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
+ * @see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-CSSStyle
+ */
+function registerCssStyleDeclaration() {
+  // TODO!
+
+  const decl = {
+    cssText,
+    parentRule,
+    properties
+  };
+  return decl;
+}
+
+/**
  * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSRule
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule
+ * @see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-CSSRule
  * @see https://static.replay.io/protocol/tot/CSS/#type-Rule
  */
 function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
+  // NOTE: type is deprecated -> don't care
+  const type = 1;
+  const {
+    cssText,
+    range,
+    selectorList = {},
+    styleSheetId: styleSheetAgentId
+  } = cdpRule.style || {};
   
-  return ruleRrpId;
+  let parentStyleSheet;
+  if (styleSheetAgentId) {
+    // trace down `styleSheetCdpId`
+    //   -> InspectorStyleSheet.Id()
+    //   -> The way to look these up is via `id_to_inspector_style_sheet_` 
+    //        and `css_style_sheet_to_inspector_style_sheet_`
+    const styleSheetObj = getPlainObjectByCdpId(styleSheetCdpId);
+    log(`DDBG CdpAsRrpCssRule - styleSheetObj - ${styleSheetObj?.constructor?.name}: ${JSON.stringify(styleSheetObj)}`);
+    const parentStyleSheetRrpId = TODO;
+  }
+  const startLine = range?.startLine;
+  const startColumn = range?.startColumn;
+  // see https://static.replay.io/protocol/tot/CSS/#type-OriginalStyleSheetLocation
+  const originalLocation = null; // TODO
+  const selectorText = selectorList?.text;
+  const style = TODO;
+
+  const rrpRule = {
+    type,
+    cssText,
+    parentStyleSheet,
+    startLine,
+    startColumn,
+    originalLocation,
+    selectorText,
+    style
+  };
+  return rrpRuleId;
 }
 
 
 /**
- * NOTE1: RRP's `CSS.Rule` is entirely based on how gecko does things.
+ * NOTE1: RRP's `CSS.Rule` is based on how gecko does things.
  *    gecko has a utility function to produce the rules in one call.
  *    But in chromium, we have to query and convert the data in multiple steps.
  * 
@@ -1722,16 +1781,40 @@ function registerCdpAsRrpCssRule(nodeObj, cdpRule) {
 function convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles) {
   const appliedRules = [];
 
-  for (const cdpRule of cdpRules) {
+  const {
+    matchedRules = [],
+    inheritedEntries = []
+  } = cdpMatchedStyles;
+
+  function addCdpRule(cdpRule) {
     // TODO: add pseudoElement support
     //   Issue: https://linear.app/replay/issue/RUN-953
     const pseudoElement = undefined;
-    const ruleRrpId = registerCdpAsRrpCssRule(nodeObj, cdpRule);
+    const rrpRuleId = registerCdpAsRrpCssRule(nodeObj, cdpRule);
     const appliedRule = {
-      rule: ruleRrpId,
+      rule: rrpRuleId,
       pseudoElement
     };
     appliedRules.push(appliedRule);
+  }
+
+  for (const cdpRule of matchedRules) {
+    addCdpRule(cdpRule);
+  }
+
+  forst (const cdpInheritedEntry of inheritedEntries) {
+    // see https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-InheritedStyleEntry
+    const {
+      inlineStyle, // inherited inline style
+      matchedCSSRules  // inherited non-inline rules from some stylesheet
+    } = cdpInheritedEntry;
+
+    // TODO: convert/add inlineStyle?
+
+    for (const matchedRule of matchedCSSRules) {
+      // matchedRule.matchingSelectors
+      addCdpRule(matchedRule.rule);
+    }
   }
 
   return { rules: appliedRules, data: {} };
@@ -2840,14 +2923,6 @@ InspectorNetworkAgent* getOrCreateInspectorNetworkAgent() {
     InspectedFrames* inspectedFrames = getOrCreateInspectedFrames();
     gInspectorNetworkAgent = MakeGarbageCollected<InspectorNetworkAgent>(
         inspectedFrames, nullptr, gInspectorSession);
-
-    // // see
-    // // https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/third_party/blink/renderer/core/inspector/protocol/network.cc;l=1520;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29;bpv=0;bpt=1
-    // Maybe<int> total_buffer_size;
-    // Maybe<int> resource_buffer_size;
-    // Maybe<int> max_post_data_size;
-    // gInspectorNetworkAgent->enable(std::move(total_buffer_size), std::move(resource_buffer_size),
-    //                                std::move(max_post_data_size));
   }
   return gInspectorNetworkAgent;
 }
@@ -2899,7 +2974,7 @@ getObjectByCdpId(v8::Isolate* isolate,
 /**
  * NOTE: Since the `RemoteObject` type is not publicly exposed, we cannot easily
  * access it in CPP space. We thus only use it in JS. This basically emulates
- * gecko's `makeDebuggeeValue` (but requires an extra parse).
+ * gecko's `makeDebuggeeValue`.
  */
 static void fromJsMakeDebuggeeValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -2914,12 +2989,8 @@ static void fromJsMakeDebuggeeValue(
       "console");  // NOTE: object_group is used for cleaning up
   auto generatePreview = false;
 
-  // NOTE: This always creates (and deletes) a new `RemoteObject` and binds it
-  // to a new id. RemoteObjectIdTypeRaw remoteObjectId =
-  // v8_inspector::StringView result =
-  // RemoteObjectIdTypeRaw result = gInspectorSession->wrapObjectGetObjectId(
-  //     context, obj, ToV8InspectorStringView(object_group), false);
-  // auto converted = String(result.c_str(), result.length());
+  // NOTE: `wrapObject` always creates a new `RemoteObject` and binds it
+  // to a new id.
   auto result = gInspectorSession->wrapObject(
       context, value, ToV8InspectorStringView(object_group), generatePreview);
 
@@ -3426,12 +3497,15 @@ static void fromJsGetMatchedStylesForNode(
     args.GetReturnValue().SetNull();
   } else {
     v8::Local<v8::Object> result = v8::Object::New(isolate);
-    if (inlineStyle.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, inlineStyle.fromJust());
-      if (!rulesJs.IsEmpty()) {
-        SetDataProperty(isolate, result, "inlineStyle", rulesJs.ToLocalChecked());
-      }
-    }
+    // NOTE: we don't seem to need `inlineStyle` for now, as its taken care of separately in 
+    //   `Pause.getObjectPreview`.
+    // if (inlineStyle.isJust()) {
+    //   auto rulesJs = convertCborToJS(isolate, inlineStyle.fromJust());
+    //   if (!rulesJs.IsEmpty()) {
+    //     SetDataProperty(isolate, result, "inlineStyle", rulesJs.ToLocalChecked());
+    //   }
+    // }
+    // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
     if (attributesStyle.isJust()) {
       auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
       if (!rulesJs.IsEmpty()) {
@@ -3449,7 +3523,7 @@ static void fromJsGetMatchedStylesForNode(
     }
     if (inheritedEntries.isJust()) {
       auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
-      SetDataProperty(isolate, result, "inheritedRules", rulesJs);
+      SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
     }
     if (keyframesRules.isJust()) {
       auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "base/macros.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/animation/css/css_animation_data.h"
 #include "third_party/blink/renderer/core/css/css_color_value.h"
 #include "third_party/blink/renderer/core/css/css_computed_style_declaration.h"
@@ -1184,6 +1185,11 @@ CSSStyleSheet* InspectorCSSAgent::getStyleSheet(const String& style_sheet_id) {
           static_cast<InspectorStyleSheet*>(inspector_style_sheet);
       return targetSheet->PageStyleSheet();
     }
+  } else {
+    recordreplay::Print(
+      "[RuntimeError] InspectorCSSAgent::getStyleSheet failed (style_sheet_id: %s, Code: %d): %s",
+      style_sheet_id.Utf8().c_str(), response.Code(), response.Message().c_str()
+    );
   }
   return nullptr;
 }
@@ -1934,9 +1940,10 @@ Response InspectorCSSAgent::AssertEnabled() {
 Response InspectorCSSAgent::AssertInspectorStyleSheetForId(
     const String& style_sheet_id,
     InspectorStyleSheet*& result) {
-  Response response = AssertEnabled();
-  if (!response.IsSuccess())
-    return response;
+  // [recordreplay] allow this to work without being enabled?
+  // Response response = AssertEnabled();
+  // if (!response.IsSuccess())
+  //   return response;
   IdToInspectorStyleSheet::iterator it =
       id_to_inspector_style_sheet_.find(style_sheet_id);
   if (it == id_to_inspector_style_sheet_.end())

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -1180,7 +1180,8 @@ CSSStyleSheet* InspectorCSSAgent::getStyleSheet(const String& style_sheet_id) {
       AssertStyleSheetForId(style_sheet_id, inspector_style_sheet);
   if (response.IsSuccess()) {
     if (!inspector_style_sheet->IsInlineStyle()) {
-      auto* targetSheet = static_cast<InspectorStyleSheet*>(inspector_style_sheet);
+      auto* targetSheet =
+          static_cast<InspectorStyleSheet*>(inspector_style_sheet);
       return targetSheet->PageStyleSheet();
     }
   }

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -1174,6 +1174,19 @@ Response InspectorCSSAgent::getStyleSheetText(const String& style_sheet_id,
   return Response::Success();
 }
 
+CSSStyleSheet* InspectorCSSAgent::getStyleSheet(const String& style_sheet_id) {
+  InspectorStyleSheetBase* inspector_style_sheet = nullptr;
+  Response response =
+      AssertStyleSheetForId(style_sheet_id, inspector_style_sheet);
+  if (response.IsSuccess()) {
+    if (!inspector_style_sheet->IsInlineStyle()) {
+      auto* targetSheet = static_cast<InspectorStyleSheet*>(inspector_style_sheet);
+      return targetSheet->PageStyleSheet();
+    }
+  }
+  return nullptr;
+}
+
 Response InspectorCSSAgent::collectClassNames(
     const String& style_sheet_id,
     std::unique_ptr<protocol::Array<String>>* class_names) {

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.h
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.h
@@ -164,7 +164,7 @@ class CORE_EXPORT InspectorCSSAgent final
                                        String* text) override;
 
   /**
-   * [recordreplay-edit] Use this to get access to the native StyleSheet object.
+   * [recordreplay] Use this to get access to the native StyleSheet object.
    */
   CSSStyleSheet* getStyleSheet(const String& style_sheet_id);
 

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.h
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.h
@@ -162,6 +162,12 @@ class CORE_EXPORT InspectorCSSAgent final
       std::unique_ptr<protocol::Array<String>>* class_names) override;
   protocol::Response getStyleSheetText(const String& style_sheet_id,
                                        String* text) override;
+
+  /**
+   * [recordreplay-edit] Use this to get access to the native StyleSheet object.
+   */
+  CSSStyleSheet* getStyleSheet(const String& style_sheet_id);
+
   protocol::Response setStyleSheetText(
       const String& style_sheet_id,
       const String& text,


### PR DESCRIPTION
* Make use of InspectorCSSAgent to get all relevant data from CDP's `CSS.getMatchedStylesForNode`
* Store relevant preview data from CSS.Rule
* Enhance Pause.getObjectPreview to produce correct preview of DOM and blink objects: `style`, `styleSheet`, `rule`
* Added `isInstanceOfNative` (also fixes RUN-1014)

https://linear.app/replay/issue/RUN-981/cssgetappliedrules-css-previews-for-pausegetobjectpreview