### PR TITLE
fix RUN-1067 - `isInstanceOfNative`, small object preview bugs

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -535,6 +535,8 @@ function isInstanceOfNative(x, target) {
   const name = target?.name;
   return name &&
     x?.constructor?.toString()?.includes('() { [native code] }') &&
+    // fix https://linear.app/replay/issue/RUN-1067/chromium-css-style-object-preview-errors-out
+    x.constructor === x.__proto__.constructor &&
     hasInProtoChain(x.constructor, name);
 }
 
@@ -621,7 +623,7 @@ function clearPauseDataCallback() {
  * @see https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
  */
 function makeDebuggeeValue(plainObject) {
-  assert(!plainObject?.objectId);
+  assert(plainObject && !plainObject.objectId);
   const remoteObject = fromJsMakeDebuggeeValue(plainObject);
   assert(remoteObject?.objectId);
   return remoteObject;
@@ -3210,7 +3212,9 @@ static void fromJsMakeDebuggeeValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  CHECK(args.Length() == 1 && "must be called with a single value");
+  // CHECK(args.Length() == 1 && "must be called with a single value");
+  CHECK(args.Length() == 1 && args[0]->IsObject() &&
+        "must be called with a single object");
 
   auto context = isolate->GetCurrentContext();
   auto value = args[0];
@@ -3221,35 +3225,17 @@ static void fromJsMakeDebuggeeValue(
 
   // NOTE: `wrapObject` always creates a new `RemoteObject` and binds it
   // to a new id.
-  auto result = gInspectorSession->wrapObject(
+  auto remoteObjSerialized = gInspectorSession->wrapObject(
       context, value, ToV8InspectorStringView(object_group), generatePreview);
 
-  // deserialize + send to JS
-  std::vector<uint8_t> cbor;
-  result->AppendSerialized(&cbor);
+  auto result = convertCborToJS(isolate, (v8_crdtp::Serializable*)remoteObjSerialized.get());
 
-  if (cbor.size() > 1) {
-    /**
-     * This is based on other code that uses `wrapObject` and sends the result
-     * to JS.
-     * @see
-     * https://github.com/replayio/chromium-v8/blob/b38bf5b0b1f149f7af3fd90a2ce12344e7191d03/src/inspector/custom-preview.cc#L123
-     */
-    std::vector<uint8_t> json;
-    v8_crdtp::json::ConvertCBORToJSON(v8_crdtp::SpanFrom(cbor), &json);
-    auto remoteObjectJsonStr =
-        v8::String::NewFromOneByte(isolate, json.data(),
-                                   v8::NewStringType::kNormal, json.size())
-            .ToLocalChecked();
-    auto s = ToCoreString(remoteObjectJsonStr);
-
-    auto remoteObject = v8::JSON::Parse(context, remoteObjectJsonStr);
-    if (!remoteObject.IsEmpty()) {
-      args.GetReturnValue().Set(remoteObject.ToLocalChecked());
-      return;
-    }
+  if (!result.IsEmpty()) {
+    args.GetReturnValue().Set(result.ToLocalChecked());
   }
-  args.GetReturnValue().SetNull();
+  else {
+    args.GetReturnValue().SetNull();
+  }
 }
 
 static void fromJsGetObjectByCdpId(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -535,7 +535,6 @@ function isInstanceOfNative(x, target) {
   const name = target?.name;
   return name &&
     x?.constructor?.toString()?.includes('() { [native code] }') &&
-    // fix https://linear.app/replay/issue/RUN-1067/chromium-css-style-object-preview-errors-out
     x.constructor === x.__proto__.constructor &&
     hasInProtoChain(x.constructor, name);
 }
@@ -3212,7 +3211,6 @@ static void fromJsMakeDebuggeeValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  // CHECK(args.Length() == 1 && "must be called with a single value");
   CHECK(args.Length() == 1 && args[0]->IsObject() &&
         "must be called with a single object");
 


### PR DESCRIPTION
* fix `isInstanceOfNative` (its still a hackfix - better solution pending)
* update `makeDebuggeeValue` to use the more resilient `convertCborToJS` utility (has more error reporting)