### PR TITLE
Don't invoke event listeners that were zapped when recording

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/js_based_event_listener.cc
+++ b/third_party/blink/renderer/bindings/core/v8/js_based_event_listener.cc
@@ -84,6 +84,9 @@ void JSBasedEventListener::Invoke(
     recordreplay::Diagnostic("[RUN-1084] JSBasedEventListener::Invoke %p %p",
                              raw, raw ? *raw : nullptr);
     bool zapped = raw && *raw == (void*)0x1baffed00baffedf;
+    bool recordedZapped = recordreplay::RecordReplayValue("JSBasedEventListener::Invoke zapped", zapped);
+    if (recordedZapped)
+      return;
     recordreplay::Assert("[RUN-1084] JSBasedEventListener::Invoke %d", zapped);
     if (zapped)
       return;


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-1084