### PR TITLE
Associate reason with EventsDisallowed mode.

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -42,6 +42,7 @@ extern "C" void V8RecordReplayOnNetworkStreamData(const char* id, size_t offset,
 extern "C" void V8RecordReplayOnNetworkStreamEnd(const char* id, size_t length);
 extern "C" bool V8RecordReplayAreEventsDisallowed();
 extern "C" void V8RecordReplayBeginDisallowEvents();
+extern "C" void V8RecordReplayBeginDisallowEventsWithLabel(const char* label);
 extern "C" void V8RecordReplayEndDisallowEvents();
 extern "C" bool V8RecordReplayAreEventsPassedThrough();
 extern "C" void V8RecordReplayBeginPassThroughEvents();
@@ -166,6 +167,10 @@ bool AreEventsDisallowed() {
 
 void BeginDisallowEvents() {
   OP(V8RecordReplayBeginDisallowEvents());
+}
+
+void BeginDisallowEventsWithLabel(const char* label) {
+  OP(V8RecordReplayBeginDisallowEventsWithLabel(label));
 }
 
 void EndDisallowEvents() {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -58,6 +58,8 @@ void EndPassThroughEvents();
 bool AreEventsPassedThrough();
 
 void BeginDisallowEvents();
+void BeginDisallowEventsWithLabel(const char* label);
+
 void EndDisallowEvents();
 bool AreEventsDisallowed();
 
@@ -71,7 +73,7 @@ struct AutoPassThroughEvents {
 };
 
 struct AutoDisallowEvents {
-  AutoDisallowEvents() { BeginDisallowEvents(); }
+  AutoDisallowEvents(const char* label) { BeginDisallowEventsWithLabel(label); }
   ~AutoDisallowEvents() { EndDisallowEvents(); }
 };
 

--- a/base/synchronization/waitable_event_posix.cc
+++ b/base/synchronization/waitable_event_posix.cc
@@ -180,7 +180,7 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
 
   absl::optional<recordreplay::AutoDisallowEvents> disallow;
   if (kernel_->record_replay_unordered_)
-    disallow.emplace();
+    disallow.emplace("WaitableEvent::TimedWait");
 
   if (wait_delta <= TimeDelta()) {
     return IsSignaled();
@@ -283,7 +283,7 @@ size_t WaitableEvent::WaitMany(WaitableEvent** raw_waitables,
                                size_t count) NO_THREAD_SAFETY_ANALYSIS {
   absl::optional<recordreplay::AutoDisallowEvents> disallow;
   if (count && raw_waitables[0]->kernel_->record_replay_unordered_)
-    disallow.emplace();
+    disallow.emplace("WaitableEvent::WaitMany");
 
   DCHECK(count) << "Cannot wait on no events";
   internal::ScopedBlockingCallWithBaseSyncPrimitives scoped_blocking_call(

--- a/base/task/sequence_manager/task_queue.cc
+++ b/base/task/sequence_manager/task_queue.cc
@@ -140,7 +140,7 @@ TaskQueue::~TaskQueue() {
   recordreplay::UnregisterPointer(this);
 
   // Because the refcount is threadsafe, destruction can happen at non-deterministic points.
-  recordreplay::AutoDisallowEvents disallow;
+  recordreplay::AutoDisallowEvents disallow("TaskQueue::~TaskQueue");
 
   ShutdownTaskQueueGracefully();
 }

--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -95,7 +95,7 @@ std::atomic_bool g_explicit_high_resolution_timer_win{false};
 TaskQueueImpl::GuardedTaskPoster::GuardedTaskPoster(TaskQueueImpl* outer)
     : outer_(outer) {
   if (recordreplay::IsRecordingOrReplaying()) {
-    recordreplay::AutoDisallowEvents disallow;
+    recordreplay::AutoDisallowEvents disallow("TaskQueueImpl::GuardedTaskPoster::GuardedTaskPoster");
     record_replay_unordered_operations_controller_.emplace();
   }
 }

--- a/base/task/sequence_manager/work_queue.cc
+++ b/base/task/sequence_manager/work_queue.cc
@@ -216,7 +216,7 @@ void WorkQueue::PushNonNestableTaskToFront(Task task) {
 }
 
 void WorkQueue::RecordReplayRunUnorderedTasks(TaskQueueImpl::TaskDeque* queue) {
-  recordreplay::AutoDisallowEvents disallow;
+  recordreplay::AutoDisallowEvents disallow("WorkQueue::RecordReplayRunUnorderedTasks");
   while (!queue->empty()) {
     Task pending_task = std::move(queue->front());
     queue->pop_front();

--- a/base/task/thread_pool/thread_group_impl.cc
+++ b/base/task/thread_pool/thread_group_impl.cc
@@ -1009,7 +1009,7 @@ ThreadGroupImpl::CreateAndRegisterWorkerLockRequired(
 
   absl::optional<recordreplay::AutoDisallowEvents> disallow;
   if (record_replay_unordered_)
-    disallow.emplace();
+    disallow.emplace("ThreadGroupImpl::CreateAndRegisterWorkerLockRequired");
 
   // WorkerThread needs |lock_| as a predecessor for its thread lock
   // because in WakeUpOneWorker, |lock_| is first acquired and then

--- a/base/task/thread_pool/thread_pool_impl.cc
+++ b/base/task/thread_pool/thread_pool_impl.cc
@@ -112,7 +112,7 @@ ThreadPoolImpl::ThreadPoolImpl(StringPiece histogram_label,
   }
 
   if (recordreplay::IsRecordingOrReplaying()) {
-    recordreplay::AutoDisallowEvents disallow;
+    recordreplay::AutoDisallowEvents disallow("ThreadPoolImpl::ThreadPoolImpl");
     record_replay_unordered_thread_group_ = std::make_unique<ThreadGroupImpl>(
         std::string(),
         kBackgroundPoolEnvironmentParams.name_suffix,

--- a/base/task/thread_pool/worker_thread.cc
+++ b/base/task/thread_pool/worker_thread.cc
@@ -288,7 +288,7 @@ void WorkerThread::UpdateThreadType(ThreadType desired_thread_type) {
 void WorkerThread::ThreadMain() {
   absl::optional<recordreplay::AutoDisallowEvents> disallow;
   if (record_replay_unordered_)
-    disallow.emplace();
+    disallow.emplace("WorkerThread::ThreadMain");
 
 #if (BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_NACL)) || BUILDFLAG(IS_FUCHSIA)
   DCHECK(io_thread_task_runner_);

--- a/third_party/abseil-cpp/absl/base/internal/sysinfo.cc
+++ b/third_party/abseil-cpp/absl/base/internal/sysinfo.cc
@@ -59,20 +59,20 @@
 
 #include <dlfcn.h>
 
-static void* gRecordReplayBeginDisallowEventsFn;
+static void* gRecordReplayBeginDisallowEventsWithLabelFn;
 
-static void RecordReplayBeginDisallowEvents() {
-  if (!gRecordReplayBeginDisallowEventsFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayBeginDisallowEvents");
+static void RecordReplayBeginDisallowEventsWithLabel(const char* label) {
+  if (!gRecordReplayBeginDisallowEventsWithLabelFn) {
+    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayBeginDisallowEventsWithLabel");
     if (!fnptr) {
-      gRecordReplayBeginDisallowEventsFn = reinterpret_cast<void*>(1);
+      gRecordReplayBeginDisallowEventsWithLabelFn = reinterpret_cast<void*>(1);
       return;
     }
-    gRecordReplayBeginDisallowEventsFn = fnptr;
+    gRecordReplayBeginDisallowEventsWithLabelFn = fnptr;
   }
 
-  if (gRecordReplayBeginDisallowEventsFn != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(gRecordReplayBeginDisallowEventsFn)();
+  if (gRecordReplayBeginDisallowEventsWithLabelFn != reinterpret_cast<void*>(1)) {
+    reinterpret_cast<void(*)(const char*)>(gRecordReplayBeginDisallowEventsWithLabelFn)(label);
   }
 }
 
@@ -387,7 +387,7 @@ int NumCPUs() {
   base_internal::LowLevelCallOnce(
       &init_num_cpus_once, []() {
         // The thread which ends up calling this can vary when replaying.
-        RecordReplayBeginDisallowEvents();
+        RecordReplayBeginDisallowEventsWithLabel("NumCPUs");
         num_cpus = GetNumCPUs();
         RecordReplayEndDisallowEvents();
       });

--- a/third_party/abseil-cpp/absl/base/internal/thread_identity.cc
+++ b/third_party/abseil-cpp/absl/base/internal/thread_identity.cc
@@ -30,20 +30,20 @@
 
 #include <dlfcn.h>
 
-static void* gRecordReplayBeginDisallowEventsFn;
+static void* gRecordReplayBeginDisallowEventsWithLabelFn;
 
-static void RecordReplayBeginDisallowEvents() {
-  if (!gRecordReplayBeginDisallowEventsFn) {
-    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayBeginDisallowEvents");
+static void RecordReplayBeginDisallowEventsWithLabel(const char* label) {
+  if (!gRecordReplayBeginDisallowEventsWithLabelFn) {
+    void* fnptr = dlsym(RTLD_DEFAULT, "RecordReplayBeginDisallowEventsWithLabel");
     if (!fnptr) {
-      gRecordReplayBeginDisallowEventsFn = reinterpret_cast<void*>(1);
+      gRecordReplayBeginDisallowEventsWithLabelFn = reinterpret_cast<void*>(1);
       return;
     }
-    gRecordReplayBeginDisallowEventsFn = fnptr;
+    gRecordReplayBeginDisallowEventsWithLabelFn = fnptr;
   }
 
-  if (gRecordReplayBeginDisallowEventsFn != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(gRecordReplayBeginDisallowEventsFn)();
+  if (gRecordReplayBeginDisallowEventsWithLabelFn != reinterpret_cast<void*>(1)) {
+    reinterpret_cast<void(*)(const char*)>(gRecordReplayBeginDisallowEventsWithLabelFn)(label);
   }
 }
 
@@ -107,7 +107,7 @@ thread_local ThreadIdentity* thread_identity_ptr = nullptr;
 void SetCurrentThreadIdentity(
     ThreadIdentity* identity, ThreadIdentityReclaimerFunction reclaimer) {
   // Setting the identity can happen at non-deterministic points.
-  RecordReplayBeginDisallowEvents();
+  RecordReplayBeginDisallowEventsWithLabel("SetCurrentThreadIdentity");
 
   assert(CurrentThreadIdentityIfPresent() == nullptr);
   // Associate our destructor.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4332,7 +4332,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 
   if (recordreplay::IsReplaying()) {
-    recordreplay::AutoDisallowEvents disallow;
+    recordreplay::AutoDisallowEvents disallow("SetupRecordReplayCommands");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
   }
 }

--- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
@@ -366,7 +366,7 @@ void MemoryCache::Prune() {
 
   // Cache state can vary when replaying, make sure we don't interact
   // with the recording while pruning.
-  recordreplay::AutoDisallowEvents disallow;
+  recordreplay::AutoDisallowEvents disallow("MemoryCache::Prune");
 
   if (in_prune_resources_)
     return;


### PR DESCRIPTION
This changes the signature of AutoDisallowEvents and its uses to associate a string reason.  That reason is currently stored in a global, but we should figure out how to pull it out and dump it into crash reports so we have easy access to it.

Not quite sure how to do that yet.