### PR TITLE
Assertions to narrow down RUN-1116

### DIFF
--- a/third_party/blink/renderer/core/css/style_sheet_contents.cc
+++ b/third_party/blink/renderer/core/css/style_sheet_contents.cc
@@ -469,6 +469,8 @@ bool StyleSheetContents::LoadCompleted() const {
 }
 
 void StyleSheetContents::CheckLoaded() {
+  recordreplay::Assert("[RUN-1116] StyleSheetContents::CheckLoaded FunctionEntry");
+
   if (IsLoading())
     return;
 

--- a/third_party/blink/renderer/core/html/html_style_element.cc
+++ b/third_party/blink/renderer/core/html/html_style_element.cc
@@ -76,6 +76,7 @@ void HTMLStyleElement::FinishParsingChildren() {
 
 Node::InsertionNotificationRequest HTMLStyleElement::InsertedInto(
     ContainerNode& insertion_point) {
+  recordreplay::Assert("[RUN-1116] HTMLStyleElement::InsertedInto FunctionEntry");
   HTMLElement::InsertedInto(insertion_point);
   if (isConnected()) {
     if (StyleElement::ProcessStyleSheet(GetDocument(), *this) ==
@@ -93,6 +94,7 @@ void HTMLStyleElement::RemovedFrom(ContainerNode& insertion_point) {
 }
 
 void HTMLStyleElement::ChildrenChanged(const ChildrenChange& change) {
+  recordreplay::Assert("[RUN-1116] HTMLStyleElement::ChildrenChanged FunctionEntry");
   HTMLElement::ChildrenChanged(change);
   if (StyleElement::ChildrenChanged(*this) ==
       StyleElement::kProcessingFatalError)


### PR DESCRIPTION
Not much information in the crash-stacks, so these just adds asserts at the top recorded and replayed frame that we can see so we get better stacks.

Closes RUN-1120 (https://linear.app/replay/issue/RUN-1120/add-assertions-to-narrow-down-run-1120)

RUN-1116 for original crash: (https://linear.app/replay/issue/RUN-1116/callstackmismatch-under-blinkstylesheetcontentscheckloaded)