### PR TITLE
Assertions in NGBlockNode and LayoutObject.

### DIFF
--- a/third_party/blink/renderer/core/layout/layout_object_child_list.cc
+++ b/third_party/blink/renderer/core/layout/layout_object_child_list.cc
@@ -36,6 +36,8 @@
 #include "third_party/blink/renderer/core/layout/ng/inline/ng_fragment_items.h"
 #include "third_party/blink/renderer/core/paint/object_paint_invalidator.h"
 
+#include "base/record_replay.h"
+
 namespace blink {
 
 namespace {
@@ -94,6 +96,10 @@ LayoutObject* LayoutObjectChildList::RemoveChildNode(
     bool notify_layout_object) {
   DCHECK_EQ(old_child->Parent(), owner);
   DCHECK_EQ(this, owner->VirtualChildren());
+
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] LayoutObjectChildList::RemoveChildNode owner=%d child=%d",
+    owner->RecordReplayId(), old_child->RecordReplayId());
 
   if (old_child->IsFloatingOrOutOfFlowPositioned())
     To<LayoutBox>(old_child)->RemoveFloatingOrPositionedChildFromBlockLists();
@@ -166,6 +172,10 @@ void LayoutObjectChildList::InsertChildNode(LayoutObject* owner,
                                             LayoutObject* new_child,
                                             LayoutObject* before_child,
                                             bool notify_layout_object) {
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] LayoutObjectChildList::InsertChildNode owner=%d new_child=%d before_child=%d",
+    owner->RecordReplayId(), new_child->RecordReplayId(), before_child->RecordReplayId());
+
   DCHECK(!new_child->Parent());
   DCHECK_EQ(this, owner->VirtualChildren());
   DCHECK(!owner->IsLayoutBlockFlow() ||

--- a/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
@@ -414,8 +414,7 @@ bool IsDeferrableContent(const NGInlineNodeData& data) {
 }  // namespace
 
 NGInlineNode::NGInlineNode(LayoutBlockFlow* block)
-    : NGLayoutInputNode(block, kInline),
-      record_replay_id_(recordreplay::NewIdMainThread("NGInlineNode")) {
+    : NGLayoutInputNode(block, kInline) {
   DCHECK(block);
   DCHECK(block->IsLayoutNGObject());
   if (!block->HasNGInlineNodeData())
@@ -1261,7 +1260,7 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
 
   // https://linear.app/replay/issue/RUN-1219
   recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText id=%d",
-    record_replay_id_);
+    RecordReplayId());
 
   TRACE_EVENT0("fonts", "NGInlineNode::ShapeText");
   const String& text_content = data->text_content;
@@ -1462,7 +1461,7 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
 void NGInlineNode::ShapeTextForFirstLineIfNeeded(NGInlineNodeData* data) const {
   // https://linear.app/replay/issue/RUN-1219
   recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextForFirstLineIfNeeded id=%d",
-    record_replay_id_);
+    RecordReplayId());
 
   // First check if the document has any :first-line rules.
   DCHECK(!data->first_line_items_);
@@ -1516,7 +1515,7 @@ void NGInlineNode::ShapeTextIncludingFirstLine(
 
   // https://linear.app/replay/issue/RUN-1219
   recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextIncludingFirstLine id=%d",
-    record_replay_id_);
+    RecordReplayId());
 
   DCHECK_NE(new_state, NGInlineNodeData::kShapingNone);
   data->shaping_state_ = new_state;
@@ -1923,7 +1922,7 @@ MinMaxSizesResult NGInlineNode::ComputeMinMaxSizes(
 
   // https://linear.app/replay/issue/RUN-1219
   recordreplay::Assert("[RUN-1219] NGInlineNode::ComputeMinMaxSizes id=%d",
-    record_replay_id_);
+    RecordReplayId());
 
   PrepareLayoutIfNeeded();
   ShapeTextOrDefer(space);

--- a/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.h
+++ b/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.h
@@ -191,9 +191,6 @@ class CORE_EXPORT NGInlineNode : public NGLayoutInputNode {
                                    NGInlineNodeData* data);
 
   friend class NGLineBreakerTest;
-public:
-  // https://linear.app/replay/issue/RUN-1219
-  int record_replay_id_;
 };
 
 inline bool NGInlineNode::IsStickyImagesQuirkForContentSize() const {

--- a/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
@@ -113,15 +113,16 @@ inline LayoutMultiColumnFlowThread* GetFlowThread(const LayoutBox& box) {
 template <typename Algorithm, typename Callback>
 NOINLINE void CreateAlgorithmAndRun(const NGLayoutAlgorithmParams& params,
                                     const Callback& callback) {
-  // https://linear.app/replay/issue/RUN-546
-  recordreplay::Assert("CreateAlgorithmAndRun Start %d",
-                       params.node.GetLayoutBox()->RecordReplayId());
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] CreateAlgorithmAndRun Start %d node_id=%d",
+                       params.node.GetLayoutBox()->RecordReplayId(),
+                       params.node.RecordReplayId());
 
   Algorithm algorithm(params);
   callback(&algorithm);
 
-  // https://linear.app/replay/issue/RUN-546
-  recordreplay::Assert("CreateAlgorithmAndRun Done");
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] CreateAlgorithmAndRun Done");
 }
 
 template <typename Callback>
@@ -1003,6 +1004,11 @@ MinMaxSizesResult NGBlockNode::ComputeMinMaxSizes(
     const MinMaxSizesType type,
     const NGConstraintSpace& constraint_space,
     const MinMaxSizesFloatInput float_input) const {
+
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] NGBlockNode::ComputeMinMaxSizes id=%d",
+    RecordReplayId());
+
   // TODO(layoutng) Can UpdateMarkerTextIfNeeded call be moved
   // somewhere else? List items need up-to-date markers before layout.
   if (IsListItem())

--- a/third_party/blink/renderer/core/layout/ng/ng_layout_input_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_layout_input_node.cc
@@ -23,6 +23,8 @@
 #include "third_party/blink/renderer/core/layout/ng/table/layout_ng_table_section.h"
 #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
 
+#include "base/record_replay.h"
+
 namespace blink {
 namespace {
 
@@ -209,6 +211,10 @@ void NGLayoutInputNode::GetOverrideIntrinsicSize(
     *computed_inline_size = LayoutUnit();
   if (ShouldApplyBlockSizeContainment() && !*computed_block_size)
     *computed_block_size = LayoutUnit();
+}
+
+void NGLayoutInputNode::InitRecordReplayId() {
+  record_replay_id_ = recordreplay::NewIdMainThread("NGInlineNode");
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/layout/ng/ng_layout_input_node.h
+++ b/third_party/blink/renderer/core/layout/ng/ng_layout_input_node.h
@@ -68,7 +68,9 @@ class CORE_EXPORT NGLayoutInputNode {
     return NGLayoutInputNode(box, type);
   }
 
-  NGLayoutInputNode(std::nullptr_t) : box_(nullptr), type_(kBlock) {}
+  NGLayoutInputNode(std::nullptr_t) : box_(nullptr), type_(kBlock) {
+    InitRecordReplayId();
+  }
 
   NGLayoutInputNodeType Type() const {
     return static_cast<NGLayoutInputNodeType>(type_);
@@ -321,7 +323,10 @@ class CORE_EXPORT NGLayoutInputNode {
 
  protected:
   NGLayoutInputNode(LayoutBox* box, NGLayoutInputNodeType type)
-      : box_(box), type_(type) {}
+      : box_(box), type_(type)
+  {
+    InitRecordReplayId();
+  }
 
   void GetOverrideIntrinsicSize(
       absl::optional<LayoutUnit>* computed_inline_size,
@@ -330,6 +335,13 @@ class CORE_EXPORT NGLayoutInputNode {
   Member<LayoutBox> box_;
 
   unsigned type_ : 1;  // NGLayoutInputNodeType
+
+private:
+  // https://linear.app/replay/issue/RUN-1219
+  void InitRecordReplayId();
+  int record_replay_id_;
+public:
+  int RecordReplayId() const { return record_replay_id_; }
 };
 
 }  // namespace blink


### PR DESCRIPTION
For #RUN-1233 (https://linear.app/replay/issue/RUN-1233)

Something is going wrong in layout, and we're only noticing it way deep in the call stack when computing min-max for inline nodes.  These asserts try to catch it higher up in the min-max compute code, when we're doing it on block nodes, as well as in changes to the layout ordering of siblings.