### PR TITLE
RUN-1061/eventsList (also kinda fixes RUN-1016 and RUN-1137)

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -53,6 +53,7 @@ extern "C" void* V8RecordReplayIdPointer(int id);
 extern "C" bool V8RecordReplayFeatureEnabled(const char* feature);
 extern "C" void V8RecordReplayBrowserEvent(const char* name, const char* payload);
 extern "C" bool V8IsMainThread();
+extern "C" void V8RecordReplayOnEvent(const char* aEvent, bool aBefore);
 extern "C" void V8RecordReplayOnMouseEvent(const char* kind,
                                            size_t clientX,
                                            size_t clientY);
@@ -211,6 +212,9 @@ void* IdPointer(int id) {
   return OP2(V8RecordReplayIdPointer(id), nullptr);
 }
 
+void OnEvent(const char* aEvent, bool aBefore) {
+  OP(V8RecordReplayOnEvent(aEvent, aBefore));
+}
 void OnMouseEvent(const char* kind,
                                 size_t clientX,
                                 size_t clientY) {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -80,6 +80,7 @@ void UnregisterPointer(const void* ptr);
 int PointerId(const void* ptr);
 void* IdPointer(int id);
 
+void OnEvent(const char* aEvent, bool aBefore);
 void OnMouseEvent(const char* kind, size_t clientX, size_t clientY);
 void OnKeyEvent(const char* kind, const char* key);
 void OnNavigationEvent(const char* kind, const char* url);

--- a/replay-scripts/.gitignore
+++ b/replay-scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.gen.*

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -84,10 +84,8 @@ let cdtEvents = cdtCategoriesRaw.map(cat => {
 });
 
 
-
 console.log('Done.');
 console.groupEnd();
-
 
 
 const code = genTs();
@@ -101,15 +99,15 @@ console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
  * ##########################################################################*/
 
 function genTs() {
-  const Indent = 4;
+  const Indent = ' '.repeat(4);
   return `\
 // <GENERATED CODE. DO NOT EDIT.>
-// NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
+// NOTE: This table is generated via \`ts-node $CHROMIUM_DIR/src/replay-scripts/gen-event-names.ts\`
 ${JSON.stringify(cdtEvents, null, 2)}
 // </GENERATED CODE. DO NOT EDIT.>`
   .split('\n')
-    .map(s => ' '.repeat(Indent) + s)
-    .join('\n');
+  .map(s => Indent + s)
+  .join('\n');
 }
 
 

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -1,3 +1,18 @@
+// Copyright 2021 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @file In this file, we take all CDT user event names, 
+ * parse them and map them against their `gecko` counterpart.
+ * It outputs (i) verification results, (ii) comparison results
+ * (iii) potential mapping problems, (iv) and C++ code that 
+ * allows easily looking up `gecko` event names by their CDT
+ * counterpart.
+ * 
+ * @see https://linear.app/replay/issue/RUN-1061#comment-bde208c4
+ */
+
 import fs from 'fs';
 import path from 'path';
 import _ from 'lodash';

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -15,7 +15,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import _ from 'lodash';
+import without from 'lodash/without';
+import startCase from 'lodash/startCase';
 import levenshtein from 'js-levenshtein';
 import { EventHandlerType } from "@replayio/protocol";
 
@@ -26,189 +27,19 @@ type EventDefinition = {
   eventTargets?: string[];
 };
 
-type EventCategory = {
-  category: string;
-  events: Array<EventDefinition>;
-  eventTargets?: string[];
-};
 
+const ChromiumSrcDir = path.resolve(__dirname, '..');
+const CdtDir = path.resolve(ChromiumSrcDir, 'third_party/devtools-frontend');
+const DOMDebuggerModelPath = path.resolve(
+  CdtDir,
+  'src/front_end/core/sdk/DOMDebuggerModel.ts'
+);
 
 /**
- * This source code is copied from CDT's `DOMDebuggerManager`.
+ * Read event descriptions from CDT's `DOMDebuggerManager.ts`.
  * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L758
  */
-const cdtEventsSrc = `this.createInstrumentationBreakpoints(
-        i18nString(UIStrings.animation),
-        ['requestAnimationFrame', 'cancelAnimationFrame', 'requestAnimationFrame.callback']);
-    this.createInstrumentationBreakpoints(
-        i18nString(UIStrings.canvas), ['canvasContextCreated', 'webglErrorFired', 'webglWarningFired']);
-    this.createInstrumentationBreakpoints(
-        i18nString(UIStrings.geolocation), ['Geolocation.getCurrentPosition', 'Geolocation.watchPosition']);
-    this.createInstrumentationBreakpoints(i18nString(UIStrings.notification), ['Notification.requestPermission']);
-    this.createInstrumentationBreakpoints(i18nString(UIStrings.parse), ['Element.setInnerHTML', 'Document.write']);
-    this.createInstrumentationBreakpoints(i18nString(UIStrings.script), ['scriptFirstStatement', 'scriptBlockedByCSP']);
-    this.createInstrumentationBreakpoints(
-        i18nString(UIStrings.timer),
-        ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setTimeout.callback', 'setInterval.callback']);
-    this.createInstrumentationBreakpoints(i18nString(UIStrings.window), ['DOMWindow.close']);
-    this.createInstrumentationBreakpoints(
-        i18nString(UIStrings.webaudio),
-        ['audioContextCreated', 'audioContextClosed', 'audioContextResumed', 'audioContextSuspended']);
-
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.media),
-        [
-          'play',      'pause',          'playing',    'canplay',    'canplaythrough', 'seeking',
-          'seeked',    'timeupdate',     'ended',      'ratechange', 'durationchange', 'volumechange',
-          'loadstart', 'progress',       'suspend',    'abort',      'error',          'emptied',
-          'stalled',   'loadedmetadata', 'loadeddata', 'waiting',
-        ],
-        ['audio', 'video']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.pictureinpicture), ['enterpictureinpicture', 'leavepictureinpicture'], ['video']);
-    this.createEventListenerBreakpoints(i18nString(UIStrings.pictureinpicture), ['resize'], ['PictureInPictureWindow']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.clipboard), ['copy', 'cut', 'paste', 'beforecopy', 'beforecut', 'beforepaste'], ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.control),
-        ['resize', 'scroll', 'zoom', 'focus', 'blur', 'select', 'change', 'submit', 'reset'], ['*']);
-    this.createEventListenerBreakpoints(i18nString(UIStrings.device), ['deviceorientation', 'devicemotion'], ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.domMutation),
-        [
-          'DOMActivate',
-          'DOMFocusIn',
-          'DOMFocusOut',
-          'DOMAttrModified',
-          'DOMCharacterDataModified',
-          'DOMNodeInserted',
-          'DOMNodeInsertedIntoDocument',
-          'DOMNodeRemoved',
-          'DOMNodeRemovedFromDocument',
-          'DOMSubtreeModified',
-          'DOMContentLoaded',
-        ],
-        ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.dragDrop), ['drag', 'dragstart', 'dragend', 'dragenter', 'dragover', 'dragleave', 'drop'],
-        ['*']);
-
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.keyboard), ['keydown', 'keyup', 'keypress', 'input'], ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.load),
-        [
-          'load',
-          'beforeunload',
-          'unload',
-          'abort',
-          'error',
-          'hashchange',
-          'popstate',
-          'navigate',
-          'navigatesuccess',
-          'navigateerror',
-          'currentchange',
-          'navigateto',
-          'navigatefrom',
-          'finish',
-          'dispose',
-        ],
-        ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.mouse),
-        [
-          'auxclick',
-          'click',
-          'dblclick',
-          'mousedown',
-          'mouseup',
-          'mouseover',
-          'mousemove',
-          'mouseout',
-          'mouseenter',
-          'mouseleave',
-          'mousewheel',
-          'wheel',
-          'contextmenu',
-        ],
-        ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.pointer),
-        [
-          'pointerover',
-          'pointerout',
-          'pointerenter',
-          'pointerleave',
-          'pointerdown',
-          'pointerup',
-          'pointermove',
-          'pointercancel',
-          'gotpointercapture',
-          'lostpointercapture',
-          'pointerrawupdate',
-        ],
-        ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.touch), ['touchstart', 'touchmove', 'touchend', 'touchcancel'], ['*']);
-    this.createEventListenerBreakpoints(i18nString(UIStrings.worker), ['message', 'messageerror'], ['*']);
-    this.createEventListenerBreakpoints(
-        i18nString(UIStrings.xhr),
-        ['readystatechange', 'load', 'loadstart', 'loadend', 'abort', 'error', 'progress', 'timeout'],
-        ['xmlhttprequest', 'xmlhttprequestupload']);`
-
-
-/** ###########################################################################
- * event normalization
- * ##########################################################################*/
-
-const manualCdtToGeckoLabelOverrides: { [key: string]: string } = {
-  // TODO: some events have been removed in gecko. Need to handle that better.
-
-  // 'hashchange': 'hashchange',
-  // 'popstate': 'popstate',
-  // 'pointerout': 'pointerout',
-
-  // 'beforeinput': 'event.keyboard.beforeinput',
-  // these are missing in CDT (but there are many more missing in gecko)
-  // '?': 'event.websocket.open',
-  // '?': 'event.websocket.message',
-  // '?': 'event.websocket.error',
-  // '?': 'event.websocket.close',
-  // '?': 'event.serviceworker.fetch',
-};
-
-const ignoredCdtEventsByCategory: { [key: string]: Set<string> } = {
-  load: new Set([
-    'beforeunload',
-    'unload',
-    'navigate',
-    'navigatesuccess',
-    'navigateerror',
-    'currentchange',
-    'navigateto',
-    'navigatefrom',
-    'finish',
-    'dispose'
-  ]),
-  pointer: new Set([
-    'pointerrawupdate'
-  ])
-}
-
-const cdtToGeckoCategoryMap: { [key: string]: string } = {
-  Xhr: 'XHR',
-  'Drag Drop': 'Drag and Drop',
-  'Dom Mutation': 'DOM Mutation'
-};
-
-/**
- * Translate category names from CDT to gecko.
- */
-function translateCDTToGeckoCategory(category: string) {
-  category = _.startCase(category);
-  return cdtToGeckoCategoryMap[category] || category;
-}
+const cdtEventsSrc = fs.readFileSync(DOMDebuggerModelPath).toString();
 
 /** ###########################################################################
  * parse CDT events
@@ -220,263 +51,82 @@ const res = cdtEventsSrc.matchAll(
 
 const cdtCategoriesRaw = [...res];
 
-// check if we (probably/hopefully) parsed CDT src correctly
-const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
-const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
+// sanity checks: if category count suddenly jumped a lot, there might be a bug
+const good = cdtCategoriesRaw.length > 20 && cdtCategoriesRaw.length < 35;
+console.log(`Found ${cdtCategoriesRaw.length} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
 
-// sanity checks: if less than 20 categories, there might be a bug
-const good = srcCategoryCount > 20 && srcCategoryCount === cdtCategoryCount;
-console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
-assert(good);
+if (!good) {
+  console.log(' ', cdtCategoriesRaw.join('\n  '));
+  die();
+}
+
+
+const cdtCategoryOverrides: { [key: string]: string } = {
+  Xhr: 'XHR',
+  'Drag Drop': 'Drag and Drop',
+  'Dom Mutation': 'DOM Mutation'
+};
+
+/**
+ * Translate category names from CDT to gecko.
+ */
+function prettyCDTCategory(category: string) {
+  category = startCase(category);
+  return cdtCategoryOverrides[category] || category;
+}
 
 let cdtEvents = cdtCategoriesRaw.map(cat => {
-  const category = cat[1];
+  const category = prettyCDTCategory(cat[1]);
   const events = eval(cat[2]);
   const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
   return {
     // attempt basic normalization
-    category: translateCDTToGeckoCategory(category),
+    category,
+    eventTargets: eventTargets.map(t => t.toLowerCase()),
     events: events.map((x: string): EventDefinition => ({
         type: x,
         label: x,
-        eventTargets
       })
-    ) as EventDefinition[],
-    eventTargets
+    ) as EventDefinition[]
   };
 });
 
-// // merge all event sets of the same name
-// const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
-// cdtEvents = Object.values(cdtEventsByCategory)
-//   .map(group => {
-//     if (group.length > 1) {
-//       console.log(`de-duplicating category: ${group[0].category}`);
-//       group.forEach((g, i) => g.category = g.category + i)
-//     }
-//     return group[0];
-//   });
 
-// console.log('Done.');
-// console.groupEnd();
+
+console.log('Done.');
+console.groupEnd();
 
 
 
-// /** ###########################################################################
-//  * compare gecko vs. CDT categories
-//  * ##########################################################################*/
+const code = genTs();
+const codeFile = __dirname + "/event-names-code.gen.ts";
+fs.writeFileSync(codeFile, code);
+console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
 
-// (async () => {
-//   if (!process.env.REPLAY_DIR) {
-//     throw new Error(`REPLAY_DIR env variable (parent path of devtools) not found`);
-//   }
-//   const devtoolsDir = path.resolve(process.env.REPLAY_DIR as string, 'devtools');
-//   const eventsSrc = path.resolve(
-//     devtoolsDir,
-//     'packages/replay-next/src/constants.ts'
-//   );
-//   if (!fs.existsSync(eventsSrc)) {
-//     throw new Error(`devtools source file for events not found:\n  ${eventsSrc}`);
-//   }
-//   const {
-//     STANDARD_EVENT_CATEGORIES: geckoEvents
-//   }: { STANDARD_EVENT_CATEGORIES: EventCategory[] } = await import(eventsSrc);
-//   console.group(`\n=== Parsing and checking CDT events`);
-
-//   console.group(`\n=== Comparing CDT and gecko categories:`);
-
-//   console.table({
-//     CDT: {
-//       categories: cdtEvents.length,
-//       events: cdtEvents.flatMap(e => e.events).length
-//     },
-//     gecko: {
-//       categories: geckoEvents.length,
-//       events: geckoEvents.flatMap(e => e.events).length
-//     }
-//   });
-
-//   // compare CDT <-> gecko categories
-//   const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
-//   const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
-
-
-//   console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
-//     categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-//   console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
-//     categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-//   const geckoEventsByCategory = Object.fromEntries(
-//     geckoEvents.map(category => ([category.category, category]))
-//   );
-
-//   console.groupEnd();
-
-
-//   /** ###########################################################################
-//    * match CDT against gecko events
-//    * ##########################################################################*/
-
-//   console.group(`\n=== Matching...`);
-
-//   let badMatches = new Set();
-//   let matchesNeedingManualVerification: [string, string][] = [];
-//   const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
-//   for (const cdtCategory of cdtEvents) {
-//     const geckoCategory = geckoEventsByCategory[cdtCategory.category];
-//     if (!geckoCategory) {
-//       // cannot currently support this category
-//       continue;
-//     }
-//     const cdtCategoryName = cdtCategory.category.toLowerCase();
-//     for (const cdtEvent of cdtCategory.events) {
-//       const { type: cdtType } = cdtEvent;
-//       let geckoType: string | undefined;
-//       if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
-//         continue;
-//       }
-//       const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
-//       if (geckoLabelOverride) {
-//         geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
-//         if (!geckoType) {
-//           // something went wrong
-//           console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
-//           badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
-//           continue;
-//         }
-//       }
-//       let closest: typeof geckoCategory.events[0] | null = null;
-//       if (!geckoType) {
-//         // for each CDT type in category (if it has no manual override):
-//         //     find the best matching gecko type in the same category
-//         // NOTE: we match against the gecko label, because it is generally a lot closer than the type
-//         // console.group(`distance matching`);
-//         closest = _.minBy(geckoCategory.events, geckoEvent => {
-//           const dist = levenshtein(geckoEvent.label, cdtType);
-//           // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
-//           return dist;
-//         })!;
-//         // console.groupEnd();
-//         geckoType = closest.type;
-//       }
-//       if (cdtEventByGeckoType[geckoType]) {
-//         if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
-//           // bad: the same gecko event matched with more than one CDT event
-//           //      and the previously existing match is not a manual override.
-//           badMatches.add(geckoType);
-//           if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
-//             console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
-//             delete cdtEventByGeckoType[geckoType];
-//           }
-//           else {
-//             console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
-//           }
-//         }
-//       }
-//       else {
-//         cdtEventByGeckoType[geckoType] = cdtEvent;
-//         if (closest && cdtType !== closest?.label) {
-//           matchesNeedingManualVerification.push([cdtType, geckoType]);
-//         }
-//       }
-//     }
-//   }
-//   console.log('Done.\n');
-//   console.groupEnd();
-
-//   // get all unmatched events
-//   const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
-//   const missingGeckoTypes = _.difference(
-//     geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
-//     matchedGeckoTypes
-//   );
-
-//   console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
-//   console.log(`${missingGeckoTypes.join('\n')}\n`);
-//   console.groupEnd();
-
-
-//   // non-exact matches need manual verification
-//   matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
-//     (c, g) => !badMatches.has(g));
-//   console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
-//   console.log(`${matchesNeedingManualVerification
-//       .map(([gt, ct]) => `${ct} => ${gt}`)
-//       .join('\n')
-//     }`);
-//   console.groupEnd();
-
-//   if (badMatches.size) {
-//     // we had bad (duplicate) matches
-//     console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
-//     // process.exit(-1); // no need to exit
-//   }
-
-
-  // finish it!
-  //  TODO: maybe use xclip
-  const code = genCpp();
-  const codeFile = __dirname + "/event-names-code.gen.cc";
-  fs.writeFileSync(codeFile, code);
-  console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
-  
-  /** ###########################################################################
-   * generate C++ code for matching
-   * ##########################################################################*/
-
-  function genCpp() {
-    const eventEntries: string[] = Object.entries(cdtEventByGeckoType)
-      .flatMap(([geckoType, cdtEvent]) =>
-        cdtEvent.eventTargets!.map(eventTarget => 
-        // { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} }
-        `{ String("${cdtEvent.type}"), {{{String("${geckoType}"), {String("${eventTarget}")}}}} }`
-        )
-      );
-
-    return `
-  // <GENERATED CODE. DO NOT EDIT.>
-  // NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
-  static const CDTEventEntryMap& getEventEntryMap() {
-    DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
-      ({
-        ${eventEntries.join(',\n      ')}
-      })
-    );
-    return cdtToGeckoMap;
-  }
-  // </GENERATED CODE. DO NOT EDIT.>`;
-  }
-})();
 
 /** ###########################################################################
- * other utils
+ * generate event table (TS)
  * ##########################################################################*/
 
-function testMeSomeLevenstein() {
-  // levenstein tests
-  const pairs = [
-    ['load', 'load'],
-    ['beforeunload', 'load']
-  ];
-  console.log('\n\nLevenshtein tests:\n' +
-    pairs
-      .map(([a, b]) => ({
-        a, b, n: levenshtein(a, b)
-      }))
-      .map(({ a, b, n }) => `${a} - ${b} = ${n}`)
-      .join('  \n')
-  );
+function genTs() {
+  const Indent = 4;
+  return `\
+// <GENERATED CODE. DO NOT EDIT.>
+// NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
+${JSON.stringify(cdtEvents, null, 2)}
+// </GENERATED CODE. DO NOT EDIT.>`
+  .split('\n')
+    .map(s => ' '.repeat(Indent) + s)
+    .join('\n');
 }
 
 
-function getInputSrcCategoryCount(input: string) {
-  return [...input.matchAll(/i18nString/gm)].length;
-}
 
-function assert(x: any) {
-  if (!x) {
-    // NOTE: in some terminals, this produces a nice, red error indicator
-    process.exit(-1);
-  }
+/** ###########################################################################
+ * utils
+ * ##########################################################################*/
+
+function die() {
+  // NOTE: in some terminals, this produces a nice, red error indicator
+  process.exit(-1);
 }

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { STANDARD_EVENT_CATEGORIES as geckoEvents } from '/home/domi/replay/devtools/packages/replay-next/src/constants';
+import path from 'path';
 import _ from 'lodash';
 import levenshtein from 'js-levenshtein';
 import { EventHandlerType } from "@replayio/protocol";
@@ -196,226 +196,240 @@ function translateCDTToGeckoCategory(category: string) {
  * go!
  * ##########################################################################*/
 
-console.group(`\n=== Parsing and checking CDT events`);
+(async () => {
+  if (!process.env.REPLAY_DIR) {
+    throw new Error(`REPLAY_DIR env variable (parent path of devtools) not found`);
+  }
+  const devtoolsDir = path.resolve(process.env.REPLAY_DIR as string, 'devtools');
+  const eventsSrc = path.resolve(
+    devtoolsDir,
+    'packages/replay-next/src/constants.ts'
+  );
+  if (!fs.existsSync(eventsSrc)) {
+    throw new Error(`devtools source file for events not found:\n  ${eventsSrc}`);
+  }
+  const { 
+    STANDARD_EVENT_CATEGORIES: geckoEvents
+  }: { STANDARD_EVENT_CATEGORIES: EventCategory[] } = await import(eventsSrc);
+  console.group(`\n=== Parsing and checking CDT events`);
 
-const res = cdtEventsSrc.matchAll(
-  /i18nString\(UIStrings\.(.+?)\),\s*?(\[[^\]]*\])(?:,\s*?(\[[^\]]*\]))?.*?/gm
-);
+  const res = cdtEventsSrc.matchAll(
+    /i18nString\(UIStrings\.(.+?)\),\s*?(\[[^\]]*\])(?:,\s*?(\[[^\]]*\]))?.*?/gm
+  );
 
-const cdtCategoriesRaw = [...res];
+  const cdtCategoriesRaw = [...res];
 
 
-// check if we (probably/hopefully) parsed CDT src correctly
-const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
-const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
+  // check if we (probably/hopefully) parsed CDT src correctly
+  const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
+  const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
 
-const good = srcCategoryCount > 0 && srcCategoryCount === cdtCategoryCount;
-console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
-assert(good);
+  const good = srcCategoryCount > 0 && srcCategoryCount === cdtCategoryCount;
+  console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
+  assert(good);
 
-let cdtEvents = cdtCategoriesRaw.map(cat => {
-  const category = cat[1];
-  const events = eval(cat[2]);
-  const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
-  return {
-    // attempt basic normalization
-    category: translateCDTToGeckoCategory(category),
-    events: events.map((x: string): EventDefinition => ({
-        type: x,
-        label: x,
-        eventTargets
-      })
-    ) as EventDefinition[],
-    eventTargets
-  };
-});
-
-// merge all event sets of the same name
-const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
-cdtEvents = Object.values(cdtEventsByCategory)
-  .map(group => {
-    if (group.length > 1) {
-      console.log(`de-duplicating category: ${group[0].category}`);
-      group.forEach((g, i) => g.category = g.category + i)
-    }
-    return group[0];
+  let cdtEvents = cdtCategoriesRaw.map(cat => {
+    const category = cat[1];
+    const events = eval(cat[2]);
+    const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
+    return {
+      // attempt basic normalization
+      category: translateCDTToGeckoCategory(category),
+      events: events.map((x: string): EventDefinition => ({
+          type: x,
+          label: x,
+          eventTargets
+        })
+      ) as EventDefinition[],
+      eventTargets
+    };
   });
 
-console.log('Done.');
-console.groupEnd();
+  // merge all event sets of the same name
+  const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
+  cdtEvents = Object.values(cdtEventsByCategory)
+    .map(group => {
+      if (group.length > 1) {
+        console.log(`de-duplicating category: ${group[0].category}`);
+        group.forEach((g, i) => g.category = g.category + i)
+      }
+      return group[0];
+    });
+
+  console.log('Done.');
+  console.groupEnd();
 
 
 
-/** ###########################################################################
- * compare gecko vs. CDT categories
- * ##########################################################################*/
+  /** ###########################################################################
+   * compare gecko vs. CDT categories
+   * ##########################################################################*/
 
-console.group(`\n=== Comparing CDT and gecko categories:`);
+  console.group(`\n=== Comparing CDT and gecko categories:`);
 
-console.table({
-  CDT: {
-    categories: cdtEvents.length,
-    events: cdtEvents.flatMap(e => e.events).length
-  },
-  gecko: {
-    categories: geckoEvents.length,
-    events: geckoEvents.flatMap(e => e.events).length
-  }
-});
+  console.table({
+    CDT: {
+      categories: cdtEvents.length,
+      events: cdtEvents.flatMap(e => e.events).length
+    },
+    gecko: {
+      categories: geckoEvents.length,
+      events: geckoEvents.flatMap(e => e.events).length
+    }
+  });
 
-// compare CDT <-> gecko categories
-const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
-const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
-
-
-console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
-  categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
-  categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-const geckoEventsByCategory = Object.fromEntries(
-  geckoEvents.map(category => ([category.category, category]))
-);
-
-console.groupEnd();
+  // compare CDT <-> gecko categories
+  const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
+  const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
 
 
-/** ###########################################################################
- * match CDT against gecko events
- * ##########################################################################*/
+  console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
+    categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
 
-console.group(`\n=== Matching...`);
+  console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
+    categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
 
-let badMatches = new Set();
-let matchesNeedingManualVerification: [string, string][] = [];
-const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
-for (const cdtCategory of cdtEvents) {
-  const geckoCategory = geckoEventsByCategory[cdtCategory.category];
-  if (!geckoCategory) {
-    // cannot currently support this category
-    continue;
-  }
-  const cdtCategoryName = cdtCategory.category.toLowerCase();
-  for (const cdtEvent of cdtCategory.events) {
-    const { type: cdtType } = cdtEvent;
-    let geckoType: string | undefined;
-    if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
+  const geckoEventsByCategory = Object.fromEntries(
+    geckoEvents.map(category => ([category.category, category]))
+  );
+
+  console.groupEnd();
+
+
+  /** ###########################################################################
+   * match CDT against gecko events
+   * ##########################################################################*/
+
+  console.group(`\n=== Matching...`);
+
+  let badMatches = new Set();
+  let matchesNeedingManualVerification: [string, string][] = [];
+  const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
+  for (const cdtCategory of cdtEvents) {
+    const geckoCategory = geckoEventsByCategory[cdtCategory.category];
+    if (!geckoCategory) {
+      // cannot currently support this category
       continue;
     }
-    const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
-    if (geckoLabelOverride) {
-      geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
-      if (!geckoType) {
-        // something went wrong
-        console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
-        badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
+    const cdtCategoryName = cdtCategory.category.toLowerCase();
+    for (const cdtEvent of cdtCategory.events) {
+      const { type: cdtType } = cdtEvent;
+      let geckoType: string | undefined;
+      if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
         continue;
       }
-    }
-    let closest: typeof geckoCategory.events[0] | null = null;
-    if (!geckoType) {
-      // for each CDT type in category (if it has no manual override):
-      //     find the best matching gecko type in the same category
-      // NOTE: we match against the gecko label, because it is generally a lot closer than the type
-      // console.group(`distance matching`);
-      closest = _.minBy(geckoCategory.events, geckoEvent => {
-        const dist = levenshtein(geckoEvent.label, cdtType);
-        // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
-        return dist;
-      })!;
-      // console.groupEnd();
-      geckoType = closest.type;
-    }
-    if (cdtEventByGeckoType[geckoType]) {
-      if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
-        // bad: the same gecko event matched with more than one CDT event
-        //      and the previously existing match is not a manual override.
-        badMatches.add(geckoType);
-        if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
-          console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
-          delete cdtEventByGeckoType[geckoType];
-        }
-        else {
-          console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
+      const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
+      if (geckoLabelOverride) {
+        geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
+        if (!geckoType) {
+          // something went wrong
+          console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
+          badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
+          continue;
         }
       }
-    }
-    else {
-      cdtEventByGeckoType[geckoType] = cdtEvent;
-      if (closest && cdtType !== closest?.label) {
-        matchesNeedingManualVerification.push([cdtType, geckoType]);
+      let closest: typeof geckoCategory.events[0] | null = null;
+      if (!geckoType) {
+        // for each CDT type in category (if it has no manual override):
+        //     find the best matching gecko type in the same category
+        // NOTE: we match against the gecko label, because it is generally a lot closer than the type
+        // console.group(`distance matching`);
+        closest = _.minBy(geckoCategory.events, geckoEvent => {
+          const dist = levenshtein(geckoEvent.label, cdtType);
+          // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
+          return dist;
+        })!;
+        // console.groupEnd();
+        geckoType = closest.type;
+      }
+      if (cdtEventByGeckoType[geckoType]) {
+        if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
+          // bad: the same gecko event matched with more than one CDT event
+          //      and the previously existing match is not a manual override.
+          badMatches.add(geckoType);
+          if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
+            console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
+            delete cdtEventByGeckoType[geckoType];
+          }
+          else {
+            console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
+          }
+        }
+      }
+      else {
+        cdtEventByGeckoType[geckoType] = cdtEvent;
+        if (closest && cdtType !== closest?.label) {
+          matchesNeedingManualVerification.push([cdtType, geckoType]);
+        }
       }
     }
   }
-}
-console.log('Done.\n');
-console.groupEnd();
+  console.log('Done.\n');
+  console.groupEnd();
 
-// get all unmatched events
-const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
-const missingGeckoTypes = _.difference(
-  geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
-  matchedGeckoTypes
-);
-
-console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
-console.log(`${missingGeckoTypes.join('\n')}\n`);
-console.groupEnd();
-
-
-// non-exact matches need manual verification
-matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
-  (c, g) => !badMatches.has(g));
-console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
-console.log(`${matchesNeedingManualVerification
-    .map(([gt, ct]) => `${ct} => ${gt}`)
-    .join('\n')
-  }`);
-console.groupEnd();
-
-if (badMatches.size) {
-  // we had bad (duplicate) matches
-  console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
-  process.exit(-1);
-}
-
-
-// finish it!
-//  TODO: maybe use xclip
-const code = genCpp();
-const codeFile = __dirname + "/event-names-code.gen.cc";
-fs.writeFileSync(codeFile, code);
-console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
-
-
-/** ###########################################################################
- * generate C++ code for matching
- * ##########################################################################*/
-
-function genCpp() {
-  const eventEntries: string[] = Object.entries(cdtEventByGeckoType)
-    .flatMap(([geckoType, cdtEvent]) =>
-      cdtEvent.eventTargets!.map(eventTarget => 
-      // { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} }
-      `{ String("${cdtEvent.type}"), {{{String("${geckoType}"), {String("${eventTarget}")}}}} }`
-      )
-    );
-
-  return `
-// <GENERATED CODE. DO NOT EDIT.>
-// NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
-static const CDTEventEntryMap& getEventEntryMap() {
-  DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
-    ({
-      ${eventEntries.join(',\n      ')}
-    })
+  // get all unmatched events
+  const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
+  const missingGeckoTypes = _.difference(
+    geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
+    matchedGeckoTypes
   );
-  return cdtToGeckoMap;
-}
-// </GENERATED CODE. DO NOT EDIT.>`;
-}
 
+  console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
+  console.log(`${missingGeckoTypes.join('\n')}\n`);
+  console.groupEnd();
+
+
+  // non-exact matches need manual verification
+  matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
+    (c, g) => !badMatches.has(g));
+  console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
+  console.log(`${matchesNeedingManualVerification
+      .map(([gt, ct]) => `${ct} => ${gt}`)
+      .join('\n')
+    }`);
+  console.groupEnd();
+
+  if (badMatches.size) {
+    // we had bad (duplicate) matches
+    console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
+    process.exit(-1);
+  }
+
+
+  // finish it!
+  //  TODO: maybe use xclip
+  const code = genCpp();
+  const codeFile = __dirname + "/event-names-code.gen.cc";
+  fs.writeFileSync(codeFile, code);
+  console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
+
+  /** ###########################################################################
+   * generate C++ code for matching
+   * ##########################################################################*/
+
+  function genCpp() {
+    const eventEntries: string[] = Object.entries(cdtEventByGeckoType)
+      .flatMap(([geckoType, cdtEvent]) =>
+        cdtEvent.eventTargets!.map(eventTarget => 
+        // { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} }
+        `{ String("${cdtEvent.type}"), {{{String("${geckoType}"), {String("${eventTarget}")}}}} }`
+        )
+      );
+
+    return `
+  // <GENERATED CODE. DO NOT EDIT.>
+  // NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
+  static const CDTEventEntryMap& getEventEntryMap() {
+    DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
+      ({
+        ${eventEntries.join(',\n      ')}
+      })
+    );
+    return cdtToGeckoMap;
+  }
+  // </GENERATED CODE. DO NOT EDIT.>`;
+  }
+})();
 
 /** ###########################################################################
  * other utils

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -3,21 +3,13 @@
 // found in the LICENSE file.
 
 /**
- * @file In this file, we take all CDT user event names, 
- * parse them and map them against their `gecko` counterpart.
- * It outputs (i) verification results, (ii) comparison results
- * (iii) potential mapping problems, (iv) and C++ code that 
- * allows easily looking up `gecko` event names by their CDT
- * counterpart.
- * 
- * @see https://linear.app/replay/issue/RUN-1061#comment-bde208c4
+ * @file In this file, we find all CDT event and category names
+ * and produce a lookup table for `devtools`.
  */
 
 import fs from 'fs';
 import path from 'path';
-import without from 'lodash/without';
 import startCase from 'lodash/startCase';
-import levenshtein from 'js-levenshtein';
 import { EventHandlerType } from "@replayio/protocol";
 
 
@@ -68,7 +60,7 @@ const cdtCategoryOverrides: { [key: string]: string } = {
 };
 
 /**
- * Translate category names from CDT to gecko.
+ * Prettier CDT category names
  */
 function prettyCDTCategory(category: string) {
   category = startCase(category);

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -33,7 +33,10 @@ type EventCategory = {
 };
 
 
-
+/**
+ * This source code is copied from CDT's `DOMDebuggerManager`.
+ * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L758
+ */
 const cdtEventsSrc = `this.createInstrumentationBreakpoints(
         i18nString(UIStrings.animation),
         ['requestAnimationFrame', 'cancelAnimationFrame', 'requestAnimationFrame.callback']);
@@ -208,207 +211,207 @@ function translateCDTToGeckoCategory(category: string) {
 }
 
 /** ###########################################################################
- * go!
+ * parse CDT events
  * ##########################################################################*/
 
-(async () => {
-  if (!process.env.REPLAY_DIR) {
-    throw new Error(`REPLAY_DIR env variable (parent path of devtools) not found`);
-  }
-  const devtoolsDir = path.resolve(process.env.REPLAY_DIR as string, 'devtools');
-  const eventsSrc = path.resolve(
-    devtoolsDir,
-    'packages/replay-next/src/constants.ts'
-  );
-  if (!fs.existsSync(eventsSrc)) {
-    throw new Error(`devtools source file for events not found:\n  ${eventsSrc}`);
-  }
-  const { 
-    STANDARD_EVENT_CATEGORIES: geckoEvents
-  }: { STANDARD_EVENT_CATEGORIES: EventCategory[] } = await import(eventsSrc);
-  console.group(`\n=== Parsing and checking CDT events`);
+const res = cdtEventsSrc.matchAll(
+  /i18nString\(UIStrings\.(.+?)\),\s*?(\[[^\]]*\])(?:,\s*?(\[[^\]]*\]))?.*?/gm
+);
 
-  const res = cdtEventsSrc.matchAll(
-    /i18nString\(UIStrings\.(.+?)\),\s*?(\[[^\]]*\])(?:,\s*?(\[[^\]]*\]))?.*?/gm
-  );
+const cdtCategoriesRaw = [...res];
 
-  const cdtCategoriesRaw = [...res];
+// check if we (probably/hopefully) parsed CDT src correctly
+const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
+const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
 
+// sanity checks: if less than 20 categories, there might be a bug
+const good = srcCategoryCount > 20 && srcCategoryCount === cdtCategoryCount;
+console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
+assert(good);
 
-  // check if we (probably/hopefully) parsed CDT src correctly
-  const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
-  const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
+let cdtEvents = cdtCategoriesRaw.map(cat => {
+  const category = cat[1];
+  const events = eval(cat[2]);
+  const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
+  return {
+    // attempt basic normalization
+    category: translateCDTToGeckoCategory(category),
+    events: events.map((x: string): EventDefinition => ({
+        type: x,
+        label: x,
+        eventTargets
+      })
+    ) as EventDefinition[],
+    eventTargets
+  };
+});
 
-  const good = srcCategoryCount > 0 && srcCategoryCount === cdtCategoryCount;
-  console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
-  assert(good);
+// // merge all event sets of the same name
+// const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
+// cdtEvents = Object.values(cdtEventsByCategory)
+//   .map(group => {
+//     if (group.length > 1) {
+//       console.log(`de-duplicating category: ${group[0].category}`);
+//       group.forEach((g, i) => g.category = g.category + i)
+//     }
+//     return group[0];
+//   });
 
-  let cdtEvents = cdtCategoriesRaw.map(cat => {
-    const category = cat[1];
-    const events = eval(cat[2]);
-    const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
-    return {
-      // attempt basic normalization
-      category: translateCDTToGeckoCategory(category),
-      events: events.map((x: string): EventDefinition => ({
-          type: x,
-          label: x,
-          eventTargets
-        })
-      ) as EventDefinition[],
-      eventTargets
-    };
-  });
-
-  // merge all event sets of the same name
-  const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
-  cdtEvents = Object.values(cdtEventsByCategory)
-    .map(group => {
-      if (group.length > 1) {
-        console.log(`de-duplicating category: ${group[0].category}`);
-        group.forEach((g, i) => g.category = g.category + i)
-      }
-      return group[0];
-    });
-
-  console.log('Done.');
-  console.groupEnd();
+// console.log('Done.');
+// console.groupEnd();
 
 
 
-  /** ###########################################################################
-   * compare gecko vs. CDT categories
-   * ##########################################################################*/
+// /** ###########################################################################
+//  * compare gecko vs. CDT categories
+//  * ##########################################################################*/
 
-  console.group(`\n=== Comparing CDT and gecko categories:`);
+// (async () => {
+//   if (!process.env.REPLAY_DIR) {
+//     throw new Error(`REPLAY_DIR env variable (parent path of devtools) not found`);
+//   }
+//   const devtoolsDir = path.resolve(process.env.REPLAY_DIR as string, 'devtools');
+//   const eventsSrc = path.resolve(
+//     devtoolsDir,
+//     'packages/replay-next/src/constants.ts'
+//   );
+//   if (!fs.existsSync(eventsSrc)) {
+//     throw new Error(`devtools source file for events not found:\n  ${eventsSrc}`);
+//   }
+//   const {
+//     STANDARD_EVENT_CATEGORIES: geckoEvents
+//   }: { STANDARD_EVENT_CATEGORIES: EventCategory[] } = await import(eventsSrc);
+//   console.group(`\n=== Parsing and checking CDT events`);
 
-  console.table({
-    CDT: {
-      categories: cdtEvents.length,
-      events: cdtEvents.flatMap(e => e.events).length
-    },
-    gecko: {
-      categories: geckoEvents.length,
-      events: geckoEvents.flatMap(e => e.events).length
-    }
-  });
+//   console.group(`\n=== Comparing CDT and gecko categories:`);
 
-  // compare CDT <-> gecko categories
-  const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
-  const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
+//   console.table({
+//     CDT: {
+//       categories: cdtEvents.length,
+//       events: cdtEvents.flatMap(e => e.events).length
+//     },
+//     gecko: {
+//       categories: geckoEvents.length,
+//       events: geckoEvents.flatMap(e => e.events).length
+//     }
+//   });
 
-
-  console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
-    categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-  console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
-    categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
-
-  const geckoEventsByCategory = Object.fromEntries(
-    geckoEvents.map(category => ([category.category, category]))
-  );
-
-  console.groupEnd();
-
-
-  /** ###########################################################################
-   * match CDT against gecko events
-   * ##########################################################################*/
-
-  console.group(`\n=== Matching...`);
-
-  let badMatches = new Set();
-  let matchesNeedingManualVerification: [string, string][] = [];
-  const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
-  for (const cdtCategory of cdtEvents) {
-    const geckoCategory = geckoEventsByCategory[cdtCategory.category];
-    if (!geckoCategory) {
-      // cannot currently support this category
-      continue;
-    }
-    const cdtCategoryName = cdtCategory.category.toLowerCase();
-    for (const cdtEvent of cdtCategory.events) {
-      const { type: cdtType } = cdtEvent;
-      let geckoType: string | undefined;
-      if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
-        continue;
-      }
-      const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
-      if (geckoLabelOverride) {
-        geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
-        if (!geckoType) {
-          // something went wrong
-          console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
-          badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
-          continue;
-        }
-      }
-      let closest: typeof geckoCategory.events[0] | null = null;
-      if (!geckoType) {
-        // for each CDT type in category (if it has no manual override):
-        //     find the best matching gecko type in the same category
-        // NOTE: we match against the gecko label, because it is generally a lot closer than the type
-        // console.group(`distance matching`);
-        closest = _.minBy(geckoCategory.events, geckoEvent => {
-          const dist = levenshtein(geckoEvent.label, cdtType);
-          // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
-          return dist;
-        })!;
-        // console.groupEnd();
-        geckoType = closest.type;
-      }
-      if (cdtEventByGeckoType[geckoType]) {
-        if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
-          // bad: the same gecko event matched with more than one CDT event
-          //      and the previously existing match is not a manual override.
-          badMatches.add(geckoType);
-          if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
-            console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
-            delete cdtEventByGeckoType[geckoType];
-          }
-          else {
-            console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
-          }
-        }
-      }
-      else {
-        cdtEventByGeckoType[geckoType] = cdtEvent;
-        if (closest && cdtType !== closest?.label) {
-          matchesNeedingManualVerification.push([cdtType, geckoType]);
-        }
-      }
-    }
-  }
-  console.log('Done.\n');
-  console.groupEnd();
-
-  // get all unmatched events
-  const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
-  const missingGeckoTypes = _.difference(
-    geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
-    matchedGeckoTypes
-  );
-
-  console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
-  console.log(`${missingGeckoTypes.join('\n')}\n`);
-  console.groupEnd();
+//   // compare CDT <-> gecko categories
+//   const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
+//   const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
 
 
-  // non-exact matches need manual verification
-  matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
-    (c, g) => !badMatches.has(g));
-  console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
-  console.log(`${matchesNeedingManualVerification
-      .map(([gt, ct]) => `${ct} => ${gt}`)
-      .join('\n')
-    }`);
-  console.groupEnd();
+//   console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
+//     categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
 
-  if (badMatches.size) {
-    // we had bad (duplicate) matches
-    console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
-    process.exit(-1);
-  }
+//   console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
+//     categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
+
+//   const geckoEventsByCategory = Object.fromEntries(
+//     geckoEvents.map(category => ([category.category, category]))
+//   );
+
+//   console.groupEnd();
+
+
+//   /** ###########################################################################
+//    * match CDT against gecko events
+//    * ##########################################################################*/
+
+//   console.group(`\n=== Matching...`);
+
+//   let badMatches = new Set();
+//   let matchesNeedingManualVerification: [string, string][] = [];
+//   const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
+//   for (const cdtCategory of cdtEvents) {
+//     const geckoCategory = geckoEventsByCategory[cdtCategory.category];
+//     if (!geckoCategory) {
+//       // cannot currently support this category
+//       continue;
+//     }
+//     const cdtCategoryName = cdtCategory.category.toLowerCase();
+//     for (const cdtEvent of cdtCategory.events) {
+//       const { type: cdtType } = cdtEvent;
+//       let geckoType: string | undefined;
+//       if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
+//         continue;
+//       }
+//       const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
+//       if (geckoLabelOverride) {
+//         geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
+//         if (!geckoType) {
+//           // something went wrong
+//           console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
+//           badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
+//           continue;
+//         }
+//       }
+//       let closest: typeof geckoCategory.events[0] | null = null;
+//       if (!geckoType) {
+//         // for each CDT type in category (if it has no manual override):
+//         //     find the best matching gecko type in the same category
+//         // NOTE: we match against the gecko label, because it is generally a lot closer than the type
+//         // console.group(`distance matching`);
+//         closest = _.minBy(geckoCategory.events, geckoEvent => {
+//           const dist = levenshtein(geckoEvent.label, cdtType);
+//           // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
+//           return dist;
+//         })!;
+//         // console.groupEnd();
+//         geckoType = closest.type;
+//       }
+//       if (cdtEventByGeckoType[geckoType]) {
+//         if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
+//           // bad: the same gecko event matched with more than one CDT event
+//           //      and the previously existing match is not a manual override.
+//           badMatches.add(geckoType);
+//           if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
+//             console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
+//             delete cdtEventByGeckoType[geckoType];
+//           }
+//           else {
+//             console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
+//           }
+//         }
+//       }
+//       else {
+//         cdtEventByGeckoType[geckoType] = cdtEvent;
+//         if (closest && cdtType !== closest?.label) {
+//           matchesNeedingManualVerification.push([cdtType, geckoType]);
+//         }
+//       }
+//     }
+//   }
+//   console.log('Done.\n');
+//   console.groupEnd();
+
+//   // get all unmatched events
+//   const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
+//   const missingGeckoTypes = _.difference(
+//     geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
+//     matchedGeckoTypes
+//   );
+
+//   console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
+//   console.log(`${missingGeckoTypes.join('\n')}\n`);
+//   console.groupEnd();
+
+
+//   // non-exact matches need manual verification
+//   matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
+//     (c, g) => !badMatches.has(g));
+//   console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
+//   console.log(`${matchesNeedingManualVerification
+//       .map(([gt, ct]) => `${ct} => ${gt}`)
+//       .join('\n')
+//     }`);
+//   console.groupEnd();
+
+//   if (badMatches.size) {
+//     // we had bad (duplicate) matches
+//     console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
+//     // process.exit(-1); // no need to exit
+//   }
 
 
   // finish it!
@@ -417,7 +420,7 @@ function translateCDTToGeckoCategory(category: string) {
   const codeFile = __dirname + "/event-names-code.gen.cc";
   fs.writeFileSync(codeFile, code);
   console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
-
+  
   /** ###########################################################################
    * generate C++ code for matching
    * ##########################################################################*/

--- a/replay-scripts/gen-event-names.ts
+++ b/replay-scripts/gen-event-names.ts
@@ -1,0 +1,450 @@
+import fs from 'fs';
+import { STANDARD_EVENT_CATEGORIES as geckoEvents } from '/home/domi/replay/devtools/packages/replay-next/src/constants';
+import _ from 'lodash';
+import levenshtein from 'js-levenshtein';
+import { EventHandlerType } from "@replayio/protocol";
+
+
+type EventDefinition = {
+  label: string;
+  type: EventHandlerType;
+  eventTargets?: string[];
+};
+
+type EventCategory = {
+  category: string;
+  events: Array<EventDefinition>;
+  eventTargets?: string[];
+};
+
+
+
+const cdtEventsSrc = `this.createInstrumentationBreakpoints(
+        i18nString(UIStrings.animation),
+        ['requestAnimationFrame', 'cancelAnimationFrame', 'requestAnimationFrame.callback']);
+    this.createInstrumentationBreakpoints(
+        i18nString(UIStrings.canvas), ['canvasContextCreated', 'webglErrorFired', 'webglWarningFired']);
+    this.createInstrumentationBreakpoints(
+        i18nString(UIStrings.geolocation), ['Geolocation.getCurrentPosition', 'Geolocation.watchPosition']);
+    this.createInstrumentationBreakpoints(i18nString(UIStrings.notification), ['Notification.requestPermission']);
+    this.createInstrumentationBreakpoints(i18nString(UIStrings.parse), ['Element.setInnerHTML', 'Document.write']);
+    this.createInstrumentationBreakpoints(i18nString(UIStrings.script), ['scriptFirstStatement', 'scriptBlockedByCSP']);
+    this.createInstrumentationBreakpoints(
+        i18nString(UIStrings.timer),
+        ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setTimeout.callback', 'setInterval.callback']);
+    this.createInstrumentationBreakpoints(i18nString(UIStrings.window), ['DOMWindow.close']);
+    this.createInstrumentationBreakpoints(
+        i18nString(UIStrings.webaudio),
+        ['audioContextCreated', 'audioContextClosed', 'audioContextResumed', 'audioContextSuspended']);
+
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.media),
+        [
+          'play',      'pause',          'playing',    'canplay',    'canplaythrough', 'seeking',
+          'seeked',    'timeupdate',     'ended',      'ratechange', 'durationchange', 'volumechange',
+          'loadstart', 'progress',       'suspend',    'abort',      'error',          'emptied',
+          'stalled',   'loadedmetadata', 'loadeddata', 'waiting',
+        ],
+        ['audio', 'video']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.pictureinpicture), ['enterpictureinpicture', 'leavepictureinpicture'], ['video']);
+    this.createEventListenerBreakpoints(i18nString(UIStrings.pictureinpicture), ['resize'], ['PictureInPictureWindow']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.clipboard), ['copy', 'cut', 'paste', 'beforecopy', 'beforecut', 'beforepaste'], ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.control),
+        ['resize', 'scroll', 'zoom', 'focus', 'blur', 'select', 'change', 'submit', 'reset'], ['*']);
+    this.createEventListenerBreakpoints(i18nString(UIStrings.device), ['deviceorientation', 'devicemotion'], ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.domMutation),
+        [
+          'DOMActivate',
+          'DOMFocusIn',
+          'DOMFocusOut',
+          'DOMAttrModified',
+          'DOMCharacterDataModified',
+          'DOMNodeInserted',
+          'DOMNodeInsertedIntoDocument',
+          'DOMNodeRemoved',
+          'DOMNodeRemovedFromDocument',
+          'DOMSubtreeModified',
+          'DOMContentLoaded',
+        ],
+        ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.dragDrop), ['drag', 'dragstart', 'dragend', 'dragenter', 'dragover', 'dragleave', 'drop'],
+        ['*']);
+
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.keyboard), ['keydown', 'keyup', 'keypress', 'input'], ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.load),
+        [
+          'load',
+          'beforeunload',
+          'unload',
+          'abort',
+          'error',
+          'hashchange',
+          'popstate',
+          'navigate',
+          'navigatesuccess',
+          'navigateerror',
+          'currentchange',
+          'navigateto',
+          'navigatefrom',
+          'finish',
+          'dispose',
+        ],
+        ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.mouse),
+        [
+          'auxclick',
+          'click',
+          'dblclick',
+          'mousedown',
+          'mouseup',
+          'mouseover',
+          'mousemove',
+          'mouseout',
+          'mouseenter',
+          'mouseleave',
+          'mousewheel',
+          'wheel',
+          'contextmenu',
+        ],
+        ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.pointer),
+        [
+          'pointerover',
+          'pointerout',
+          'pointerenter',
+          'pointerleave',
+          'pointerdown',
+          'pointerup',
+          'pointermove',
+          'pointercancel',
+          'gotpointercapture',
+          'lostpointercapture',
+          'pointerrawupdate',
+        ],
+        ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.touch), ['touchstart', 'touchmove', 'touchend', 'touchcancel'], ['*']);
+    this.createEventListenerBreakpoints(i18nString(UIStrings.worker), ['message', 'messageerror'], ['*']);
+    this.createEventListenerBreakpoints(
+        i18nString(UIStrings.xhr),
+        ['readystatechange', 'load', 'loadstart', 'loadend', 'abort', 'error', 'progress', 'timeout'],
+        ['xmlhttprequest', 'xmlhttprequestupload']);`
+
+
+/** ###########################################################################
+ * event normalization
+ * ##########################################################################*/
+
+const manualCdtToGeckoLabelOverrides: { [key: string]: string } = {
+  // TODO: some events have been removed in gecko. Need to handle that better.
+
+  // 'hashchange': 'hashchange',
+  // 'popstate': 'popstate',
+  // 'pointerout': 'pointerout',
+
+  // 'beforeinput': 'event.keyboard.beforeinput',
+  // these are missing in CDT (but there are many more missing in gecko)
+  // '?': 'event.websocket.open',
+  // '?': 'event.websocket.message',
+  // '?': 'event.websocket.error',
+  // '?': 'event.websocket.close',
+  // '?': 'event.serviceworker.fetch',
+};
+
+const ignoredCdtEventsByCategory: { [key: string]: Set<string> } = {
+  load: new Set([
+    'beforeunload',
+    'unload',
+    'navigate',
+    'navigatesuccess',
+    'navigateerror',
+    'currentchange',
+    'navigateto',
+    'navigatefrom',
+    'finish',
+    'dispose'
+  ]),
+  pointer: new Set([
+    'pointerrawupdate'
+  ])
+}
+
+const cdtToGeckoCategoryMap: { [key: string]: string } = {
+  Xhr: 'XHR',
+  'Drag Drop': 'Drag and Drop',
+  'Dom Mutation': 'DOM Mutation'
+};
+
+/**
+ * Translate category names from CDT to gecko.
+ */
+function translateCDTToGeckoCategory(category: string) {
+  category = _.startCase(category);
+  return cdtToGeckoCategoryMap[category] || category;
+}
+
+/** ###########################################################################
+ * go!
+ * ##########################################################################*/
+
+console.group(`\n=== Parsing and checking CDT events`);
+
+const res = cdtEventsSrc.matchAll(
+  /i18nString\(UIStrings\.(.+?)\),\s*?(\[[^\]]*\])(?:,\s*?(\[[^\]]*\]))?.*?/gm
+);
+
+const cdtCategoriesRaw = [...res];
+
+
+// check if we (probably/hopefully) parsed CDT src correctly
+const srcCategoryCount = getInputSrcCategoryCount(cdtEventsSrc);
+const cdtCategoryCount = getInputSrcCategoryCount(cdtCategoriesRaw.join('\n'));
+
+const good = srcCategoryCount > 0 && srcCategoryCount === cdtCategoryCount;
+console.log(`Found ${good ? srcCategoryCount : `${cdtCategoryCount}/${srcCategoryCount}`} CDT source categories (w/ duplicates) ${good ? '✅' : '❌'}`);
+assert(good);
+
+let cdtEvents = cdtCategoriesRaw.map(cat => {
+  const category = cat[1];
+  const events = eval(cat[2]);
+  const eventTargets = (cat[3] && eval(cat[3]) || ['*']) as string[];
+  return {
+    // attempt basic normalization
+    category: translateCDTToGeckoCategory(category),
+    events: events.map((x: string): EventDefinition => ({
+        type: x,
+        label: x,
+        eventTargets
+      })
+    ) as EventDefinition[],
+    eventTargets
+  };
+});
+
+// merge all event sets of the same name
+const cdtEventsByCategory = _.groupBy(cdtEvents, e => e.category);
+cdtEvents = Object.values(cdtEventsByCategory)
+  .map(group => {
+    if (group.length > 1) {
+      console.log(`de-duplicating category: ${group[0].category}`);
+      group.forEach((g, i) => g.category = g.category + i)
+    }
+    return group[0];
+  });
+
+console.log('Done.');
+console.groupEnd();
+
+
+
+/** ###########################################################################
+ * compare gecko vs. CDT categories
+ * ##########################################################################*/
+
+console.group(`\n=== Comparing CDT and gecko categories:`);
+
+console.table({
+  CDT: {
+    categories: cdtEvents.length,
+    events: cdtEvents.flatMap(e => e.events).length
+  },
+  gecko: {
+    categories: geckoEvents.length,
+    events: geckoEvents.flatMap(e => e.events).length
+  }
+});
+
+// compare CDT <-> gecko categories
+const categoriesNotInGecko: EventCategory[] = _.differenceBy(cdtEvents, geckoEvents, 'category');
+const categoriesNotInCDT = _.differenceBy(geckoEvents, cdtEvents, 'category');
+
+
+console.log(`Found ${categoriesNotInGecko.length} Categories in CDT but not in gecko:\n `,
+  categoriesNotInGecko.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
+
+console.log(`\nFound ${categoriesNotInCDT.length} Categories in gecko but not in CDT:\n `,
+  categoriesNotInCDT.map(cat => `${cat.category} (${cat.events.length})`).join('\n  '));
+
+const geckoEventsByCategory = Object.fromEntries(
+  geckoEvents.map(category => ([category.category, category]))
+);
+
+console.groupEnd();
+
+
+/** ###########################################################################
+ * match CDT against gecko events
+ * ##########################################################################*/
+
+console.group(`\n=== Matching...`);
+
+let badMatches = new Set();
+let matchesNeedingManualVerification: [string, string][] = [];
+const cdtEventByGeckoType: { [key: string]: EventDefinition } = {};
+for (const cdtCategory of cdtEvents) {
+  const geckoCategory = geckoEventsByCategory[cdtCategory.category];
+  if (!geckoCategory) {
+    // cannot currently support this category
+    continue;
+  }
+  const cdtCategoryName = cdtCategory.category.toLowerCase();
+  for (const cdtEvent of cdtCategory.events) {
+    const { type: cdtType } = cdtEvent;
+    let geckoType: string | undefined;
+    if (ignoredCdtEventsByCategory[cdtCategoryName]?.has(cdtType)) {
+      continue;
+    }
+    const geckoLabelOverride = manualCdtToGeckoLabelOverrides[cdtType];
+    if (geckoLabelOverride) {
+      geckoType = geckoCategory.events.find(e => e.label === geckoLabelOverride)?.type;
+      if (!geckoType) {
+        // something went wrong
+        console.error(`BAD MATCH: manualCdtToGeckoLabelOverrides had unmatched geckoLabel="${geckoLabelOverride}" for cdtType="${cdtType}"`);
+        badMatches.add(`<missing geckoType for geckoLabelOverride=${geckoLabelOverride}>`);
+        continue;
+      }
+    }
+    let closest: typeof geckoCategory.events[0] | null = null;
+    if (!geckoType) {
+      // for each CDT type in category (if it has no manual override):
+      //     find the best matching gecko type in the same category
+      // NOTE: we match against the gecko label, because it is generally a lot closer than the type
+      // console.group(`distance matching`);
+      closest = _.minBy(geckoCategory.events, geckoEvent => {
+        const dist = levenshtein(geckoEvent.label, cdtType);
+        // console.log(`${[geckoEvent.label, cdtType]}: ${dist}`);
+        return dist;
+      })!;
+      // console.groupEnd();
+      geckoType = closest.type;
+    }
+    if (cdtEventByGeckoType[geckoType]) {
+      if (!manualCdtToGeckoLabelOverrides[cdtEventByGeckoType[geckoType].type]) {
+        // bad: the same gecko event matched with more than one CDT event
+        //      and the previously existing match is not a manual override.
+        badMatches.add(geckoType);
+        if (cdtEventByGeckoType[geckoType].label !== closest?.label) {
+          console.error(`BAD MATCH in "${cdtCategoryName}": gecko type "${geckoType}" (${closest?.label}) fuzzy-matched CDT types "${cdtEventByGeckoType[geckoType].type}" and "${cdtType}"`);
+          delete cdtEventByGeckoType[geckoType];
+        }
+        else {
+          console.error(`BAD MATCH in "${cdtCategoryName}": CDT type "${cdtType}" had invalid match w/ gecko type "${geckoType}" (already matched CDT type "${cdtEventByGeckoType[geckoType].type}")`);
+        }
+      }
+    }
+    else {
+      cdtEventByGeckoType[geckoType] = cdtEvent;
+      if (closest && cdtType !== closest?.label) {
+        matchesNeedingManualVerification.push([cdtType, geckoType]);
+      }
+    }
+  }
+}
+console.log('Done.\n');
+console.groupEnd();
+
+// get all unmatched events
+const matchedGeckoTypes = Object.keys(cdtEventByGeckoType);
+const missingGeckoTypes = _.difference(
+  geckoEvents.flatMap(e => e.events.map(ee => ee.type)),
+  matchedGeckoTypes
+);
+
+console.group(`=== Found ${missingGeckoTypes.length} unmatched gecko events:`)
+console.log(`${missingGeckoTypes.join('\n')}\n`);
+console.groupEnd();
+
+
+// non-exact matches need manual verification
+matchesNeedingManualVerification = matchesNeedingManualVerification.filter(
+  (c, g) => !badMatches.has(g));
+console.group(`=== Found ${matchesNeedingManualVerification.length} matches needing manual verification:`);
+console.log(`${matchesNeedingManualVerification
+    .map(([gt, ct]) => `${ct} => ${gt}`)
+    .join('\n')
+  }`);
+console.groupEnd();
+
+if (badMatches.size) {
+  // we had bad (duplicate) matches
+  console.error(`\n\nConvert script FAILED due to ${badMatches.size} bad matches.\n  => Fix up manualCdtToGeckoEventOverrides and try again.`);
+  process.exit(-1);
+}
+
+
+// finish it!
+//  TODO: maybe use xclip
+const code = genCpp();
+const codeFile = __dirname + "/event-names-code.gen.cc";
+fs.writeFileSync(codeFile, code);
+console.log(`\n=== Generated code has been written to:\n  ${codeFile}\n`);
+
+
+/** ###########################################################################
+ * generate C++ code for matching
+ * ##########################################################################*/
+
+function genCpp() {
+  const eventEntries: string[] = Object.entries(cdtEventByGeckoType)
+    .flatMap(([geckoType, cdtEvent]) =>
+      cdtEvent.eventTargets!.map(eventTarget => 
+      // { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} }
+      `{ String("${cdtEvent.type}"), {{{String("${geckoType}"), {String("${eventTarget}")}}}} }`
+      )
+    );
+
+  return `
+// <GENERATED CODE. DO NOT EDIT.>
+// NOTE: This code is generated via \`ts-node scripts/gen-event-names.ts\`
+static const CDTEventEntryMap& getEventEntryMap() {
+  DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
+    ({
+      ${eventEntries.join(',\n      ')}
+    })
+  );
+  return cdtToGeckoMap;
+}
+// </GENERATED CODE. DO NOT EDIT.>`;
+}
+
+
+/** ###########################################################################
+ * other utils
+ * ##########################################################################*/
+
+function testMeSomeLevenstein() {
+  // levenstein tests
+  const pairs = [
+    ['load', 'load'],
+    ['beforeunload', 'load']
+  ];
+  console.log('\n\nLevenshtein tests:\n' +
+    pairs
+      .map(([a, b]) => ({
+        a, b, n: levenshtein(a, b)
+      }))
+      .map(({ a, b, n }) => `${a} - ${b} = ${n}`)
+      .join('  \n')
+  );
+}
+
+
+function getInputSrcCategoryCount(input: string) {
+  return [...input.matchAll(/i18nString/gm)].length;
+}
+
+function assert(x: any) {
+  if (!x) {
+    // NOTE: in some terminals, this produces a nice, red error indicator
+    process.exit(-1);
+  }
+}

--- a/replay-scripts/package-lock.json
+++ b/replay-scripts/package-lock.json
@@ -1,0 +1,453 @@
+{
+  "name": "scripts-scratchpad",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scripts-scratchpad",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@replayio/protocol": "^0.37.0",
+        "clipboardy": "^3.0.0",
+        "js-levenshtein": "^1.1.6",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/lodash": "^4.14.191",
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@replayio/protocol": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@replayio/protocol/-/protocol-0.37.0.tgz",
+      "integrity": "sha512-RwQqNBP9gsiRzmQbJUH5vqj3EGP/l1Ie/SEylInuW0ao2WC66BshqgLLfGnPvzp5+sDfhrcT7KxCuUceNNAlLg=="
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
+  "dependencies": {
+    "@replayio/protocol": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@replayio/protocol/-/protocol-0.37.0.tgz",
+      "integrity": "sha512-RwQqNBP9gsiRzmQbJUH5vqj3EGP/l1Ie/SEylInuW0ao2WC66BshqgLLfGnPvzp5+sDfhrcT7KxCuUceNNAlLg=="
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
+    "arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
+    },
+    "clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "requires": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    }
+  }
+}

--- a/replay-scripts/package.json
+++ b/replay-scripts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "scripts-scratchpad",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@replayio/protocol": "^0.37.0",
+    "clipboardy": "^3.0.0",
+    "js-levenshtein": "^1.1.6",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/js-levenshtein": "^1.1.1",
+    "@types/lodash": "^4.14.191",
+    "@types/node": "^18.11.18"
+  }
+}

--- a/replay-scripts/package.json
+++ b/replay-scripts/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "@replayio/protocol": "^0.37.0",
-    "clipboardy": "^3.0.0",
     "js-levenshtein": "^1.1.6",
     "lodash": "^4.17.21"
   },

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -83,7 +83,7 @@ const char* gReplayScript = R""""(
 
 const EmptyArray = Object.freeze([]); // reduce unnecessary mem churn
 
-const Verbose = false;
+const Verbose = 1;
 const VerboseCommands = Verbose;
 
 const {
@@ -96,6 +96,7 @@ const {
   getCurrentError,
 
   fromJsMakeDebuggeeValue,
+  fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
   fromJsGetNodeId,
   fromJsGetBoxModel,
@@ -438,6 +439,14 @@ function Pause_evaluateInFrame({ frameId, expression }) {
 
   const rv = doEvaluation();
   return buildRrpObjectResult(rv);
+
+  if (expression === '[...arguments]') {
+    // hackfix (TODO: fix in gecko and frontend later)
+    // -> return `arguments` of given frame
+    //  see: https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
+    const args = fromJsGetArgumentsInFrame(frame.callFrameId);
+    return args && [...args] || [];
+  }
 
   function doEvaluation() {
     // In order to do the evaluation in the right frame, the same number of
@@ -3244,8 +3253,30 @@ static void fromJsMakeDebuggeeValue(
   }
 }
 
-static void fromJsGetObjectByCdpId(
+static void fromJsGetArgumentsInFrame(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "must be called with a single object");
+  v8::Isolate* isolate = args.GetIsolate();
+
+  // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
+  // future-work: can this be improved?
+  v8::String::Utf8Value frameId(isolate, args[0]);
+  const uint8_t* frameIdPtr = reinterpret_cast<const uint8_t*>(*frameId);
+  v8_inspector::StringView frameIdV8(frameIdPtr, frameId.length());
+
+  // v8::Isolate* isolate = args.GetIsolate();
+  auto result = gInspectorSession->getArgumentsOfCallFrame(frameIdV8);
+
+  if (result.IsEmpty()) {
+    args.GetReturnValue().SetNull();
+  } else {
+    args.GetReturnValue().Set(result.ToLocalChecked());
+  }
+}
+
+static void fromJsGetObjectByCdpId(
+  const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "[RuntimeError] must be called with a single string");
 
@@ -3265,920 +3296,943 @@ static void fromJsGetObjectByCdpId(
   }
 }
 
-/** ###########################################################################
- * Networking
- * ##########################################################################*/
+  /** ###########################################################################
+   * Networking
+   * ##########################################################################*/
 
-// Represents a known network request.  Created and added to
-// `gActiveNetworkRequests` when the request is first seen.  Removed
-// when the request finishes or fails.
-struct NetworkRequestStatus {
-  size_t response_data_received;
-  size_t request_data_sent;
-  std::string method;
-  uint64_t bookmark;
-  NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
-  : response_data_received(0),
-    request_data_sent(0),
-    method(method),
-    bookmark(bookmark)
-  {}
-};
-// Map of active network requests.
-std::unordered_map<std::string, NetworkRequestStatus>*
-  gActiveNetworkRequests = nullptr;
+  // Represents a known network request.  Created and added to
+  // `gActiveNetworkRequests` when the request is first seen.  Removed
+  // when the request finishes or fails.
+  struct NetworkRequestStatus {
+    size_t response_data_received;
+    size_t request_data_sent;
+    std::string method;
+    uint64_t bookmark;
+    NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
+        : response_data_received(0),
+          request_data_sent(0),
+          method(method),
+          bookmark(bookmark) {}
+  };
+  // Map of active network requests.
+  std::unordered_map<std::string, NetworkRequestStatus>*
+      gActiveNetworkRequests = nullptr;
 
-// Globals storing values to be returned to controller commands
-// `GetCurrentNetwork*`
-static base::Value *gCurrentNetworkRequestEvent = nullptr;
-static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
+  // Globals storing values to be returned to controller commands
+  // `GetCurrentNetwork*`
+  static base::Value* gCurrentNetworkRequestEvent = nullptr;
+  static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
 
-static void GetCurrentNetworkRequestEvent(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (!gCurrentNetworkRequestEvent) {
-    return;
+  static void GetCurrentNetworkRequestEvent(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    if (!gCurrentNetworkRequestEvent) {
+      return;
+    }
+
+    v8::Isolate* isolate = args.GetIsolate();
+    std::string json;
+    base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
+    v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
+    args.GetReturnValue().Set(json_string);
   }
 
-  v8::Isolate* isolate = args.GetIsolate();
-  std::string json;
-  base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
-  v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
-  args.GetReturnValue().Set(json_string);
-}
+  static void GetCurrentNetworkStreamData(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(gCurrentNetworkStreamData);
 
-static void GetCurrentNetworkStreamData(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(gCurrentNetworkStreamData);
+    v8::Isolate* isolate = args.GetIsolate();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  v8::Isolate* isolate = args.GetIsolate();
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    // Expect params: { index, length }
+    v8::Local<v8::Object> params = args[0]->ToObject(context).ToLocalChecked();
+    size_t index = params->Get(context, ToV8String(isolate, "index"))
+                       .ToLocalChecked()
+                       ->NumberValue(context)
+                       .ToChecked();
+    size_t length = params->Get(context, ToV8String(isolate, "length"))
+                        .ToLocalChecked()
+                        ->NumberValue(context)
+                        .ToChecked();
+    size_t size = gCurrentNetworkStreamData->size();
 
-  // Expect params: { index, length }
-  v8::Local<v8::Object> params =
-    args[0]->ToObject(context).ToLocalChecked();
-  size_t index =
-    params->Get(context, ToV8String(isolate, "index"))
-      .ToLocalChecked()->NumberValue(context).ToChecked();
-  size_t length =
-    params->Get(context, ToV8String(isolate, "length"))
-      .ToLocalChecked()->NumberValue(context).ToChecked();
-  size_t size = gCurrentNetworkStreamData->size();
+    if ((size < index) || ((size - index) < length)) {
+      recordreplay::Print(
+          "GetCurrentNetworkStreamData: Out of range slice"
+          " (size=%u, requested=%u-%u)",
+          (unsigned)size, (unsigned)index, (unsigned)(index + length));
+      return;
+    }
 
-  if ((size < index) || ((size - index) < length)) {
-    recordreplay::Print(
-      "GetCurrentNetworkStreamData: Out of range slice"
-      " (size=%u, requested=%u-%u)",
-      (unsigned) size,
-      (unsigned) index,
-      (unsigned) (index + length)
-    );
-    return;
+    uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
+    std::string encoded =
+        base::Base64Encode(base::span<const uint8_t>(bytes, length));
+    char* encoded_cstr = strdup(encoded.c_str());
+    char* encoded_end = encoded_cstr + encoded.length();
+    for (char* cur = encoded_cstr; cur < encoded_end; cur++) {
+      if (*cur == '-') {
+        *cur = '+';
+      }
+      if (*cur == '_') {
+        *cur = '/';
+      }
+    }
+
+    v8::Local<v8::Object> result = v8::Object::New(isolate);
+    result
+        ->Set(context, ToV8String(isolate, "kind"), ToV8String(isolate, "data"))
+        .Check();
+    result
+        ->Set(context, ToV8String(isolate, "value"),
+              ToV8String(isolate, encoded_cstr))
+        .Check();
+    args.GetReturnValue().Set(result);
   }
 
-  uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
-  std::string encoded = base::Base64Encode(
-    base::span<const uint8_t>(bytes, length)
-  );
-  char* encoded_cstr = strdup(encoded.c_str());
-  char* encoded_end = encoded_cstr + encoded.length();
-  for (char *cur = encoded_cstr; cur < encoded_end; cur++) {
-    if (*cur == '-') { *cur = '+'; }
-    if (*cur == '_') { *cur = '/'; }
+  static std::string MakeRequestIdentifier(uint64_t identifier) {
+    char request_id[64];
+    snprintf(request_id, 64, "%d.%lu", (int)getpid(),
+             (unsigned long)identifier);
+    return std::string(request_id);
   }
 
-  v8::Local<v8::Object> result = v8::Object::New(isolate);
-  result->Set(context,
-    ToV8String(isolate, "kind"),
-    ToV8String(isolate, "data")
-  ).Check();
-  result->Set(context,
-    ToV8String(isolate, "value"),
-    ToV8String(isolate, encoded_cstr)
-  ).Check();
-  args.GetReturnValue().Set(result);
-}
+  static void HandleNetworkPrepareRequestEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    std::string request_id = *info.FindPath("requestId")->GetIfString();
+    if (gActiveNetworkRequests->find(request_id) !=
+        gActiveNetworkRequests->end()) {
+      // If the request already exists, this is a redirect.
+      // Chromium will send a "Network.ResourceRedirect" event which will
+      // be handled by `HandleNetworkPrepareRequestEvent` below.
+      return;
+    }
 
-static std::string MakeRequestIdentifier(uint64_t identifier) {
-  char request_id[64];
-  snprintf(request_id, 64, "%d.%lu", (int) getpid(), (unsigned long) identifier);
-  return std::string(request_id);
-}
+    // Save request info in a global table.
+    // Associate with it the following info which may be needed later if
+    // the request is redirected:
+    //   - the request method
+    //   - the request bookmark
+    std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+    uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
+    gActiveNetworkRequests->insert(
+        {request_id, NetworkRequestStatus(request_method, bookmark)});
 
-static void HandleNetworkPrepareRequestEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  std::string request_id = *info.FindPath("requestId")->GetIfString();
-  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
-    // If the request already exists, this is a redirect.
-    // Chromium will send a "Network.ResourceRedirect" event which will
-    // be handled by `HandleNetworkPrepareRequestEvent` below.
-    return;
-  }
+    // Register the request.
+    recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
 
-  // Save request info in a global table.
-  // Associate with it the following info which may be needed later if
-  // the request is redirected:
-  //   - the request method
-  //   - the request bookmark
-  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
-  uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
-  gActiveNetworkRequests->insert(
-    { request_id, NetworkRequestStatus(request_method, bookmark) }
-  );
-
-  // Register the request.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
-
-  // Package and emit a network request event with the appropriate info.
-  base::DictionaryValue event;
-  event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
-  event.SetString("requestMethod", request_method);
-  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
-  const base::Value* request_cause_value = info.FindPath("requestCause");
-  if (request_cause_value) {
-    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->CreateDeepCopy()));
-  }
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkResourceRedirectEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-
-  // Retreive the existing request data which should already have been
-  // registered by `HandleNetworkPrepareRequestEvent`.
-  uint64_t identifier =
-    *info.FindPath("identifier")->GetIfDouble();
-  std::string request_id = MakeRequestIdentifier(identifier);
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("No original request for navigation redirect: %s",
-      request_id.c_str());
-    return;
-  }
-
-  // Register a new network request with the same request id as the original
-  // for this redirect.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
-
-  // Package and emit a network request event.
-  // The request_method is obtained from the saved request info.
-  base::DictionaryValue event;
-  event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
-  event.SetString("requestMethod", request_info->second.method);
-  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
-  const base::Value* request_cause_value = info.FindPath("requestCause");
-  if (request_cause_value) {
-    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->CreateDeepCopy()));
-  }
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-
-  // Navigation events are network requests that are not resource requests.
-  // They are directed here (the renderer process) from the content process.
-  // They have no associated bookmark, as we can't take bookmarks in the
-  // content process.
-
-  // Ensure that a request with the same ID has not already been registered.
-  std::string request_id = *info.FindPath("requestId")->GetIfString();
-  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
-    recordreplay::Print("Duplicate request id: %s", request_id.c_str());
-    return;
-  }
-  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
-  gActiveNetworkRequests->insert({ request_id, NetworkRequestStatus(request_method) });
-
-  // A navigation event is a new network request, so call the `OnNetworkRequest` hook.
-  // Navigation events have no bookmarks associated with them.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http", /* bookmark = */ 0);
-
-  // Package and emit a network request event.
-  base::DictionaryValue event;
-  event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
-  event.SetString("requestMethod", request_method);
-  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
-  event.SetString("requestCause", "document");
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkNavigationRedirectEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-
-  // Navigation redirect events are, as with navigation events, sent from
-  // the content process to the renderer process.
-
-  // Ensure that a request with the same ID has not already been registered.
-  std::string request_id = *info.FindPath("requestId")->GetIfString();
-  // This is a redirect, so an existing request should have been registered
-  // with the same id.
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("No original request for navigation redirect: %s",
-      request_id.c_str());
-    return;
-  }
-
-  // A navigation redirect event is a new network request.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
-
-  // Package and emit a network request event.
-  // The request method is obtained from the saved request info.
-  base::DictionaryValue event;
-  event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
-  event.SetString("requestMethod", request_info->second.method);
-  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
-  event.SetString("requestCause", "document");
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkRequestDataFormEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  std::string request_id = *info.FindPath("requestId")->GetIfString();
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("Unknown request for request data: %s",
-      request_id.c_str());
-    return;
-  }
-
-  // If we're receiving a RequestData.Form event, all the
-  // request data is present and none should have been already received.
-  CHECK(request_info->second.request_data_sent == 0);
-
-  { // Send a "request-body" network request event.
-    base::DictionaryValue requestBodyEvent;
-    requestBodyEvent.SetString("kind", "request-body");
-
-    gCurrentNetworkRequestEvent = &requestBodyEvent;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  std::string stream_id = "request-" + request_id;
-
-  // Call StreamStart API.
-  recordreplay::OnNetworkStreamStart(
-    stream_id.c_str(), "request-data", request_id.c_str()
-  );
-
-  // Call StreamData API.
-  size_t length = *info.FindPath("dataLength")->GetIfDouble();
-
-  CHECK(length >= 0);
-  gCurrentNetworkStreamData->clear();
-  const std::string *data_base64 = info.FindPath("data")->GetIfString();
-  if (data_base64) {
-    const uint8_t* data =
-      reinterpret_cast<const uint8_t *>(data_base64->c_str());
-    gCurrentNetworkStreamData->insert(
-      gCurrentNetworkStreamData->begin(),
-      data,
-      data + data_base64->length()
-    );
-    size_t offset = request_info->second.response_data_received;
-    recordreplay::OnNetworkStreamData(
-      stream_id.c_str(), offset, length, /* bookmark = */ 0
-    );
-    gCurrentNetworkStreamData->clear();
-  }
-  request_info->second.request_data_sent += length;
-}
-
-static void HandleNetworkDidReceiveResponseEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  uint64_t identifier =
-    *info.FindPath("identifier")->GetIfDouble();
-  std::string request_id = MakeRequestIdentifier(identifier);
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("Unknown request received response: %s",
-      request_id.c_str());
-    return;
-  }
-
-  base::DictionaryValue event;
-  event.SetString("kind", "response");
-  event.Set("responseHeaders", std::unique_ptr<base::Value>(
-    info.FindPath("responseHeaders")->CreateDeepCopy()
-  ));
-  event.Set("responseProtocolVersion", std::unique_ptr<base::Value>(
-    info.FindPath("responseProtocolVersion")->CreateDeepCopy()
-  ));
-  event.Set("responseStatus", std::unique_ptr<base::Value>(
-    info.FindPath("responseStatus")->CreateDeepCopy()
-  ));
-  event.Set("responseStatusText", std::unique_ptr<base::Value>(
-    info.FindPath("responseStatusText")->CreateDeepCopy()
-  ));
-  event.Set("responseFromCache", std::unique_ptr<base::Value>(
-    info.FindPath("responseFromCache")->CreateDeepCopy()
-  ));
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkDidFinishLoadingEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  uint64_t identifier =
-    *info.FindPath("identifier")->GetIfDouble();
-  std::string request_id = MakeRequestIdentifier(identifier);
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("Unknown request finished loading: %s",
-      request_id.c_str());
-    return;
-  }
-
-  base::DictionaryValue event;
-  event.SetString("kind", "request-done");
-  event.Set("encodedBodySize", std::unique_ptr<base::Value>(
-    info.FindPath("encodedBodySize")->CreateDeepCopy()
-  ));
-  event.Set("decodedBodySize", std::unique_ptr<base::Value>(
-    info.FindPath("decodedBodySize")->CreateDeepCopy()
-  ));
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkDidFailLoadingEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  uint64_t identifier =
-    *info.FindPath("identifier")->GetIfDouble();
-  std::string request_id = MakeRequestIdentifier(identifier);
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("Unknown request failed loading: %s",
-      request_id.c_str());
-    return;
-  }
-
-  base::DictionaryValue event;
-  event.SetString("kind", "request-failed");
-  event.Set("requestFailedReason", std::unique_ptr<base::Value>(
-    info.FindPath("requestFailedReason")->CreateDeepCopy()
-  ));
-
-  gCurrentNetworkRequestEvent = &event;
-  recordreplay::OnNetworkRequestEvent(request_id.c_str());
-  gCurrentNetworkRequestEvent = nullptr;
-}
-
-static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) {
-  CHECK(gActiveNetworkRequests);
-  CHECK(gCurrentNetworkStreamData);
-  // Get request info.
-  uint64_t identifier =
-    *info.FindPath("identifier")->GetIfDouble();
-  std::string request_id = MakeRequestIdentifier(identifier);
-  auto request_info = gActiveNetworkRequests->find(request_id);
-  if (request_info == gActiveNetworkRequests->end()) {
-    recordreplay::Print("Unknown request received data: %s",
-      request_id.c_str());
-    return;
-  }
-
-  std::string stream_id = "response-" + request_id;
-
-  // The first byte of data received triggers a "response-body" event.
-  if (request_info->second.response_data_received == 0) {
+    // Package and emit a network request event with the appropriate info.
     base::DictionaryValue event;
-    event.SetString("kind", "response-body");
+    event.SetString("kind", "request");
+    event.Set("requestUrl", std::unique_ptr<base::Value>(
+                                info.FindPath("requestUrl")->CreateDeepCopy()));
+    event.SetString("requestMethod", request_method);
+    event.Set("requestHeaders",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("requestHeaders")->CreateDeepCopy()));
+    const base::Value* request_cause_value = info.FindPath("requestCause");
+    if (request_cause_value) {
+      event.Set("requestCause", std::unique_ptr<base::Value>(
+                                    request_cause_value->CreateDeepCopy()));
+    }
 
     gCurrentNetworkRequestEvent = &event;
     recordreplay::OnNetworkRequestEvent(request_id.c_str());
     gCurrentNetworkRequestEvent = nullptr;
-
-    recordreplay::OnNetworkStreamStart(
-      stream_id.c_str(), "response-data", request_id.c_str()
-    );
   }
 
-  // Sending stream data.
-  size_t length = *info.FindPath("dataLength")->GetIfDouble();
-  CHECK(length >= 0);
+  static void HandleNetworkResourceRedirectEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
 
-  gCurrentNetworkStreamData->clear();
-  const std::string *data_base64 = info.FindPath("data")->GetIfString();
-  if (data_base64) {
-    std::string out_string;
-    if (!base::Base64Decode(*data_base64, &out_string)) {
-      recordreplay::Print("Unknown request received data: %s",
-        request_id.c_str());
+    // Retreive the existing request data which should already have been
+    // registered by `HandleNetworkPrepareRequestEvent`.
+    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+    std::string request_id = MakeRequestIdentifier(identifier);
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("No original request for navigation redirect: %s",
+                          request_id.c_str());
       return;
     }
-    const uint8_t* data =
-      reinterpret_cast<const uint8_t *>(out_string.c_str());
-    gCurrentNetworkStreamData->insert(
-      gCurrentNetworkStreamData->begin(),
-      data,
-      data + out_string.length()
-    );
-    size_t offset = request_info->second.response_data_received;
-    recordreplay::OnNetworkStreamData(
-      stream_id.c_str(), offset, length, /* bookmark = */ 0
-    );
+
+    // Register a new network request with the same request id as the original
+    // for this redirect.
+    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                   request_info->second.bookmark);
+
+    // Package and emit a network request event.
+    // The request_method is obtained from the saved request info.
+    base::DictionaryValue event;
+    event.SetString("kind", "request");
+    event.Set("requestUrl", std::unique_ptr<base::Value>(
+                                info.FindPath("requestUrl")->CreateDeepCopy()));
+    event.SetString("requestMethod", request_info->second.method);
+    event.Set("requestHeaders",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("requestHeaders")->CreateDeepCopy()));
+    const base::Value* request_cause_value = info.FindPath("requestCause");
+    if (request_cause_value) {
+      event.Set("requestCause", std::unique_ptr<base::Value>(
+                                    request_cause_value->CreateDeepCopy()));
+    }
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+
+    // Navigation events are network requests that are not resource requests.
+    // They are directed here (the renderer process) from the content process.
+    // They have no associated bookmark, as we can't take bookmarks in the
+    // content process.
+
+    // Ensure that a request with the same ID has not already been registered.
+    std::string request_id = *info.FindPath("requestId")->GetIfString();
+    if (gActiveNetworkRequests->find(request_id) !=
+        gActiveNetworkRequests->end()) {
+      recordreplay::Print("Duplicate request id: %s", request_id.c_str());
+      return;
+    }
+    std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+    gActiveNetworkRequests->insert(
+        {request_id, NetworkRequestStatus(request_method)});
+
+    // A navigation event is a new network request, so call the
+    // `OnNetworkRequest` hook. Navigation events have no bookmarks associated
+    // with them.
+    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                   /* bookmark = */ 0);
+
+    // Package and emit a network request event.
+    base::DictionaryValue event;
+    event.SetString("kind", "request");
+    event.Set("requestUrl", std::unique_ptr<base::Value>(
+                                info.FindPath("requestUrl")->CreateDeepCopy()));
+    event.SetString("requestMethod", request_method);
+    event.Set("requestHeaders",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("requestHeaders")->CreateDeepCopy()));
+    event.SetString("requestCause", "document");
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkNavigationRedirectEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+
+    // Navigation redirect events are, as with navigation events, sent from
+    // the content process to the renderer process.
+
+    // Ensure that a request with the same ID has not already been registered.
+    std::string request_id = *info.FindPath("requestId")->GetIfString();
+    // This is a redirect, so an existing request should have been registered
+    // with the same id.
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("No original request for navigation redirect: %s",
+                          request_id.c_str());
+      return;
+    }
+
+    // A navigation redirect event is a new network request.
+    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                   request_info->second.bookmark);
+
+    // Package and emit a network request event.
+    // The request method is obtained from the saved request info.
+    base::DictionaryValue event;
+    event.SetString("kind", "request");
+    event.Set("requestUrl", std::unique_ptr<base::Value>(
+                                info.FindPath("requestUrl")->CreateDeepCopy()));
+    event.SetString("requestMethod", request_info->second.method);
+    event.Set("requestHeaders",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("requestHeaders")->CreateDeepCopy()));
+    event.SetString("requestCause", "document");
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkRequestDataFormEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    std::string request_id = *info.FindPath("requestId")->GetIfString();
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("Unknown request for request data: %s",
+                          request_id.c_str());
+      return;
+    }
+
+    // If we're receiving a RequestData.Form event, all the
+    // request data is present and none should have been already received.
+    CHECK(request_info->second.request_data_sent == 0);
+
+    {  // Send a "request-body" network request event.
+      base::DictionaryValue requestBodyEvent;
+      requestBodyEvent.SetString("kind", "request-body");
+
+      gCurrentNetworkRequestEvent = &requestBodyEvent;
+      recordreplay::OnNetworkRequestEvent(request_id.c_str());
+      gCurrentNetworkRequestEvent = nullptr;
+    }
+
+    std::string stream_id = "request-" + request_id;
+
+    // Call StreamStart API.
+    recordreplay::OnNetworkStreamStart(stream_id.c_str(), "request-data",
+                                       request_id.c_str());
+
+    // Call StreamData API.
+    size_t length = *info.FindPath("dataLength")->GetIfDouble();
+
+    CHECK(length >= 0);
     gCurrentNetworkStreamData->clear();
+    const std::string* data_base64 = info.FindPath("data")->GetIfString();
+    if (data_base64) {
+      const uint8_t* data =
+          reinterpret_cast<const uint8_t*>(data_base64->c_str());
+      gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
+                                        data, data + data_base64->length());
+      size_t offset = request_info->second.response_data_received;
+      recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
+                                        /* bookmark = */ 0);
+      gCurrentNetworkStreamData->clear();
+    }
+    request_info->second.request_data_sent += length;
   }
-  request_info->second.response_data_received += length;
-}
 
-/** ###########################################################################
- * blink (DOM, CSS etc.)
- * @see https://static.replay.io/protocol/tot/DOM/
- * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
- * ##########################################################################*/
-
-static bool checkCDPResponse(const char* label,
-                             const protocol::Response& response,
-                             const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (!response.IsSuccess()) {
-    recordreplay::Print(
-        "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s",
-        label,
-        response.Code(),
-        response.Message().c_str());
-
-    // result is null
-    args.GetReturnValue().SetNull();
-    return false;
-  }
-  return true;
-}
-
-static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "[RuntimeError] must be called with a single string");
-
-  v8::Isolate* isolate = args.GetIsolate();
-
-  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
-  // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
-  v8::String::Utf8Value cdpId(isolate, args[0]);
-  const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
-  v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
-
-  v8::Local<v8::Object> nodeObj;
-  if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
-    Node* node = V8Node::ToImpl(nodeObj);
-    if (node) {
-      // hackfix: bind node here
-      //   (if the DOMAgent was enabled, it would track nodes automatically)
-      int nodeId = domAgent->BindDocumentNode(node);
-      args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
+  static void HandleNetworkDidReceiveResponseEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+    std::string request_id = MakeRequestIdentifier(identifier);
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("Unknown request received response: %s",
+                          request_id.c_str());
       return;
+    }
+
+    base::DictionaryValue event;
+    event.SetString("kind", "response");
+    event.Set("responseHeaders",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("responseHeaders")->CreateDeepCopy()));
+    event.Set("responseProtocolVersion",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("responseProtocolVersion")->CreateDeepCopy()));
+    event.Set("responseStatus",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("responseStatus")->CreateDeepCopy()));
+    event.Set("responseStatusText",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("responseStatusText")->CreateDeepCopy()));
+    event.Set("responseFromCache",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("responseFromCache")->CreateDeepCopy()));
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkDidFinishLoadingEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+    std::string request_id = MakeRequestIdentifier(identifier);
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("Unknown request finished loading: %s",
+                          request_id.c_str());
+      return;
+    }
+
+    base::DictionaryValue event;
+    event.SetString("kind", "request-done");
+    event.Set("encodedBodySize",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("encodedBodySize")->CreateDeepCopy()));
+    event.Set("decodedBodySize",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("decodedBodySize")->CreateDeepCopy()));
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkDidFailLoadingEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+    std::string request_id = MakeRequestIdentifier(identifier);
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("Unknown request failed loading: %s",
+                          request_id.c_str());
+      return;
+    }
+
+    base::DictionaryValue event;
+    event.SetString("kind", "request-failed");
+    event.Set("requestFailedReason",
+              std::unique_ptr<base::Value>(
+                  info.FindPath("requestFailedReason")->CreateDeepCopy()));
+
+    gCurrentNetworkRequestEvent = &event;
+    recordreplay::OnNetworkRequestEvent(request_id.c_str());
+    gCurrentNetworkRequestEvent = nullptr;
+  }
+
+  static void HandleNetworkDidReceiveDataEvent(
+      const base::DictionaryValue& info) {
+    CHECK(gActiveNetworkRequests);
+    CHECK(gCurrentNetworkStreamData);
+    // Get request info.
+    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+    std::string request_id = MakeRequestIdentifier(identifier);
+    auto request_info = gActiveNetworkRequests->find(request_id);
+    if (request_info == gActiveNetworkRequests->end()) {
+      recordreplay::Print("Unknown request received data: %s",
+                          request_id.c_str());
+      return;
+    }
+
+    std::string stream_id = "response-" + request_id;
+
+    // The first byte of data received triggers a "response-body" event.
+    if (request_info->second.response_data_received == 0) {
+      base::DictionaryValue event;
+      event.SetString("kind", "response-body");
+
+      gCurrentNetworkRequestEvent = &event;
+      recordreplay::OnNetworkRequestEvent(request_id.c_str());
+      gCurrentNetworkRequestEvent = nullptr;
+
+      recordreplay::OnNetworkStreamStart(stream_id.c_str(), "response-data",
+                                         request_id.c_str());
+    }
+
+    // Sending stream data.
+    size_t length = *info.FindPath("dataLength")->GetIfDouble();
+    CHECK(length >= 0);
+
+    gCurrentNetworkStreamData->clear();
+    const std::string* data_base64 = info.FindPath("data")->GetIfString();
+    if (data_base64) {
+      std::string out_string;
+      if (!base::Base64Decode(*data_base64, &out_string)) {
+        recordreplay::Print("Unknown request received data: %s",
+                            request_id.c_str());
+        return;
+      }
+      const uint8_t* data =
+          reinterpret_cast<const uint8_t*>(out_string.c_str());
+      gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
+                                        data, data + out_string.length());
+      size_t offset = request_info->second.response_data_received;
+      recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
+                                        /* bookmark = */ 0);
+      gCurrentNetworkStreamData->clear();
+    }
+    request_info->second.response_data_received += length;
+  }
+
+  /** ###########################################################################
+   * blink (DOM, CSS etc.)
+   * @see https://static.replay.io/protocol/tot/DOM/
+   * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
+   * ##########################################################################*/
+
+  static bool checkCDPResponse(
+      const char* label, const protocol::Response& response,
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    if (!response.IsSuccess()) {
+      recordreplay::Print(
+          "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s", label,
+          response.Code(), response.Message().c_str());
+
+      // result is null
+      args.GetReturnValue().SetNull();
+      return false;
+    }
+    return true;
+  }
+
+  static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(args.Length() == 1 && args[0]->IsString() &&
+          "[RuntimeError] must be called with a single string");
+
+    v8::Isolate* isolate = args.GetIsolate();
+
+    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+    // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
+    v8::String::Utf8Value cdpId(isolate, args[0]);
+    const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
+    v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
+
+    v8::Local<v8::Object> nodeObj;
+    if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
+      Node* node = V8Node::ToImpl(nodeObj);
+      if (node) {
+        // hackfix: bind node here
+        //   (if the DOMAgent was enabled, it would track nodes automatically)
+        int nodeId = domAgent->BindDocumentNode(node);
+        args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
+        return;
+      } else {
+        recordreplay::Print(
+            "[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
+      }
+    } else { /* already reported */
+    }
+
+    // auto response = domAgent->requestNode(cdpId, &nodeId);
+    args.GetReturnValue().SetNull();
+  }
+
+  static void fromJsGetBoxModel(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(args.Length() == 1 && args[0]->IsNumber() &&
+          "[RuntimeError] must be called with a single number");
+
+    v8::Isolate* isolate = args.GetIsolate();
+    auto nodeId = (int)args[0].As<v8::Integer>()->Value();
+
+    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+    int backend_node_id = 0;
+    String object_id;
+    std::unique_ptr<protocol::DOM::BoxModel> boxModel;
+    auto response =
+        domAgent->getBoxModel(nodeId, backend_node_id, object_id, &boxModel);
+
+    if (!response.IsSuccess()) {
+      recordreplay::Print(
+          "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, "
+          "Code: "
+          "%d): %s",
+          nodeId, response.Code(), response.Message().c_str());
     } else {
-      recordreplay::Print("[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
-    }
-  } else { /* already reported */
-  }
-
-  // auto response = domAgent->requestNode(cdpId, &nodeId);
-  args.GetReturnValue().SetNull();
-}
-
-
-static void fromJsGetBoxModel(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsNumber() &&
-        "[RuntimeError] must be called with a single number");
-
-  v8::Isolate* isolate = args.GetIsolate();
-  auto nodeId = (int)args[0].As<v8::Integer>()->Value();
-
-  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
-  int backend_node_id = 0;
-  String object_id;
-  std::unique_ptr<protocol::DOM::BoxModel> boxModel;
-  auto response =
-      domAgent->getBoxModel(nodeId, backend_node_id, object_id, &boxModel);
-
-  if (!response.IsSuccess()) {
-    recordreplay::Print(
-        "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, Code: "
-        "%d): %s",
-        nodeId, response.Code(), response.Message().c_str());
-  } else {
-    auto result = convertCborToJS(isolate, boxModel.get());
-    if (!result.IsEmpty()) {
-      args.GetReturnValue().Set(result.ToLocalChecked());
-      return;
-    }
-  }
-
-  args.GetReturnValue().SetNull();
-}
-
-
-static void fromJsGetMatchedStylesForNode(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsNumber() &&
-        "[RuntimeError] must be called with a single number");
-
-  v8::Isolate* isolate = args.GetIsolate();
-  auto nodeId = (int)args[0].As<v8::Integer>()->Value();
-
-  auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
-
-  Maybe<protocol::CSS::CSSStyle> inlineStyle;
-  Maybe<protocol::CSS::CSSStyle> attributesStyle;
-  Maybe<protocol::Array<protocol::CSS::RuleMatch>> matchedRules;
-  Maybe<protocol::Array<protocol::CSS::PseudoElementMatches>> pseudoIdMatches;
-  Maybe<protocol::Array<protocol::CSS::InheritedStyleEntry>> inheritedEntries;
-  Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>> keyframesRules;
-
-  auto response = cssAgent->getMatchedStylesForNode(
-      nodeId, &inlineStyle, &attributesStyle, &matchedRules,
-      &pseudoIdMatches, &inheritedEntries, nullptr, &keyframesRules, nullptr);
-
-  // WIP: will fix everything up and clean up when done w/ RUN-981
-
-  if (!response.IsSuccess()) {
-    recordreplay::Print(
-        "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, Code: "
-        "%d): %s",
-        nodeId, response.Code(), response.Message().c_str());
-    args.GetReturnValue().SetNull();
-  } else {
-    v8::Local<v8::Object> result = v8::Object::New(isolate);
-    // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
-    if (attributesStyle.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
-      if (!rulesJs.IsEmpty()) {
-        SetDataProperty(isolate, result, "attributesStyle",
-                        rulesJs.ToLocalChecked());
+      auto result = convertCborToJS(isolate, boxModel.get());
+      if (!result.IsEmpty()) {
+        args.GetReturnValue().Set(result.ToLocalChecked());
+        return;
       }
     }
-    if (matchedRules.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
-      SetDataProperty(isolate, result, "matchedRules", rulesJs);
+
+    args.GetReturnValue().SetNull();
+  }
+
+  static void fromJsGetMatchedStylesForNode(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(args.Length() == 1 && args[0]->IsNumber() &&
+          "[RuntimeError] must be called with a single number");
+
+    v8::Isolate* isolate = args.GetIsolate();
+    auto nodeId = (int)args[0].As<v8::Integer>()->Value();
+
+    auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
+
+    Maybe<protocol::CSS::CSSStyle> inlineStyle;
+    Maybe<protocol::CSS::CSSStyle> attributesStyle;
+    Maybe<protocol::Array<protocol::CSS::RuleMatch>> matchedRules;
+    Maybe<protocol::Array<protocol::CSS::PseudoElementMatches>> pseudoIdMatches;
+    Maybe<protocol::Array<protocol::CSS::InheritedStyleEntry>> inheritedEntries;
+    Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>> keyframesRules;
+
+    auto response = cssAgent->getMatchedStylesForNode(
+        nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
+        &inheritedEntries, nullptr, &keyframesRules, nullptr);
+
+    // WIP: will fix everything up and clean up when done w/ RUN-981
+
+    if (!response.IsSuccess()) {
+      recordreplay::Print(
+          "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, "
+          "Code: "
+          "%d): %s",
+          nodeId, response.Code(), response.Message().c_str());
+      args.GetReturnValue().SetNull();
+    } else {
+      v8::Local<v8::Object> result = v8::Object::New(isolate);
+      // NOTE: not sure what `attributesStyle` is and how its different from
+      // `inlineStyle`?
+      if (attributesStyle.isJust()) {
+        auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
+        if (!rulesJs.IsEmpty()) {
+          SetDataProperty(isolate, result, "attributesStyle",
+                          rulesJs.ToLocalChecked());
+        }
+      }
+      if (matchedRules.isJust()) {
+        auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
+        SetDataProperty(isolate, result, "matchedRules", rulesJs);
+      }
+      if (pseudoIdMatches.isJust()) {
+        auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
+        SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
+      }
+      if (inheritedEntries.isJust()) {
+        auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
+        SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
+      }
+      if (keyframesRules.isJust()) {
+        auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
+        SetDataProperty(isolate, result, "keyframesRules", rulesJs);
+      }
+      args.GetReturnValue().Set(result);
     }
-    if (pseudoIdMatches.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
-      SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
+  }
+
+  static void fromJsCssGetStylesheetByCpdId(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(args.Length() == 1 && args[0]->IsString() &&
+          "[RuntimeError] must be called with a single string");
+
+    v8::Isolate* isolate = args.GetIsolate();
+
+    auto sheetId = ToCoreString(args[0].As<v8::String>());
+    auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
+
+    CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
+    v8::Local<v8::Value> v8StyleSheet;
+    if (styleSheet && getV8FromBlinkObject(isolate, styleSheet, v8StyleSheet)) {
+      args.GetReturnValue().Set(v8StyleSheet);
+    } else {
+      args.GetReturnValue().SetNull();
     }
-    if (inheritedEntries.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
-      SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
+  }
+
+  static void fromJsDomPerformSearch(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(args.Length() == 1 && args[0]->IsString() &&
+          "[RuntimeError] must be called with a single string");
+
+    v8::Isolate* isolate = args.GetIsolate();
+
+    auto query = ToCoreString(args[0].As<v8::String>());
+    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+    bool includeUserAgentShadowDom = true;
+    String searchId;
+    int resultCount;
+    auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
+                                            &searchId, &resultCount);
+    if (checkCDPResponse("DOM.performSearch", response, args)) {
+      if (resultCount) {
+        int fromIndex = 0;
+        int toIndex = resultCount;
+        std::unique_ptr<protocol::Array<int>> nodeIds;
+        response =
+            domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
+        if (checkCDPResponse("DOM.getSearchResults", response, args)) {
+          v8::Local<v8::Array> result = v8::Array::New(isolate);
+          uint32_t nWritten = 0;
+          for (uint32_t i = 0; i < nodeIds->size(); ++i) {
+            int nodeId = (*nodeIds)[i];
+            auto* node = domAgent->NodeForId(nodeId);
+            v8::Local<v8::Value> v8Node;
+            if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
+              v8::Local<v8::Context> context = isolate->GetCurrentContext();
+              result->Set(context, nWritten++, v8Node).Check();
+            }
+          }
+          args.GetReturnValue().Set(result);
+        }
+      } else {
+        v8::Local<v8::Array> result = v8::Array::New(isolate);
+        args.GetReturnValue().Set(result);
+      }
+
+      // clean up
+      domAgent->discardSearchResults(searchId);
     }
-    if (keyframesRules.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
-      SetDataProperty(isolate, result, "keyframesRules", rulesJs);
+  }
+
+  static void fromJsCollectEventListeners(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    CHECK(
+        args.Length() == 1 && args[0]->IsObject() &&
+        "[RuntimeError] must be called with a single plain object (DOM node)");
+
+    v8::Isolate* isolate = args.GetIsolate();
+    auto context = isolate->GetCurrentContext();
+    auto nodeObject = args[0].As<v8::Object>();
+    auto* node = V8Node::ToImpl(nodeObject);
+
+    v8::Local<v8::Array> result = v8::Array::New(isolate);
+    if (!node) {
+      recordreplay::Print(
+          "[RuntimeError] fromJsCollectEventListeners invalid argument is not "
+          "blink Node");
+    } else {
+      auto report_for_all_contexts = true;
+      V8EventListenerInfoList eventListenerInfos;
+      InspectorDOMDebuggerAgent::CollectEventListeners(
+          isolate, node, nodeObject, node, report_for_all_contexts,
+          &eventListenerInfos);
+
+      uint32_t i = 0;
+      for (const auto& info : eventListenerInfos) {
+        auto v8Info = v8::Object::New(isolate);
+        SetDataProperty(isolate, v8Info, "type",
+                        V8String(isolate, info.event_type));
+        SetDataProperty(isolate, v8Info, "capture",
+                        v8::Boolean::New(isolate, info.use_capture));
+        SetDataProperty(isolate, v8Info, "handler", info.effective_function);
+        result->Set(context, i++, v8Info).Check();
+      }
     }
     args.GetReturnValue().Set(result);
   }
-}
 
- 
-static void fromJsCssGetStylesheetByCpdId(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "[RuntimeError] must be called with a single string");
+  /** ###########################################################################
+   * misc
+   * ##########################################################################*/
 
-  v8::Isolate* isolate = args.GetIsolate();
-
-  auto sheetId = ToCoreString(args[0].As<v8::String>());
-  auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
-
-  CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
-  v8::Local<v8::Value> v8StyleSheet;
-  if (styleSheet && getV8FromBlinkObject(isolate, styleSheet, v8StyleSheet)) {
-    args.GetReturnValue().Set(v8StyleSheet);
-  } else {
-    args.GetReturnValue().SetNull();
-  }
-}
-
-static void fromJsDomPerformSearch(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "[RuntimeError] must be called with a single string");
-
-  v8::Isolate* isolate = args.GetIsolate();
-
-  auto query = ToCoreString(args[0].As<v8::String>());
-  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
-  bool includeUserAgentShadowDom = true;
-  String searchId;
-  int resultCount;
-  auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
-                                          &searchId, &resultCount);
-  if (checkCDPResponse("DOM.performSearch", response, args)) {
-    if (resultCount) {
-      int fromIndex = 0;
-      int toIndex = resultCount;
-      std::unique_ptr<protocol::Array<int>> nodeIds;
-      response =
-          domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
-      if (checkCDPResponse("DOM.getSearchResults", response, args)) {
-        v8::Local<v8::Array> result = v8::Array::New(isolate);
-        uint32_t nWritten = 0;
-        for (uint32_t i = 0; i < nodeIds->size(); ++i) {
-          int nodeId = (*nodeIds)[i];
-          auto* node = domAgent->NodeForId(nodeId);
-          v8::Local<v8::Value> v8Node;
-          if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
-            v8::Local<v8::Context> context = isolate->GetCurrentContext();
-            result->Set(context, nWritten++, v8Node).Check();
-          }
-        }
-        args.GetReturnValue().Set(result);
-      }
+  // Handle incoming browser events.
+  static void HandleBrowserEvent(const char* name, const char* payload) {
+    base::Value val = base::JSONReader::Read(payload).value_or(base::Value());
+    assert(!val.is_none() && "Browser event JSON failed");
+    assert(!val.is_dict() && "Browser event JSON is not a dictionary");
+    if (!strcmp(name, "Network.PrepareRequest")) {
+      HandleNetworkPrepareRequestEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.ResourceRedirect")) {
+      HandleNetworkResourceRedirectEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.RequestData.Form")) {
+      HandleNetworkRequestDataFormEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.DidReceiveResponse")) {
+      HandleNetworkDidReceiveResponseEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.DidFinishLoading")) {
+      HandleNetworkDidFinishLoadingEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.DidFailLoading")) {
+      HandleNetworkDidFailLoadingEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.DidReceiveData")) {
+      HandleNetworkDidReceiveDataEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.Navigation")) {
+      HandleNetworkNavigationEvent(base::Value::AsDictionaryValue(val));
+    } else if (!strcmp(name, "Network.NavigationRedirect")) {
+      HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
     } else {
-      v8::Local<v8::Array> result = v8::Array::New(isolate);
-      args.GetReturnValue().Set(result);
-    }
-
-    // clean up
-    domAgent->discardSearchResults(searchId);
-  }
-}
-
-static void fromJsCollectEventListeners(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsObject() &&
-        "[RuntimeError] must be called with a single plain object (DOM node)");
-
-  v8::Isolate* isolate = args.GetIsolate();
-  auto context = isolate->GetCurrentContext();
-  auto nodeObject = args[0].As<v8::Object>();
-  auto* node = V8Node::ToImpl(nodeObject);
-
-  v8::Local<v8::Array> result = v8::Array::New(isolate);
-  if (!node) {
-    recordreplay::Print("[RuntimeError] fromJsCollectEventListeners invalid argument is not blink Node");
-  }
-  else {
-    auto report_for_all_contexts = true;
-    V8EventListenerInfoList eventListenerInfos;
-    InspectorDOMDebuggerAgent::CollectEventListeners(
-        isolate, node, nodeObject, node, report_for_all_contexts,
-        &eventListenerInfos);
-
-    uint32_t i = 0;
-    for (const auto& info : eventListenerInfos) {
-      auto v8Info = v8::Object::New(isolate);
-      SetDataProperty(isolate, v8Info, "type",
-                      V8String(isolate, info.event_type));
-      SetDataProperty(isolate, v8Info, "capture",
-                      v8::Boolean::New(isolate, info.use_capture));
-      SetDataProperty(isolate, v8Info, "handler", info.effective_function);
-      result->Set(context, i++, v8Info).Check();
+      recordreplay::Print("HandleBrowserEvent received unrecognized event %s",
+                          name);
     }
   }
-  args.GetReturnValue().Set(result);
-}
 
-/** ###########################################################################
- * misc
- * ##########################################################################*/
+  // Called from page page javascript.
+  // `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
+  // Since this function is called from userland JS, we avoid assertions.
+  // We don't want flawed uses of the API to crash the recording.
+  static void InvokeOnAnnotation(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    if (!(args.Length() >= 2 && args[0]->IsString())) {
+      recordreplay::Print("%s called with incorrect arguments",
+                          AnnotationHookJSName);
+      return;
+    }
 
-// Handle incoming browser events.
-static void HandleBrowserEvent(const char* name, const char* payload) {
-  base::Value val = base::JSONReader::Read(payload).value_or(base::Value());
-  assert(!val.is_none() && "Browser event JSON failed");
-  assert(!val.is_dict() && "Browser event JSON is not a dictionary");
-  if (!strcmp(name, "Network.PrepareRequest")) {
-    HandleNetworkPrepareRequestEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.ResourceRedirect")) {
-    HandleNetworkResourceRedirectEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.RequestData.Form")) {
-    HandleNetworkRequestDataFormEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.DidReceiveResponse")) {
-    HandleNetworkDidReceiveResponseEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.DidFinishLoading")) {
-    HandleNetworkDidFinishLoadingEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.DidFailLoading")) {
-    HandleNetworkDidFailLoadingEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.DidReceiveData")) {
-    HandleNetworkDidReceiveDataEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.Navigation")) {
-    HandleNetworkNavigationEvent(base::Value::AsDictionaryValue(val));
-  } else if (!strcmp(name, "Network.NavigationRedirect")) {
-    HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
-  } else {
-    recordreplay::Print("HandleBrowserEvent received unrecognized event %s", name);
-  }
-}
+    v8::Isolate* isolate = args.GetIsolate();
+    v8::Local<v8::Object> payload = v8::Object::New(isolate);
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    payload->Set(context, ToV8String(isolate, "message"), args[1]).Check();
 
-// Called from page page javascript.
-// `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
-// Since this function is called from userland JS, we avoid assertions.
-// We don't want flawed uses of the API to crash the recording.
-static void InvokeOnAnnotation(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (! (args.Length() >= 2 && args[0]->IsString())) {
-    recordreplay::Print("%s called with incorrect arguments",
-      AnnotationHookJSName);
-    return;
+    v8::Local<v8::String> json;
+    if (!v8::JSON::Stringify(context, payload).ToLocal(&json)) {
+      recordreplay::Print("%s contents failed to json stringify",
+                          AnnotationHookJSName);
+      return;
+    }
+
+    v8::String::Utf8Value kind(args.GetIsolate(), args[0]);
+    v8::String::Utf8Value contents(args.GetIsolate(), json);
+    recordreplay::OnAnnotation(*kind, *contents);
   }
 
-  v8::Isolate* isolate = args.GetIsolate();
-  v8::Local<v8::Object> payload = v8::Object::New(isolate);
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  payload->Set(context, ToV8String(isolate, "message"), args[1]).Check();
+  extern "C" void V8RecordReplaySetAPIObjectIdCallback(
+      int (*callback)(v8::Local<v8::Object>));
+  extern "C" void V8RecordReplayRegisterBrowserEventCallback(
+      void (*callback)(const char* name, const char* payload));
 
-  v8::Local<v8::String> json;
-  if (!v8::JSON::Stringify(context, payload).ToLocal(&json)) {
-    recordreplay::Print("%s contents failed to json stringify",
-      AnnotationHookJSName);
-    return;
+  static void RunScript(v8::Isolate * isolate, v8::Local<v8::Context> context,
+                        const char* script, const char* filename) {
+    v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
+    v8::ScriptOrigin origin(isolate, filename_string);
+
+    v8::Local<v8::String> source = ToV8String(isolate, script);
+
+    // TODO: check for errors after `Compile` and `Run` -
+    // https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
+    v8::Local<v8::Script> compiled =
+        v8::Script::Compile(context, source, &origin).ToLocalChecked();
+    compiled->Run(context).ToLocalChecked();
   }
 
-  v8::String::Utf8Value kind(args.GetIsolate(), args[0]);
-  v8::String::Utf8Value contents(args.GetIsolate(), json);
-  recordreplay::OnAnnotation(*kind, *contents);
-}
-
-extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
-extern "C" void V8RecordReplayRegisterBrowserEventCallback(
-  void (*callback)(const char* name, const char* payload)
-);
-
-static void RunScript(v8::Isolate* isolate, v8::Local<v8::Context> context, const char* script, const char* filename) {
-  v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
-  v8::ScriptOrigin origin(isolate, filename_string);
-
-  v8::Local<v8::String> source = ToV8String(isolate, script);
-
-  // TODO: check for errors after `Compile` and `Run` - https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
-  v8::Local<v8::Script> compiled = v8::Script::Compile(context, source, &origin).ToLocalChecked();
-  compiled->Run(context).ToLocalChecked();
-}
-
-static bool TestEnv(const char* env) {
-  const char* v = getenv(env);
-  return v && v[0] && v[0] != '0';
-}
-
-
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
-  V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
-  V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
-
-  gLocalFrame = localFrame;
-
-  gActiveNetworkRequests =
-      new std::unordered_map<std::string, NetworkRequestStatus>();
-  gCurrentNetworkStreamData = new std::vector<uint8_t>();
-
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-
-  // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
-  // the page window global.
-  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
-                      InvokeOnAnnotation);
-
-  v8::Local<v8::Object> args = v8::Object::New(isolate);
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__", args);
-
-  SetFunctionProperty(isolate, args, "log",
-                      LogCallback);
-
-  // CDP debugger functionality
-  SetFunctionProperty(isolate, args, "setCDPMessageCallback",
-                      SetCDPMessageCallback);
-  SetFunctionProperty(isolate, args, "sendCDPMessage",
-                      SendCDPMessage);
-  SetFunctionProperty(isolate, args, "setCommandCallback",
-                      v8::FunctionCallbackRecordReplaySetCommandCallback);
-
-  // Object Management
-  SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
-                      fromJsMakeDebuggeeValue);
-  SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
-                      fromJsGetObjectByCdpId);
-
-  // networking
-  SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
-                      GetCurrentNetworkRequestEvent);
-  SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
-                      GetCurrentNetworkStreamData);
-
-  // DOM, blink, API stuff
-  // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
-  //                     jsGetObjectIdForAnyObject);
-  // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
-  // jsPreviewBlinkObjectForObjectId);
-  SetFunctionProperty(isolate, args, "fromJsGetNodeId", fromJsGetNodeId);
-  SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
-  SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForNode",
-                      fromJsGetMatchedStylesForNode);
-  SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
-                      fromJsCssGetStylesheetByCpdId);
-  SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
-                      fromJsCollectEventListeners);
-  SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
-                      fromJsDomPerformSearch);
-
-  // unsorted RR stuff
-  SetFunctionProperty(
-      isolate, args, "setClearPauseDataCallback",
-      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-  SetFunctionProperty(isolate, args, "getCurrentError",
-                      GetCurrentError);
-  SetFunctionProperty(isolate, args, "getRecordingId",
-                      GetRecordingId);
-  SetFunctionProperty(isolate, args, "sha256DigestHex",
-                      SHA256DigestHex);
-  SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
-                      WriteToRecordingDirectory);
-  SetFunctionProperty(isolate, args, "addRecordingEvent",
-                      AddRecordingEvent);
-  SetFunctionProperty(isolate, args, "addNewScriptHandler",
-                      v8::FunctionCallbackRecordReplayAddNewScriptHandler);
-  SetFunctionProperty(isolate, args, "getScriptSource",
-                      v8::FunctionCallbackRecordReplayGetScriptSource);
-  SetFunctionProperty(isolate, args, "getPersistentId",
-                      GetPersistentId);
-  SetFunctionProperty(isolate, args, "checkPersistentId",
-                      CheckPersistentId);
-
-  // This URL will prevent the script from being reported to the recorder.
-  const char* InternalScriptURL = "record-replay-internal";
-
-  if (recordreplay::FeatureEnabled("collect-source-maps") &&
-      !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
-    RunScript(isolate, context, gSourceMapScript, InternalScriptURL);
+  static bool TestEnv(const char* env) {
+    const char* v = getenv(env);
+    return v && v[0] && v[0] != '0';
   }
 
-  if (recordreplay::IsReplaying()) {
-    recordreplay::AutoDisallowEvents disallow;
-    RunScript(isolate, context, gReplayScript, InternalScriptURL);
+  void SetupRecordReplayCommands(v8::Isolate * isolate,
+                                 LocalFrame * localFrame) {
+    V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
+    V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
-    // initialize InspectorDOMDebuggerAgent, so it can pick up user events
-    getOrCreateInspectorDOMDebuggerAgent(isolate);
+    gLocalFrame = localFrame;
+
+    gActiveNetworkRequests =
+        new std::unordered_map<std::string, NetworkRequestStatus>();
+    gCurrentNetworkStreamData = new std::vector<uint8_t>();
+
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+    // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
+    // the page window global.
+    SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
+                        InvokeOnAnnotation);
+
+    v8::Local<v8::Object> args = v8::Object::New(isolate);
+    DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
+                   args);
+
+    SetFunctionProperty(isolate, args, "log", LogCallback);
+
+    // CDP debugger functionality
+    SetFunctionProperty(isolate, args, "setCDPMessageCallback",
+                        SetCDPMessageCallback);
+    SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
+    SetFunctionProperty(isolate, args, "setCommandCallback",
+                        v8::FunctionCallbackRecordReplaySetCommandCallback);
+
+    // Object Management
+    SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
+                        fromJsMakeDebuggeeValue);
+    SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
+                        fromJsGetArgumentsInFrame);
+    SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
+                        fromJsGetObjectByCdpId);
+
+    // networking
+    SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
+                        GetCurrentNetworkRequestEvent);
+    SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
+                        GetCurrentNetworkStreamData);
+
+    // DOM, blink, API stuff
+    // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
+    //                     jsGetObjectIdForAnyObject);
+    // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
+    // jsPreviewBlinkObjectForObjectId);
+    SetFunctionProperty(isolate, args, "fromJsGetNodeId", fromJsGetNodeId);
+    SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
+    SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForNode",
+                        fromJsGetMatchedStylesForNode);
+    SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
+                        fromJsCssGetStylesheetByCpdId);
+    SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
+                        fromJsCollectEventListeners);
+    SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
+                        fromJsDomPerformSearch);
+
+    // unsorted RR stuff
+    SetFunctionProperty(
+        isolate, args, "setClearPauseDataCallback",
+        v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+    SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
+    SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
+    SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
+    SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
+                        WriteToRecordingDirectory);
+    SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
+    SetFunctionProperty(isolate, args, "addNewScriptHandler",
+                        v8::FunctionCallbackRecordReplayAddNewScriptHandler);
+    SetFunctionProperty(isolate, args, "getScriptSource",
+                        v8::FunctionCallbackRecordReplayGetScriptSource);
+    SetFunctionProperty(isolate, args, "getPersistentId", GetPersistentId);
+    SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
+
+    // This URL will prevent the script from being reported to the recorder.
+    const char* InternalScriptURL = "record-replay-internal";
+
+    if (recordreplay::FeatureEnabled("collect-source-maps") &&
+        !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
+      RunScript(isolate, context, gSourceMapScript, InternalScriptURL);
+    }
+
+    if (recordreplay::IsReplaying()) {
+      recordreplay::AutoDisallowEvents disallow;
+      RunScript(isolate, context, gReplayScript, InternalScriptURL);
+
+      // initialize InspectorDOMDebuggerAgent, so it can pick up user events
+      getOrCreateInspectorDOMDebuggerAgent(isolate);
+    }
   }
-}
 
-void RunInitialRecordReplayScripts(v8::Isolate* isolate) {
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  void RunInitialRecordReplayScripts(v8::Isolate * isolate) {
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  if (recordreplay::FeatureEnabled("react-devtools-backend") &&
-      !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
-    // Note: We use a special URL for the react devtools as this script needs
-    // to be reported to the recorder so that evaluations can be performed in
-    // its frames.
-    RunScript(isolate, context, gReactDevtoolsScript, "record-replay-react-devtools");
-  }
-}
-
-extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
-
-static ErrorEvent* gCurrentErrorEvent;
-
-void RecordReplayOnErrorEvent(ErrorEvent* error_event) {
-  if (!v8::IsMainThread()) {
-    return;
+    if (recordreplay::FeatureEnabled("react-devtools-backend") &&
+        !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
+      // Note: We use a special URL for the react devtools as this script needs
+      // to be reported to the recorder so that evaluations can be performed in
+      // its frames.
+      RunScript(isolate, context, gReactDevtoolsScript,
+                "record-replay-react-devtools");
+    }
   }
 
-  CHECK(!gCurrentErrorEvent);
-  gCurrentErrorEvent = error_event;
+  extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
 
-  size_t bookmark = error_event->record_replay_bookmark();
-  V8RecordReplayOnConsoleMessage(bookmark);
+  static ErrorEvent* gCurrentErrorEvent;
 
-  gCurrentErrorEvent = nullptr;
-}
+  void RecordReplayOnErrorEvent(ErrorEvent * error_event) {
+    if (!v8::IsMainThread()) {
+      return;
+    }
 
-static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (!gCurrentErrorEvent) {
-    return;
+    CHECK(!gCurrentErrorEvent);
+    gCurrentErrorEvent = error_event;
+
+    size_t bookmark = error_event->record_replay_bookmark();
+    V8RecordReplayOnConsoleMessage(bookmark);
+
+    gCurrentErrorEvent = nullptr;
   }
 
-  v8::Isolate* isolate = args.GetIsolate();
-  v8::Local<v8::Object> rv = v8::Object::New(isolate);
+  static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    if (!gCurrentErrorEvent) {
+      return;
+    }
 
-  SetDataProperty(isolate, rv, "message",
-                  ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
-  SetDataProperty(isolate, rv, "filename",
-                  ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
-  SetDataProperty(isolate, rv, "line", v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
-  SetDataProperty(isolate, rv, "column", v8::Number::New(isolate, gCurrentErrorEvent->colno()));
-  SetDataProperty(isolate, rv, "scriptId",
-                  v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
+    v8::Isolate* isolate = args.GetIsolate();
+    v8::Local<v8::Object> rv = v8::Object::New(isolate);
 
-  args.GetReturnValue().Set(rv);
-}
+    SetDataProperty(
+        isolate, rv, "message",
+        ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
+    SetDataProperty(
+        isolate, rv, "filename",
+        ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
+    SetDataProperty(isolate, rv, "line",
+                    v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
+    SetDataProperty(isolate, rv, "column",
+                    v8::Number::New(isolate, gCurrentErrorEvent->colno()));
+    SetDataProperty(
+        isolate, rv, "scriptId",
+        v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
+
+    args.GetReturnValue().Set(rv);
+  }
 
 }  // namespace blink

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1108,7 +1108,7 @@ ProtocolObjectPreview.prototype = {
       const propKeys = [...Object.getOwnPropertyNames(proto), ...Object.getOwnPropertySymbols(proto)];
       
       // TODO: allow all getters - https://linear.app/replay/issue/RUN-1016#comment-90c46ba7
-      const allowedGetters = new Set(['type', 'fromElement', 'target']);
+      const allowedGetters = new Set(['type', 'fromElement', 'target', 'isTrusted']);
 
       for (const propKey of propKeys) {
         if (propKey === "__proto__" || addedProps.has(propKey)) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -441,8 +441,7 @@ function Pause_evaluateInFrame({ frameId, expression }) {
   return buildRrpObjectResult(rv);
 
   if (expression === '[...arguments]') {
-    // hackfix (TODO: fix in gecko and frontend later)
-    // -> return `arguments` of given frame
+    // short-circuit hackfix: return `arguments` of given frame
     //  see: https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
     const args = fromJsGetArgumentsInFrame(frame.callFrameId);
     return args && [...args] || [];

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -438,8 +438,13 @@ function Pause_evaluateInFrame({ frameId, expression }) {
   const frame = frames[index];
 
   if (expression === '[...arguments]') {
-    // short-circuit hackfix: return `arguments` of given frame
-    //  see: https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
+    // Short-circuit hackfix: "universal `arguments`" for any frame. This 
+    // serves to allow the `MAPPER` used by the `devtools` event analysis
+    // to get all arguments for any JS event callback. `arguments` are available
+    // by default in many function frames. However, arrow functions do not 
+    // support them. This "solution" makes sure, `[...arguments]` are 
+    // always available.
+    // See: https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
     const args = fromJsGetArgumentsInFrame(frame.callFrameId);
     const argsCdp = makeDebuggeeValue(args && [...args] || []);
     return buildRrpObjectResult({ result: argsCdp });

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -521,6 +521,23 @@ function Graphics_getDevicePixelRatio() {
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
+ * NOTE: this is not a guarantee, since `toString()` can be overridden.
+ */
+function isProbablyNativeFunction(f) {
+  return isNativeFunctionDescription(f.toString());
+}
+
+function isNativeFunctionDescription(functionString) {
+  return functionString?.endsWith('() { [native code] }');
+}
+
+// TODO: fix this mess!
+function isPrototype(x) {
+  // this logic is very flawed
+  return x.constructor !== x.__proto__.constructor;
+}
+
+/**
  * Check whether given object `x` is instance of class of given `target.name`,
  * and also has a `native` constructor.
  * NOTE: ideal solution is `x instanceof global[name]`, but we cannot do that.
@@ -537,8 +554,10 @@ function isInstanceOfNative(x, target) {
   // hackfix: check if its native, and has `name` in inheritance chain
   const name = target?.name;
   return name &&
-    x?.constructor?.toString()?.includes('() { [native code] }') &&
+    x?.constructor?.toString &&
+    // avoid false positives for `prototypes` of native classes
     x.constructor === x.__proto__.constructor &&
+    isProbablyNativeFunction(x.constructor) &&
     hasInProtoChain(x.constructor, name);
 }
 
@@ -624,11 +643,15 @@ function clearPauseDataCallback() {
  * @return {CDP.Runtime.RemoteObject}
  * @see https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
  */
-function makeDebuggeeValue(plainObject) {
-  assert(plainObject && !plainObject.objectId);
-  const remoteObject = fromJsMakeDebuggeeValue(plainObject);
-  assert(remoteObject?.objectId);
+function makeDebuggeeValue(plainValue) {
+  assert(!plainValue?.objectId);
+  const remoteObject = fromJsMakeDebuggeeValue(plainValue);
   return remoteObject;
+}
+
+function createRrpValueRaw(plainValue) {
+  const cdpObject = makeDebuggeeValue(plainValue);
+  return buildRrpObjectFromCdpObject(cdpObject);
 }
 
 /**
@@ -738,7 +761,7 @@ function registerRrpPreview(rrpObjectPreview, plainObject) {
     rrpId = gRrpIdByPlainObject.get(plainObject);
   }
 
-  // NOTE: there is no cdpObject because there is no `CDP.Runtime.RemoteObject`.
+  // NOTE: we built a custom "preview object" without a cdpObject, and sometimes without a plainObject
   const cdpObject = null;
   return registerNewRrpObject(rrpId, cdpObject, rrpObjectPreview, plainObject);
 }
@@ -828,20 +851,6 @@ function buildRrpObjectFromCdpObject(cdpObject) {
   }
 }
 
-// /**
-//  * NOTE: This is called `createProtocolValueRaw` in gecko
-//  */
-// function buildRrpObjectFromPlainValue(value) {
-//   let cdpObject;
-//   if (isNonNullObject(value)) {
-//     const rrpId = registerPlainObject(value);
-//     cdpObject = gCdpObjectsByRrpId.get(rrpId);
-//   }
-//   else {
-//     cdpObject = makeDebuggeeValue(value);
-//   }
-//   return buildRrpObjectFromCdpObject(cdpObject);
-// }
 
 /**
  * 
@@ -1033,22 +1042,26 @@ ProtocolObjectPreview.prototype = {
     this.properties.push(property);
   },
 
-  addGetterValue(name, cdpValue, ownerCdpObj, force = false) {
-    if (isObjectPropertyBlacklisted(ownerCdpObj, name)) {
+  addGetterValue(propKey, plainGetter, ownerCdpObject, force = false) {
+    const propName = propKey.toString();
+    if (isObjectPropertyBlacklisted(ownerCdpObject, propName)) {
       return;
     }
+    
     if (!this.getterValues) {
       this.getterValues = new Map();
     }
-    if (this.getterValues.has(name)) {
-      return;
-    }
-    if (!this.startAddItem(force)) {
+    if (this.getterValues.has(propKey)) {
       return;
     }
 
-    const value = buildRrpObjectFromCdpObject(cdpValue);
-    this.getterValues.set(name, { name, ...value });
+    const rrpValue = evalPropRrp(this.raw, propKey);
+    if (rrpValue) {
+      if (!this.startAddItem(force)) {
+        return;
+      }
+      this.getterValues.set(propName, { name: propName, ...rrpValue });
+    }
   },
 
 
@@ -1064,15 +1077,15 @@ ProtocolObjectPreview.prototype = {
 
   fill() {
     // NOTE: we could also use "Runtime.evaluate" with `{ generatePreview: true }`
-    const allProperties = sendMessage("Runtime.getProperties", {
+    // WARNING: this CDP call can cause `UpdateLayout` which calls divergences
+    const cdpProperties = sendMessage("Runtime.getProperties", {
       objectId: this.cdpObj.objectId,
       ownProperties: true,
       generatePreview: false,
     });
-    const properties = allProperties.result;
 
-    // Add data for DOM/CSS objects
-    this.extra = previewBlinkObject(this.cdpObj, allProperties) || {};
+    // Add data for blink objects
+    this.extra = previewBlinkObject(this.cdpObj) || {};
 
     // Add class-specific data.
     const previewer = CustomPreviewers[this.cdpObj.className];
@@ -1083,45 +1096,66 @@ ProtocolObjectPreview.prototype = {
           // NOTE: in chromium we add these to `properties`, but in gecko we add these to `getterValues`
           requiredProperties.push(entry);
         } else {
-          entry.call(this, allProperties);
+          entry.call(this, cdpProperties);
         }
       }
     }
 
-    let prototype;
-    for (const prop of properties) {
-      if (prop.name == "__proto__") {
-        prototype = prop;
-      } else {
-        const protocolProperty = createProtocolPropertyDescriptor(prop);
-        const force = requiredProperties.includes(prop.name);
-        this.addProperty(protocolProperty, force);
-      }
-    }
 
-    let prototypeRrpId;
-    let getterValues;
-    if (prototype?.value?.objectId) {
-      prototypeRrpId = registerCdpObject(prototype.value);
-      const protoProps = sendMessage("Runtime.getProperties", {
-        objectId: prototype.value.objectId,
-        ownProperties: false
-      });
-      for (const prop of protoProps.result) {
-        if (prop.name === "__proto__") {
+    // add properties + getterValues (based on what we did in gecko).
+    const recurse = this.level === "noProperties";
+    const addedProps = new Set();
+    let proto = this.raw;
+    do {
+      const propKeys = [...Object.getOwnPropertyNames(proto), ...Object.getOwnPropertySymbols(proto)];
+      // hackfix: only allow a few native getters to be executed for now, since 
+      //      many of them cause "Progress counter mismatch at checkpoint"
+      const allowedGetters = new Set(['type', 'fromElement', 'target']);
+      for (const propKey of propKeys) {
+        if (propKey === "__proto__" || addedProps.has(propKey)) {
           continue;
         }
-        if (prop.value) {
-          // this.addGetterValue(prop.name, prop.value, this.cdpObj);
+        addedProps.add(propKey);
+        const prop = Object.getOwnPropertyDescriptor(this.raw, propKey);
+        if (!prop) {
+          continue;
         }
-        else if (prop.get) {
-          // TODO: call getter without side-effects? - https://linear.app/replay/issue/RUN-1016
-        }
-      }
 
-      if (this.getterValues) {
-        getterValues = [...this.getterValues.values()];
+        const isNativeGetter = prop.get && isProbablyNativeFunction(prop.get);
+        const allowedGetter = allowedGetters.has(propKey);
+
+        if (
+          isNativeGetter &&
+          allowedGetter
+        ) {
+          // get native getters
+          this.addGetterValue(propKey, prop.get, this.cdpObj);
+        }
+        else if (
+          // only add props of the first level
+          proto === this.raw ||
+          isNativeGetter // also allow native getters to show up
+        ) { 
+          const protocolProperty = createRrpPropertyDescriptor(this.raw, propKey, prop);
+          const force = requiredProperties.includes(prop.name);
+          this.addProperty(protocolProperty, force);
+        }
       }
+      if (!recurse) {
+        break;
+      }
+      proto = Object.getPrototypeOf(proto);
+    }
+    while (proto && proto.constructor !== Object); // ignore Object
+
+    let prototypeCdp = getInternalProp(cdpProperties, '[[Prototype]]')?.value;
+    let prototypeRrpId;
+    let getterValues;
+    if (prototypeCdp) {
+      prototypeRrpId = registerCdpObject(prototypeCdp);
+    }
+    if (this.getterValues) {
+      getterValues = [...this.getterValues.values()];
     }
 
     return {
@@ -1143,7 +1177,7 @@ function getDescriptionCount(description) {
   }
 }
 
-function previewBlinkObject(cdpObject, allProperties) {
+function previewBlinkObject(cdpObject, cdpProperties) {
   const cdpId = cdpObject.objectId;
   const rrpId = gRrpIdByCdpId.get(cdpId);
   assert(rrpId);
@@ -1278,12 +1312,12 @@ function previewTypedArray() {
   }
 }
 
-function previewSetMap(allProperties) {
-  if (!allProperties.internalProperties) {
+function previewSetMap(cdpProperties) {
+  if (!cdpProperties.internalProperties) {
     return;
   }
 
-  const internal = allProperties.internalProperties.find(prop => prop.name == "[[Entries]]");
+  const internal = cdpProperties.internalProperties.find(prop => prop.name == "[[Entries]]");
   if (!internal || !internal.value || !internal.value.objectId) {
     return;
   }
@@ -1346,15 +1380,23 @@ const ErrorProperties = [
   previewError,
 ];
 
-function previewFunction(allProperties) {
-  const nameProperty = allProperties.result.find(prop => prop.name == "name");
+function getInternalProp(cdpProperties, name) {
+  return cdpProperties.internalProperties?.find(
+    prop => prop.name == name
+  );
+}
+
+function getInternalFunctionLocationProp(cdpProperties) {
+  return getInternalProp(cdpProperties, '[[FunctionLocation]]');
+}
+
+function previewFunction(cdpProperties) {
+  const nameProperty = cdpProperties.result.find(prop => prop.name == "name");
   if (nameProperty) {
     this.extra.functionName = nameProperty.value.value;
   }
 
-  const locationProperty = allProperties.internalProperties.find(
-    prop => prop.name == "[[FunctionLocation]]"
-  );
+  const locationProperty = getInternalFunctionLocationProp(cdpProperties);
   if (locationProperty) {
     this.extra.functionLocation = createProtocolLocation(locationProperty.value.value);
   }
@@ -1391,11 +1433,28 @@ const CustomPreviewers = {
   Function: [previewFunction],
 };
 
-function createProtocolPropertyDescriptor(desc) {
-  const { name, value, writable, get, set, configurable, enumerable, symbol } = desc;
+/**
+ * Get given prop from given object and get its value.
+ * Return RRP wrapper.
+ */
+function evalPropRrp(owner, propKey) {
+  try {
+    Verbose && log(`DDBG running evalProp for prop "${propKey.toString()}"...`);
+    const plainValue = owner[propKey];
+    Verbose && log(`DDBG ran evalProp on ${propKey.toString()}`);
+    return createRrpValueRaw(plainValue);
+  }
+  catch (err) {
+    log(`[RuntimeError] prop evaluation exception - calling ${propKey.toString()} on object: ${err.stack}`);
+    return null;
+  }
+}
 
-  const rv = value ? buildRrpObjectFromCdpObject(value) : {};
-  rv.name = name;
+function createRrpPropertyDescriptor(owner, propKey, desc) {
+  const { value, writable, get, set, configurable, enumerable } = desc;
+
+  let rv = value && evalPropRrp(owner, propKey) || {};
+  rv.name = propKey.toString();
 
   let flags = 0;
   if (writable) {
@@ -1418,9 +1477,7 @@ function createProtocolPropertyDescriptor(desc) {
     rv.set = registerCdpObject(set);
   }
 
-  if (symbol) {
-    rv.isSymbol = true;
-  }
+  rv.isSymbol = typeof propKey === 'symbol';
 
   return rv;
 }
@@ -3228,8 +3285,8 @@ static void fromJsMakeDebuggeeValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  CHECK(args.Length() == 1 && args[0]->IsObject() &&
-        "must be called with a single object");
+  CHECK(args.Length() == 1 &&
+        "must be called with a single value");
 
   auto context = isolate->GetCurrentContext();
   auto value = args[0];

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -83,7 +83,7 @@ const char* gReplayScript = R""""(
 
 const EmptyArray = Object.freeze([]); // reduce unnecessary mem churn
 
-const Verbose = 1;
+const Verbose = false;
 const VerboseCommands = Verbose;
 
 const {
@@ -418,14 +418,14 @@ function getStackFrames() {
 
 
 // Build a protocol Result object from a result/exceptionDetails CDP rval.
-function buildRrpObjectResult({ result, exceptionDetails }) {
-  const value = buildRrpObjectFromCdpObject(result);
+function buildRrpObjectResult({ result: cdpResult, exceptionDetails }) {
+  const rrpId = buildRrpObjectFromCdpObject(cdpResult);
   const protocolResult = { data: {} };
 
   if (exceptionDetails) {
-    protocolResult.exception = value;
+    protocolResult.exception = rrpId;
   } else {
-    protocolResult.returned = value;
+    protocolResult.returned = rrpId;
   }
   return { result: protocolResult };
 }
@@ -437,15 +437,16 @@ function Pause_evaluateInFrame({ frameId, expression }) {
   assert(index < frames.length);
   const frame = frames[index];
 
-  const rv = doEvaluation();
-  return buildRrpObjectResult(rv);
-
   if (expression === '[...arguments]') {
     // short-circuit hackfix: return `arguments` of given frame
     //  see: https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
     const args = fromJsGetArgumentsInFrame(frame.callFrameId);
-    return args && [...args] || [];
+    const argsCdp = makeDebuggeeValue(args && [...args] || []);
+    return buildRrpObjectResult({ result: argsCdp });
   }
+
+  const rv = doEvaluation();
+  return buildRrpObjectResult(rv);
 
   function doEvaluation() {
     // In order to do the evaluation in the right frame, the same number of
@@ -528,13 +529,11 @@ function isProbablyNativeFunction(f) {
 }
 
 function isNativeFunctionDescription(functionString) {
-  return functionString?.endsWith('() { [native code] }');
+  return functionString?.endsWith('() { [native code] }') || false;
 }
 
-// TODO: fix this mess!
-function isPrototype(x) {
-  // this logic is very flawed
-  return x.constructor !== x.__proto__.constructor;
+function isPrototype(x) { 
+  return x === x.constructor.prototype;
 }
 
 /**
@@ -553,10 +552,9 @@ function isInstanceOfNative(x, target) {
 
   // hackfix: check if its native, and has `name` in inheritance chain
   const name = target?.name;
-  return name &&
-    x?.constructor?.toString &&
-    // avoid false positives for `prototypes` of native classes
-    x.constructor === x.__proto__.constructor &&
+  return x?.constructor && name &&
+    // avoid false positives for prototypes (see https://linear.app/replay/issue/RUN-1067)
+    x.constructor === x.__proto__?.constructor &&
     isProbablyNativeFunction(x.constructor) &&
     hasInProtoChain(x.constructor, name);
 }
@@ -638,7 +636,7 @@ function clearPauseDataCallback() {
 }
 
 /**
- * Creates and returns a new `RemoteObject` for given JS object.
+ * Creates and returns a new `CDP.RemoteObject` for given JS object.
  * 
  * @return {CDP.Runtime.RemoteObject}
  * @see https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
@@ -1103,20 +1101,21 @@ ProtocolObjectPreview.prototype = {
 
 
     // add properties + getterValues (based on what we did in gecko).
-    const recurse = this.level === "noProperties";
+    const dontRecurse = this.level === "noProperties";
     const addedProps = new Set();
     let proto = this.raw;
     do {
       const propKeys = [...Object.getOwnPropertyNames(proto), ...Object.getOwnPropertySymbols(proto)];
-      // hackfix: only allow a few native getters to be executed for now, since 
-      //      many of them cause "Progress counter mismatch at checkpoint"
+      
+      // TODO: allow all getters - https://linear.app/replay/issue/RUN-1016#comment-90c46ba7
       const allowedGetters = new Set(['type', 'fromElement', 'target']);
+
       for (const propKey of propKeys) {
         if (propKey === "__proto__" || addedProps.has(propKey)) {
           continue;
         }
         addedProps.add(propKey);
-        const prop = Object.getOwnPropertyDescriptor(this.raw, propKey);
+        const prop = Object.getOwnPropertyDescriptor(proto, propKey);
         if (!prop) {
           continue;
         }
@@ -1125,23 +1124,23 @@ ProtocolObjectPreview.prototype = {
         const allowedGetter = allowedGetters.has(propKey);
 
         if (
+          !isPrototype(this.raw) && // don't try to execute getters on prototypes
           isNativeGetter &&
           allowedGetter
         ) {
-          // get native getters
+          // evaluate native getter props
           this.addGetterValue(propKey, prop.get, this.cdpObj);
         }
         else if (
-          // only add props of the first level
-          proto === this.raw ||
-          isNativeGetter // also allow native getters to show up
-        ) { 
+          proto === this.raw
+        ) {
+          // only add complete prop data for own props
           const protocolProperty = createRrpPropertyDescriptor(this.raw, propKey, prop);
           const force = requiredProperties.includes(prop.name);
           this.addProperty(protocolProperty, force);
         }
       }
-      if (!recurse) {
+      if (dontRecurse) {
         break;
       }
       proto = Object.getPrototypeOf(proto);
@@ -1439,9 +1438,7 @@ const CustomPreviewers = {
  */
 function evalPropRrp(owner, propKey) {
   try {
-    Verbose && log(`DDBG running evalProp for prop "${propKey.toString()}"...`);
     const plainValue = owner[propKey];
-    Verbose && log(`DDBG ran evalProp on ${propKey.toString()}`);
     return createRrpValueRaw(plainValue);
   }
   catch (err) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3349,943 +3349,943 @@ static void fromJsGetObjectByCdpId(
   }
 }
 
-  /** ###########################################################################
-   * Networking
-   * ##########################################################################*/
+/** ###########################################################################
+ * Networking
+ * ##########################################################################*/
 
-  // Represents a known network request.  Created and added to
-  // `gActiveNetworkRequests` when the request is first seen.  Removed
-  // when the request finishes or fails.
-  struct NetworkRequestStatus {
-    size_t response_data_received;
-    size_t request_data_sent;
-    std::string method;
-    uint64_t bookmark;
-    NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
-        : response_data_received(0),
-          request_data_sent(0),
-          method(method),
-          bookmark(bookmark) {}
-  };
-  // Map of active network requests.
-  std::unordered_map<std::string, NetworkRequestStatus>*
-      gActiveNetworkRequests = nullptr;
+// Represents a known network request.  Created and added to
+// `gActiveNetworkRequests` when the request is first seen.  Removed
+// when the request finishes or fails.
+struct NetworkRequestStatus {
+  size_t response_data_received;
+  size_t request_data_sent;
+  std::string method;
+  uint64_t bookmark;
+  NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
+      : response_data_received(0),
+        request_data_sent(0),
+        method(method),
+        bookmark(bookmark) {}
+};
+// Map of active network requests.
+std::unordered_map<std::string, NetworkRequestStatus>*
+    gActiveNetworkRequests = nullptr;
 
-  // Globals storing values to be returned to controller commands
-  // `GetCurrentNetwork*`
-  static base::Value* gCurrentNetworkRequestEvent = nullptr;
-  static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
+// Globals storing values to be returned to controller commands
+// `GetCurrentNetwork*`
+static base::Value* gCurrentNetworkRequestEvent = nullptr;
+static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
 
-  static void GetCurrentNetworkRequestEvent(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    if (!gCurrentNetworkRequestEvent) {
-      return;
-    }
-
-    v8::Isolate* isolate = args.GetIsolate();
-    std::string json;
-    base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
-    v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
-    args.GetReturnValue().Set(json_string);
+static void GetCurrentNetworkRequestEvent(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!gCurrentNetworkRequestEvent) {
+    return;
   }
 
-  static void GetCurrentNetworkStreamData(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(gCurrentNetworkStreamData);
+  v8::Isolate* isolate = args.GetIsolate();
+  std::string json;
+  base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
+  v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
+  args.GetReturnValue().Set(json_string);
+}
 
-    v8::Isolate* isolate = args.GetIsolate();
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+static void GetCurrentNetworkStreamData(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(gCurrentNetworkStreamData);
 
-    // Expect params: { index, length }
-    v8::Local<v8::Object> params = args[0]->ToObject(context).ToLocalChecked();
-    size_t index = params->Get(context, ToV8String(isolate, "index"))
-                       .ToLocalChecked()
-                       ->NumberValue(context)
-                       .ToChecked();
-    size_t length = params->Get(context, ToV8String(isolate, "length"))
-                        .ToLocalChecked()
-                        ->NumberValue(context)
-                        .ToChecked();
-    size_t size = gCurrentNetworkStreamData->size();
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-    if ((size < index) || ((size - index) < length)) {
-      recordreplay::Print(
-          "GetCurrentNetworkStreamData: Out of range slice"
-          " (size=%u, requested=%u-%u)",
-          (unsigned)size, (unsigned)index, (unsigned)(index + length));
-      return;
-    }
+  // Expect params: { index, length }
+  v8::Local<v8::Object> params = args[0]->ToObject(context).ToLocalChecked();
+  size_t index = params->Get(context, ToV8String(isolate, "index"))
+                      .ToLocalChecked()
+                      ->NumberValue(context)
+                      .ToChecked();
+  size_t length = params->Get(context, ToV8String(isolate, "length"))
+                      .ToLocalChecked()
+                      ->NumberValue(context)
+                      .ToChecked();
+  size_t size = gCurrentNetworkStreamData->size();
 
-    uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
-    std::string encoded =
-        base::Base64Encode(base::span<const uint8_t>(bytes, length));
-    char* encoded_cstr = strdup(encoded.c_str());
-    char* encoded_end = encoded_cstr + encoded.length();
-    for (char* cur = encoded_cstr; cur < encoded_end; cur++) {
-      if (*cur == '-') {
-        *cur = '+';
-      }
-      if (*cur == '_') {
-        *cur = '/';
-      }
-    }
-
-    v8::Local<v8::Object> result = v8::Object::New(isolate);
-    result
-        ->Set(context, ToV8String(isolate, "kind"), ToV8String(isolate, "data"))
-        .Check();
-    result
-        ->Set(context, ToV8String(isolate, "value"),
-              ToV8String(isolate, encoded_cstr))
-        .Check();
-    args.GetReturnValue().Set(result);
+  if ((size < index) || ((size - index) < length)) {
+    recordreplay::Print(
+        "GetCurrentNetworkStreamData: Out of range slice"
+        " (size=%u, requested=%u-%u)",
+        (unsigned)size, (unsigned)index, (unsigned)(index + length));
+    return;
   }
 
-  static std::string MakeRequestIdentifier(uint64_t identifier) {
-    char request_id[64];
-    snprintf(request_id, 64, "%d.%lu", (int)getpid(),
-             (unsigned long)identifier);
-    return std::string(request_id);
+  uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
+  std::string encoded =
+      base::Base64Encode(base::span<const uint8_t>(bytes, length));
+  char* encoded_cstr = strdup(encoded.c_str());
+  char* encoded_end = encoded_cstr + encoded.length();
+  for (char* cur = encoded_cstr; cur < encoded_end; cur++) {
+    if (*cur == '-') {
+      *cur = '+';
+    }
+    if (*cur == '_') {
+      *cur = '/';
+    }
   }
 
-  static void HandleNetworkPrepareRequestEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    std::string request_id = *info.FindPath("requestId")->GetIfString();
-    if (gActiveNetworkRequests->find(request_id) !=
-        gActiveNetworkRequests->end()) {
-      // If the request already exists, this is a redirect.
-      // Chromium will send a "Network.ResourceRedirect" event which will
-      // be handled by `HandleNetworkPrepareRequestEvent` below.
-      return;
-    }
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  result
+      ->Set(context, ToV8String(isolate, "kind"), ToV8String(isolate, "data"))
+      .Check();
+  result
+      ->Set(context, ToV8String(isolate, "value"),
+            ToV8String(isolate, encoded_cstr))
+      .Check();
+  args.GetReturnValue().Set(result);
+}
 
-    // Save request info in a global table.
-    // Associate with it the following info which may be needed later if
-    // the request is redirected:
-    //   - the request method
-    //   - the request bookmark
-    std::string request_method = *info.FindPath("requestMethod")->GetIfString();
-    uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
-    gActiveNetworkRequests->insert(
-        {request_id, NetworkRequestStatus(request_method, bookmark)});
+static std::string MakeRequestIdentifier(uint64_t identifier) {
+  char request_id[64];
+  snprintf(request_id, 64, "%d.%lu", (int)getpid(),
+            (unsigned long)identifier);
+  return std::string(request_id);
+}
 
-    // Register the request.
-    recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
+static void HandleNetworkPrepareRequestEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  if (gActiveNetworkRequests->find(request_id) !=
+      gActiveNetworkRequests->end()) {
+    // If the request already exists, this is a redirect.
+    // Chromium will send a "Network.ResourceRedirect" event which will
+    // be handled by `HandleNetworkPrepareRequestEvent` below.
+    return;
+  }
 
-    // Package and emit a network request event with the appropriate info.
-    base::DictionaryValue event;
-    event.SetString("kind", "request");
-    event.Set("requestUrl", std::unique_ptr<base::Value>(
-                                info.FindPath("requestUrl")->CreateDeepCopy()));
-    event.SetString("requestMethod", request_method);
-    event.Set("requestHeaders",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("requestHeaders")->CreateDeepCopy()));
-    const base::Value* request_cause_value = info.FindPath("requestCause");
-    if (request_cause_value) {
-      event.Set("requestCause", std::unique_ptr<base::Value>(
-                                    request_cause_value->CreateDeepCopy()));
-    }
+  // Save request info in a global table.
+  // Associate with it the following info which may be needed later if
+  // the request is redirected:
+  //   - the request method
+  //   - the request bookmark
+  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+  uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
+  gActiveNetworkRequests->insert(
+      {request_id, NetworkRequestStatus(request_method, bookmark)});
 
-    gCurrentNetworkRequestEvent = &event;
+  // Register the request.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
+
+  // Package and emit a network request event with the appropriate info.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(
+                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.SetString("requestMethod", request_method);
+  event.Set("requestHeaders",
+            std::unique_ptr<base::Value>(
+                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  const base::Value* request_cause_value = info.FindPath("requestCause");
+  if (request_cause_value) {
+    event.Set("requestCause", std::unique_ptr<base::Value>(
+                                  request_cause_value->CreateDeepCopy()));
+  }
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkResourceRedirectEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Retreive the existing request data which should already have been
+  // registered by `HandleNetworkPrepareRequestEvent`.
+  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("No original request for navigation redirect: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  // Register a new network request with the same request id as the original
+  // for this redirect.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                  request_info->second.bookmark);
+
+  // Package and emit a network request event.
+  // The request_method is obtained from the saved request info.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(
+                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.SetString("requestMethod", request_info->second.method);
+  event.Set("requestHeaders",
+            std::unique_ptr<base::Value>(
+                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  const base::Value* request_cause_value = info.FindPath("requestCause");
+  if (request_cause_value) {
+    event.Set("requestCause", std::unique_ptr<base::Value>(
+                                  request_cause_value->CreateDeepCopy()));
+  }
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Navigation events are network requests that are not resource requests.
+  // They are directed here (the renderer process) from the content process.
+  // They have no associated bookmark, as we can't take bookmarks in the
+  // content process.
+
+  // Ensure that a request with the same ID has not already been registered.
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  if (gActiveNetworkRequests->find(request_id) !=
+      gActiveNetworkRequests->end()) {
+    recordreplay::Print("Duplicate request id: %s", request_id.c_str());
+    return;
+  }
+  std::string request_method = *info.FindPath("requestMethod")->GetIfString();
+  gActiveNetworkRequests->insert(
+      {request_id, NetworkRequestStatus(request_method)});
+
+  // A navigation event is a new network request, so call the
+  // `OnNetworkRequest` hook. Navigation events have no bookmarks associated
+  // with them.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                  /* bookmark = */ 0);
+
+  // Package and emit a network request event.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(
+                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.SetString("requestMethod", request_method);
+  event.Set("requestHeaders",
+            std::unique_ptr<base::Value>(
+                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.SetString("requestCause", "document");
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkNavigationRedirectEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+
+  // Navigation redirect events are, as with navigation events, sent from
+  // the content process to the renderer process.
+
+  // Ensure that a request with the same ID has not already been registered.
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  // This is a redirect, so an existing request should have been registered
+  // with the same id.
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("No original request for navigation redirect: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  // A navigation redirect event is a new network request.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
+                                  request_info->second.bookmark);
+
+  // Package and emit a network request event.
+  // The request method is obtained from the saved request info.
+  base::DictionaryValue event;
+  event.SetString("kind", "request");
+  event.Set("requestUrl", std::unique_ptr<base::Value>(
+                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.SetString("requestMethod", request_info->second.method);
+  event.Set("requestHeaders",
+            std::unique_ptr<base::Value>(
+                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.SetString("requestCause", "document");
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkRequestDataFormEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  std::string request_id = *info.FindPath("requestId")->GetIfString();
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("Unknown request for request data: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  // If we're receiving a RequestData.Form event, all the
+  // request data is present and none should have been already received.
+  CHECK(request_info->second.request_data_sent == 0);
+
+  {  // Send a "request-body" network request event.
+    base::DictionaryValue requestBodyEvent;
+    requestBodyEvent.SetString("kind", "request-body");
+
+    gCurrentNetworkRequestEvent = &requestBodyEvent;
     recordreplay::OnNetworkRequestEvent(request_id.c_str());
     gCurrentNetworkRequestEvent = nullptr;
   }
 
-  static void HandleNetworkResourceRedirectEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
+  std::string stream_id = "request-" + request_id;
 
-    // Retreive the existing request data which should already have been
-    // registered by `HandleNetworkPrepareRequestEvent`.
-    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
-    std::string request_id = MakeRequestIdentifier(identifier);
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("No original request for navigation redirect: %s",
-                          request_id.c_str());
-      return;
-    }
+  // Call StreamStart API.
+  recordreplay::OnNetworkStreamStart(stream_id.c_str(), "request-data",
+                                      request_id.c_str());
 
-    // Register a new network request with the same request id as the original
-    // for this redirect.
-    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                   request_info->second.bookmark);
+  // Call StreamData API.
+  size_t length = *info.FindPath("dataLength")->GetIfDouble();
 
-    // Package and emit a network request event.
-    // The request_method is obtained from the saved request info.
-    base::DictionaryValue event;
-    event.SetString("kind", "request");
-    event.Set("requestUrl", std::unique_ptr<base::Value>(
-                                info.FindPath("requestUrl")->CreateDeepCopy()));
-    event.SetString("requestMethod", request_info->second.method);
-    event.Set("requestHeaders",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("requestHeaders")->CreateDeepCopy()));
-    const base::Value* request_cause_value = info.FindPath("requestCause");
-    if (request_cause_value) {
-      event.Set("requestCause", std::unique_ptr<base::Value>(
-                                    request_cause_value->CreateDeepCopy()));
-    }
-
-    gCurrentNetworkRequestEvent = &event;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-
-    // Navigation events are network requests that are not resource requests.
-    // They are directed here (the renderer process) from the content process.
-    // They have no associated bookmark, as we can't take bookmarks in the
-    // content process.
-
-    // Ensure that a request with the same ID has not already been registered.
-    std::string request_id = *info.FindPath("requestId")->GetIfString();
-    if (gActiveNetworkRequests->find(request_id) !=
-        gActiveNetworkRequests->end()) {
-      recordreplay::Print("Duplicate request id: %s", request_id.c_str());
-      return;
-    }
-    std::string request_method = *info.FindPath("requestMethod")->GetIfString();
-    gActiveNetworkRequests->insert(
-        {request_id, NetworkRequestStatus(request_method)});
-
-    // A navigation event is a new network request, so call the
-    // `OnNetworkRequest` hook. Navigation events have no bookmarks associated
-    // with them.
-    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                   /* bookmark = */ 0);
-
-    // Package and emit a network request event.
-    base::DictionaryValue event;
-    event.SetString("kind", "request");
-    event.Set("requestUrl", std::unique_ptr<base::Value>(
-                                info.FindPath("requestUrl")->CreateDeepCopy()));
-    event.SetString("requestMethod", request_method);
-    event.Set("requestHeaders",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("requestHeaders")->CreateDeepCopy()));
-    event.SetString("requestCause", "document");
-
-    gCurrentNetworkRequestEvent = &event;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  static void HandleNetworkNavigationRedirectEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-
-    // Navigation redirect events are, as with navigation events, sent from
-    // the content process to the renderer process.
-
-    // Ensure that a request with the same ID has not already been registered.
-    std::string request_id = *info.FindPath("requestId")->GetIfString();
-    // This is a redirect, so an existing request should have been registered
-    // with the same id.
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("No original request for navigation redirect: %s",
-                          request_id.c_str());
-      return;
-    }
-
-    // A navigation redirect event is a new network request.
-    recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                   request_info->second.bookmark);
-
-    // Package and emit a network request event.
-    // The request method is obtained from the saved request info.
-    base::DictionaryValue event;
-    event.SetString("kind", "request");
-    event.Set("requestUrl", std::unique_ptr<base::Value>(
-                                info.FindPath("requestUrl")->CreateDeepCopy()));
-    event.SetString("requestMethod", request_info->second.method);
-    event.Set("requestHeaders",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("requestHeaders")->CreateDeepCopy()));
-    event.SetString("requestCause", "document");
-
-    gCurrentNetworkRequestEvent = &event;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  static void HandleNetworkRequestDataFormEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    std::string request_id = *info.FindPath("requestId")->GetIfString();
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("Unknown request for request data: %s",
-                          request_id.c_str());
-      return;
-    }
-
-    // If we're receiving a RequestData.Form event, all the
-    // request data is present and none should have been already received.
-    CHECK(request_info->second.request_data_sent == 0);
-
-    {  // Send a "request-body" network request event.
-      base::DictionaryValue requestBodyEvent;
-      requestBodyEvent.SetString("kind", "request-body");
-
-      gCurrentNetworkRequestEvent = &requestBodyEvent;
-      recordreplay::OnNetworkRequestEvent(request_id.c_str());
-      gCurrentNetworkRequestEvent = nullptr;
-    }
-
-    std::string stream_id = "request-" + request_id;
-
-    // Call StreamStart API.
-    recordreplay::OnNetworkStreamStart(stream_id.c_str(), "request-data",
-                                       request_id.c_str());
-
-    // Call StreamData API.
-    size_t length = *info.FindPath("dataLength")->GetIfDouble();
-
-    CHECK(length >= 0);
+  CHECK(length >= 0);
+  gCurrentNetworkStreamData->clear();
+  const std::string* data_base64 = info.FindPath("data")->GetIfString();
+  if (data_base64) {
+    const uint8_t* data =
+        reinterpret_cast<const uint8_t*>(data_base64->c_str());
+    gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
+                                      data, data + data_base64->length());
+    size_t offset = request_info->second.response_data_received;
+    recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
+                                      /* bookmark = */ 0);
     gCurrentNetworkStreamData->clear();
-    const std::string* data_base64 = info.FindPath("data")->GetIfString();
-    if (data_base64) {
-      const uint8_t* data =
-          reinterpret_cast<const uint8_t*>(data_base64->c_str());
-      gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
-                                        data, data + data_base64->length());
-      size_t offset = request_info->second.response_data_received;
-      recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
-                                        /* bookmark = */ 0);
-      gCurrentNetworkStreamData->clear();
-    }
-    request_info->second.request_data_sent += length;
+  }
+  request_info->second.request_data_sent += length;
+}
+
+static void HandleNetworkDidReceiveResponseEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("Unknown request received response: %s",
+                        request_id.c_str());
+    return;
   }
 
-  static void HandleNetworkDidReceiveResponseEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
-    std::string request_id = MakeRequestIdentifier(identifier);
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("Unknown request received response: %s",
-                          request_id.c_str());
-      return;
-    }
+  base::DictionaryValue event;
+  event.SetString("kind", "response");
+  event.Set("responseHeaders",
+            std::unique_ptr<base::Value>(
+                info.FindPath("responseHeaders")->CreateDeepCopy()));
+  event.Set("responseProtocolVersion",
+            std::unique_ptr<base::Value>(
+                info.FindPath("responseProtocolVersion")->CreateDeepCopy()));
+  event.Set("responseStatus",
+            std::unique_ptr<base::Value>(
+                info.FindPath("responseStatus")->CreateDeepCopy()));
+  event.Set("responseStatusText",
+            std::unique_ptr<base::Value>(
+                info.FindPath("responseStatusText")->CreateDeepCopy()));
+  event.Set("responseFromCache",
+            std::unique_ptr<base::Value>(
+                info.FindPath("responseFromCache")->CreateDeepCopy()));
 
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkDidFinishLoadingEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("Unknown request finished loading: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  base::DictionaryValue event;
+  event.SetString("kind", "request-done");
+  event.Set("encodedBodySize",
+            std::unique_ptr<base::Value>(
+                info.FindPath("encodedBodySize")->CreateDeepCopy()));
+  event.Set("decodedBodySize",
+            std::unique_ptr<base::Value>(
+                info.FindPath("decodedBodySize")->CreateDeepCopy()));
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkDidFailLoadingEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("Unknown request failed loading: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  base::DictionaryValue event;
+  event.SetString("kind", "request-failed");
+  event.Set("requestFailedReason",
+            std::unique_ptr<base::Value>(
+                info.FindPath("requestFailedReason")->CreateDeepCopy()));
+
+  gCurrentNetworkRequestEvent = &event;
+  recordreplay::OnNetworkRequestEvent(request_id.c_str());
+  gCurrentNetworkRequestEvent = nullptr;
+}
+
+static void HandleNetworkDidReceiveDataEvent(
+    const base::DictionaryValue& info) {
+  CHECK(gActiveNetworkRequests);
+  CHECK(gCurrentNetworkStreamData);
+  // Get request info.
+  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  std::string request_id = MakeRequestIdentifier(identifier);
+  auto request_info = gActiveNetworkRequests->find(request_id);
+  if (request_info == gActiveNetworkRequests->end()) {
+    recordreplay::Print("Unknown request received data: %s",
+                        request_id.c_str());
+    return;
+  }
+
+  std::string stream_id = "response-" + request_id;
+
+  // The first byte of data received triggers a "response-body" event.
+  if (request_info->second.response_data_received == 0) {
     base::DictionaryValue event;
-    event.SetString("kind", "response");
-    event.Set("responseHeaders",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("responseHeaders")->CreateDeepCopy()));
-    event.Set("responseProtocolVersion",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("responseProtocolVersion")->CreateDeepCopy()));
-    event.Set("responseStatus",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("responseStatus")->CreateDeepCopy()));
-    event.Set("responseStatusText",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("responseStatusText")->CreateDeepCopy()));
-    event.Set("responseFromCache",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("responseFromCache")->CreateDeepCopy()));
+    event.SetString("kind", "response-body");
 
     gCurrentNetworkRequestEvent = &event;
     recordreplay::OnNetworkRequestEvent(request_id.c_str());
     gCurrentNetworkRequestEvent = nullptr;
+
+    recordreplay::OnNetworkStreamStart(stream_id.c_str(), "response-data",
+                                        request_id.c_str());
   }
 
-  static void HandleNetworkDidFinishLoadingEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
-    std::string request_id = MakeRequestIdentifier(identifier);
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("Unknown request finished loading: %s",
-                          request_id.c_str());
-      return;
-    }
+  // Sending stream data.
+  size_t length = *info.FindPath("dataLength")->GetIfDouble();
+  CHECK(length >= 0);
 
-    base::DictionaryValue event;
-    event.SetString("kind", "request-done");
-    event.Set("encodedBodySize",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("encodedBodySize")->CreateDeepCopy()));
-    event.Set("decodedBodySize",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("decodedBodySize")->CreateDeepCopy()));
-
-    gCurrentNetworkRequestEvent = &event;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  static void HandleNetworkDidFailLoadingEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
-    std::string request_id = MakeRequestIdentifier(identifier);
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
-      recordreplay::Print("Unknown request failed loading: %s",
-                          request_id.c_str());
-      return;
-    }
-
-    base::DictionaryValue event;
-    event.SetString("kind", "request-failed");
-    event.Set("requestFailedReason",
-              std::unique_ptr<base::Value>(
-                  info.FindPath("requestFailedReason")->CreateDeepCopy()));
-
-    gCurrentNetworkRequestEvent = &event;
-    recordreplay::OnNetworkRequestEvent(request_id.c_str());
-    gCurrentNetworkRequestEvent = nullptr;
-  }
-
-  static void HandleNetworkDidReceiveDataEvent(
-      const base::DictionaryValue& info) {
-    CHECK(gActiveNetworkRequests);
-    CHECK(gCurrentNetworkStreamData);
-    // Get request info.
-    uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
-    std::string request_id = MakeRequestIdentifier(identifier);
-    auto request_info = gActiveNetworkRequests->find(request_id);
-    if (request_info == gActiveNetworkRequests->end()) {
+  gCurrentNetworkStreamData->clear();
+  const std::string* data_base64 = info.FindPath("data")->GetIfString();
+  if (data_base64) {
+    std::string out_string;
+    if (!base::Base64Decode(*data_base64, &out_string)) {
       recordreplay::Print("Unknown request received data: %s",
                           request_id.c_str());
       return;
     }
-
-    std::string stream_id = "response-" + request_id;
-
-    // The first byte of data received triggers a "response-body" event.
-    if (request_info->second.response_data_received == 0) {
-      base::DictionaryValue event;
-      event.SetString("kind", "response-body");
-
-      gCurrentNetworkRequestEvent = &event;
-      recordreplay::OnNetworkRequestEvent(request_id.c_str());
-      gCurrentNetworkRequestEvent = nullptr;
-
-      recordreplay::OnNetworkStreamStart(stream_id.c_str(), "response-data",
-                                         request_id.c_str());
-    }
-
-    // Sending stream data.
-    size_t length = *info.FindPath("dataLength")->GetIfDouble();
-    CHECK(length >= 0);
-
+    const uint8_t* data =
+        reinterpret_cast<const uint8_t*>(out_string.c_str());
+    gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
+                                      data, data + out_string.length());
+    size_t offset = request_info->second.response_data_received;
+    recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
+                                      /* bookmark = */ 0);
     gCurrentNetworkStreamData->clear();
-    const std::string* data_base64 = info.FindPath("data")->GetIfString();
-    if (data_base64) {
-      std::string out_string;
-      if (!base::Base64Decode(*data_base64, &out_string)) {
-        recordreplay::Print("Unknown request received data: %s",
-                            request_id.c_str());
-        return;
-      }
-      const uint8_t* data =
-          reinterpret_cast<const uint8_t*>(out_string.c_str());
-      gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
-                                        data, data + out_string.length());
-      size_t offset = request_info->second.response_data_received;
-      recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
-                                        /* bookmark = */ 0);
-      gCurrentNetworkStreamData->clear();
-    }
-    request_info->second.response_data_received += length;
   }
+  request_info->second.response_data_received += length;
+}
 
-  /** ###########################################################################
-   * blink (DOM, CSS etc.)
-   * @see https://static.replay.io/protocol/tot/DOM/
-   * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
-   * ##########################################################################*/
+/** ###########################################################################
+ * blink (DOM, CSS etc.)
+ * @see https://static.replay.io/protocol/tot/DOM/
+ * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
+ * ##########################################################################*/
 
-  static bool checkCDPResponse(
-      const char* label, const protocol::Response& response,
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    if (!response.IsSuccess()) {
-      recordreplay::Print(
-          "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s", label,
-          response.Code(), response.Message().c_str());
+static bool checkCDPResponse(
+    const char* label, const protocol::Response& response,
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!response.IsSuccess()) {
+    recordreplay::Print(
+        "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s", label,
+        response.Code(), response.Message().c_str());
 
-      // result is null
-      args.GetReturnValue().SetNull();
-      return false;
-    }
-    return true;
-  }
-
-  static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.Length() == 1 && args[0]->IsString() &&
-          "[RuntimeError] must be called with a single string");
-
-    v8::Isolate* isolate = args.GetIsolate();
-
-    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
-    // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
-    v8::String::Utf8Value cdpId(isolate, args[0]);
-    const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
-    v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
-
-    v8::Local<v8::Object> nodeObj;
-    if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
-      Node* node = V8Node::ToImpl(nodeObj);
-      if (node) {
-        // hackfix: bind node here
-        //   (if the DOMAgent was enabled, it would track nodes automatically)
-        int nodeId = domAgent->BindDocumentNode(node);
-        args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
-        return;
-      } else {
-        recordreplay::Print(
-            "[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
-      }
-    } else { /* already reported */
-    }
-
-    // auto response = domAgent->requestNode(cdpId, &nodeId);
+    // result is null
     args.GetReturnValue().SetNull();
+    return false;
+  }
+  return true;
+}
+
+static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "[RuntimeError] must be called with a single string");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+  // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
+  v8::String::Utf8Value cdpId(isolate, args[0]);
+  const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
+  v8_inspector::StringView cdpIdV8(cdpIdPtr, cdpId.length());
+
+  v8::Local<v8::Object> nodeObj;
+  if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
+    Node* node = V8Node::ToImpl(nodeObj);
+    if (node) {
+      // hackfix: bind node here
+      //   (if the DOMAgent was enabled, it would track nodes automatically)
+      int nodeId = domAgent->BindDocumentNode(node);
+      args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
+      return;
+    } else {
+      recordreplay::Print(
+          "[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
+    }
+  } else { /* already reported */
   }
 
-  static void fromJsGetBoxModel(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.Length() == 1 && args[0]->IsNumber() &&
-          "[RuntimeError] must be called with a single number");
+  // auto response = domAgent->requestNode(cdpId, &nodeId);
+  args.GetReturnValue().SetNull();
+}
 
-    v8::Isolate* isolate = args.GetIsolate();
-    auto nodeId = (int)args[0].As<v8::Integer>()->Value();
+static void fromJsGetBoxModel(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsNumber() &&
+        "[RuntimeError] must be called with a single number");
 
-    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+  v8::Isolate* isolate = args.GetIsolate();
+  auto nodeId = (int)args[0].As<v8::Integer>()->Value();
 
-    int backend_node_id = 0;
-    String object_id;
-    std::unique_ptr<protocol::DOM::BoxModel> boxModel;
-    auto response =
-        domAgent->getBoxModel(nodeId, backend_node_id, object_id, &boxModel);
+  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
 
-    if (!response.IsSuccess()) {
-      recordreplay::Print(
-          "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, "
-          "Code: "
-          "%d): %s",
-          nodeId, response.Code(), response.Message().c_str());
-    } else {
-      auto result = convertCborToJS(isolate, boxModel.get());
-      if (!result.IsEmpty()) {
-        args.GetReturnValue().Set(result.ToLocalChecked());
-        return;
-      }
+  int backend_node_id = 0;
+  String object_id;
+  std::unique_ptr<protocol::DOM::BoxModel> boxModel;
+  auto response =
+      domAgent->getBoxModel(nodeId, backend_node_id, object_id, &boxModel);
+
+  if (!response.IsSuccess()) {
+    recordreplay::Print(
+        "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, "
+        "Code: "
+        "%d): %s",
+        nodeId, response.Code(), response.Message().c_str());
+  } else {
+    auto result = convertCborToJS(isolate, boxModel.get());
+    if (!result.IsEmpty()) {
+      args.GetReturnValue().Set(result.ToLocalChecked());
+      return;
     }
+  }
 
+  args.GetReturnValue().SetNull();
+}
+
+static void fromJsGetMatchedStylesForNode(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsNumber() &&
+        "[RuntimeError] must be called with a single number");
+
+  v8::Isolate* isolate = args.GetIsolate();
+  auto nodeId = (int)args[0].As<v8::Integer>()->Value();
+
+  auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
+
+  Maybe<protocol::CSS::CSSStyle> inlineStyle;
+  Maybe<protocol::CSS::CSSStyle> attributesStyle;
+  Maybe<protocol::Array<protocol::CSS::RuleMatch>> matchedRules;
+  Maybe<protocol::Array<protocol::CSS::PseudoElementMatches>> pseudoIdMatches;
+  Maybe<protocol::Array<protocol::CSS::InheritedStyleEntry>> inheritedEntries;
+  Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>> keyframesRules;
+
+  auto response = cssAgent->getMatchedStylesForNode(
+      nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
+      &inheritedEntries, nullptr, &keyframesRules, nullptr);
+
+  // WIP: will fix everything up and clean up when done w/ RUN-981
+
+  if (!response.IsSuccess()) {
+    recordreplay::Print(
+        "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, "
+        "Code: "
+        "%d): %s",
+        nodeId, response.Code(), response.Message().c_str());
     args.GetReturnValue().SetNull();
-  }
-
-  static void fromJsGetMatchedStylesForNode(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.Length() == 1 && args[0]->IsNumber() &&
-          "[RuntimeError] must be called with a single number");
-
-    v8::Isolate* isolate = args.GetIsolate();
-    auto nodeId = (int)args[0].As<v8::Integer>()->Value();
-
-    auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
-
-    Maybe<protocol::CSS::CSSStyle> inlineStyle;
-    Maybe<protocol::CSS::CSSStyle> attributesStyle;
-    Maybe<protocol::Array<protocol::CSS::RuleMatch>> matchedRules;
-    Maybe<protocol::Array<protocol::CSS::PseudoElementMatches>> pseudoIdMatches;
-    Maybe<protocol::Array<protocol::CSS::InheritedStyleEntry>> inheritedEntries;
-    Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>> keyframesRules;
-
-    auto response = cssAgent->getMatchedStylesForNode(
-        nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
-        &inheritedEntries, nullptr, &keyframesRules, nullptr);
-
-    // WIP: will fix everything up and clean up when done w/ RUN-981
-
-    if (!response.IsSuccess()) {
-      recordreplay::Print(
-          "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, "
-          "Code: "
-          "%d): %s",
-          nodeId, response.Code(), response.Message().c_str());
-      args.GetReturnValue().SetNull();
-    } else {
-      v8::Local<v8::Object> result = v8::Object::New(isolate);
-      // NOTE: not sure what `attributesStyle` is and how its different from
-      // `inlineStyle`?
-      if (attributesStyle.isJust()) {
-        auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
-        if (!rulesJs.IsEmpty()) {
-          SetDataProperty(isolate, result, "attributesStyle",
-                          rulesJs.ToLocalChecked());
-        }
+  } else {
+    v8::Local<v8::Object> result = v8::Object::New(isolate);
+    // NOTE: not sure what `attributesStyle` is and how its different from
+    // `inlineStyle`?
+    if (attributesStyle.isJust()) {
+      auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
+      if (!rulesJs.IsEmpty()) {
+        SetDataProperty(isolate, result, "attributesStyle",
+                        rulesJs.ToLocalChecked());
       }
-      if (matchedRules.isJust()) {
-        auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
-        SetDataProperty(isolate, result, "matchedRules", rulesJs);
-      }
-      if (pseudoIdMatches.isJust()) {
-        auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
-        SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
-      }
-      if (inheritedEntries.isJust()) {
-        auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
-        SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
-      }
-      if (keyframesRules.isJust()) {
-        auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
-        SetDataProperty(isolate, result, "keyframesRules", rulesJs);
-      }
-      args.GetReturnValue().Set(result);
     }
-  }
-
-  static void fromJsCssGetStylesheetByCpdId(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.Length() == 1 && args[0]->IsString() &&
-          "[RuntimeError] must be called with a single string");
-
-    v8::Isolate* isolate = args.GetIsolate();
-
-    auto sheetId = ToCoreString(args[0].As<v8::String>());
-    auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
-
-    CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
-    v8::Local<v8::Value> v8StyleSheet;
-    if (styleSheet && getV8FromBlinkObject(isolate, styleSheet, v8StyleSheet)) {
-      args.GetReturnValue().Set(v8StyleSheet);
-    } else {
-      args.GetReturnValue().SetNull();
+    if (matchedRules.isJust()) {
+      auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
+      SetDataProperty(isolate, result, "matchedRules", rulesJs);
     }
-  }
-
-  static void fromJsDomPerformSearch(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.Length() == 1 && args[0]->IsString() &&
-          "[RuntimeError] must be called with a single string");
-
-    v8::Isolate* isolate = args.GetIsolate();
-
-    auto query = ToCoreString(args[0].As<v8::String>());
-    auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
-    bool includeUserAgentShadowDom = true;
-    String searchId;
-    int resultCount;
-    auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
-                                            &searchId, &resultCount);
-    if (checkCDPResponse("DOM.performSearch", response, args)) {
-      if (resultCount) {
-        int fromIndex = 0;
-        int toIndex = resultCount;
-        std::unique_ptr<protocol::Array<int>> nodeIds;
-        response =
-            domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
-        if (checkCDPResponse("DOM.getSearchResults", response, args)) {
-          v8::Local<v8::Array> result = v8::Array::New(isolate);
-          uint32_t nWritten = 0;
-          for (uint32_t i = 0; i < nodeIds->size(); ++i) {
-            int nodeId = (*nodeIds)[i];
-            auto* node = domAgent->NodeForId(nodeId);
-            v8::Local<v8::Value> v8Node;
-            if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
-              v8::Local<v8::Context> context = isolate->GetCurrentContext();
-              result->Set(context, nWritten++, v8Node).Check();
-            }
-          }
-          args.GetReturnValue().Set(result);
-        }
-      } else {
-        v8::Local<v8::Array> result = v8::Array::New(isolate);
-        args.GetReturnValue().Set(result);
-      }
-
-      // clean up
-      domAgent->discardSearchResults(searchId);
+    if (pseudoIdMatches.isJust()) {
+      auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
+      SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
     }
-  }
-
-  static void fromJsCollectEventListeners(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(
-        args.Length() == 1 && args[0]->IsObject() &&
-        "[RuntimeError] must be called with a single plain object (DOM node)");
-
-    v8::Isolate* isolate = args.GetIsolate();
-    auto context = isolate->GetCurrentContext();
-    auto nodeObject = args[0].As<v8::Object>();
-    auto* node = V8Node::ToImpl(nodeObject);
-
-    v8::Local<v8::Array> result = v8::Array::New(isolate);
-    if (!node) {
-      recordreplay::Print(
-          "[RuntimeError] fromJsCollectEventListeners invalid argument is not "
-          "blink Node");
-    } else {
-      auto report_for_all_contexts = true;
-      V8EventListenerInfoList eventListenerInfos;
-      InspectorDOMDebuggerAgent::CollectEventListeners(
-          isolate, node, nodeObject, node, report_for_all_contexts,
-          &eventListenerInfos);
-
-      uint32_t i = 0;
-      for (const auto& info : eventListenerInfos) {
-        auto v8Info = v8::Object::New(isolate);
-        SetDataProperty(isolate, v8Info, "type",
-                        V8String(isolate, info.event_type));
-        SetDataProperty(isolate, v8Info, "capture",
-                        v8::Boolean::New(isolate, info.use_capture));
-        SetDataProperty(isolate, v8Info, "handler", info.effective_function);
-        result->Set(context, i++, v8Info).Check();
-      }
+    if (inheritedEntries.isJust()) {
+      auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
+      SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
+    }
+    if (keyframesRules.isJust()) {
+      auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
+      SetDataProperty(isolate, result, "keyframesRules", rulesJs);
     }
     args.GetReturnValue().Set(result);
   }
+}
 
-  /** ###########################################################################
-   * misc
-   * ##########################################################################*/
+static void fromJsCssGetStylesheetByCpdId(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "[RuntimeError] must be called with a single string");
 
-  // Handle incoming browser events.
-  static void HandleBrowserEvent(const char* name, const char* payload) {
-    base::Value val = base::JSONReader::Read(payload).value_or(base::Value());
-    assert(!val.is_none() && "Browser event JSON failed");
-    assert(!val.is_dict() && "Browser event JSON is not a dictionary");
-    if (!strcmp(name, "Network.PrepareRequest")) {
-      HandleNetworkPrepareRequestEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.ResourceRedirect")) {
-      HandleNetworkResourceRedirectEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.RequestData.Form")) {
-      HandleNetworkRequestDataFormEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.DidReceiveResponse")) {
-      HandleNetworkDidReceiveResponseEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.DidFinishLoading")) {
-      HandleNetworkDidFinishLoadingEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.DidFailLoading")) {
-      HandleNetworkDidFailLoadingEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.DidReceiveData")) {
-      HandleNetworkDidReceiveDataEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.Navigation")) {
-      HandleNetworkNavigationEvent(base::Value::AsDictionaryValue(val));
-    } else if (!strcmp(name, "Network.NavigationRedirect")) {
-      HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto sheetId = ToCoreString(args[0].As<v8::String>());
+  auto* cssAgent = getOrCreateInspectorCSSAgent(isolate);
+
+  CSSStyleSheet* styleSheet = cssAgent->getStyleSheet(sheetId);
+  v8::Local<v8::Value> v8StyleSheet;
+  if (styleSheet && getV8FromBlinkObject(isolate, styleSheet, v8StyleSheet)) {
+    args.GetReturnValue().Set(v8StyleSheet);
+  } else {
+    args.GetReturnValue().SetNull();
+  }
+}
+
+static void fromJsDomPerformSearch(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "[RuntimeError] must be called with a single string");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto query = ToCoreString(args[0].As<v8::String>());
+  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
+
+  bool includeUserAgentShadowDom = true;
+  String searchId;
+  int resultCount;
+  auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
+                                          &searchId, &resultCount);
+  if (checkCDPResponse("DOM.performSearch", response, args)) {
+    if (resultCount) {
+      int fromIndex = 0;
+      int toIndex = resultCount;
+      std::unique_ptr<protocol::Array<int>> nodeIds;
+      response =
+          domAgent->getSearchResults(searchId, fromIndex, toIndex, &nodeIds);
+      if (checkCDPResponse("DOM.getSearchResults", response, args)) {
+        v8::Local<v8::Array> result = v8::Array::New(isolate);
+        uint32_t nWritten = 0;
+        for (uint32_t i = 0; i < nodeIds->size(); ++i) {
+          int nodeId = (*nodeIds)[i];
+          auto* node = domAgent->NodeForId(nodeId);
+          v8::Local<v8::Value> v8Node;
+          if (node && getV8FromBlinkObject(isolate, node, v8Node)) {
+            v8::Local<v8::Context> context = isolate->GetCurrentContext();
+            result->Set(context, nWritten++, v8Node).Check();
+          }
+        }
+        args.GetReturnValue().Set(result);
+      }
     } else {
-      recordreplay::Print("HandleBrowserEvent received unrecognized event %s",
-                          name);
-    }
-  }
-
-  // Called from page page javascript.
-  // `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
-  // Since this function is called from userland JS, we avoid assertions.
-  // We don't want flawed uses of the API to crash the recording.
-  static void InvokeOnAnnotation(
-      const v8::FunctionCallbackInfo<v8::Value>& args) {
-    if (!(args.Length() >= 2 && args[0]->IsString())) {
-      recordreplay::Print("%s called with incorrect arguments",
-                          AnnotationHookJSName);
-      return;
+      v8::Local<v8::Array> result = v8::Array::New(isolate);
+      args.GetReturnValue().Set(result);
     }
 
-    v8::Isolate* isolate = args.GetIsolate();
-    v8::Local<v8::Object> payload = v8::Object::New(isolate);
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    payload->Set(context, ToV8String(isolate, "message"), args[1]).Check();
-
-    v8::Local<v8::String> json;
-    if (!v8::JSON::Stringify(context, payload).ToLocal(&json)) {
-      recordreplay::Print("%s contents failed to json stringify",
-                          AnnotationHookJSName);
-      return;
-    }
-
-    v8::String::Utf8Value kind(args.GetIsolate(), args[0]);
-    v8::String::Utf8Value contents(args.GetIsolate(), json);
-    recordreplay::OnAnnotation(*kind, *contents);
+    // clean up
+    domAgent->discardSearchResults(searchId);
   }
+}
 
-  extern "C" void V8RecordReplaySetAPIObjectIdCallback(
-      int (*callback)(v8::Local<v8::Object>));
-  extern "C" void V8RecordReplayRegisterBrowserEventCallback(
-      void (*callback)(const char* name, const char* payload));
+static void fromJsCollectEventListeners(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(
+      args.Length() == 1 && args[0]->IsObject() &&
+      "[RuntimeError] must be called with a single plain object (DOM node)");
 
-  static void RunScript(v8::Isolate * isolate, v8::Local<v8::Context> context,
-                        const char* script, const char* filename) {
-    v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
-    v8::ScriptOrigin origin(isolate, filename_string);
+  v8::Isolate* isolate = args.GetIsolate();
+  auto context = isolate->GetCurrentContext();
+  auto nodeObject = args[0].As<v8::Object>();
+  auto* node = V8Node::ToImpl(nodeObject);
 
-    v8::Local<v8::String> source = ToV8String(isolate, script);
+  v8::Local<v8::Array> result = v8::Array::New(isolate);
+  if (!node) {
+    recordreplay::Print(
+        "[RuntimeError] fromJsCollectEventListeners invalid argument is not "
+        "blink Node");
+  } else {
+    auto report_for_all_contexts = true;
+    V8EventListenerInfoList eventListenerInfos;
+    InspectorDOMDebuggerAgent::CollectEventListeners(
+        isolate, node, nodeObject, node, report_for_all_contexts,
+        &eventListenerInfos);
 
-    // TODO: check for errors after `Compile` and `Run` -
-    // https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
-    v8::Local<v8::Script> compiled =
-        v8::Script::Compile(context, source, &origin).ToLocalChecked();
-    compiled->Run(context).ToLocalChecked();
-  }
-
-  static bool TestEnv(const char* env) {
-    const char* v = getenv(env);
-    return v && v[0] && v[0] != '0';
-  }
-
-  void SetupRecordReplayCommands(v8::Isolate * isolate,
-                                 LocalFrame * localFrame) {
-    V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
-    V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
-
-    gLocalFrame = localFrame;
-
-    gActiveNetworkRequests =
-        new std::unordered_map<std::string, NetworkRequestStatus>();
-    gCurrentNetworkStreamData = new std::vector<uint8_t>();
-
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
-
-    // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
-    // the page window global.
-    SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
-                        InvokeOnAnnotation);
-
-    v8::Local<v8::Object> args = v8::Object::New(isolate);
-    DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                   args);
-
-    SetFunctionProperty(isolate, args, "log", LogCallback);
-
-    // CDP debugger functionality
-    SetFunctionProperty(isolate, args, "setCDPMessageCallback",
-                        SetCDPMessageCallback);
-    SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
-    SetFunctionProperty(isolate, args, "setCommandCallback",
-                        v8::FunctionCallbackRecordReplaySetCommandCallback);
-
-    // Object Management
-    SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
-                        fromJsMakeDebuggeeValue);
-    SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
-                        fromJsGetArgumentsInFrame);
-    SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
-                        fromJsGetObjectByCdpId);
-
-    // networking
-    SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
-                        GetCurrentNetworkRequestEvent);
-    SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
-                        GetCurrentNetworkStreamData);
-
-    // DOM, blink, API stuff
-    // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
-    //                     jsGetObjectIdForAnyObject);
-    // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
-    // jsPreviewBlinkObjectForObjectId);
-    SetFunctionProperty(isolate, args, "fromJsGetNodeId", fromJsGetNodeId);
-    SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
-    SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForNode",
-                        fromJsGetMatchedStylesForNode);
-    SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
-                        fromJsCssGetStylesheetByCpdId);
-    SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
-                        fromJsCollectEventListeners);
-    SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
-                        fromJsDomPerformSearch);
-
-    // unsorted RR stuff
-    SetFunctionProperty(
-        isolate, args, "setClearPauseDataCallback",
-        v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-    SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
-    SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
-    SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
-    SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
-                        WriteToRecordingDirectory);
-    SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
-    SetFunctionProperty(isolate, args, "addNewScriptHandler",
-                        v8::FunctionCallbackRecordReplayAddNewScriptHandler);
-    SetFunctionProperty(isolate, args, "getScriptSource",
-                        v8::FunctionCallbackRecordReplayGetScriptSource);
-    SetFunctionProperty(isolate, args, "getPersistentId", GetPersistentId);
-    SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
-
-    // This URL will prevent the script from being reported to the recorder.
-    const char* InternalScriptURL = "record-replay-internal";
-
-    if (recordreplay::FeatureEnabled("collect-source-maps") &&
-        !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
-      RunScript(isolate, context, gSourceMapScript, InternalScriptURL);
-    }
-
-    if (recordreplay::IsReplaying()) {
-      recordreplay::AutoDisallowEvents disallow;
-      RunScript(isolate, context, gReplayScript, InternalScriptURL);
-
-      // initialize InspectorDOMDebuggerAgent, so it can pick up user events
-      getOrCreateInspectorDOMDebuggerAgent(isolate);
+    uint32_t i = 0;
+    for (const auto& info : eventListenerInfos) {
+      auto v8Info = v8::Object::New(isolate);
+      SetDataProperty(isolate, v8Info, "type",
+                      V8String(isolate, info.event_type));
+      SetDataProperty(isolate, v8Info, "capture",
+                      v8::Boolean::New(isolate, info.use_capture));
+      SetDataProperty(isolate, v8Info, "handler", info.effective_function);
+      result->Set(context, i++, v8Info).Check();
     }
   }
+  args.GetReturnValue().Set(result);
+}
 
-  void RunInitialRecordReplayScripts(v8::Isolate * isolate) {
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+/** ###########################################################################
+ * misc
+ * ##########################################################################*/
 
-    if (recordreplay::FeatureEnabled("react-devtools-backend") &&
-        !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
-      // Note: We use a special URL for the react devtools as this script needs
-      // to be reported to the recorder so that evaluations can be performed in
-      // its frames.
-      RunScript(isolate, context, gReactDevtoolsScript,
-                "record-replay-react-devtools");
-    }
+// Handle incoming browser events.
+static void HandleBrowserEvent(const char* name, const char* payload) {
+  base::Value val = base::JSONReader::Read(payload).value_or(base::Value());
+  assert(!val.is_none() && "Browser event JSON failed");
+  assert(!val.is_dict() && "Browser event JSON is not a dictionary");
+  if (!strcmp(name, "Network.PrepareRequest")) {
+    HandleNetworkPrepareRequestEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.ResourceRedirect")) {
+    HandleNetworkResourceRedirectEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.RequestData.Form")) {
+    HandleNetworkRequestDataFormEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.DidReceiveResponse")) {
+    HandleNetworkDidReceiveResponseEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.DidFinishLoading")) {
+    HandleNetworkDidFinishLoadingEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.DidFailLoading")) {
+    HandleNetworkDidFailLoadingEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.DidReceiveData")) {
+    HandleNetworkDidReceiveDataEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.Navigation")) {
+    HandleNetworkNavigationEvent(base::Value::AsDictionaryValue(val));
+  } else if (!strcmp(name, "Network.NavigationRedirect")) {
+    HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
+  } else {
+    recordreplay::Print("HandleBrowserEvent received unrecognized event %s",
+                        name);
+  }
+}
+
+// Called from page page javascript.
+// `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
+// Since this function is called from userland JS, we avoid assertions.
+// We don't want flawed uses of the API to crash the recording.
+static void InvokeOnAnnotation(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!(args.Length() >= 2 && args[0]->IsString())) {
+    recordreplay::Print("%s called with incorrect arguments",
+                        AnnotationHookJSName);
+    return;
   }
 
-  extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Object> payload = v8::Object::New(isolate);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  payload->Set(context, ToV8String(isolate, "message"), args[1]).Check();
 
-  static ErrorEvent* gCurrentErrorEvent;
-
-  void RecordReplayOnErrorEvent(ErrorEvent * error_event) {
-    if (!v8::IsMainThread()) {
-      return;
-    }
-
-    CHECK(!gCurrentErrorEvent);
-    gCurrentErrorEvent = error_event;
-
-    size_t bookmark = error_event->record_replay_bookmark();
-    V8RecordReplayOnConsoleMessage(bookmark);
-
-    gCurrentErrorEvent = nullptr;
+  v8::Local<v8::String> json;
+  if (!v8::JSON::Stringify(context, payload).ToLocal(&json)) {
+    recordreplay::Print("%s contents failed to json stringify",
+                        AnnotationHookJSName);
+    return;
   }
 
-  static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    if (!gCurrentErrorEvent) {
-      return;
-    }
+  v8::String::Utf8Value kind(args.GetIsolate(), args[0]);
+  v8::String::Utf8Value contents(args.GetIsolate(), json);
+  recordreplay::OnAnnotation(*kind, *contents);
+}
 
-    v8::Isolate* isolate = args.GetIsolate();
-    v8::Local<v8::Object> rv = v8::Object::New(isolate);
+extern "C" void V8RecordReplaySetAPIObjectIdCallback(
+    int (*callback)(v8::Local<v8::Object>));
+extern "C" void V8RecordReplayRegisterBrowserEventCallback(
+    void (*callback)(const char* name, const char* payload));
 
-    SetDataProperty(
-        isolate, rv, "message",
-        ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
-    SetDataProperty(
-        isolate, rv, "filename",
-        ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
-    SetDataProperty(isolate, rv, "line",
-                    v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
-    SetDataProperty(isolate, rv, "column",
-                    v8::Number::New(isolate, gCurrentErrorEvent->colno()));
-    SetDataProperty(
-        isolate, rv, "scriptId",
-        v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
+static void RunScript(v8::Isolate * isolate, v8::Local<v8::Context> context,
+                      const char* script, const char* filename) {
+  v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
+  v8::ScriptOrigin origin(isolate, filename_string);
 
-    args.GetReturnValue().Set(rv);
+  v8::Local<v8::String> source = ToV8String(isolate, script);
+
+  // TODO: check for errors after `Compile` and `Run` -
+  // https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
+  v8::Local<v8::Script> compiled =
+      v8::Script::Compile(context, source, &origin).ToLocalChecked();
+  compiled->Run(context).ToLocalChecked();
+}
+
+static bool TestEnv(const char* env) {
+  const char* v = getenv(env);
+  return v && v[0] && v[0] != '0';
+}
+
+void SetupRecordReplayCommands(v8::Isolate * isolate,
+                                LocalFrame * localFrame) {
+  V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
+  V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
+
+  gLocalFrame = localFrame;
+
+  gActiveNetworkRequests =
+      new std::unordered_map<std::string, NetworkRequestStatus>();
+  gCurrentNetworkStreamData = new std::vector<uint8_t>();
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+  // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
+  // the page window global.
+  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
+                      InvokeOnAnnotation);
+
+  v8::Local<v8::Object> args = v8::Object::New(isolate);
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
+                  args);
+
+  SetFunctionProperty(isolate, args, "log", LogCallback);
+
+  // CDP debugger functionality
+  SetFunctionProperty(isolate, args, "setCDPMessageCallback",
+                      SetCDPMessageCallback);
+  SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
+  SetFunctionProperty(isolate, args, "setCommandCallback",
+                      v8::FunctionCallbackRecordReplaySetCommandCallback);
+
+  // Object Management
+  SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
+                      fromJsMakeDebuggeeValue);
+  SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
+                      fromJsGetArgumentsInFrame);
+  SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
+                      fromJsGetObjectByCdpId);
+
+  // networking
+  SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
+                      GetCurrentNetworkRequestEvent);
+  SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
+                      GetCurrentNetworkStreamData);
+
+  // DOM, blink, API stuff
+  // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
+  //                     jsGetObjectIdForAnyObject);
+  // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
+  // jsPreviewBlinkObjectForObjectId);
+  SetFunctionProperty(isolate, args, "fromJsGetNodeId", fromJsGetNodeId);
+  SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
+  SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForNode",
+                      fromJsGetMatchedStylesForNode);
+  SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
+                      fromJsCssGetStylesheetByCpdId);
+  SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
+                      fromJsCollectEventListeners);
+  SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
+                      fromJsDomPerformSearch);
+
+  // unsorted RR stuff
+  SetFunctionProperty(
+      isolate, args, "setClearPauseDataCallback",
+      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+  SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
+  SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
+  SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
+  SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
+                      WriteToRecordingDirectory);
+  SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
+  SetFunctionProperty(isolate, args, "addNewScriptHandler",
+                      v8::FunctionCallbackRecordReplayAddNewScriptHandler);
+  SetFunctionProperty(isolate, args, "getScriptSource",
+                      v8::FunctionCallbackRecordReplayGetScriptSource);
+  SetFunctionProperty(isolate, args, "getPersistentId", GetPersistentId);
+  SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
+
+  // This URL will prevent the script from being reported to the recorder.
+  const char* InternalScriptURL = "record-replay-internal";
+
+  if (recordreplay::FeatureEnabled("collect-source-maps") &&
+      !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
+    RunScript(isolate, context, gSourceMapScript, InternalScriptURL);
   }
+
+  if (recordreplay::IsReplaying()) {
+    recordreplay::AutoDisallowEvents disallow;
+    RunScript(isolate, context, gReplayScript, InternalScriptURL);
+
+    // initialize InspectorDOMDebuggerAgent, so it can pick up user events
+    getOrCreateInspectorDOMDebuggerAgent(isolate);
+  }
+}
+
+void RunInitialRecordReplayScripts(v8::Isolate * isolate) {
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+  if (recordreplay::FeatureEnabled("react-devtools-backend") &&
+      !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
+    // Note: We use a special URL for the react devtools as this script needs
+    // to be reported to the recorder so that evaluations can be performed in
+    // its frames.
+    RunScript(isolate, context, gReactDevtoolsScript,
+              "record-replay-react-devtools");
+  }
+}
+
+extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
+
+static ErrorEvent* gCurrentErrorEvent;
+
+void RecordReplayOnErrorEvent(ErrorEvent * error_event) {
+  if (!v8::IsMainThread()) {
+    return;
+  }
+
+  CHECK(!gCurrentErrorEvent);
+  gCurrentErrorEvent = error_event;
+
+  size_t bookmark = error_event->record_replay_bookmark();
+  V8RecordReplayOnConsoleMessage(bookmark);
+
+  gCurrentErrorEvent = nullptr;
+}
+
+static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!gCurrentErrorEvent) {
+    return;
+  }
+
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Object> rv = v8::Object::New(isolate);
+
+  SetDataProperty(
+      isolate, rv, "message",
+      ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
+  SetDataProperty(
+      isolate, rv, "filename",
+      ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
+  SetDataProperty(isolate, rv, "line",
+                  v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
+  SetDataProperty(isolate, rv, "column",
+                  v8::Number::New(isolate, gCurrentErrorEvent->colno()));
+  SetDataProperty(
+      isolate, rv, "scriptId",
+      v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
+
+  args.GetReturnValue().Set(rv);
+}
 
 }  // namespace blink

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3349,111 +3349,67 @@ static void fromJsGetObjectByCdpId(
   }
 }
 
-/** ###########################################################################
- * Networking
- * ##########################################################################*/
-
-// Represents a known network request.  Created and added to
-// `gActiveNetworkRequests` when the request is first seen.  Removed
-// when the request finishes or fails.
-struct NetworkRequestStatus {
-  size_t response_data_received;
-  size_t request_data_sent;
-  std::string method;
-  uint64_t bookmark;
-  NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
-      : response_data_received(0),
-        request_data_sent(0),
-        method(method),
-        bookmark(bookmark) {}
-};
-// Map of active network requests.
-std::unordered_map<std::string, NetworkRequestStatus>*
-    gActiveNetworkRequests = nullptr;
-
-// Globals storing values to be returned to controller commands
-// `GetCurrentNetwork*`
-static base::Value* gCurrentNetworkRequestEvent = nullptr;
-static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
-
-static void GetCurrentNetworkRequestEvent(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (!gCurrentNetworkRequestEvent) {
-    return;
-  }
-
-  v8::Isolate* isolate = args.GetIsolate();
-  std::string json;
-  base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
-  v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
-  args.GetReturnValue().Set(json_string);
-}
-
-static void GetCurrentNetworkStreamData(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
+static void GetCurrentNetworkStreamData(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(gCurrentNetworkStreamData);
 
   v8::Isolate* isolate = args.GetIsolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   // Expect params: { index, length }
-  v8::Local<v8::Object> params = args[0]->ToObject(context).ToLocalChecked();
-  size_t index = params->Get(context, ToV8String(isolate, "index"))
-                      .ToLocalChecked()
-                      ->NumberValue(context)
-                      .ToChecked();
-  size_t length = params->Get(context, ToV8String(isolate, "length"))
-                      .ToLocalChecked()
-                      ->NumberValue(context)
-                      .ToChecked();
+  v8::Local<v8::Object> params =
+    args[0]->ToObject(context).ToLocalChecked();
+  size_t index =
+    params->Get(context, ToV8String(isolate, "index"))
+      .ToLocalChecked()->NumberValue(context).ToChecked();
+  size_t length =
+    params->Get(context, ToV8String(isolate, "length"))
+      .ToLocalChecked()->NumberValue(context).ToChecked();
   size_t size = gCurrentNetworkStreamData->size();
 
   if ((size < index) || ((size - index) < length)) {
     recordreplay::Print(
-        "GetCurrentNetworkStreamData: Out of range slice"
-        " (size=%u, requested=%u-%u)",
-        (unsigned)size, (unsigned)index, (unsigned)(index + length));
+      "GetCurrentNetworkStreamData: Out of range slice"
+      " (size=%u, requested=%u-%u)",
+      (unsigned) size,
+      (unsigned) index,
+      (unsigned) (index + length)
+    );
     return;
   }
 
   uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
-  std::string encoded =
-      base::Base64Encode(base::span<const uint8_t>(bytes, length));
+  std::string encoded = base::Base64Encode(
+    base::span<const uint8_t>(bytes, length)
+  );
   char* encoded_cstr = strdup(encoded.c_str());
   char* encoded_end = encoded_cstr + encoded.length();
-  for (char* cur = encoded_cstr; cur < encoded_end; cur++) {
-    if (*cur == '-') {
-      *cur = '+';
-    }
-    if (*cur == '_') {
-      *cur = '/';
-    }
+  for (char *cur = encoded_cstr; cur < encoded_end; cur++) {
+    if (*cur == '-') { *cur = '+'; }
+    if (*cur == '_') { *cur = '/'; }
   }
 
   v8::Local<v8::Object> result = v8::Object::New(isolate);
-  result
-      ->Set(context, ToV8String(isolate, "kind"), ToV8String(isolate, "data"))
-      .Check();
-  result
-      ->Set(context, ToV8String(isolate, "value"),
-            ToV8String(isolate, encoded_cstr))
-      .Check();
+  result->Set(context,
+    ToV8String(isolate, "kind"),
+    ToV8String(isolate, "data")
+  ).Check();
+  result->Set(context,
+    ToV8String(isolate, "value"),
+    ToV8String(isolate, encoded_cstr)
+  ).Check();
   args.GetReturnValue().Set(result);
 }
 
 static std::string MakeRequestIdentifier(uint64_t identifier) {
   char request_id[64];
-  snprintf(request_id, 64, "%d.%lu", (int)getpid(),
-            (unsigned long)identifier);
+  snprintf(request_id, 64, "%d.%lu", (int) getpid(), (unsigned long) identifier);
   return std::string(request_id);
 }
 
-static void HandleNetworkPrepareRequestEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkPrepareRequestEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
   std::string request_id = *info.FindPath("requestId")->GetIfString();
-  if (gActiveNetworkRequests->find(request_id) !=
-      gActiveNetworkRequests->end()) {
+  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
     // If the request already exists, this is a redirect.
     // Chromium will send a "Network.ResourceRedirect" event which will
     // be handled by `HandleNetworkPrepareRequestEvent` below.
@@ -3468,7 +3424,8 @@ static void HandleNetworkPrepareRequestEvent(
   std::string request_method = *info.FindPath("requestMethod")->GetIfString();
   uint64_t bookmark = *info.FindPath("bookmark")->GetIfDouble();
   gActiveNetworkRequests->insert(
-      {request_id, NetworkRequestStatus(request_method, bookmark)});
+    { request_id, NetworkRequestStatus(request_method, bookmark) }
+  );
 
   // Register the request.
   recordreplay::OnNetworkRequest(request_id.c_str(), "http", bookmark);
@@ -3476,16 +3433,12 @@ static void HandleNetworkPrepareRequestEvent(
   // Package and emit a network request event with the appropriate info.
   base::DictionaryValue event;
   event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(
-                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
   event.SetString("requestMethod", request_method);
-  event.Set("requestHeaders",
-            std::unique_ptr<base::Value>(
-                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
   const base::Value* request_cause_value = info.FindPath("requestCause");
   if (request_cause_value) {
-    event.Set("requestCause", std::unique_ptr<base::Value>(
-                                  request_cause_value->CreateDeepCopy()));
+    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->CreateDeepCopy()));
   }
 
   gCurrentNetworkRequestEvent = &event;
@@ -3493,40 +3446,35 @@ static void HandleNetworkPrepareRequestEvent(
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkResourceRedirectEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkResourceRedirectEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
 
   // Retreive the existing request data which should already have been
   // registered by `HandleNetworkPrepareRequestEvent`.
-  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
   std::string request_id = MakeRequestIdentifier(identifier);
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("No original request for navigation redirect: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
   // Register a new network request with the same request id as the original
   // for this redirect.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                  request_info->second.bookmark);
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
 
   // Package and emit a network request event.
   // The request_method is obtained from the saved request info.
   base::DictionaryValue event;
   event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(
-                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
   event.SetString("requestMethod", request_info->second.method);
-  event.Set("requestHeaders",
-            std::unique_ptr<base::Value>(
-                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
   const base::Value* request_cause_value = info.FindPath("requestCause");
   if (request_cause_value) {
-    event.Set("requestCause", std::unique_ptr<base::Value>(
-                                  request_cause_value->CreateDeepCopy()));
+    event.Set("requestCause", std::unique_ptr<base::Value>(request_cause_value->CreateDeepCopy()));
   }
 
   gCurrentNetworkRequestEvent = &event;
@@ -3544,30 +3492,23 @@ static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
 
   // Ensure that a request with the same ID has not already been registered.
   std::string request_id = *info.FindPath("requestId")->GetIfString();
-  if (gActiveNetworkRequests->find(request_id) !=
-      gActiveNetworkRequests->end()) {
+  if (gActiveNetworkRequests->find(request_id) != gActiveNetworkRequests->end()) {
     recordreplay::Print("Duplicate request id: %s", request_id.c_str());
     return;
   }
   std::string request_method = *info.FindPath("requestMethod")->GetIfString();
-  gActiveNetworkRequests->insert(
-      {request_id, NetworkRequestStatus(request_method)});
+  gActiveNetworkRequests->insert({ request_id, NetworkRequestStatus(request_method) });
 
-  // A navigation event is a new network request, so call the
-  // `OnNetworkRequest` hook. Navigation events have no bookmarks associated
-  // with them.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                  /* bookmark = */ 0);
+  // A navigation event is a new network request, so call the `OnNetworkRequest` hook.
+  // Navigation events have no bookmarks associated with them.
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", /* bookmark = */ 0);
 
   // Package and emit a network request event.
   base::DictionaryValue event;
   event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(
-                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
   event.SetString("requestMethod", request_method);
-  event.Set("requestHeaders",
-            std::unique_ptr<base::Value>(
-                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
   event.SetString("requestCause", "document");
 
   gCurrentNetworkRequestEvent = &event;
@@ -3575,8 +3516,7 @@ static void HandleNetworkNavigationEvent(const base::DictionaryValue& info) {
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkNavigationRedirectEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkNavigationRedirectEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
 
   // Navigation redirect events are, as with navigation events, sent from
@@ -3589,24 +3529,20 @@ static void HandleNetworkNavigationRedirectEvent(
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("No original request for navigation redirect: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
   // A navigation redirect event is a new network request.
-  recordreplay::OnNetworkRequest(request_id.c_str(), "http",
-                                  request_info->second.bookmark);
+  recordreplay::OnNetworkRequest(request_id.c_str(), "http", request_info->second.bookmark);
 
   // Package and emit a network request event.
   // The request method is obtained from the saved request info.
   base::DictionaryValue event;
   event.SetString("kind", "request");
-  event.Set("requestUrl", std::unique_ptr<base::Value>(
-                              info.FindPath("requestUrl")->CreateDeepCopy()));
+  event.Set("requestUrl", std::unique_ptr<base::Value>(info.FindPath("requestUrl")->CreateDeepCopy()));
   event.SetString("requestMethod", request_info->second.method);
-  event.Set("requestHeaders",
-            std::unique_ptr<base::Value>(
-                info.FindPath("requestHeaders")->CreateDeepCopy()));
+  event.Set("requestHeaders", std::unique_ptr<base::Value>(info.FindPath("requestHeaders")->CreateDeepCopy()));
   event.SetString("requestCause", "document");
 
   gCurrentNetworkRequestEvent = &event;
@@ -3614,14 +3550,13 @@ static void HandleNetworkNavigationRedirectEvent(
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkRequestDataFormEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkRequestDataFormEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
   std::string request_id = *info.FindPath("requestId")->GetIfString();
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request for request data: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
@@ -3629,7 +3564,7 @@ static void HandleNetworkRequestDataFormEvent(
   // request data is present and none should have been already received.
   CHECK(request_info->second.request_data_sent == 0);
 
-  {  // Send a "request-body" network request event.
+  { // Send a "request-body" network request event.
     base::DictionaryValue requestBodyEvent;
     requestBodyEvent.SetString("kind", "request-body");
 
@@ -3641,123 +3576,128 @@ static void HandleNetworkRequestDataFormEvent(
   std::string stream_id = "request-" + request_id;
 
   // Call StreamStart API.
-  recordreplay::OnNetworkStreamStart(stream_id.c_str(), "request-data",
-                                      request_id.c_str());
+  recordreplay::OnNetworkStreamStart(
+    stream_id.c_str(), "request-data", request_id.c_str()
+  );
 
   // Call StreamData API.
   size_t length = *info.FindPath("dataLength")->GetIfDouble();
 
   CHECK(length >= 0);
   gCurrentNetworkStreamData->clear();
-  const std::string* data_base64 = info.FindPath("data")->GetIfString();
+  const std::string *data_base64 = info.FindPath("data")->GetIfString();
   if (data_base64) {
     const uint8_t* data =
-        reinterpret_cast<const uint8_t*>(data_base64->c_str());
-    gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
-                                      data, data + data_base64->length());
+      reinterpret_cast<const uint8_t *>(data_base64->c_str());
+    gCurrentNetworkStreamData->insert(
+      gCurrentNetworkStreamData->begin(),
+      data,
+      data + data_base64->length()
+    );
     size_t offset = request_info->second.response_data_received;
-    recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
-                                      /* bookmark = */ 0);
+    recordreplay::OnNetworkStreamData(
+      stream_id.c_str(), offset, length, /* bookmark = */ 0
+    );
     gCurrentNetworkStreamData->clear();
   }
   request_info->second.request_data_sent += length;
 }
 
-static void HandleNetworkDidReceiveResponseEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkDidReceiveResponseEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
-  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
   std::string request_id = MakeRequestIdentifier(identifier);
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request received response: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
   base::DictionaryValue event;
   event.SetString("kind", "response");
-  event.Set("responseHeaders",
-            std::unique_ptr<base::Value>(
-                info.FindPath("responseHeaders")->CreateDeepCopy()));
-  event.Set("responseProtocolVersion",
-            std::unique_ptr<base::Value>(
-                info.FindPath("responseProtocolVersion")->CreateDeepCopy()));
-  event.Set("responseStatus",
-            std::unique_ptr<base::Value>(
-                info.FindPath("responseStatus")->CreateDeepCopy()));
-  event.Set("responseStatusText",
-            std::unique_ptr<base::Value>(
-                info.FindPath("responseStatusText")->CreateDeepCopy()));
-  event.Set("responseFromCache",
-            std::unique_ptr<base::Value>(
-                info.FindPath("responseFromCache")->CreateDeepCopy()));
+  event.Set("responseHeaders", std::unique_ptr<base::Value>(
+    info.FindPath("responseHeaders")->CreateDeepCopy()
+  ));
+  event.Set("responseProtocolVersion", std::unique_ptr<base::Value>(
+    info.FindPath("responseProtocolVersion")->CreateDeepCopy()
+  ));
+  event.Set("responseStatus", std::unique_ptr<base::Value>(
+    info.FindPath("responseStatus")->CreateDeepCopy()
+  ));
+  event.Set("responseStatusText", std::unique_ptr<base::Value>(
+    info.FindPath("responseStatusText")->CreateDeepCopy()
+  ));
+  event.Set("responseFromCache", std::unique_ptr<base::Value>(
+    info.FindPath("responseFromCache")->CreateDeepCopy()
+  ));
 
   gCurrentNetworkRequestEvent = &event;
   recordreplay::OnNetworkRequestEvent(request_id.c_str());
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkDidFinishLoadingEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkDidFinishLoadingEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
-  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
   std::string request_id = MakeRequestIdentifier(identifier);
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request finished loading: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
   base::DictionaryValue event;
   event.SetString("kind", "request-done");
-  event.Set("encodedBodySize",
-            std::unique_ptr<base::Value>(
-                info.FindPath("encodedBodySize")->CreateDeepCopy()));
-  event.Set("decodedBodySize",
-            std::unique_ptr<base::Value>(
-                info.FindPath("decodedBodySize")->CreateDeepCopy()));
+  event.Set("encodedBodySize", std::unique_ptr<base::Value>(
+    info.FindPath("encodedBodySize")->CreateDeepCopy()
+  ));
+  event.Set("decodedBodySize", std::unique_ptr<base::Value>(
+    info.FindPath("decodedBodySize")->CreateDeepCopy()
+  ));
 
   gCurrentNetworkRequestEvent = &event;
   recordreplay::OnNetworkRequestEvent(request_id.c_str());
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkDidFailLoadingEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkDidFailLoadingEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
-  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
   std::string request_id = MakeRequestIdentifier(identifier);
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request failed loading: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
   base::DictionaryValue event;
   event.SetString("kind", "request-failed");
-  event.Set("requestFailedReason",
-            std::unique_ptr<base::Value>(
-                info.FindPath("requestFailedReason")->CreateDeepCopy()));
+  event.Set("requestFailedReason", std::unique_ptr<base::Value>(
+    info.FindPath("requestFailedReason")->CreateDeepCopy()
+  ));
 
   gCurrentNetworkRequestEvent = &event;
   recordreplay::OnNetworkRequestEvent(request_id.c_str());
   gCurrentNetworkRequestEvent = nullptr;
 }
 
-static void HandleNetworkDidReceiveDataEvent(
-    const base::DictionaryValue& info) {
+static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) {
   CHECK(gActiveNetworkRequests);
   CHECK(gCurrentNetworkStreamData);
   // Get request info.
-  uint64_t identifier = *info.FindPath("identifier")->GetIfDouble();
+  uint64_t identifier =
+    *info.FindPath("identifier")->GetIfDouble();
   std::string request_id = MakeRequestIdentifier(identifier);
   auto request_info = gActiveNetworkRequests->find(request_id);
   if (request_info == gActiveNetworkRequests->end()) {
     recordreplay::Print("Unknown request received data: %s",
-                        request_id.c_str());
+      request_id.c_str());
     return;
   }
 
@@ -3772,8 +3712,9 @@ static void HandleNetworkDidReceiveDataEvent(
     recordreplay::OnNetworkRequestEvent(request_id.c_str());
     gCurrentNetworkRequestEvent = nullptr;
 
-    recordreplay::OnNetworkStreamStart(stream_id.c_str(), "response-data",
-                                        request_id.c_str());
+    recordreplay::OnNetworkStreamStart(
+      stream_id.c_str(), "response-data", request_id.c_str()
+    );
   }
 
   // Sending stream data.
@@ -3781,21 +3722,25 @@ static void HandleNetworkDidReceiveDataEvent(
   CHECK(length >= 0);
 
   gCurrentNetworkStreamData->clear();
-  const std::string* data_base64 = info.FindPath("data")->GetIfString();
+  const std::string *data_base64 = info.FindPath("data")->GetIfString();
   if (data_base64) {
     std::string out_string;
     if (!base::Base64Decode(*data_base64, &out_string)) {
       recordreplay::Print("Unknown request received data: %s",
-                          request_id.c_str());
+        request_id.c_str());
       return;
     }
     const uint8_t* data =
-        reinterpret_cast<const uint8_t*>(out_string.c_str());
-    gCurrentNetworkStreamData->insert(gCurrentNetworkStreamData->begin(),
-                                      data, data + out_string.length());
+      reinterpret_cast<const uint8_t *>(out_string.c_str());
+    gCurrentNetworkStreamData->insert(
+      gCurrentNetworkStreamData->begin(),
+      data,
+      data + out_string.length()
+    );
     size_t offset = request_info->second.response_data_received;
-    recordreplay::OnNetworkStreamData(stream_id.c_str(), offset, length,
-                                      /* bookmark = */ 0);
+    recordreplay::OnNetworkStreamData(
+      stream_id.c_str(), offset, length, /* bookmark = */ 0
+    );
     gCurrentNetworkStreamData->clear();
   }
   request_info->second.response_data_received += length;
@@ -3806,6 +3751,7 @@ static void HandleNetworkDidReceiveDataEvent(
  * @see https://static.replay.io/protocol/tot/DOM/
  * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
  * ##########################################################################*/
+
 
 static bool checkCDPResponse(
     const char* label, const protocol::Response& response,

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3349,6 +3349,46 @@ static void fromJsGetObjectByCdpId(
   }
 }
 
+/** ###########################################################################
+ * Networking
+ * ##########################################################################*/
+
+// Represents a known network request.  Created and added to
+// `gActiveNetworkRequests` when the request is first seen.  Removed
+// when the request finishes or fails.
+struct NetworkRequestStatus {
+  size_t response_data_received;
+  size_t request_data_sent;
+  std::string method;
+  uint64_t bookmark;
+  NetworkRequestStatus(std::string& method, uint64_t bookmark = 0)
+  : response_data_received(0),
+    request_data_sent(0),
+    method(method),
+    bookmark(bookmark)
+  {}
+};
+// Map of active network requests.
+std::unordered_map<std::string, NetworkRequestStatus>*
+  gActiveNetworkRequests = nullptr;
+
+// Globals storing values to be returned to controller commands
+// `GetCurrentNetwork*`
+static base::Value *gCurrentNetworkRequestEvent = nullptr;
+static std::vector<uint8_t>* gCurrentNetworkStreamData = nullptr;
+
+static void GetCurrentNetworkRequestEvent(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (!gCurrentNetworkRequestEvent) {
+    return;
+  }
+
+  v8::Isolate* isolate = args.GetIsolate();
+  std::string json;
+  base::JSONWriter::Write(*gCurrentNetworkRequestEvent, &json);
+  v8::Local<v8::String> json_string = ToV8String(isolate, json.c_str());
+  args.GetReturnValue().Set(json_string);
+}
+
 static void GetCurrentNetworkStreamData(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(gCurrentNetworkStreamData);
 
@@ -3752,14 +3792,15 @@ static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) 
  * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
  * ##########################################################################*/
 
-
-static bool checkCDPResponse(
-    const char* label, const protocol::Response& response,
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
+static bool checkCDPResponse(const char* label,
+                             const protocol::Response& response,
+                             const v8::FunctionCallbackInfo<v8::Value>& args) {
   if (!response.IsSuccess()) {
     recordreplay::Print(
-        "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s", label,
-        response.Code(), response.Message().c_str());
+        "[RuntimeError] CDP call \"%s\" failed (Code: %d): %s",
+        label,
+        response.Code(),
+        response.Message().c_str());
 
     // result is null
     args.GetReturnValue().SetNull();
@@ -3791,8 +3832,7 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
       return;
     } else {
-      recordreplay::Print(
-          "[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
+      recordreplay::Print("[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
     }
   } else { /* already reported */
   }
@@ -3800,6 +3840,7 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   // auto response = domAgent->requestNode(cdpId, &nodeId);
   args.GetReturnValue().SetNull();
 }
+
 
 static void fromJsGetBoxModel(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -3819,8 +3860,7 @@ static void fromJsGetBoxModel(
 
   if (!response.IsSuccess()) {
     recordreplay::Print(
-        "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, "
-        "Code: "
+        "[RuntimeError] InspectorDOMAgent.getBoxModel failed (nodeId: %d, Code: "
         "%d): %s",
         nodeId, response.Code(), response.Message().c_str());
   } else {
@@ -3833,6 +3873,7 @@ static void fromJsGetBoxModel(
 
   args.GetReturnValue().SetNull();
 }
+
 
 static void fromJsGetMatchedStylesForNode(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -3852,22 +3893,20 @@ static void fromJsGetMatchedStylesForNode(
   Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>> keyframesRules;
 
   auto response = cssAgent->getMatchedStylesForNode(
-      nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
-      &inheritedEntries, nullptr, &keyframesRules, nullptr);
+      nodeId, &inlineStyle, &attributesStyle, &matchedRules,
+      &pseudoIdMatches, &inheritedEntries, nullptr, &keyframesRules, nullptr);
 
   // WIP: will fix everything up and clean up when done w/ RUN-981
 
   if (!response.IsSuccess()) {
     recordreplay::Print(
-        "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, "
-        "Code: "
+        "[RuntimeError] CSS.getMatchedStylesForNode failed (nodeId: %d, Code: "
         "%d): %s",
         nodeId, response.Code(), response.Message().c_str());
     args.GetReturnValue().SetNull();
   } else {
     v8::Local<v8::Object> result = v8::Object::New(isolate);
-    // NOTE: not sure what `attributesStyle` is and how its different from
-    // `inlineStyle`?
+    // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
     if (attributesStyle.isJust()) {
       auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
       if (!rulesJs.IsEmpty()) {
@@ -3895,6 +3934,7 @@ static void fromJsGetMatchedStylesForNode(
   }
 }
 
+ 
 static void fromJsCssGetStylesheetByCpdId(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
@@ -3960,11 +4000,9 @@ static void fromJsDomPerformSearch(
   }
 }
 
-static void fromJsCollectEventListeners(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(
-      args.Length() == 1 && args[0]->IsObject() &&
-      "[RuntimeError] must be called with a single plain object (DOM node)");
+static void fromJsCollectEventListeners(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsObject() &&
+        "[RuntimeError] must be called with a single plain object (DOM node)");
 
   v8::Isolate* isolate = args.GetIsolate();
   auto context = isolate->GetCurrentContext();
@@ -3973,10 +4011,9 @@ static void fromJsCollectEventListeners(
 
   v8::Local<v8::Array> result = v8::Array::New(isolate);
   if (!node) {
-    recordreplay::Print(
-        "[RuntimeError] fromJsCollectEventListeners invalid argument is not "
-        "blink Node");
-  } else {
+    recordreplay::Print("[RuntimeError] fromJsCollectEventListeners invalid argument is not blink Node");
+  }
+  else {
     auto report_for_all_contexts = true;
     V8EventListenerInfoList eventListenerInfos;
     InspectorDOMDebuggerAgent::CollectEventListeners(
@@ -4025,8 +4062,7 @@ static void HandleBrowserEvent(const char* name, const char* payload) {
   } else if (!strcmp(name, "Network.NavigationRedirect")) {
     HandleNetworkNavigationRedirectEvent(base::Value::AsDictionaryValue(val));
   } else {
-    recordreplay::Print("HandleBrowserEvent received unrecognized event %s",
-                        name);
+    recordreplay::Print("HandleBrowserEvent received unrecognized event %s", name);
   }
 }
 
@@ -4034,11 +4070,10 @@ static void HandleBrowserEvent(const char* name, const char* payload) {
 // `function __RECORD_REPLAY_ANNOTATION_HOOK__(kind, contents)`
 // Since this function is called from userland JS, we avoid assertions.
 // We don't want flawed uses of the API to crash the recording.
-static void InvokeOnAnnotation(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  if (!(args.Length() >= 2 && args[0]->IsString())) {
+static void InvokeOnAnnotation(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (! (args.Length() >= 2 && args[0]->IsString())) {
     recordreplay::Print("%s called with incorrect arguments",
-                        AnnotationHookJSName);
+      AnnotationHookJSName);
     return;
   }
 
@@ -4050,7 +4085,7 @@ static void InvokeOnAnnotation(
   v8::Local<v8::String> json;
   if (!v8::JSON::Stringify(context, payload).ToLocal(&json)) {
     recordreplay::Print("%s contents failed to json stringify",
-                        AnnotationHookJSName);
+      AnnotationHookJSName);
     return;
   }
 
@@ -4059,22 +4094,19 @@ static void InvokeOnAnnotation(
   recordreplay::OnAnnotation(*kind, *contents);
 }
 
-extern "C" void V8RecordReplaySetAPIObjectIdCallback(
-    int (*callback)(v8::Local<v8::Object>));
+extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
 extern "C" void V8RecordReplayRegisterBrowserEventCallback(
-    void (*callback)(const char* name, const char* payload));
+  void (*callback)(const char* name, const char* payload)
+);
 
-static void RunScript(v8::Isolate * isolate, v8::Local<v8::Context> context,
-                      const char* script, const char* filename) {
+static void RunScript(v8::Isolate* isolate, v8::Local<v8::Context> context, const char* script, const char* filename) {
   v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
   v8::ScriptOrigin origin(isolate, filename_string);
 
   v8::Local<v8::String> source = ToV8String(isolate, script);
 
-  // TODO: check for errors after `Compile` and `Run` -
-  // https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
-  v8::Local<v8::Script> compiled =
-      v8::Script::Compile(context, source, &origin).ToLocalChecked();
+  // TODO: check for errors after `Compile` and `Run` - https://linear.app/replay/issue/RUN-955/chromium-should-not-diverge-and-crash-if-greplayscript-does-not
+  v8::Local<v8::Script> compiled = v8::Script::Compile(context, source, &origin).ToLocalChecked();
   compiled->Run(context).ToLocalChecked();
 }
 
@@ -4083,8 +4115,9 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
-void SetupRecordReplayCommands(v8::Isolate * isolate,
-                                LocalFrame * localFrame) {
+
+
+void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
@@ -4102,15 +4135,16 @@ void SetupRecordReplayCommands(v8::Isolate * isolate,
                       InvokeOnAnnotation);
 
   v8::Local<v8::Object> args = v8::Object::New(isolate);
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                  args);
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__", args);
 
-  SetFunctionProperty(isolate, args, "log", LogCallback);
+  SetFunctionProperty(isolate, args, "log",
+                      LogCallback);
 
   // CDP debugger functionality
   SetFunctionProperty(isolate, args, "setCDPMessageCallback",
                       SetCDPMessageCallback);
-  SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
+  SetFunctionProperty(isolate, args, "sendCDPMessage",
+                      SendCDPMessage);
   SetFunctionProperty(isolate, args, "setCommandCallback",
                       v8::FunctionCallbackRecordReplaySetCommandCallback);
 
@@ -4148,18 +4182,24 @@ void SetupRecordReplayCommands(v8::Isolate * isolate,
   SetFunctionProperty(
       isolate, args, "setClearPauseDataCallback",
       v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-  SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
-  SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
-  SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
+  SetFunctionProperty(isolate, args, "getCurrentError",
+                      GetCurrentError);
+  SetFunctionProperty(isolate, args, "getRecordingId",
+                      GetRecordingId);
+  SetFunctionProperty(isolate, args, "sha256DigestHex",
+                      SHA256DigestHex);
   SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
                       WriteToRecordingDirectory);
-  SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
+  SetFunctionProperty(isolate, args, "addRecordingEvent",
+                      AddRecordingEvent);
   SetFunctionProperty(isolate, args, "addNewScriptHandler",
                       v8::FunctionCallbackRecordReplayAddNewScriptHandler);
   SetFunctionProperty(isolate, args, "getScriptSource",
                       v8::FunctionCallbackRecordReplayGetScriptSource);
-  SetFunctionProperty(isolate, args, "getPersistentId", GetPersistentId);
-  SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
+  SetFunctionProperty(isolate, args, "getPersistentId",
+                      GetPersistentId);
+  SetFunctionProperty(isolate, args, "checkPersistentId",
+                      CheckPersistentId);
 
   // This URL will prevent the script from being reported to the recorder.
   const char* InternalScriptURL = "record-replay-internal";
@@ -4178,7 +4218,7 @@ void SetupRecordReplayCommands(v8::Isolate * isolate,
   }
 }
 
-void RunInitialRecordReplayScripts(v8::Isolate * isolate) {
+void RunInitialRecordReplayScripts(v8::Isolate* isolate) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
@@ -4186,8 +4226,7 @@ void RunInitialRecordReplayScripts(v8::Isolate * isolate) {
     // Note: We use a special URL for the react devtools as this script needs
     // to be reported to the recorder so that evaluations can be performed in
     // its frames.
-    RunScript(isolate, context, gReactDevtoolsScript,
-              "record-replay-react-devtools");
+    RunScript(isolate, context, gReactDevtoolsScript, "record-replay-react-devtools");
   }
 }
 
@@ -4195,7 +4234,7 @@ extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
 
 static ErrorEvent* gCurrentErrorEvent;
 
-void RecordReplayOnErrorEvent(ErrorEvent * error_event) {
+void RecordReplayOnErrorEvent(ErrorEvent* error_event) {
   if (!v8::IsMainThread()) {
     return;
   }
@@ -4217,19 +4256,14 @@ static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   v8::Local<v8::Object> rv = v8::Object::New(isolate);
 
-  SetDataProperty(
-      isolate, rv, "message",
-      ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
-  SetDataProperty(
-      isolate, rv, "filename",
-      ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
-  SetDataProperty(isolate, rv, "line",
-                  v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
-  SetDataProperty(isolate, rv, "column",
-                  v8::Number::New(isolate, gCurrentErrorEvent->colno()));
-  SetDataProperty(
-      isolate, rv, "scriptId",
-      v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
+  SetDataProperty(isolate, rv, "message",
+                  ToV8String(isolate, gCurrentErrorEvent->message().Utf8().c_str()));
+  SetDataProperty(isolate, rv, "filename",
+                  ToV8String(isolate, gCurrentErrorEvent->filename().Utf8().c_str()));
+  SetDataProperty(isolate, rv, "line", v8::Number::New(isolate, gCurrentErrorEvent->lineno()));
+  SetDataProperty(isolate, rv, "column", v8::Number::New(isolate, gCurrentErrorEvent->colno()));
+  SetDataProperty(isolate, rv, "scriptId",
+                  v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
 
   args.GetReturnValue().Set(rv);
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -26,6 +26,7 @@
 #include "third_party/blink/renderer/core/inspector/inspector_css_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_dom_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h"
+#include "third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_network_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_resource_container.h"
 #include "third_party/blink/renderer/core/inspector/inspector_resource_content_loader.h"
@@ -3096,6 +3097,7 @@ v8::MaybeLocal<v8::Value> convertCborToJSMaybe(v8::Isolate* isolate,
 
 static LocalFrame* gLocalFrame;
 static InspectorDOMAgent* gInspectorDomAgent;
+static InspectorDOMDebuggerAgent* gInspectorDomDebuggerAgent;
 static InspectorNetworkAgent* gInspectorNetworkAgent;
 static InspectorCSSAgent* gInspectorCssAgent;
 static InspectedFrames* gInspectedFrames;
@@ -3123,9 +3125,21 @@ InspectorDOMAgent* getOrCreateInspectorDOMAgent(v8::Isolate* isolate) {
   return gInspectorDomAgent;
 }
 
+InspectorDOMDebuggerAgent* getOrCreateInspectorDOMDebuggerAgent(v8::Isolate* isolate) {
+  if (!gInspectorDomDebuggerAgent) {
+    gInspectorDomDebuggerAgent =
+        MakeGarbageCollected<InspectorDOMDebuggerAgent>(
+            isolate, getOrCreateInspectorDOMAgent(isolate), gInspectorSession);
+
+    // NOTE: registering the agent here allows it to receive `UserCallback` events
+    //   see https://linear.app/replay/issue/RUN-1061#comment-d059a1ce
+    gLocalFrame->GetProbeSink()->AddInspectorDOMDebuggerAgent(gInspectorDomDebuggerAgent);
+  }
+  return gInspectorDomDebuggerAgent;
+}
+
 InspectorNetworkAgent* getOrCreateInspectorNetworkAgent() {
   if (!gInspectorNetworkAgent) {
-    // NOTE: based on WebDevToolsAgentImpl::AttachSession
     InspectedFrames* inspectedFrames = getOrCreateInspectedFrames();
     gInspectorNetworkAgent = MakeGarbageCollected<InspectorNetworkAgent>(
         inspectedFrames, nullptr, gInspectorSession);
@@ -4111,6 +4125,9 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   if (recordreplay::IsReplaying()) {
     recordreplay::AutoDisallowEvents disallow;
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
+
+    // initialize InspectorDOMDebuggerAgent, so it can pick up user events
+    getOrCreateInspectorDOMDebuggerAgent(isolate);
   }
 }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -926,8 +926,12 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
 // [replay] lookup qualified event names
 //   -> https://linear.app/replay/issue/RUN-1061/chromium-render-eventslist
 
-// C++ grammar example: https://replit.com/@Domiii/nested-static-initializers#main.cpp
-
+/**
+ * CDTEventEntry takes all kinds of static-initialized data, and convert it into a
+ * simple map<String, String>.
+ * C++ playground for nested static initializers:
+ *   -> https://replit.com/@Domiii/nested-static-initializers#main.cpp
+ */
 struct CDTEventEntry {
   std::unordered_map<String, String> qualifiedNamesByTargetName_;
 
@@ -941,19 +945,163 @@ struct CDTEventEntry {
     }
   }
 };
+
 using CDTEventEntryMap = std::unordered_map<String, CDTEventEntry>;
 
+
 // <GENERATED CODE. DO NOT EDIT.>
+// NOTE: This code is generated via `ts-node scripts/gen-event-names.ts`
 static const CDTEventEntryMap& getEventEntryMap() {
   DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
     ({
+      { String("requestAnimationFrame"), {{{String("animationframe.request"), {String("*")}}}} },
+      { String("cancelAnimationFrame"), {{{String("animationframe.cancel"), {String("*")}}}} },
+      { String("requestAnimationFrame.callback"), {{{String("animationframe.fire"), {String("*")}}}} },
+      { String("setTimeout"), {{{String("timer.timeout.set"), {String("*")}}}} },
+      { String("clearTimeout"), {{{String("timer.timeout.clear"), {String("*")}}}} },
+      { String("setInterval"), {{{String("timer.interval.set"), {String("*")}}}} },
+      { String("clearInterval"), {{{String("timer.interval.clear"), {String("*")}}}} },
       { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} },
-      { String("click"), {{{String("event.mouse.click"), {String("*")}}}} }
+      { String("setInterval.callback"), {{{String("timer.interval.fire"), {String("*")}}}} },
+      { String("play"), {{{String("event.media.play"), {String("audio")}}}} },
+      { String("play"), {{{String("event.media.play"), {String("video")}}}} },
+      { String("pause"), {{{String("event.media.pause"), {String("audio")}}}} },
+      { String("pause"), {{{String("event.media.pause"), {String("video")}}}} },
+      { String("playing"), {{{String("event.media.playing"), {String("audio")}}}} },
+      { String("playing"), {{{String("event.media.playing"), {String("video")}}}} },
+      { String("canplay"), {{{String("event.media.canplay"), {String("audio")}}}} },
+      { String("canplay"), {{{String("event.media.canplay"), {String("video")}}}} },
+      { String("canplaythrough"), {{{String("event.media.canplaythrough"), {String("audio")}}}} },
+      { String("canplaythrough"), {{{String("event.media.canplaythrough"), {String("video")}}}} },
+      { String("seeking"), {{{String("event.media.seeking"), {String("audio")}}}} },
+      { String("seeking"), {{{String("event.media.seeking"), {String("video")}}}} },
+      { String("seeked"), {{{String("event.media.seeked"), {String("audio")}}}} },
+      { String("seeked"), {{{String("event.media.seeked"), {String("video")}}}} },
+      { String("timeupdate"), {{{String("event.media.timeupdate"), {String("audio")}}}} },
+      { String("timeupdate"), {{{String("event.media.timeupdate"), {String("video")}}}} },
+      { String("ended"), {{{String("event.media.ended"), {String("audio")}}}} },
+      { String("ended"), {{{String("event.media.ended"), {String("video")}}}} },
+      { String("ratechange"), {{{String("event.media.ratechange"), {String("audio")}}}} },
+      { String("ratechange"), {{{String("event.media.ratechange"), {String("video")}}}} },
+      { String("durationchange"), {{{String("event.media.durationchange"), {String("audio")}}}} },
+      { String("durationchange"), {{{String("event.media.durationchange"), {String("video")}}}} },
+      { String("volumechange"), {{{String("event.media.volumechange"), {String("audio")}}}} },
+      { String("volumechange"), {{{String("event.media.volumechange"), {String("video")}}}} },
+      { String("loadstart"), {{{String("event.media.loadstart"), {String("audio")}}}} },
+      { String("loadstart"), {{{String("event.media.loadstart"), {String("video")}}}} },
+      { String("progress"), {{{String("event.media.progress"), {String("audio")}}}} },
+      { String("progress"), {{{String("event.media.progress"), {String("video")}}}} },
+      { String("suspend"), {{{String("event.media.suspend"), {String("audio")}}}} },
+      { String("suspend"), {{{String("event.media.suspend"), {String("video")}}}} },
+      { String("abort"), {{{String("event.media.abort"), {String("audio")}}}} },
+      { String("abort"), {{{String("event.media.abort"), {String("video")}}}} },
+      { String("error"), {{{String("event.media.error"), {String("audio")}}}} },
+      { String("error"), {{{String("event.media.error"), {String("video")}}}} },
+      { String("emptied"), {{{String("event.media.emptied"), {String("audio")}}}} },
+      { String("emptied"), {{{String("event.media.emptied"), {String("video")}}}} },
+      { String("stalled"), {{{String("event.media.stalled"), {String("audio")}}}} },
+      { String("stalled"), {{{String("event.media.stalled"), {String("video")}}}} },
+      { String("loadedmetadata"), {{{String("event.media.loadedmetadata"), {String("audio")}}}} },
+      { String("loadedmetadata"), {{{String("event.media.loadedmetadata"), {String("video")}}}} },
+      { String("loadeddata"), {{{String("event.media.loadeddata"), {String("audio")}}}} },
+      { String("loadeddata"), {{{String("event.media.loadeddata"), {String("video")}}}} },
+      { String("waiting"), {{{String("event.media.waiting"), {String("audio")}}}} },
+      { String("waiting"), {{{String("event.media.waiting"), {String("video")}}}} },
+      { String("copy"), {{{String("event.clipboard.copy"), {String("*")}}}} },
+      { String("cut"), {{{String("event.clipboard.cut"), {String("*")}}}} },
+      { String("paste"), {{{String("event.clipboard.paste"), {String("*")}}}} },
+      { String("beforecopy"), {{{String("event.clipboard.beforecopy"), {String("*")}}}} },
+      { String("beforecut"), {{{String("event.clipboard.beforecut"), {String("*")}}}} },
+      { String("beforepaste"), {{{String("event.clipboard.beforepaste"), {String("*")}}}} },
+      { String("resize"), {{{String("event.control.resize"), {String("*")}}}} },
+      { String("scroll"), {{{String("event.control.scroll"), {String("*")}}}} },
+      { String("zoom"), {{{String("event.control.zoom"), {String("*")}}}} },
+      { String("focus"), {{{String("event.control.focus"), {String("*")}}}} },
+      { String("blur"), {{{String("event.control.blur"), {String("*")}}}} },
+      { String("select"), {{{String("event.control.select"), {String("*")}}}} },
+      { String("change"), {{{String("event.control.change"), {String("*")}}}} },
+      { String("submit"), {{{String("event.control.submit"), {String("*")}}}} },
+      { String("reset"), {{{String("event.control.reset"), {String("*")}}}} },
+      { String("deviceorientation"), {{{String("event.device.deviceorientation"), {String("*")}}}} },
+      { String("devicemotion"), {{{String("event.device.devicemotio"), {String("*")}}}} },
+      { String("DOMActivate"), {{{String("event.dom-mutation.DOMActivate"), {String("*")}}}} },
+      { String("DOMFocusIn"), {{{String("event.dom-mutation.DOMFocusIn"), {String("*")}}}} },
+      { String("DOMFocusOut"), {{{String("event.dom-mutation.DOMFocusOut"), {String("*")}}}} },
+      { String("DOMAttrModified"), {{{String("event.dom-mutation.DOMAttrModified"), {String("*")}}}} },
+      { String("DOMCharacterDataModified"), {{{String("event.dom-mutation.DOMCharacterDataModified"), {String("*")}}}} },
+      { String("DOMNodeInserted"), {{{String("event.dom-mutation.DOMNodeInserted"), {String("*")}}}} },
+      { String("DOMNodeInsertedIntoDocument"), {{{String("event.dom-mutation.DOMNodeInsertedIntoDocument"), {String("*")}}}} },
+      { String("DOMNodeRemoved"), {{{String("event.dom-mutation.DOMNodeRemoved"), {String("*")}}}} },
+      { String("DOMNodeRemovedFromDocument"), {{{String("event.dom-mutation.DOMNodeRemovedIntoDocument"), {String("*")}}}} },
+      { String("DOMSubtreeModified"), {{{String("event.dom-mutation.DOMSubtreeModified"), {String("*")}}}} },
+      { String("DOMContentLoaded"), {{{String("event.dom-mutation.DOMContentLoaded"), {String("*")}}}} },
+      { String("drag"), {{{String("event.drag-and-drop.drag"), {String("*")}}}} },
+      { String("dragstart"), {{{String("event.drag-and-drop.dragstart"), {String("*")}}}} },
+      { String("dragend"), {{{String("event.drag-and-drop.dragend"), {String("*")}}}} },
+      { String("dragenter"), {{{String("event.drag-and-drop.dragenter"), {String("*")}}}} },
+      { String("dragover"), {{{String("event.drag-and-drop.dragover"), {String("*")}}}} },
+      { String("dragleave"), {{{String("event.drag-and-drop.dragleave"), {String("*")}}}} },
+      { String("drop"), {{{String("event.drag-and-drop.drop"), {String("*")}}}} },
+      { String("keydown"), {{{String("event.keyboard.keydown"), {String("*")}}}} },
+      { String("keyup"), {{{String("event.keyboard.keyup"), {String("*")}}}} },
+      { String("keypress"), {{{String("event.keyboard.keypress"), {String("*")}}}} },
+      { String("input"), {{{String("event.keyboard.input"), {String("*")}}}} },
+      { String("load"), {{{String("event.load.load"), {String("*")}}}} },
+      { String("abort"), {{{String("event.load.abort"), {String("*")}}}} },
+      { String("error"), {{{String("event.load.error"), {String("*")}}}} },
+      { String("hashchange"), {{{String("event.load.hashchange"), {String("*")}}}} },
+      { String("popstate"), {{{String("event.load.popstate"), {String("*")}}}} },
+      { String("auxclick"), {{{String("event.mouse.auxclick"), {String("*")}}}} },
+      { String("click"), {{{String("event.mouse.click"), {String("*")}}}} },
+      { String("dblclick"), {{{String("event.mouse.dblclick"), {String("*")}}}} },
+      { String("mousedown"), {{{String("event.mouse.mousedown"), {String("*")}}}} },
+      { String("mouseup"), {{{String("event.mouse.mouseup"), {String("*")}}}} },
+      { String("mouseover"), {{{String("event.mouse.mouseover"), {String("*")}}}} },
+      { String("mousemove"), {{{String("event.mouse.mousemove"), {String("*")}}}} },
+      { String("mouseout"), {{{String("event.mouse.mouseout"), {String("*")}}}} },
+      { String("mouseenter"), {{{String("event.mouse.mouseenter"), {String("*")}}}} },
+      { String("mouseleave"), {{{String("event.mouse.mouseleave"), {String("*")}}}} },
+      { String("mousewheel"), {{{String("event.mouse.mousewheel"), {String("*")}}}} },
+      { String("wheel"), {{{String("event.mouse.wheel"), {String("*")}}}} },
+      { String("contextmenu"), {{{String("event.mouse.contextmenu"), {String("*")}}}} },
+      { String("pointerover"), {{{String("event.pointer.pointerover"), {String("*")}}}} },
+      { String("pointerout"), {{{String("event.pointer.pointerout"), {String("*")}}}} },
+      { String("pointerenter"), {{{String("event.pointer.pointerenter"), {String("*")}}}} },
+      { String("pointerleave"), {{{String("event.pointer.pointerleave"), {String("*")}}}} },
+      { String("pointerdown"), {{{String("event.pointer.pointerdown"), {String("*")}}}} },
+      { String("pointerup"), {{{String("event.pointer.pointerup"), {String("*")}}}} },
+      { String("pointermove"), {{{String("event.pointer.pointermove"), {String("*")}}}} },
+      { String("pointercancel"), {{{String("event.pointer.pointercancel"), {String("*")}}}} },
+      { String("gotpointercapture"), {{{String("event.pointer.gotpointercapture"), {String("*")}}}} },
+      { String("lostpointercapture"), {{{String("event.pointer.lostpointercapture"), {String("*")}}}} },
+      { String("touchstart"), {{{String("event.touch.touchstart"), {String("*")}}}} },
+      { String("touchmove"), {{{String("event.touch.touchmove"), {String("*")}}}} },
+      { String("touchend"), {{{String("event.touch.touchend"), {String("*")}}}} },
+      { String("touchcancel"), {{{String("event.touch.touchcancel"), {String("*")}}}} },
+      { String("message"), {{{String("event.message"), {String("*")}}}} },
+      { String("messageerror"), {{{String("event.messageerror"), {String("*")}}}} },
+      { String("readystatechange"), {{{String("event.xhr.readystatechange"), {String("xmlhttprequest")}}}} },
+      { String("readystatechange"), {{{String("event.xhr.readystatechange"), {String("xmlhttprequestupload")}}}} },
+      { String("load"), {{{String("event.xhr.load"), {String("xmlhttprequest")}}}} },
+      { String("load"), {{{String("event.xhr.load"), {String("xmlhttprequestupload")}}}} },
+      { String("loadstart"), {{{String("event.xhr.loadstart"), {String("xmlhttprequest")}}}} },
+      { String("loadstart"), {{{String("event.xhr.loadstart"), {String("xmlhttprequestupload")}}}} },
+      { String("loadend"), {{{String("event.xhr.loadend"), {String("xmlhttprequest")}}}} },
+      { String("loadend"), {{{String("event.xhr.loadend"), {String("xmlhttprequestupload")}}}} },
+      { String("abort"), {{{String("event.xhr.abort"), {String("xmlhttprequest")}}}} },
+      { String("abort"), {{{String("event.xhr.abort"), {String("xmlhttprequestupload")}}}} },
+      { String("error"), {{{String("event.xhr.error"), {String("xmlhttprequest")}}}} },
+      { String("error"), {{{String("event.xhr.error"), {String("xmlhttprequestupload")}}}} },
+      { String("progress"), {{{String("event.xhr.progress"), {String("xmlhttprequest")}}}} },
+      { String("progress"), {{{String("event.xhr.progress"), {String("xmlhttprequestupload")}}}} },
+      { String("timeout"), {{{String("event.xhr.timeout"), {String("xmlhttprequest")}}}} },
+      { String("timeout"), {{{String("event.xhr.timeout"), {String("xmlhttprequestupload")}}}} }
     })
   );
   return cdtToGeckoMap;
 }
-// </GENERATED CODE. DO NOT EDIT.>`;
+// </GENERATED CODE. DO NOT EDIT.>
+
 
 static String buildCdtEventName(
     const String& eventName, 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -728,22 +728,22 @@ void InspectorDOMDebuggerAgent::ScriptExecutionBlockedByCSP(
 }
 
 // Call `ReplayOnEvent` for the given event *before* it happened.
-static void ReplayNotifyWill(const String& eventName,
+static void ReplayNotifyBeforeEvent(const String& eventName,
                               EventTarget* eventTarget = nullptr,
                               bool isCallback = false);
 
 // Call `ReplayOnEvent` for the given event *after* it happened.
-static void ReplayNotifyDid(const String& eventName,
+static void ReplayNotifyAfterEvent(const String& eventName,
                             EventTarget* eventTarget = nullptr,
                             bool isCallback = false);
 
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
-  ReplayNotifyWill("scriptFirstStatement");
+  ReplayNotifyBeforeEvent("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
-  ReplayNotifyDid("scriptFirstStatement");
+  ReplayNotifyAfterEvent("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 
@@ -754,11 +754,11 @@ void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
     Node* node = probe.event_target->ToNode();
     String target_name =
         node ? node->nodeName() : probe.event_target->InterfaceName();
-    ReplayNotifyWill(name, probe.event_target, false);
+    ReplayNotifyBeforeEvent(name, probe.event_target, false);
     AllowNativeBreakpoint(name, &target_name, false);
     return;
   }
-  ReplayNotifyWill(name, nullptr, true);
+  ReplayNotifyBeforeEvent(name, nullptr, true);
   AllowNativeBreakpoint(name + ".callback", nullptr, false);
 }
 
@@ -766,10 +766,10 @@ void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
 
   if (probe.event_target) {
-    ReplayNotifyDid(name, probe.event_target, false);
+    ReplayNotifyAfterEvent(name, probe.event_target, false);
   }
   else {
-    ReplayNotifyDid(name, nullptr, true);
+    ReplayNotifyAfterEvent(name, nullptr, true);
   }
 
   CancelNativeBreakpoint();
@@ -934,7 +934,7 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
 
 
 // [replay] This code's primary purpose is to lookup qualified event names.
-// At the core is the ReplayGetQualifiedEventName function, which takes CDT
+// At the core is the ReplayMakeEventName function, which takes CDT
 // event data, and uses it to lookup the `gecko` qualified event name,
 // which the frontend (currently) expects.
 // See: https://linear.app/replay/issue/RUN-1061#comment-bde208c4
@@ -959,225 +959,53 @@ struct CDTEventEntry {
   }
 };
 
-using CDTEventEntryMap = std::unordered_map<String, CDTEventEntry>;
 
+// [replay]
 
-// <GENERATED CODE. DO NOT EDIT.>
-// NOTE: This code is generated via `ts-node scripts/gen-event-names.ts`
-static const CDTEventEntryMap& getEventEntryMap() {
-  DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
-    ({
-      { String("requestAnimationFrame"), {{{String("animationframe.request"), {String("*")}}}} },
-      { String("cancelAnimationFrame"), {{{String("animationframe.cancel"), {String("*")}}}} },
-      { String("requestAnimationFrame.callback"), {{{String("animationframe.fire"), {String("*")}}}} },
-      { String("setTimeout"), {{{String("timer.timeout.set"), {String("*")}}}} },
-      { String("clearTimeout"), {{{String("timer.timeout.clear"), {String("*")}}}} },
-      { String("setInterval"), {{{String("timer.interval.set"), {String("*")}}}} },
-      { String("clearInterval"), {{{String("timer.interval.clear"), {String("*")}}}} },
-      { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} },
-      { String("setInterval.callback"), {{{String("timer.interval.fire"), {String("*")}}}} },
-      { String("play"), {{{String("event.media.play"), {String("audio")}}}} },
-      { String("play"), {{{String("event.media.play"), {String("video")}}}} },
-      { String("pause"), {{{String("event.media.pause"), {String("audio")}}}} },
-      { String("pause"), {{{String("event.media.pause"), {String("video")}}}} },
-      { String("playing"), {{{String("event.media.playing"), {String("audio")}}}} },
-      { String("playing"), {{{String("event.media.playing"), {String("video")}}}} },
-      { String("canplay"), {{{String("event.media.canplay"), {String("audio")}}}} },
-      { String("canplay"), {{{String("event.media.canplay"), {String("video")}}}} },
-      { String("canplaythrough"), {{{String("event.media.canplaythrough"), {String("audio")}}}} },
-      { String("canplaythrough"), {{{String("event.media.canplaythrough"), {String("video")}}}} },
-      { String("seeking"), {{{String("event.media.seeking"), {String("audio")}}}} },
-      { String("seeking"), {{{String("event.media.seeking"), {String("video")}}}} },
-      { String("seeked"), {{{String("event.media.seeked"), {String("audio")}}}} },
-      { String("seeked"), {{{String("event.media.seeked"), {String("video")}}}} },
-      { String("timeupdate"), {{{String("event.media.timeupdate"), {String("audio")}}}} },
-      { String("timeupdate"), {{{String("event.media.timeupdate"), {String("video")}}}} },
-      { String("ended"), {{{String("event.media.ended"), {String("audio")}}}} },
-      { String("ended"), {{{String("event.media.ended"), {String("video")}}}} },
-      { String("ratechange"), {{{String("event.media.ratechange"), {String("audio")}}}} },
-      { String("ratechange"), {{{String("event.media.ratechange"), {String("video")}}}} },
-      { String("durationchange"), {{{String("event.media.durationchange"), {String("audio")}}}} },
-      { String("durationchange"), {{{String("event.media.durationchange"), {String("video")}}}} },
-      { String("volumechange"), {{{String("event.media.volumechange"), {String("audio")}}}} },
-      { String("volumechange"), {{{String("event.media.volumechange"), {String("video")}}}} },
-      { String("loadstart"), {{{String("event.media.loadstart"), {String("audio")}}}} },
-      { String("loadstart"), {{{String("event.media.loadstart"), {String("video")}}}} },
-      { String("progress"), {{{String("event.media.progress"), {String("audio")}}}} },
-      { String("progress"), {{{String("event.media.progress"), {String("video")}}}} },
-      { String("suspend"), {{{String("event.media.suspend"), {String("audio")}}}} },
-      { String("suspend"), {{{String("event.media.suspend"), {String("video")}}}} },
-      { String("abort"), {{{String("event.media.abort"), {String("audio")}}}} },
-      { String("abort"), {{{String("event.media.abort"), {String("video")}}}} },
-      { String("error"), {{{String("event.media.error"), {String("audio")}}}} },
-      { String("error"), {{{String("event.media.error"), {String("video")}}}} },
-      { String("emptied"), {{{String("event.media.emptied"), {String("audio")}}}} },
-      { String("emptied"), {{{String("event.media.emptied"), {String("video")}}}} },
-      { String("stalled"), {{{String("event.media.stalled"), {String("audio")}}}} },
-      { String("stalled"), {{{String("event.media.stalled"), {String("video")}}}} },
-      { String("loadedmetadata"), {{{String("event.media.loadedmetadata"), {String("audio")}}}} },
-      { String("loadedmetadata"), {{{String("event.media.loadedmetadata"), {String("video")}}}} },
-      { String("loadeddata"), {{{String("event.media.loadeddata"), {String("audio")}}}} },
-      { String("loadeddata"), {{{String("event.media.loadeddata"), {String("video")}}}} },
-      { String("waiting"), {{{String("event.media.waiting"), {String("audio")}}}} },
-      { String("waiting"), {{{String("event.media.waiting"), {String("video")}}}} },
-      { String("copy"), {{{String("event.clipboard.copy"), {String("*")}}}} },
-      { String("cut"), {{{String("event.clipboard.cut"), {String("*")}}}} },
-      { String("paste"), {{{String("event.clipboard.paste"), {String("*")}}}} },
-      { String("beforecopy"), {{{String("event.clipboard.beforecopy"), {String("*")}}}} },
-      { String("beforecut"), {{{String("event.clipboard.beforecut"), {String("*")}}}} },
-      { String("beforepaste"), {{{String("event.clipboard.beforepaste"), {String("*")}}}} },
-      { String("resize"), {{{String("event.control.resize"), {String("*")}}}} },
-      { String("scroll"), {{{String("event.control.scroll"), {String("*")}}}} },
-      { String("zoom"), {{{String("event.control.zoom"), {String("*")}}}} },
-      { String("focus"), {{{String("event.control.focus"), {String("*")}}}} },
-      { String("blur"), {{{String("event.control.blur"), {String("*")}}}} },
-      { String("select"), {{{String("event.control.select"), {String("*")}}}} },
-      { String("change"), {{{String("event.control.change"), {String("*")}}}} },
-      { String("submit"), {{{String("event.control.submit"), {String("*")}}}} },
-      { String("reset"), {{{String("event.control.reset"), {String("*")}}}} },
-      { String("deviceorientation"), {{{String("event.device.deviceorientation"), {String("*")}}}} },
-      { String("devicemotion"), {{{String("event.device.devicemotio"), {String("*")}}}} },
-      { String("DOMActivate"), {{{String("event.dom-mutation.DOMActivate"), {String("*")}}}} },
-      { String("DOMFocusIn"), {{{String("event.dom-mutation.DOMFocusIn"), {String("*")}}}} },
-      { String("DOMFocusOut"), {{{String("event.dom-mutation.DOMFocusOut"), {String("*")}}}} },
-      { String("DOMAttrModified"), {{{String("event.dom-mutation.DOMAttrModified"), {String("*")}}}} },
-      { String("DOMCharacterDataModified"), {{{String("event.dom-mutation.DOMCharacterDataModified"), {String("*")}}}} },
-      { String("DOMNodeInserted"), {{{String("event.dom-mutation.DOMNodeInserted"), {String("*")}}}} },
-      { String("DOMNodeInsertedIntoDocument"), {{{String("event.dom-mutation.DOMNodeInsertedIntoDocument"), {String("*")}}}} },
-      { String("DOMNodeRemoved"), {{{String("event.dom-mutation.DOMNodeRemoved"), {String("*")}}}} },
-      { String("DOMNodeRemovedFromDocument"), {{{String("event.dom-mutation.DOMNodeRemovedIntoDocument"), {String("*")}}}} },
-      { String("DOMSubtreeModified"), {{{String("event.dom-mutation.DOMSubtreeModified"), {String("*")}}}} },
-      { String("DOMContentLoaded"), {{{String("event.dom-mutation.DOMContentLoaded"), {String("*")}}}} },
-      { String("drag"), {{{String("event.drag-and-drop.drag"), {String("*")}}}} },
-      { String("dragstart"), {{{String("event.drag-and-drop.dragstart"), {String("*")}}}} },
-      { String("dragend"), {{{String("event.drag-and-drop.dragend"), {String("*")}}}} },
-      { String("dragenter"), {{{String("event.drag-and-drop.dragenter"), {String("*")}}}} },
-      { String("dragover"), {{{String("event.drag-and-drop.dragover"), {String("*")}}}} },
-      { String("dragleave"), {{{String("event.drag-and-drop.dragleave"), {String("*")}}}} },
-      { String("drop"), {{{String("event.drag-and-drop.drop"), {String("*")}}}} },
-      { String("keydown"), {{{String("event.keyboard.keydown"), {String("*")}}}} },
-      { String("keyup"), {{{String("event.keyboard.keyup"), {String("*")}}}} },
-      { String("keypress"), {{{String("event.keyboard.keypress"), {String("*")}}}} },
-      { String("input"), {{{String("event.keyboard.input"), {String("*")}}}} },
-      { String("load"), {{{String("event.load.load"), {String("*")}}}} },
-      { String("abort"), {{{String("event.load.abort"), {String("*")}}}} },
-      { String("error"), {{{String("event.load.error"), {String("*")}}}} },
-      { String("hashchange"), {{{String("event.load.hashchange"), {String("*")}}}} },
-      { String("popstate"), {{{String("event.load.popstate"), {String("*")}}}} },
-      { String("auxclick"), {{{String("event.mouse.auxclick"), {String("*")}}}} },
-      { String("click"), {{{String("event.mouse.click"), {String("*")}}}} },
-      { String("dblclick"), {{{String("event.mouse.dblclick"), {String("*")}}}} },
-      { String("mousedown"), {{{String("event.mouse.mousedown"), {String("*")}}}} },
-      { String("mouseup"), {{{String("event.mouse.mouseup"), {String("*")}}}} },
-      { String("mouseover"), {{{String("event.mouse.mouseover"), {String("*")}}}} },
-      { String("mousemove"), {{{String("event.mouse.mousemove"), {String("*")}}}} },
-      { String("mouseout"), {{{String("event.mouse.mouseout"), {String("*")}}}} },
-      { String("mouseenter"), {{{String("event.mouse.mouseenter"), {String("*")}}}} },
-      { String("mouseleave"), {{{String("event.mouse.mouseleave"), {String("*")}}}} },
-      { String("mousewheel"), {{{String("event.mouse.mousewheel"), {String("*")}}}} },
-      { String("wheel"), {{{String("event.mouse.wheel"), {String("*")}}}} },
-      { String("contextmenu"), {{{String("event.mouse.contextmenu"), {String("*")}}}} },
-      { String("pointerover"), {{{String("event.pointer.pointerover"), {String("*")}}}} },
-      { String("pointerout"), {{{String("event.pointer.pointerout"), {String("*")}}}} },
-      { String("pointerenter"), {{{String("event.pointer.pointerenter"), {String("*")}}}} },
-      { String("pointerleave"), {{{String("event.pointer.pointerleave"), {String("*")}}}} },
-      { String("pointerdown"), {{{String("event.pointer.pointerdown"), {String("*")}}}} },
-      { String("pointerup"), {{{String("event.pointer.pointerup"), {String("*")}}}} },
-      { String("pointermove"), {{{String("event.pointer.pointermove"), {String("*")}}}} },
-      { String("pointercancel"), {{{String("event.pointer.pointercancel"), {String("*")}}}} },
-      { String("gotpointercapture"), {{{String("event.pointer.gotpointercapture"), {String("*")}}}} },
-      { String("lostpointercapture"), {{{String("event.pointer.lostpointercapture"), {String("*")}}}} },
-      { String("touchstart"), {{{String("event.touch.touchstart"), {String("*")}}}} },
-      { String("touchmove"), {{{String("event.touch.touchmove"), {String("*")}}}} },
-      { String("touchend"), {{{String("event.touch.touchend"), {String("*")}}}} },
-      { String("touchcancel"), {{{String("event.touch.touchcancel"), {String("*")}}}} },
-      { String("message"), {{{String("event.message"), {String("*")}}}} },
-      { String("messageerror"), {{{String("event.messageerror"), {String("*")}}}} },
-      { String("readystatechange"), {{{String("event.xhr.readystatechange"), {String("xmlhttprequest")}}}} },
-      { String("readystatechange"), {{{String("event.xhr.readystatechange"), {String("xmlhttprequestupload")}}}} },
-      { String("load"), {{{String("event.xhr.load"), {String("xmlhttprequest")}}}} },
-      { String("load"), {{{String("event.xhr.load"), {String("xmlhttprequestupload")}}}} },
-      { String("loadstart"), {{{String("event.xhr.loadstart"), {String("xmlhttprequest")}}}} },
-      { String("loadstart"), {{{String("event.xhr.loadstart"), {String("xmlhttprequestupload")}}}} },
-      { String("loadend"), {{{String("event.xhr.loadend"), {String("xmlhttprequest")}}}} },
-      { String("loadend"), {{{String("event.xhr.loadend"), {String("xmlhttprequestupload")}}}} },
-      { String("abort"), {{{String("event.xhr.abort"), {String("xmlhttprequest")}}}} },
-      { String("abort"), {{{String("event.xhr.abort"), {String("xmlhttprequestupload")}}}} },
-      { String("error"), {{{String("event.xhr.error"), {String("xmlhttprequest")}}}} },
-      { String("error"), {{{String("event.xhr.error"), {String("xmlhttprequestupload")}}}} },
-      { String("progress"), {{{String("event.xhr.progress"), {String("xmlhttprequest")}}}} },
-      { String("progress"), {{{String("event.xhr.progress"), {String("xmlhttprequestupload")}}}} },
-      { String("timeout"), {{{String("event.xhr.timeout"), {String("xmlhttprequest")}}}} },
-      { String("timeout"), {{{String("event.xhr.timeout"), {String("xmlhttprequestupload")}}}} }
-    })
-  );
-  return cdtToGeckoMap;
-}
-// </GENERATED CODE. DO NOT EDIT.>
-
-
-static String buildCdtEventName(
-    const String& eventName, 
-    bool isCallback) {
-  if (isCallback) {
-    StringBuilder builder;
-    builder.Append(eventName);
-    builder.Append(".callback");
-    return builder.ToString();
-  }
-  return eventName;
-}
-
-static const String& ReplayGetQualifiedEventName(const String& eventNameRaw,
-                                                 EventTarget* eventTarget,
-                                                 bool isCallback) {
-  DEFINE_STATIC_LOCAL(String, asterisk, ("*"));
+// This gathers the data points necessary for the "event breakpoint matching logic" of CDT.
+// Source:
+// https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L958
+static String ReplayMakeEventName(const String& eventNameRaw,
+                                         EventTarget* eventTarget,
+                                         bool isCallback) {
   DEFINE_STATIC_LOCAL(String, emptyString, (""));
 
-  const auto& eventMap = getEventEntryMap();
-  auto eventName = buildCdtEventName(eventNameRaw, isCallback);
-  auto resultEntry = eventMap.find(eventName);
-  if (resultEntry != eventMap.end()) {
-    // get EventTarget name
-    String targetName;
-    if (eventTarget) {
-      Node* node = eventTarget->ToNode();
-      targetName = node ? node->nodeName() : eventTarget->InterfaceName();
-    } else {
-      targetName = asterisk;
-    }
-
-    // look-up qualified name
-    const auto& nameMap = resultEntry->second.qualifiedNamesByTargetName_;
-    auto qualifiedName = nameMap.find(targetName);
-    if (qualifiedName == nameMap.end() && eventTarget) {
-      qualifiedName = nameMap.find(asterisk);
-    }
-    if (qualifiedName != nameMap.end()) {
-      return qualifiedName->second;
-    }
+  // build final name
+  StringBuilder builder;
+  builder.Append(eventNameRaw);
+  if (isCallback) {
+    builder.Append(".callback");
   }
-  return emptyString;
+
+  if (eventTarget) {
+    // Sadly, this is necessary because the lookup logic needs to distinguish
+    // between event and target name:
+    // The event name itself is ambiguous. To resolve it, sometimes the target
+    // name needs to be used, sometimes it needs to be omitted.
+    // Thus, we need to keep them logically separate.
+    Node* node = eventTarget->ToNode();
+    auto targetName = node ? node->nodeName() : eventTarget->InterfaceName();
+    builder.Append(",");
+    builder.Append(targetName);
+  }
+
+  return builder.ToString();
 }
 
-void ReplayNotifyWill(const String& eventName, 
+void ReplayNotifyBeforeEvent(const String& eventName, 
                       EventTarget* eventTarget,
                       bool isCallback) {
-  const String& qualifiedEventName = 
-      ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
-  if (!qualifiedEventName.empty()) {
-    recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
-  }
+  String qualifiedEventName = 
+      ReplayMakeEventName(eventName, eventTarget, isCallback);
+  recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
 }
 
-void ReplayNotifyDid(const String& eventName,
+void ReplayNotifyAfterEvent(const String& eventName,
                      EventTarget* eventTarget,
                      bool isCallback) {
-  const String& qualifiedEventName =
-      ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
-  if (!qualifiedEventName.empty()) {
-    recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);
-  }
+  String qualifiedEventName =
+      ReplayMakeEventName(eventName, eventTarget, isCallback);
+  recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -767,8 +767,7 @@ void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
 
   if (probe.event_target) {
     ReplayNotifyAfterEvent(name, probe.event_target, false);
-  }
-  else {
+  } else {
     ReplayNotifyAfterEvent(name, nullptr, true);
   }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -934,7 +934,7 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
 
 
 // [replay] This code's primary purpose is to lookup qualified event names.
-// At the core is the ReplayMakeEventName function, which takes CDT
+// At the core is the ReplayEventType function, which takes CDT
 // event data, and uses it to lookup the `gecko` qualified event name,
 // which the frontend (currently) expects.
 // See: https://linear.app/replay/issue/RUN-1061#comment-bde208c4
@@ -962,17 +962,15 @@ struct CDTEventEntry {
 
 // [replay]
 
-// This gathers the data points necessary for the "event breakpoint matching logic" of CDT.
-// Source:
+// This gathers and encodes the data points necessary for the "event breakpoint
+// matching logic" of CDT. Based on DOMDebuggerModel:
 // https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L958
-static String ReplayMakeEventName(const String& eventNameRaw,
+static String ReplayEventType(const String& eventTypeRaw,
                                          EventTarget* eventTarget,
                                          bool isCallback) {
-  DEFINE_STATIC_LOCAL(String, emptyString, (""));
-
   // build final name
   StringBuilder builder;
-  builder.Append(eventNameRaw);
+  builder.Append(eventTypeRaw);
   if (isCallback) {
     builder.Append(".callback");
   }
@@ -996,7 +994,9 @@ void ReplayNotifyBeforeEvent(const String& eventName,
                       EventTarget* eventTarget,
                       bool isCallback) {
   String qualifiedEventName = 
-      ReplayMakeEventName(eventName, eventTarget, isCallback);
+      ReplayEventType(eventName, eventTarget, isCallback);
+  recordreplay::Print("DDBG ReplayNotifyBeforeEvent %s",
+                      qualifiedEventName.Ascii().c_str());
   recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
 }
 
@@ -1004,7 +1004,9 @@ void ReplayNotifyAfterEvent(const String& eventName,
                      EventTarget* eventTarget,
                      bool isCallback) {
   String qualifiedEventName =
-      ReplayMakeEventName(eventName, eventTarget, isCallback);
+      ReplayEventType(eventName, eventTarget, isCallback);
+  recordreplay::Print("DDBG ReplayNotifyAfterEvent %s",
+                      qualifiedEventName.Ascii().c_str());
   recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);
 }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -856,7 +856,7 @@ void InspectorDOMDebuggerAgent::SetEnabled(bool enabled) {
   if (!recordreplay::HasDivergedFromRecording() || (
       instrumenting_agents_ && dom_agent_)
     ) {
-    // [replay] `instrumenting_agents_` is generally not available
+    // [replay] `instrumenting_agents_` is generally not available to us
     if (enabled && !enabled_.Get()) {
       instrumenting_agents_->AddInspectorDOMDebuggerAgent(this);
       dom_agent_->AddDOMListener(this);
@@ -933,39 +933,12 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
 }
 
 
-// [replay] This code's primary purpose is to lookup qualified event names.
-// At the core is the ReplayEventType function, which takes CDT
-// event data, and uses it to lookup the `gecko` qualified event name,
-// which the frontend (currently) expects.
-// See: https://linear.app/replay/issue/RUN-1061#comment-bde208c4
-
-/**
- * CDTEventEntry takes all kinds of static-initialized data, and convert it into a
- * simple map<String, String>.
- * Also, here is a C++ playground for nested static initializers:
- *   https://replit.com/@Domiii/nested-static-initializers#main.cpp
- */
-struct CDTEventEntry {
-  std::unordered_map<String, String> qualifiedNamesByTargetName_;
-
-  CDTEventEntry(const std::vector<std::tuple<String, std::vector<String>>>&&
-                    targetNamesByQualifiedName) {
-    for (const auto& [qualifiedName, targetNames] :
-         targetNamesByQualifiedName) {
-      for (const auto& targetName : targetNames) {
-        qualifiedNamesByTargetName_.insert({targetName, qualifiedName});
-      }
-    }
-  }
-};
-
-
 // [replay]
 
 // This gathers and encodes the data points necessary for the "event breakpoint
 // matching logic" of CDT. Based on DOMDebuggerModel:
 // https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L958
-static String ReplayEventType(const String& eventTypeRaw,
+static String MakeReplayEventType(const String& eventTypeRaw,
                                          EventTarget* eventTarget,
                                          bool isCallback) {
   // build final name
@@ -994,7 +967,7 @@ void ReplayNotifyBeforeEvent(const String& eventName,
                       EventTarget* eventTarget,
                       bool isCallback) {
   String qualifiedEventName = 
-      ReplayEventType(eventName, eventTarget, isCallback);
+      MakeReplayEventType(eventName, eventTarget, isCallback);
   recordreplay::Print("DDBG ReplayNotifyBeforeEvent %s",
                       qualifiedEventName.Ascii().c_str());
   recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
@@ -1004,7 +977,7 @@ void ReplayNotifyAfterEvent(const String& eventName,
                      EventTarget* eventTarget,
                      bool isCallback) {
   String qualifiedEventName =
-      ReplayEventType(eventName, eventTarget, isCallback);
+      MakeReplayEventType(eventName, eventTarget, isCallback);
   recordreplay::Print("DDBG ReplayNotifyAfterEvent %s",
                       qualifiedEventName.Ascii().c_str());
   recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -727,6 +727,16 @@ void InspectorDOMDebuggerAgent::ScriptExecutionBlockedByCSP(
   PauseOnNativeEventIfNeeded(std::move(event_data), true);
 }
 
+// Call `ReplayOnEvent` for the given event *before* it happened.
+static void ReplayNotifyWill(const String& eventName,
+                              EventTarget* eventTarget = nullptr,
+                              bool isCallback = false);
+
+// Call `ReplayOnEvent` for the given event *after* it happened.
+static void ReplayNotifyDid(const String& eventName,
+                            EventTarget* eventTarget = nullptr,
+                            bool isCallback = false);
+
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
   ReplayNotifyWill("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
@@ -923,14 +933,17 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
 }
 
 
-// [replay] lookup qualified event names
-//   -> https://linear.app/replay/issue/RUN-1061/chromium-render-eventslist
+// [replay] This code's primary purpose is to lookup qualified event names.
+// At the core is the ReplayGetQualifiedEventName function, which takes CDT
+// event data, and uses it to lookup the `gecko` qualified event name,
+// which the frontend (currently) expects.
+// See: https://linear.app/replay/issue/RUN-1061#comment-bde208c4
 
 /**
  * CDTEventEntry takes all kinds of static-initialized data, and convert it into a
  * simple map<String, String>.
- * C++ playground for nested static initializers:
- *   -> https://replit.com/@Domiii/nested-static-initializers#main.cpp
+ * Also, here is a C++ playground for nested static initializers:
+ *   https://replit.com/@Domiii/nested-static-initializers#main.cpp
  */
 struct CDTEventEntry {
   std::unordered_map<String, String> qualifiedNamesByTargetName_;
@@ -1147,19 +1160,19 @@ static const String& ReplayGetQualifiedEventName(const String& eventNameRaw,
   return emptyString;
 }
 
-void InspectorDOMDebuggerAgent::ReplayNotifyWill(const String& eventName, 
-EventTarget* eventTarget, bool isCallback) {
+void ReplayNotifyWill(const String& eventName, 
+                      EventTarget* eventTarget,
+                      bool isCallback) {
   const String& qualifiedEventName = 
       ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
-
   if (!qualifiedEventName.empty()) {
     recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
   }
 }
 
-void InspectorDOMDebuggerAgent::ReplayNotifyDid(const String& eventName,
-                                                       EventTarget* eventTarget,
-                                                       bool isCallback) {
+void ReplayNotifyDid(const String& eventName,
+                     EventTarget* eventTarget,
+                     bool isCallback) {
   const String& qualifiedEventName =
       ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
   if (!qualifiedEventName.empty()) {

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -737,8 +737,9 @@ void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
 
   // TODO: normalize all event names
   //  -> https://github.com/replayio/devtools/blob/962efa1ff77dc8d0181c8ade76ddffef33def6f7/packages/replay-next/src/constants.ts#L12
-  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Will %s",
-                      name ? name.Ascii().c_str() : "");
+  auto isCallback = !!probe.event_target;
+  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Will %s (callback: %d)",
+                      name ? name.Ascii().c_str() : "", isCallback);
   if (name == "click") {
     recordreplay::OnEvent("event.mouse.click", true);
   } else if (name == "setTimeout") {
@@ -758,6 +759,7 @@ void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
 void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
 
+  // TODO: sync w/ Will
   recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Did %s",
                       name ? name.Ascii().c_str() : "");
   if (name == "click") {

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -28,6 +28,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <unordered_map>
+#include <tuple>
+
 #include "third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h"
 
 #include "third_party/blink/renderer/bindings/core/v8/js_based_event_listener.h"
@@ -725,47 +728,38 @@ void InspectorDOMDebuggerAgent::ScriptExecutionBlockedByCSP(
 }
 
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
+  ReplayNotifyWill("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
+  ReplayNotifyDid("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 
 void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
 
-  // TODO: normalize all event names
-  //  -> https://github.com/replayio/devtools/blob/962efa1ff77dc8d0181c8ade76ddffef33def6f7/packages/replay-next/src/constants.ts#L12
-  auto isCallback = !!probe.event_target;
-  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Will %s (callback: %d)",
-                      name ? name.Ascii().c_str() : "", isCallback);
-  if (name == "click") {
-    recordreplay::OnEvent("event.mouse.click", true);
-  } else if (name == "setTimeout") {
-    recordreplay::OnEvent("timer.timeout.set", true);
-  }
-
   if (probe.event_target) {
     Node* node = probe.event_target->ToNode();
     String target_name =
         node ? node->nodeName() : probe.event_target->InterfaceName();
+    ReplayNotifyWill(name, probe.event_target, false);
     AllowNativeBreakpoint(name, &target_name, false);
     return;
   }
+  ReplayNotifyWill(name, nullptr, true);
   AllowNativeBreakpoint(name + ".callback", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
 
-  // TODO: sync w/ Will
-  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Did %s",
-                      name ? name.Ascii().c_str() : "");
-  if (name == "click") {
-    recordreplay::OnEvent("event.mouse.click", false);
-  } else if (name == "setTimeout") {
-    recordreplay::OnEvent("timer.timeout.set", false);
+  if (probe.event_target) {
+    ReplayNotifyDid(name, probe.event_target, false);
+  }
+  else {
+    ReplayNotifyDid(name, nullptr, true);
   }
 
   CancelNativeBreakpoint();
@@ -926,6 +920,103 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
       v8_inspector::protocol::Debugger::API::Paused::ReasonEnum::CSPViolation);
 
   v8_session_->breakProgram(listener, json_view);
+}
+
+
+// [replay] lookup qualified event names
+//   -> https://linear.app/replay/issue/RUN-1061/chromium-render-eventslist
+
+// C++ grammar example: https://replit.com/@Domiii/nested-static-initializers#main.cpp
+
+struct CDTEventEntry {
+  std::unordered_map<String, String> qualifiedNamesByTargetName_;
+
+  CDTEventEntry(const std::vector<std::tuple<String, std::vector<String>>>&&
+                    targetNamesByQualifiedName) {
+    for (const auto& [qualifiedName, targetNames] :
+         targetNamesByQualifiedName) {
+      for (const auto& targetName : targetNames) {
+        qualifiedNamesByTargetName_.insert({targetName, qualifiedName});
+      }
+    }
+  }
+};
+using CDTEventEntryMap = std::unordered_map<String, CDTEventEntry>;
+
+// <GENERATED CODE. DO NOT EDIT.>
+static const CDTEventEntryMap& getEventEntryMap() {
+  DEFINE_STATIC_LOCAL(CDTEventEntryMap, cdtToGeckoMap, 
+    ({
+      { String("setTimeout.callback"), {{{String("timer.timeout.fire"), {String("*")}}}} },
+      { String("click"), {{{String("event.mouse.click"), {String("*")}}}} }
+    })
+  );
+  return cdtToGeckoMap;
+}
+// </GENERATED CODE. DO NOT EDIT.>`;
+
+static String buildCdtEventName(
+    const String& eventName, 
+    bool isCallback) {
+  if (isCallback) {
+    StringBuilder builder;
+    builder.Append(eventName);
+    builder.Append(".callback");
+    return builder.ToString();
+  }
+  return eventName;
+}
+
+static const String& ReplayGetQualifiedEventName(const String& eventNameRaw,
+                                                 EventTarget* eventTarget,
+                                                 bool isCallback) {
+  DEFINE_STATIC_LOCAL(String, asterisk, ("*"));
+  DEFINE_STATIC_LOCAL(String, emptyString, (""));
+
+  const auto& eventMap = getEventEntryMap();
+  auto eventName = buildCdtEventName(eventNameRaw, isCallback);
+  auto resultEntry = eventMap.find(eventName);
+  if (resultEntry != eventMap.end()) {
+    // get EventTarget name
+    String targetName;
+    if (eventTarget) {
+      Node* node = eventTarget->ToNode();
+      targetName = node ? node->nodeName() : eventTarget->InterfaceName();
+    } else {
+      targetName = asterisk;
+    }
+
+    // look-up qualified name
+    const auto& nameMap = resultEntry->second.qualifiedNamesByTargetName_;
+    auto qualifiedName = nameMap.find(targetName);
+    if (qualifiedName == nameMap.end() && eventTarget) {
+      qualifiedName = nameMap.find(asterisk);
+    }
+    if (qualifiedName != nameMap.end()) {
+      return qualifiedName->second;
+    }
+  }
+  return emptyString;
+}
+
+void InspectorDOMDebuggerAgent::ReplayNotifyWill(const String& eventName, 
+EventTarget* eventTarget, bool isCallback) {
+  const String& qualifiedEventName = 
+      ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
+
+  if (!qualifiedEventName.empty()) {
+    recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
+  }
+}
+
+void InspectorDOMDebuggerAgent::ReplayNotifyDid(const String& eventName,
+                                                       EventTarget* eventTarget,
+                                                       bool isCallback) {
+  const String& qualifiedEventName =
+      ReplayGetQualifiedEventName(eventName, eventTarget, isCallback);
+  if (!qualifiedEventName.empty()) {
+    recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);
+  }
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -734,6 +734,17 @@ void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
 
 void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
+
+  // TODO: normalize all event names
+  //  -> https://github.com/replayio/devtools/blob/962efa1ff77dc8d0181c8ade76ddffef33def6f7/packages/replay-next/src/constants.ts#L12
+  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Will %s",
+                      name ? name.Ascii().c_str() : "");
+  if (name == "click") {
+    recordreplay::OnEvent("event.mouse.click", true);
+  } else if (name == "setTimeout") {
+    recordreplay::OnEvent("timer.timeout.set", true);
+  }
+
   if (probe.event_target) {
     Node* node = probe.event_target->ToNode();
     String target_name =
@@ -745,6 +756,16 @@ void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
+  String name = probe.name ? String(probe.name) : probe.atomic_name;
+
+  recordreplay::Print("DDBG InspectorDOMDebuggerAgent::Did %s",
+                      name ? name.Ascii().c_str() : "");
+  if (name == "click") {
+    recordreplay::OnEvent("event.mouse.click", false);
+  } else if (name == "setTimeout") {
+    recordreplay::OnEvent("timer.timeout.set", false);
+  }
+
   CancelNativeBreakpoint();
 }
 
@@ -826,14 +847,19 @@ void InspectorDOMDebuggerAgent::DidRemoveBreakpoint() {
 }
 
 void InspectorDOMDebuggerAgent::SetEnabled(bool enabled) {
-  if (enabled && !enabled_.Get()) {
-    instrumenting_agents_->AddInspectorDOMDebuggerAgent(this);
-    dom_agent_->AddDOMListener(this);
-    enabled_.Set(true);
-  } else if (!enabled && enabled_.Get()) {
-    instrumenting_agents_->RemoveInspectorDOMDebuggerAgent(this);
-    dom_agent_->RemoveDOMListener(this);
-    enabled_.Set(false);
+  if (!recordreplay::HasDivergedFromRecording() || (
+      instrumenting_agents_ && dom_agent_)
+    ) {
+    // [replay] `instrumenting_agents_` is generally not available
+    if (enabled && !enabled_.Get()) {
+      instrumenting_agents_->AddInspectorDOMDebuggerAgent(this);
+      dom_agent_->AddDOMListener(this);
+      enabled_.Set(true);
+    } else if (!enabled && enabled_.Get()) {
+      instrumenting_agents_->RemoveInspectorDOMDebuggerAgent(this);
+      dom_agent_->RemoveDOMListener(this);
+      enabled_.Set(false);
+    }
   }
 }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h
@@ -195,6 +195,14 @@ class CORE_EXPORT InspectorDOMDebuggerAgent final
   InspectorAgentState::BooleanMap xhr_breakpoints_;
   InspectorAgentState::BooleanMap event_listener_breakpoints_;
   InspectorAgentState::BooleanMap csp_violation_breakpoints_;
+
+  // [replay]
+  static void ReplayNotifyWill(const String& eventName,
+                               EventTarget* eventTarget = nullptr,
+                               bool isCallback = false);
+  static void ReplayNotifyDid(const String& eventName,
+                              EventTarget* eventTarget = nullptr,
+                              bool isCallback = false);
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h
@@ -195,14 +195,6 @@ class CORE_EXPORT InspectorDOMDebuggerAgent final
   InspectorAgentState::BooleanMap xhr_breakpoints_;
   InspectorAgentState::BooleanMap event_listener_breakpoints_;
   InspectorAgentState::BooleanMap csp_violation_breakpoints_;
-
-  // [replay]
-  static void ReplayNotifyWill(const String& eventName,
-                               EventTarget* eventTarget = nullptr,
-                               bool isCallback = false);
-  static void ReplayNotifyDid(const String& eventName,
-                              EventTarget* eventTarget = nullptr,
-                              bool isCallback = false);
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
@@ -153,8 +153,15 @@ scoped_refptr<FontDataForRangeSet> FontFallbackIterator::Next(
 
   if (fallback_stage_ == kFirstCandidateForNotdefGlyph) {
     fallback_stage_ = kOutOfLuck;
-    if (!first_candidate_)
-      FontCache::CrashWithFontInfo(&font_description_);
+    if (!first_candidate_) {
+      // [replay] hackfix: try not to crash if a font symbol cannot be found
+      scoped_refptr<SimpleFontData> system_font = UniqueSystemFontForHintList(hint_list);
+      if (system_font) {
+        // Fallback fonts are not retained in the FontDataCache.
+        return UniqueOrNext(base::AdoptRef(new FontDataForRangeSet(system_font)),
+                            hint_list);
+      }
+    }
     return first_candidate_;
   }
 


### PR DESCRIPTION
fix RUN-1061 (https://linear.app/replay/issue/RUN-1061/chromium-render-eventslist)
* Tap into `InspectorDOMDebuggerAgent` to capture all user callback calls
* `fromJsGetArgumentsInFrame`: Make available `arguments` to `Pause.evaluateInFrame` for any function frame
* add `replay-scripts/gen-event-names.ts` to convert CDT event names to "qualified event names"

fix RUN-1016 (https://linear.app/replay/issue/RUN-1016/fix-pauseobjectpreviewgettervalues)
* (Partially) Fix `getObjectPreview` to produce a better preview of Event objects

fix RUN-1137 (https://linear.app/replay/issue/RUN-1137/chromium-crashes-if-no-perfect-font-has-been-found)
* Fix a font-related crash
