### PR TITLE
Allow EventsDisallowed within SequenceManagerImpl::GetTickClockl

### DIFF
--- a/base/task/sequence_manager/sequence_manager_impl.cc
+++ b/base/task/sequence_manager/sequence_manager_impl.cc
@@ -1165,7 +1165,7 @@ void SequenceManagerImpl::SetDefaultTaskRunner(
 }
 
 const TickClock* SequenceManagerImpl::GetTickClock() const {
-  return any_thread_clock();
+  return any_thread_clock_maybe_events_disallowed();
 }
 
 TimeTicks SequenceManagerImpl::NowTicks() const {

--- a/base/task/sequence_manager/sequence_manager_impl.h
+++ b/base/task/sequence_manager/sequence_manager_impl.h
@@ -497,7 +497,7 @@ class BASE_EXPORT SequenceManagerImpl
     return clock_.load(std::memory_order_acquire);
   }
 
-  const base::TickClock* any_thread_clock_maybe_events_disallowed() {
+  const base::TickClock* any_thread_clock_maybe_events_disallowed() const {
     if (recordreplay::AreEventsDisallowed()) {
       recordreplay::AutoPassThroughEvents pt;
       return any_thread_clock();


### PR DESCRIPTION
Fixes #RUN-1204 (https://linear.app/replay/issue/RUN-1204/allow-eventsdisallowed-within-sequencemanagerimplgettickclock)

Under #RUN-1203 (https://linear.app/replay/issue/RUN-1203/[wandb]-ordered-lock-with-events-disallowed-atomic)