### PR TITLE
Implement remaining React DevTools stub functionality

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2044,16 +2044,30 @@ const char* gReactDevtoolsScript = R""""(
 
 (() => {
 
+const stubFiberRoots = {};
+
 const stubHook = {
   supportsFiber: true,
   inject,
   onCommitFiberUnmount,
   onCommitFiberRoot,
   onPostCommitFiberRoot,
-  renderers: [],
+  renderers: new Map(),
 };
 
+
+function stubGetFiberRoots(rendererID) {
+  const roots = stubFiberRoots;
+
+  if (!roots[rendererID]) {
+    roots[rendererID] = new Set();
+  }
+
+  return roots[rendererID];
+}
+
 window.__REACT_DEVTOOLS_SAVED_RENDERERS__ = [];
+window.__REACT_DEVTOOLS_STUB_FIBER_ROOTS = stubFiberRoots;
 
 Object.defineProperty(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
   configurable: true,
@@ -2077,6 +2091,17 @@ function onCommitFiberUnmount(rendererID, fiber) {
 }
 
 function onCommitFiberRoot(rendererID, root, priorityLevel) {
+  const mountedRoots = stubGetFiberRoots(rendererID);
+  const current = root.current;
+  const isKnownRoot = mountedRoots.has(root);
+  const isUnmounting = current.memoizedState == null || current.memoizedState.element == null; // Keep track of mounted roots so we can hydrate when DevTools connect.
+
+  if (!isKnownRoot && !isUnmounting) {
+    mountedRoots.add(root);
+  } else if (isKnownRoot && isUnmounting) {
+    mountedRoots.delete(root);
+  }
+  
   window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "commit-fiber-root");
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2054,7 +2054,7 @@ const hook = {
 };
 
 Object.defineProperty(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
-  configurable: false,
+  configurable: true,
   enumerable: false,
   get() {
     return hook;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2044,7 +2044,7 @@ const char* gReactDevtoolsScript = R""""(
 
 (() => {
 
-const hook = {
+const stubHook = {
   supportsFiber: true,
   inject,
   onCommitFiberUnmount,
@@ -2053,11 +2053,13 @@ const hook = {
   renderers: [],
 };
 
+window.__REACT_DEVTOOLS_SAVED_RENDERERS__ = [];
+
 Object.defineProperty(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
   configurable: true,
   enumerable: false,
   get() {
-    return hook;
+    return stubHook;
   }
 });
 
@@ -2066,6 +2068,7 @@ let uidCounter = 0;
 function inject(renderer) {
   const id = ++uidCounter;
   window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "inject");
+  window.__REACT_DEVTOOLS_SAVED_RENDERERS__.push(renderer);
   return id;
 }
 


### PR DESCRIPTION
- Made the global hook object writeable so that it can be deleted later during processing for a given pause (allowing the real RDT hook to be injected and installed)
- Saved the React renderer instances separately so they can be added into the real RDT hook post-installation
- Duplicated the "mounted roots" tracking from the RDT logic so that we can also pass those to the real hook later