### PR TITLE
Fix CompareMemberByPointerId usage

### DIFF
--- a/third_party/blink/renderer/core/css/post_style_update_scope.cc
+++ b/third_party/blink/renderer/core/css/post_style_update_scope.cc
@@ -46,7 +46,7 @@ void PostStyleUpdateScope::Apply() {
   for (auto& element : pending)
     pending_vector.push_back(element);
   std::sort(pending_vector.begin(), pending_vector.end(),
-            recordreplay::CompareMemberByPointerId<Member<Element>>());
+            recordreplay::CompareMemberByRecordReplayId<Member<Element>>());
   for (auto& element : pending_vector) {
     ElementAnimations* element_animations = element->GetElementAnimations();
     if (!element_animations)


### PR DESCRIPTION
This fixes a bug in #326 where we were calling PointerId(element) instead of element->RecordReplayId() to sort an array.  The former isn't valid because we don't register elements or other ScriptWrappable objects.