### PR TITLE
fix RUN-1074 - allow embedding LOCAL driver binary

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,15 @@
+// Copyright 2021 Record Replay Inc.
+
 const fs = require("fs");
+const path = require("path");
 const { spawnSync } = require("child_process");
+
+const { REPLAY_LOCAL_DRIVER_DIR } = process.env;
+
+if (REPLAY_LOCAL_DRIVER_DIR && process.env.DRIVER_REVISION) {
+  // local driver should generally be latest
+  throw new Error("Conflicting build settings: environment variables DRIVER_REVISION and REPLAY_LOCAL_DRIVER_DIR cannot coexist.");
+}
 
 // Ensure that the git repository is "trusted", otherwise we'll get errors like:
 // fatal: unsafe repository ('/chromium/src' is owned by someone else)
@@ -16,36 +26,51 @@ if (currentPlatform() == "macOS") {
   spawnChecked("touch", [`${__dirname}/chrome/app/chrome_exe_main_mac.cc`]);
 }
 
-// Download the record/replay driver archive, using the latest version unless
-// it was overridden via the environment.
-let driverArchive = `${currentPlatform()}-recordreplay.tgz`;
-let downloadArchive = driverArchive;
-if (process.env.DRIVER_REVISION) {
-  downloadArchive = `${currentPlatform()}-recordreplay-${
-    process.env.DRIVER_REVISION
-  }.tgz`;
+if (!REPLAY_LOCAL_DRIVER_DIR) {
+  // Download the record/replay driver archive, using the latest version unless
+  // it was overridden via the environment.
+  console.log(`Downloading driver...`);
+  let driverArchive = `${currentPlatform()}-recordreplay.tgz`;
+  let downloadArchive = driverArchive;
+  if (process.env.DRIVER_REVISION) {
+    downloadArchive = `${currentPlatform()}-recordreplay-${
+      process.env.DRIVER_REVISION
+    }.tgz`;
+  }
+  spawnChecked(
+    "curl",
+    [
+      `https://static.replay.io/downloads/${downloadArchive}`,
+      "-o",
+      driverArchive,
+    ],
+    { stdio: "inherit" }
+  );
+  spawnChecked("tar", ["xf", driverArchive]);
+  fs.unlinkSync(driverArchive);
 }
-const driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
-const driverJSON = `${currentPlatform()}-recordreplay.json`;
-spawnChecked(
-  "curl",
-  [
-    `https://static.replay.io/downloads/${downloadArchive}`,
-    "-o",
-    driverArchive,
-  ],
-  { stdio: "inherit" }
-);
-spawnChecked("tar", ["xf", driverArchive]);
-fs.unlinkSync(driverArchive);
+
+
+let driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
+let driverJSON = `${currentPlatform()}-recordreplay.json`;
+if (REPLAY_LOCAL_DRIVER_DIR) {
+  driverFile = path.resolve(REPLAY_LOCAL_DRIVER_DIR, driverFile);
+  driverJSON = path.resolve(REPLAY_LOCAL_DRIVER_DIR, driverJSON);
+}
 
 // Embed the driver in the source.
+console.log(`Embedding ${REPLAY_LOCAL_DRIVER_DIR ? 'LOCAL' : 'DOWNLOADED'} driver...`);
 const driverContents = fs.readFileSync(driverFile);
 const { revision: driverRevision, date: driverDate } = JSON.parse(
   fs.readFileSync(driverJSON, "utf8")
 );
-fs.unlinkSync(driverFile);
-fs.unlinkSync(driverJSON);
+
+if (!REPLAY_LOCAL_DRIVER_DIR) {
+  // cleanup
+  fs.unlinkSync(driverFile);
+  fs.unlinkSync(driverJSON);
+}
+
 let driverString = "";
 for (let i = 0; i < driverContents.length; i++) {
   driverString += `\\${driverContents[i].toString(8)}`;
@@ -62,7 +87,6 @@ namespace recordreplay {
 );
 
 const useGoma = !process.env.NO_GOMA;
-
 if (useGoma) {
   // ensure goma is started for cloud builds with engflow
   spawnChecked("goma_ctl", ["restart"]);
@@ -71,9 +95,13 @@ if (useGoma) {
 // ensure that build configuration is written with correct paths
 spawnChecked("gn", ["gen", "out/Release"]);
 
+console.log(`Building...`);
 spawnChecked("autoninja", ["-C", "out/Release", "chrome"], {
   stdio: "inherit",
 });
+
+console.log(`Build finished.`);
+
 
 function spawnChecked(cmd, args, options) {
   const prettyCmd = [cmd].concat(args).join(" ");

--- a/build.js
+++ b/build.js
@@ -1,4 +1,6 @@
-// Copyright 2021 Record Replay Inc.
+// Copyright 2021 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 const fs = require("fs");
 const path = require("path");

--- a/copyLinuxBuild.js
+++ b/copyLinuxBuild.js
@@ -1,4 +1,7 @@
-// Copyright 2021 Record Replay Inc.
+// Copyright 2021 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 /* Copy the build artifacts which are actually needed to a new directory. */
 
 const fs = require("fs");

--- a/copyLinuxBuild.js
+++ b/copyLinuxBuild.js
@@ -1,3 +1,4 @@
+// Copyright 2021 Record Replay Inc.
 /* Copy the build artifacts which are actually needed to a new directory. */
 
 const fs = require("fs");

--- a/uploadChromiumBuildToCloudDevelopment.sh
+++ b/uploadChromiumBuildToCloudDevelopment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Copyright 2021 Record Replay Inc.
+
+# Copyright 2021 Record Replay Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 # Use the current dir as reference point.
 DIR=$(pwd)

--- a/uploadChromiumBuildToCloudDevelopment.sh
+++ b/uploadChromiumBuildToCloudDevelopment.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright 2021 Record Replay Inc.
 
 # Use the current dir as reference point.
 DIR=$(pwd)
@@ -68,12 +69,12 @@ else
   echo
   echo RUNNING copyLinuxBuild.js
   mkdir "${TMP_DIR}/replay-chromium"
-  node copyLinuxBuild.js "${DIST_DIR}" "${TMP_DIR}/replay-chromium"
+  time node copyLinuxBuild.js "${DIST_DIR}" "${TMP_DIR}/replay-chromium"
 
   # Create the archive
   echo
   echo ARCHIVING "${TMP_DIR}/replay-chromium"
-  (cd "${TMP_DIR}" && tar cfJ ./archive.tar.xz replay-chromium)
+  cd "${TMP_DIR}" && time tar cfJ ./archive.tar.xz replay-chromium
 fi
 
 # Copy the build to s3
@@ -81,7 +82,7 @@ if [ -z "${DO_UPLOAD_BUILD}" ]; then
   echo "Skipping UPLOAD_BUILD"
 else
   echo "UPLOADING BUILD to ${S3_BUILD_PREFIX}.xz"
-  aws s3 cp "${TMP_DIR}/archive.tar.xz" "${S3_BUILD_PREFIX}.tar.xz"
+  time aws s3 cp "${TMP_DIR}/archive.tar.xz" "${S3_BUILD_PREFIX}.tar.xz"
 fi
 
 # Build the symbols file
@@ -91,23 +92,23 @@ if [ -z "${DO_SYMBOLICATE}" ]; then
   echo "Skipping SYMBOLICATE"
 else
   echo "SYMBOLICATING ${DIST_DIR}/chrome into ${SYMBOLS_OUT}"
-  nm "${DIST_DIR}/chrome" | grep '^[a-f0-9]\+ [tTw]' >"${TMP_DIR}/symbols"
+  time nm "${DIST_DIR}/chrome" | grep '^[a-f0-9]\+ [tTw]' >"${TMP_DIR}/symbols"
   echo "{ \"chrome\": {" >"${SYMBOLS_OUT}"
-  cat "${TMP_DIR}/symbols" | \
+  time cat "${TMP_DIR}/symbols" | \
     perl -pe '/0+([a-f0-9]+) . (.*)$/; $a = hex $1; $b = $2; $_ = "  \"$a\": \"$b\",\n";' \
     >>"${SYMBOLS_OUT}"
     #sed 's/^0\+\([a-f0-9]\+\) . \(.*\)$/  0x\1: "\2",/' >>"${SYMBOLS_OUT}"
   echo "  \"dummy\": \"dummy-entry-without-comma-at-end-of-line\"" >>"${SYMBOLS_OUT}"
   echo "}}" >>"${SYMBOLS_OUT}"
 
-  (cd "${TMP_DIR}" && tar czf "./${SYMBOLS_ARCHIVE_NAME}" "${BUILD_ID}.symbols.json")
+  (cd "${TMP_DIR}" && time tar czf "./${SYMBOLS_ARCHIVE_NAME}" "${BUILD_ID}.symbols.json")
 fi
 
 if [ -z "${DO_UPLOAD_SYMBOLS}" ]; then
   echo "Skipping UPLOAD_SYMBOLS"
 else
   echo "UPLOADING SYMBOLS to ${S3_SYMBOLS_DIR}/${SYMBOLS_ARCHIVE_NAME}"
-  aws s3 cp "${TMP_DIR}/${SYMBOLS_ARCHIVE_NAME}" "${S3_SYMBOLS_DIR}/${SYMBOLS_ARCHIVE_NAME}"
+  time aws s3 cp "${TMP_DIR}/${SYMBOLS_ARCHIVE_NAME}" "${S3_SYMBOLS_DIR}/${SYMBOLS_ARCHIVE_NAME}"
 fi
 
 # No, I'm not going to rm -rf the tmpdir.  That command should never appear


### PR DESCRIPTION
* enable `build.js` to also embed a LOCAL driver binary
  * -> https://linear.app/replay/issue/RUN-1074/allow-buildjs-to-embed-local-instead-of-downloaded-driver
* snuck a change to `uploadChromiumBuildToCloudDevelopment.sh` in, to report timings on all individual steps, so we can better understand the exact extent of the bottlenecks standing in the way of fast cloud dev (at the risk that it might not get accepted)