### PR TITLE
Ordered lock usage fix in InspectorTaskRunner::Dispose

### DIFF
--- a/third_party/blink/renderer/core/inspector/inspector_task_runner.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_task_runner.cc
@@ -25,7 +25,7 @@ void InspectorTaskRunner::InitIsolate(v8::Isolate* isolate) {
 }
 
 void InspectorTaskRunner::Dispose() {
-  base::AutoLock locker(lock_);
+  recordreplay::AutoLockMaybeEventsDisallowed locker(lock_);
   disposed_ = true;
   isolate_ = nullptr;
   isolate_task_runner_ = nullptr;


### PR DESCRIPTION
`InspectorTaskRunner::Dispose` may be called under GC sweeping, when events are disallowed.

PR for #RUN-1199 (https://linear.app/replay/issue/RUN-1199/use-autolockmaybeeventsdisallowed-in-blinkinspectortaskrunnerdispose)

Underlying crash #RUN-1196 (https://linear.app/replay/issue/RUN-1196/eventsdisallowed-trylock-with-label=sweepersweepforallocationifrunning)