### PR TITLE
RUN-1033: DOM.performSearch

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -527,10 +527,8 @@ function isInstanceOfNative(x, target) {
    * @see https://github.com/replayio/chromium-v8/blob/51140a440949dbbeea7a4e6c2185ccdeb8b6276e/src/objects/objects.cc#L929
    * @see https://github.com/replayio/chromium-v8/blob/51140a440949dbbeea7a4e6c2185ccdeb8b6276e/src/objects/js-objects.cc#170
    */
-  // old sln: check assortment of props
-  // if (plainObject?.nodeType > 0 && plainObject.nodeType <= 11 && plainObject.appendChild && plainObject.cloneNode) {
 
-  // new sln (also a hackfix): check if its native, and has `name` in inheritance chain
+  // hackfix: check if its native, and has `name` in inheritance chain
   const name = target?.name;
   return name &&
     x?.constructor?.toString()?.includes('() { [native code] }') &&
@@ -1155,18 +1153,6 @@ function previewBlinkObject(cdpObject, allProperties) {
       style: previewBlinkStyle(plainObject)
     }
   }
-  
-  // if (isInstanceOfNative(plainObject, CSSRule)) {
-  //   return {
-  //     rule: previewBlinkRule(plainObject)
-  //   }
-  // }
-  // if (isInstanceOfNative(plainObject, CSSStyleSheet)) {
-  //   return {
-  //     styleSheet: previewBlinkStyleSheet(plainObject)
-  //   }
-  // }
-
 }
 
 function previewBlinkNode(node) {
@@ -1235,9 +1221,6 @@ function previewBlinkNode(node) {
 function previewBlinkStyle(style) {
   // NOTE: this is for inline styles, where there is no parentRule
   let parentRule = undefined;
-  // if (style.parentRule) {
-  //   parentRule = registerPlainObject(style.parentRule);
-  // }
 
   const properties = [];
   for (let i = 0; i < style.length; i++) {
@@ -1678,7 +1661,7 @@ function DOM_getBoxModel({ node: nodeRrpId }) {
 function DOM_getEventListeners({ node }) {
   const listeners = [];
 
-  // TODO: adopt from gecko code ↓
+  // TODO: ↓ adopt from gecko code - https://linear.app/replay/issue/RUN-1034
 
   // const nodeObj = getObjectFromId(node).unsafeDereference();
   // const listenerInfo = Services.els.getListenerInfoFor(nodeObj) || [];
@@ -2018,16 +2001,6 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
     // NOTE: CSS domain commands are not accessible via `sendMessage`, so we have to get the data indirectly.
     // const cdpMatchedStyles = sendMessage('CSS.getMatchedStylesForNode', { nodeId });
     const cdpMatchedStyles = fromJsGetMatchedStylesForNode(nodeId);
-
-
-    // NOTE: we don't seem to need `inlineStyle` for now, as its taken care of separately in 
-    //   `Pause.getObjectPreview`.
-    // if (inlineStyle.isJust()) {
-    //   auto rulesJs = convertCborToJS(isolate, inlineStyle.fromJust());
-    //   if (!rulesJs.IsEmpty()) {
-    //     SetDataProperty(isolate, result, "inlineStyle", rulesJs.ToLocalChecked());
-    //   }
-    // }
     rules = convertCdpToRrpCssRules(nodeObj, cdpMatchedStyles);
     gCssRulesByNodeRrpId.set(nodeRrpId, rules);
   }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1717,8 +1717,7 @@ function DOM_performSearch({ query }) {
   query = query.trim();
   const nodeObjects = fromJsDomPerformSearch(query);
   const nodeRrpIds = nodeObjects
-    ?.map(node => gRrpIdByPlainObject.get(node))
-    .filter(rrpId => !!rrpId)
+    ?.map(registerPlainObject)
    || [];
 
   return { nodes: nodeRrpIds, data: {} };
@@ -3162,7 +3161,7 @@ static bool getV8FromBlinkObject(
 
   // weird
   P("[RuntimeError] getV8FromBlinkObject failed");
-    return false;
+  return false;
 }
 
 /**
@@ -3871,7 +3870,9 @@ static void fromJsDomPerformSearch(
           int nodeId = (*nodeIds)[i];
           auto* node = domAgent->NodeForId(nodeId);
           v8::Local<v8::Value> v8Node;
+          P("DDBG performSearch %d %d", i, !!node);
           if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
+            P("DDBG performSearch2 %d %d", i, !!node);
             v8::Local<v8::Context> context = isolate->GetCurrentContext();
             result->Set(context, nWritten++, v8Node).Check();
           }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -104,6 +104,7 @@ const {
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForNode,
   fromJsCssGetStylesheetByCpdId,
+  fromJsDomPerformSearch,
 
   // network
   getCurrentNetworkRequestEvent,
@@ -263,6 +264,7 @@ const CommandCallbacks = {
   "DOM.getBoxModel": DOM_getBoxModel,
   "DOM.getEventListeners": DOM_getEventListeners,
   "DOM.querySelector": DOM_querySelector,
+  "DOM.performSearch": DOM_performSearch,
   "CSS.getComputedStyle": CSS_getComputedStyle,
   "CSS.getAppliedRules": CSS_getAppliedRules
 };
@@ -1725,6 +1727,21 @@ function DOM_querySelector({ node, selector }) {
 }
 
 /** ###########################################################################
+ * {@link DOM_performSearch}
+ * ##########################################################################*/
+
+function DOM_performSearch({ query }) {
+  const nodeObjects = fromJsDomPerformSearch(query);
+  const nodeRrpIds = nodeObjects
+    ?.map(node => gRrpIdByPlainObject.get(node))
+    .filter(rrpId => !!rrpId)
+   || [];
+
+  return { nodes: nodeRrpIds, data: {} };
+}
+
+
+/** ###########################################################################
  * {@link CSS_getComputedStyle}
  * ##########################################################################*/
 
@@ -3154,6 +3171,26 @@ getObjectByCdpId(v8::Isolate* isolate,
 }
 
 /**
+ * Returns the matching object or null.
+ * Should generally never return null.
+ */
+static bool getV8FromBlinkObject(
+    v8::Isolate* isolate,
+    ScriptWrappable* blinkObject,
+    v8::Local<v8::Value>& result) {
+  ScriptState* scriptState = ScriptState::Current(isolate);
+  v8::Local<v8::Value> v8Object;
+  if (blinkObject->WrapV2(scriptState).ToLocal(&v8Object)) {
+    result = v8Object;
+    return true;
+  }
+
+  // weird
+  P("[RuntimeError] getV8FromBlinkObject failed");
+    return false;
+}
+
+/**
  * NOTE: Since the `RemoteObject` type is not publicly exposed, we cannot easily
  * access it in CPP space. We thus only use it in JS. This basically emulates
  * gecko's `makeDebuggeeValue`.
@@ -3210,7 +3247,6 @@ static void fromJsGetObjectByCdpId(
         "[RuntimeError] must be called with a single string");
 
   v8::Isolate* isolate = args.GetIsolate();
-  auto context = isolate->GetCurrentContext();
 
   // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
   // future-work: can this be improved?
@@ -3218,15 +3254,11 @@ static void fromJsGetObjectByCdpId(
   const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
   v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
 
-  v8::Local<v8::Value> plainObject;
-  std::unique_ptr<v8_inspector::StringBuffer> error;
-  if (!gInspectorSession->unwrapObject(&error, cdpIdV8, &plainObject, &context,
-                                       nullptr)) {
-    recordreplay::Print("[RuntimError] could not lookup cdpId: %s",
-                        ToCoreString(error->string()).Ascii().c_str());
-    args.GetReturnValue().SetNull();
-  } else {
+  v8::Local<v8::Object> plainObject;
+  if (getObjectByCdpId(isolate, cdpIdV8, plainObject)) {
     args.GetReturnValue().Set(plainObject);
+  } else {
+    args.GetReturnValue().SetNull();
   }
 }
 
@@ -3674,7 +3706,7 @@ static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) 
  * ##########################################################################*/
 
 static bool checkCDPResponse(const char* label,
-                             const Response& response,
+                             const protocol::Response& response,
                              const v8::FunctionCallbackInfo<v8::Value>& args) {
   if (!response.IsSuccess()) {
     recordreplay::Print(
@@ -3708,7 +3740,7 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
     Node* node = V8Node::ToImpl(nodeObj);
     if (node) {
       // hackfix: bind node here
-      //   (if the DOMAgent was enabled, it would track DOM automatically)
+      //   (if the DOMAgent was enabled, it would track nodes automatically)
       int nodeId = domAgent->BindDocumentNode(node);
       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
       return;
@@ -3827,15 +3859,12 @@ static void fromJsCssGetStylesheetByCpdId(
   auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
 
   CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
-  if (styleSheet) {
-    v8::Local<v8::Value> jsStyleSheet;
-    ScriptState* scriptState = ScriptState::Current(isolate);
-    if (styleSheet->WrapV2(scriptState).ToLocal(&jsStyleSheet)) {
-      args.GetReturnValue().Set(jsStyleSheet);
-      return;
-    }
+  v8::Local<v8::Value> v8StyleSheet;
+  if (styleSheet && getV8FromBlinkObject(isolate, styleSheet, v8StyleSheet)) {
+    args.GetReturnValue().Set(v8StyleSheet);
+  } else {
+    args.GetReturnValue().SetNull();
   }
-  args.GetReturnValue().SetNull();
 }
 
 static void fromJsDomPerformSearch(
@@ -3848,7 +3877,7 @@ static void fromJsDomPerformSearch(
   auto query = ToCoreString(args[0].As<v8::String>());
   auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
 
-  bool includeUserAgentShadowDom = false;
+  bool includeUserAgentShadowDom = true;
   String searchId;
   int resultCount;
   auto response = domAgent->performSearch(query, includeUserAgentShadowDom, &searchId, &resultCount);
@@ -3857,15 +3886,25 @@ static void fromJsDomPerformSearch(
       int fromIndex = 0;
       int toIndex = resultCount;
       std::unique_ptr<protocol::Array<int>> nodeIds;
-      response = domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
+      response =
+          domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
       if (checkCDPResponse("DOM.getSearchResults", response, args)) {
-        v8::Local<v8::Array> nodes = v8::Array::New(isolate);
-        // TODO: (1) iterate nodeIds -> (2) get v8 objects -> (3) send to JS -> (4) convert to rrpId
-        args.GetReturnValue().Set(nodes);
+        v8::Local<v8::Array> result = v8::Array::New(isolate);
+        uint32_t nWritten = 0;
+        for (uint32_t i = 0; i < nodeIds->size(); ++i) {
+          int nodeId = (*nodeIds)[i];
+          auto* node = domAgent->NodeForId(nodeId);
+          v8::Local<v8::Value> v8Node;
+          if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
+            v8::Local<v8::Context> context = isolate->GetCurrentContext();
+            result->Set(context, nWritten++, v8Node).Check();
+          }
+        }
+        args.GetReturnValue().Set(result);
       }
     } else {
-      v8::Local<v8::Array> nodes = v8::Array::New(isolate);
-      args.GetReturnValue().Set(nodes);
+      v8::Local<v8::Array> result = v8::Array::New(isolate);
+      args.GetReturnValue().Set(result);
     }
   }
 }
@@ -4006,6 +4045,8 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
                       fromJsGetMatchedStylesForNode);
   SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
                       fromJsCssGetStylesheetByCpdId);
+  SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
+                      fromJsDomPerformSearch);
 
   // unsorted RR stuff
   SetFunctionProperty(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1714,6 +1714,7 @@ function DOM_querySelector({ node, selector }) {
  * ##########################################################################*/
 
 function DOM_performSearch({ query }) {
+  query = query.trim();
   const nodeObjects = fromJsDomPerformSearch(query);
   const nodeRrpIds = nodeObjects
     ?.map(node => gRrpIdByPlainObject.get(node))
@@ -3075,7 +3076,8 @@ static InspectedFrames* getOrCreateInspectedFrames() {
 }
 
 // NOTE: we need to instantiate all inspectors indivudally because we 
-//    are not fully hooked up with a `DevToolsSession` + `UberDispatcher`
+//    are not fully hooked up with a `DevToolsSession` + `UberDispatcher`.
+//    We also cannot enable them for the same reason.
 InspectorDOMAgent* getOrCreateInspectorDOMAgent(v8::Isolate* isolate) {
   if (!gInspectorDomAgent) {
     // NOTE: based on WebDevToolsAgentImpl::AttachSession
@@ -3083,8 +3085,8 @@ InspectorDOMAgent* getOrCreateInspectorDOMAgent(v8::Isolate* isolate) {
     InspectedFrames* inspectedFrames = getOrCreateInspectedFrames();
     gInspectorDomAgent = MakeGarbageCollected<InspectorDOMAgent>(
         isolate, inspectedFrames, gInspectorSession);
-    // NOTE: we cannot easily enable without a full session active
-    // gInspectorDomAgent->enable();
+
+    gInspectorDomAgent->FrameDocumentUpdated(gLocalFrame);
   }
   return gInspectorDomAgent;
 }
@@ -3853,7 +3855,8 @@ static void fromJsDomPerformSearch(
   bool includeUserAgentShadowDom = true;
   String searchId;
   int resultCount;
-  auto response = domAgent->performSearch(query, includeUserAgentShadowDom, &searchId, &resultCount);
+  auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
+                                          &searchId, &resultCount);
   if (checkCDPResponse("DOM.performSearch", response, args)) {
     if (resultCount) {
       int fromIndex = 0;
@@ -3879,6 +3882,9 @@ static void fromJsDomPerformSearch(
       v8::Local<v8::Array> result = v8::Array::New(isolate);
       args.GetReturnValue().Set(result);
     }
+
+    // clean up
+    domAgent->discardSearchResults(searchId);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3673,6 +3673,23 @@ static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) 
  * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
  * ##########################################################################*/
 
+static bool checkCDPResponse(const char* label,
+                             const Response& response,
+                             const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!response.IsSuccess()) {
+    recordreplay::Print(
+        "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s",
+        label,
+        response.Code(),
+        response.Message().c_str());
+
+    // result is null
+    args.GetReturnValue().SetNull();
+    return false;
+  }
+  return true;
+}
+
 static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "[RuntimeError] must be called with a single string");
@@ -3802,7 +3819,7 @@ static void fromJsGetMatchedStylesForNode(
 static void fromJsCssGetStylesheetByCpdId(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "[RuntimeError] must be called with a single number");
+        "[RuntimeError] must be called with a single string");
 
   v8::Isolate* isolate = args.GetIsolate();
 
@@ -3819,6 +3836,38 @@ static void fromJsCssGetStylesheetByCpdId(
     }
   }
   args.GetReturnValue().SetNull();
+}
+
+static void fromJsDomPerformSearch(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "[RuntimeError] must be called with a single string");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto query = ToCoreString(args[0].As<v8::String>());
+  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+  bool includeUserAgentShadowDom = false;
+  String searchId;
+  int resultCount;
+  auto response = domAgent->performSearch(query, includeUserAgentShadowDom, &searchId, &resultCount);
+  if (checkCDPResponse("DOM.performSearch", response, args)) {
+    if (resultCount) {
+      int fromIndex = 0;
+      int toIndex = resultCount;
+      std::unique_ptr<protocol::Array<int>> nodeIds;
+      response = domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
+      if (checkCDPResponse("DOM.getSearchResults", response, args)) {
+        v8::Local<v8::Array> nodes = v8::Array::New(isolate);
+        // TODO: (1) iterate nodeIds -> (2) get v8 objects -> (3) send to JS -> (4) convert to rrpId
+        args.GetReturnValue().Set(nodes);
+      }
+    } else {
+      v8::Local<v8::Array> nodes = v8::Array::New(isolate);
+      args.GetReturnValue().Set(nodes);
+    }
+  }
 }
 
 /** ###########################################################################

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -1933,6 +1933,10 @@ InspectorStyleSheet* InspectorCSSAgent::ViaInspectorStyleSheet(
 }
 
 Response InspectorCSSAgent::AssertEnabled() {
+  if (recordreplay::HasDivergedFromRecording()) {
+    // [replay] act as though it is enabled
+    return Response::Success();
+  }
   return enable_completed_ ? Response::Success()
                            : Response::ServerError("CSS agent was not enabled");
 }
@@ -1940,10 +1944,10 @@ Response InspectorCSSAgent::AssertEnabled() {
 Response InspectorCSSAgent::AssertInspectorStyleSheetForId(
     const String& style_sheet_id,
     InspectorStyleSheet*& result) {
-  // [replay] we cannot currently enable these during replay
-  // Response response = AssertEnabled();
-  // if (!response.IsSuccess())
-  //   return response;
+  Response response = AssertEnabled();
+  if (!response.IsSuccess())
+    return response;
+
   IdToInspectorStyleSheet::iterator it =
       id_to_inspector_style_sheet_.find(style_sheet_id);
   if (it == id_to_inspector_style_sheet_.end())

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -1940,7 +1940,7 @@ Response InspectorCSSAgent::AssertEnabled() {
 Response InspectorCSSAgent::AssertInspectorStyleSheetForId(
     const String& style_sheet_id,
     InspectorStyleSheet*& result) {
-  // [recordreplay] allow this to work without being enabled?
+  // [replay] we cannot currently enable these during replay
   // Response response = AssertEnabled();
   // if (!response.IsSuccess())
   //   return response;

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
@@ -768,36 +768,38 @@ int InspectorDOMAgent::PushNodePathToFrontend(Node* node_to_push,
   if (!document_)
     return 0;
 
-  // [replay] PushNodePathToFrontend is bad when `DevToolsSession` not active
-  //    TODO: This does not handle dangling nodes properly - https://linear.app/replay/issue/RUN-1005/
-  return BindDocumentNode(node_to_push);
+  if (!enabled_.Get() && recordreplay::HasDivergedFromRecording()) {
+    // [replay] hackfix: track node if `DevToolsSession` is not active
+    //    TODO: This might not handle dangling nodes properly - https://linear.app/replay/issue/RUN-1005/
+    return BindDocumentNode(node_to_push);
+  }
 
-  // if (!document_node_to_id_map_->Contains(document_))
-  //   return 0;
-  // // Return id in case the node is known.
-  // int result = node_map->at(node_to_push);
-  // if (result)
-  //   return result;
+  if (!document_node_to_id_map_->Contains(document_))
+    return 0;
+  // Return id in case the node is known.
+  int result = node_map->at(node_to_push);
+  if (result)
+    return result;
 
-  // Node* node = node_to_push;
-  // HeapVector<Member<Node>> path;
+  Node* node = node_to_push;
+  HeapVector<Member<Node>> path;
 
-  // while (true) {
-  //   Node* parent = InnerParentNode(node);
-  //   if (!parent)
-  //     return 0;
-  //   path.push_back(parent);
-  //   if (node_map->at(parent))
-  //     break;
-  //   node = parent;
-  // }
+  while (true) {
+    Node* parent = InnerParentNode(node);
+    if (!parent)
+      return 0;
+    path.push_back(parent);
+    if (node_map->at(parent))
+      break;
+    node = parent;
+  }
 
-  // for (int i = path.size() - 1; i >= 0; --i) {
-  //   int node_id = node_map->at(path.at(i).Get());
-  //   DCHECK(node_id);
-  //   PushChildNodesToFrontend(node_id);
-  // }
-  // return node_map->at(node_to_push);
+  for (int i = path.size() - 1; i >= 0; --i) {
+    int node_id = node_map->at(path.at(i).Get());
+    DCHECK(node_id);
+    PushChildNodesToFrontend(node_id);
+  }
+  return node_map->at(node_to_push);
 }
 
 int InspectorDOMAgent::PushNodePathToFrontend(Node* node_to_push) {
@@ -1061,9 +1063,13 @@ Response InspectorDOMAgent::performSearch(
     Maybe<bool> optional_include_user_agent_shadow_dom,
     String* search_id,
     int* result_count) {
-  // [replay] we cannot currently enable these during replay
-  // if (!enabled_.Get())
-  //   return Response::ServerError("DOM agent is not enabled");
+  
+  if (!recordreplay::HasDivergedFromRecording()) {
+    // [replay] act as though it is enabled
+    if (!enabled_.Get()) {
+      return Response::ServerError("DOM agent is not enabled");
+    }
+  }
 
   // FIXME: Few things are missing here:
   // 1) Search works with node granularity - number of matches within node is

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
@@ -1057,8 +1057,9 @@ Response InspectorDOMAgent::performSearch(
     Maybe<bool> optional_include_user_agent_shadow_dom,
     String* search_id,
     int* result_count) {
-  if (!enabled_.Get())
-    return Response::ServerError("DOM agent is not enabled");
+  // [replay] comment this out since we cannot currently enable these during replay
+  // if (!enabled_.Get())
+  //   return Response::ServerError("DOM agent is not enabled");
 
   // FIXME: Few things are missing here:
   // 1) Search works with node granularity - number of matches within node is

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
@@ -1218,8 +1218,11 @@ Response InspectorDOMAgent::getSearchResults(
     return Response::ServerError("Invalid search result range");
 
   *node_ids = std::make_unique<protocol::Array<int>>();
-  for (int i = from_index; i < to_index; ++i)
-    (*node_ids)->emplace_back(PushNodePathToFrontend((*it->value)[i].Get()));
+  for (int i = from_index; i < to_index; ++i) {
+    // [replay] PushNodePathToFrontend is unnecessary (and crashes) when nodes are not tracked
+    // (*node_ids)->emplace_back(PushNodePathToFrontend((*it->value)[i].Get()));
+    (*node_ids)->emplace_back(BindDocumentNode((*it->value)[i].Get()));
+  }
   return Response::Success();
 }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
@@ -767,33 +767,37 @@ int InspectorDOMAgent::PushNodePathToFrontend(Node* node_to_push,
   // InspectorDOMAgent might have been resetted already. See crbug.com/450491
   if (!document_)
     return 0;
-  if (!document_node_to_id_map_->Contains(document_))
-    return 0;
 
-  // Return id in case the node is known.
-  int result = node_map->at(node_to_push);
-  if (result)
-    return result;
+  // [replay] PushNodePathToFrontend is bad when `DevToolsSession` not active
+  //    TODO: This does not handle dangling nodes properly - https://linear.app/replay/issue/RUN-1005/
+  return BindDocumentNode(node_to_push);
 
-  Node* node = node_to_push;
-  HeapVector<Member<Node>> path;
+  // if (!document_node_to_id_map_->Contains(document_))
+  //   return 0;
+  // // Return id in case the node is known.
+  // int result = node_map->at(node_to_push);
+  // if (result)
+  //   return result;
 
-  while (true) {
-    Node* parent = InnerParentNode(node);
-    if (!parent)
-      return 0;
-    path.push_back(parent);
-    if (node_map->at(parent))
-      break;
-    node = parent;
-  }
+  // Node* node = node_to_push;
+  // HeapVector<Member<Node>> path;
 
-  for (int i = path.size() - 1; i >= 0; --i) {
-    int node_id = node_map->at(path.at(i).Get());
-    DCHECK(node_id);
-    PushChildNodesToFrontend(node_id);
-  }
-  return node_map->at(node_to_push);
+  // while (true) {
+  //   Node* parent = InnerParentNode(node);
+  //   if (!parent)
+  //     return 0;
+  //   path.push_back(parent);
+  //   if (node_map->at(parent))
+  //     break;
+  //   node = parent;
+  // }
+
+  // for (int i = path.size() - 1; i >= 0; --i) {
+  //   int node_id = node_map->at(path.at(i).Get());
+  //   DCHECK(node_id);
+  //   PushChildNodesToFrontend(node_id);
+  // }
+  // return node_map->at(node_to_push);
 }
 
 int InspectorDOMAgent::PushNodePathToFrontend(Node* node_to_push) {
@@ -1057,7 +1061,7 @@ Response InspectorDOMAgent::performSearch(
     Maybe<bool> optional_include_user_agent_shadow_dom,
     String* search_id,
     int* result_count) {
-  // [replay] comment this out since we cannot currently enable these during replay
+  // [replay] we cannot currently enable these during replay
   // if (!enabled_.Get())
   //   return Response::ServerError("DOM agent is not enabled");
 
@@ -1219,9 +1223,7 @@ Response InspectorDOMAgent::getSearchResults(
 
   *node_ids = std::make_unique<protocol::Array<int>>();
   for (int i = from_index; i < to_index; ++i) {
-    // [replay] PushNodePathToFrontend is unnecessary (and crashes) when nodes are not tracked
-    // (*node_ids)->emplace_back(PushNodePathToFrontend((*it->value)[i].Get()));
-    (*node_ids)->emplace_back(BindDocumentNode((*it->value)[i].Get()));
+    (*node_ids)->emplace_back(PushNodePathToFrontend((*it->value)[i].Get()));
   }
   return Response::Success();
 }

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.h
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.h
@@ -316,7 +316,7 @@ class CORE_EXPORT InspectorDOMAgent final
   protocol::Response AssertElement(int node_id, Element*&);
   Document* GetDocument() const { return document_.Get(); }
 
-  // [replay-edit] Offer a simple solution to get-or-create nodeId for in-document nodes.
+  // [replay] Offer a simple solution to get-or-create nodeId for in-document nodes.
   int BindDocumentNode(Node*);
 
  private:


### PR DESCRIPTION
* fix RUN-1033
* use `CDP`'s `performSearch` -> `getSearchResults` -> `discardSearchResults` to search the DOM tree
* hackfix: replace some of Chromium's calls to `PushNodePathToFrontend` with our custom `BindDocumentNode`
* remove commented code

link: https://linear.app/replay/issue/RUN-1033/chromium-commands-domperformsearch