### PR TITLE
RUN-1227: use `unique_leaky_ptr` for all `PowerModeVoter`s

### DIFF
--- a/android_webview/browser/gfx/begin_frame_source_webview.h
+++ b/android_webview/browser/gfx/begin_frame_source_webview.h
@@ -12,6 +12,7 @@
 #include "base/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/no_destructor.h"
+#include "base/record_replay.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "components/viz/common/frame_sinks/begin_frame_source.h"
 #include "components/viz/service/frame_sinks/external_begin_frame_source_android.h"
@@ -67,7 +68,7 @@ class BeginFrameSourceWebView : public viz::ExternalBeginFrameSource {
   std::unique_ptr<BeginFrameObserver> parent_observer_;
   bool inside_begin_frame_ = false;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
 };
 
 // RootBeginFrameSourceWebView is subclass of BeginFrameSourceWebView that

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -204,9 +204,10 @@ class SCOPED_LOCKABLE AutoUnlockMaybeEventsDisallowed {
   base::Lock& lock_;
 };
 
-// This drop-in replacement of unique_ptr purposefully leaks owned memory, so as
-// to avoid unwanted cleanup operations, usually in non-deterministic execution
-// paths. First discussed here:
+// This drop-in replacement for unique_ptr purposefully leaks owned memory
+// in non-deterministic execution paths, so as not to perform cleanup operations
+// that require deterministic execution.
+// First discussed here:
 // https://linear.app/replay/issue/RUN-1227/divergence-frameschedulerimpl-destroys-powermodevoter
 // Playground: https://replit.com/@Domiii/Leak-Unique-Ptr#main.cpp
 template <typename T>
@@ -245,8 +246,11 @@ public:
 
   // dtor
   ~unique_leaky_ptr() {
-    // -> leak the allocated memory, before destructing `unique_ptr`.
-    p.release();
+    if (AreEventsDisallowed()) {
+      // Leak the allocated memory before destructing `unique_ptr`
+      // when inside a non-deterministic execution path.
+      p.release();
+    }
   }
 };
 

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -12,6 +12,7 @@
 #include "base/thread_annotations.h"
 
 #include <cstdint>
+#include <memory>
 
 namespace base {
   class DictionaryValue;
@@ -201,6 +202,52 @@ class SCOPED_LOCKABLE AutoUnlockMaybeEventsDisallowed {
 
  private:
   base::Lock& lock_;
+};
+
+// This drop-in replacement of unique_ptr purposefully leaks owned memory, so as
+// to avoid unwanted cleanup operations, usually in non-deterministic execution
+// paths. First discussed here:
+// https://linear.app/replay/issue/RUN-1227/divergence-frameschedulerimpl-destroys-powermodevoter
+// Playground: https://replit.com/@Domiii/Leak-Unique-Ptr#main.cpp
+template <typename T>
+class unique_leaky_ptr {
+  std::unique_ptr<T> p;
+
+public:
+  // copy ctor
+  template <typename T_>
+  unique_leaky_ptr(T_&) = delete;
+
+  // copy assignment
+  template <typename T_>
+  unique_leaky_ptr& operator=(const T_&) = delete;
+
+  // move ctors
+  unique_leaky_ptr(unique_leaky_ptr&& u) : unique_leaky_ptr(std::move(u.p)) {}
+  template <typename T_>
+  unique_leaky_ptr(T_&& u) : p(std::move(u)) {}
+
+  // move assignments
+  unique_leaky_ptr& operator=(unique_leaky_ptr&& u) noexcept {
+    p = std::move(u.p);
+  }
+  template <typename T_>
+  unique_leaky_ptr& operator=(T_&& val) noexcept {
+    p = val;
+    return *this;
+  }
+
+  // Return the stored pointer.
+  T* operator->() const noexcept { return get(); }
+
+  /// Return the stored pointer.
+  T* get() const noexcept { return p.get(); }
+
+  // dtor
+  ~unique_leaky_ptr() {
+    // -> leak the allocated memory, before destructing `unique_ptr`.
+    p.release();
+  }
 };
 
 } // namespace recordreplay

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -215,19 +215,21 @@ class unique_leaky_ptr {
   std::unique_ptr<T> p;
 
 public:
+  using pointer = T*;
+ 
   // copy ctor
   template <typename T_>
   unique_leaky_ptr(T_&) = delete;
-
+ 
   // copy assignment
   template <typename T_>
   unique_leaky_ptr& operator=(const T_&) = delete;
-
+ 
   // move ctors
   unique_leaky_ptr(unique_leaky_ptr&& u) : unique_leaky_ptr(std::move(u.p)) {}
   template <typename T_>
   unique_leaky_ptr(T_&& u) : p(std::move(u)) {}
-
+ 
   // move assignments
   unique_leaky_ptr& operator=(unique_leaky_ptr&& u) noexcept {
     p = std::move(u.p);
@@ -239,10 +241,16 @@ public:
   }
 
   // Return the stored pointer.
-  T* operator->() const noexcept { return get(); }
+  pointer operator->() const noexcept { return get(); }
+  pointer get() const noexcept { return p.get(); }
 
-  /// Return the stored pointer.
-  T* get() const noexcept { return p.get(); }
+  // Return @c true if the stored pointer is not null.
+  explicit operator bool() const noexcept {
+    return !!p;
+  }
+
+  // Release ownership of any stored pointer.
+  pointer release() noexcept { return p.release(); }
 
   // dtor
   ~unique_leaky_ptr() {

--- a/cc/scheduler/scheduler.h
+++ b/cc/scheduler/scheduler.h
@@ -11,6 +11,7 @@
 
 #include "base/cancelable_callback.h"
 #include "base/memory/raw_ptr.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "cc/cc_export.h"
@@ -354,7 +355,7 @@ class CC_EXPORT Scheduler : public viz::BeginFrameObserverBase {
   // arrive so that |client_| can be informed about changes.
   base::TimeDelta last_frame_interval_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
   power_scheduler::PowerMode last_power_mode_vote_ =
       power_scheduler::PowerMode::kIdle;
 

--- a/components/viz/service/frame_sinks/compositor_frame_sink_support.h
+++ b/components/viz/service/frame_sinks/compositor_frame_sink_support.h
@@ -14,6 +14,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/read_only_shared_memory_region.h"
 #include "base/memory/weak_ptr.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "components/viz/common/frame_sinks/begin_frame_source.h"
@@ -421,7 +422,7 @@ class VIZ_SERVICE_EXPORT CompositorFrameSinkSupport
   // single-page-app transitions.
   SurfaceAnimationManager surface_animation_manager_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
 
   base::flat_set<base::PlatformThreadId> thread_ids_;
 

--- a/content/browser/renderer_host/render_widget_host_impl.h
+++ b/content/browser/renderer_host/render_widget_host_impl.h
@@ -24,6 +24,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/process/kill.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "build/build_config.h"
@@ -1471,8 +1472,8 @@ class CONTENT_EXPORT RenderWidgetHostImpl
 
   mojo::Remote<blink::mojom::WidgetCompositor> widget_compositor_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_input_voter_;
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_loading_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_input_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_loading_voter_;
   absl::optional<BrowserUIThreadScheduler::UserInputActiveHandle>
       user_input_active_handle_;
 

--- a/content/browser/web_contents/web_contents_impl.h
+++ b/content/browser/web_contents/web_contents_impl.h
@@ -24,6 +24,7 @@
 #include "base/memory/safe_ref.h"
 #include "base/observer_list.h"
 #include "base/process/kill.h"
+#include "base/record_replay.h"
 #include "base/scoped_observation.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
@@ -2326,7 +2327,7 @@ class CONTENT_EXPORT WebContentsImpl : public WebContents,
 
   std::unique_ptr<PrerenderHostRegistry> prerender_host_registry_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> audible_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> audible_power_mode_voter_;
 
   viz::FrameSinkId xr_render_target_;
 

--- a/content/common/process_visibility_tracker.h
+++ b/content/common/process_visibility_tracker.h
@@ -8,6 +8,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/no_destructor.h"
 #include "base/observer_list_threadsafe.h"
+#include "base/record_replay.h"
 #include "base/sequence_checker.h"
 #include "base/synchronization/lock.h"
 #include "base/thread_annotations.h"
@@ -53,7 +54,7 @@ class CONTENT_EXPORT ProcessVisibilityTracker {
   scoped_refptr<base::ObserverListThreadSafe<ProcessVisibilityObserver>>
       observers_ GUARDED_BY(lock_);
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_visibility_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_visibility_voter_;
   SEQUENCE_CHECKER(main_thread_);
 };
 

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -418,13 +418,6 @@ LocalFrameMojoHandler::LocalFrameMojoHandler(blink::LocalFrame& frame)
       WrapWeakPersistent(this)));
 }
 
-LocalFrameMojoHandler::~LocalFrameMojoHandler() {
-  // Avoid destroying power mode voters at non-deterministic points, as their
-  // vote will affect the arbiter's behavior.
-  if (recordreplay::AreEventsDisallowed())
-    script_execution_power_mode_voter_.release();
-}
-
 void LocalFrameMojoHandler::Trace(Visitor* visitor) const {
   visitor->Trace(frame_);
   visitor->Trace(back_forward_cache_controller_host_remote_);

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -50,8 +50,6 @@ class LocalFrameMojoHandler
       public device::mojom::blink::DevicePostureProviderClient {
  public:
   explicit LocalFrameMojoHandler(blink::LocalFrame& frame);
-  ~LocalFrameMojoHandler() override;
-
   void Trace(Visitor* visitor) const;
 
   void WasAttachedAsLocalMainFrame();

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCAL_FRAME_MOJO_HANDLER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCAL_FRAME_MOJO_HANDLER_H_
 
+#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "services/device/public/mojom/device_posture_provider.mojom-blink.h"
@@ -285,7 +286,7 @@ class LocalFrameMojoHandler
   device::mojom::blink::DevicePostureType current_device_posture_ =
       device::mojom::blink::DevicePostureType::kContinuous;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter>
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter>
       script_execution_power_mode_voter_;
 };
 

--- a/third_party/blink/renderer/core/loader/resource_load_observer_for_frame.h
+++ b/third_party/blink/renderer/core/loader/resource_load_observer_for_frame.h
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 
 #include "base/containers/span.h"
+#include "base/record_replay.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/frame/web_feature_forward.h"
@@ -70,7 +71,7 @@ class CORE_EXPORT ResourceLoadObserverForFrame final
 
   void UpdatePowerModeVote();
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
 
   // There are some overlap between |document_loader_|, |document_| and
   // |fetcher_properties_|. Use |fetcher_properties_| whenever possible.

--- a/third_party/blink/renderer/platform/graphics/begin_frame_provider.cc
+++ b/third_party/blink/renderer/platform/graphics/begin_frame_provider.cc
@@ -40,13 +40,6 @@ BeginFrameProvider::BeginFrameProvider(
           power_scheduler::PowerModeArbiter::GetInstance()->NewVoter(
               "PowerModeVoter.Animation.Worker")) {}
 
-BeginFrameProvider::~BeginFrameProvider() {
-  // Avoid destroying power mode voters at non-deterministic points, as their
-  // vote will affect the arbiter's behavior.
-  if (recordreplay::AreEventsDisallowed())
-    animation_power_mode_voter_.release();
-}
-
 void BeginFrameProvider::ResetCompositorFrameSink() {
   compositor_frame_sink_.reset();
   efs_receiver_.reset();

--- a/third_party/blink/renderer/platform/graphics/begin_frame_provider.h
+++ b/third_party/blink/renderer/platform/graphics/begin_frame_provider.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/notreached.h"
+#include "base/record_replay.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -95,7 +96,7 @@ class PLATFORM_EXPORT BeginFrameProvider
   HeapMojoRemote<viz::mojom::blink::CompositorFrameSink> compositor_frame_sink_;
   Member<BeginFrameProviderClient> begin_frame_client_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/platform/graphics/begin_frame_provider.h
+++ b/third_party/blink/renderer/platform/graphics/begin_frame_provider.h
@@ -76,7 +76,6 @@ class PLATFORM_EXPORT BeginFrameProvider
 
   void Trace(Visitor*) const;
 
-  ~BeginFrameProvider() override;
 
  private:
   void OnMojoConnectionError(uint32_t custom_reason,

--- a/third_party/blink/renderer/platform/graphics/canvas_resource_dispatcher.h
+++ b/third_party/blink/renderer/platform/graphics/canvas_resource_dispatcher.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/memory/read_only_shared_memory_region.h"
+#include "base/record_replay.h"
 #include "cc/paint/paint_flags.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "components/viz/common/frame_sinks/begin_frame_args.h"
@@ -155,7 +156,7 @@ class PLATFORM_EXPORT CanvasResourceDispatcher
 
   CanvasResourceDispatcherClient* client_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
 
   scoped_refptr<base::SingleThreadTaskRunner>
       agent_group_scheduler_compositor_task_runner_;

--- a/third_party/blink/renderer/platform/graphics/video_frame_submitter.h
+++ b/third_party/blink/renderer/platform/graphics/video_frame_submitter.h
@@ -9,6 +9,7 @@
 
 #include "base/memory/read_only_shared_memory_region.h"
 #include "base/memory/weak_ptr.h"
+#include "base/record_replay.h"
 #include "base/threading/thread_checker.h"
 #include "base/timer/timer.h"
 #include "cc/metrics/frame_sequence_tracker_collection.h"
@@ -225,7 +226,7 @@ class PLATFORM_EXPORT VideoFrameSubmitter
   // presented.
   base::flat_set<uint32_t> ignorable_submitted_frames_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> power_mode_voter_;
 
   THREAD_CHECKER(thread_checker_);
 

--- a/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.h
@@ -345,7 +345,7 @@ class PLATFORM_EXPORT FrameSchedulerImpl : public FrameScheduler,
   TraceableState<bool, TracingCategory::kInfo> waiting_for_contentful_paint_;
   TraceableState<bool, TracingCategory::kInfo> waiting_for_meaningful_paint_;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> loading_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> loading_power_mode_voter_;
 
   // TODO(altimin): Remove after we have have 1:1 relationship between frames
   // and documents.

--- a/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.h
@@ -13,6 +13,7 @@
 #include "base/containers/flat_map.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "base/record_replay.h"
 #include "base/task/sequence_manager/task_queue.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"

--- a/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.h
@@ -16,6 +16,7 @@
 #include "base/metrics/single_sample_metrics.h"
 #include "base/observer_list.h"
 #include "base/profiler/sample_metadata.h"
+#include "base/record_replay.h"
 #include "base/synchronization/lock.h"
 #include "base/task/sequence_manager/task_queue.h"
 #include "base/task/sequence_manager/task_time_observer.h"
@@ -860,7 +861,7 @@ class PLATFORM_EXPORT MainThreadSchedulerImpl
 
     WTF::Vector<AgentGroupSchedulerScope> agent_group_scheduler_scope_stack;
 
-    std::unique_ptr<power_scheduler::PowerModeVoter> audible_power_mode_voter;
+    recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> audible_power_mode_voter;
 
     std::unique_ptr<TaskAttributionTracker> task_attribution_tracker;
     WTF::HashSet<AgentGroupSchedulerImpl*> agent_group_schedulers;

--- a/third_party/blink/renderer/platform/widget/input/synchronous_compositor_proxy.h
+++ b/third_party/blink/renderer/platform/widget/input/synchronous_compositor_proxy.h
@@ -10,6 +10,7 @@
 
 #include "base/callback.h"
 #include "base/memory/writable_shared_memory_region.h"
+#include "base/record_replay.h"
 #include "components/viz/common/frame_timing_details_map.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
@@ -132,7 +133,7 @@ class SynchronousCompositorProxy : public blink::SynchronousInputHandler,
   mojo::AssociatedReceiver<mojom::blink::SynchronousCompositor> receiver_{this};
   bool use_in_process_zero_copy_software_draw_ = false;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> animation_power_mode_voter_;
 
   const bool viz_frame_submission_enabled_;
 

--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.h
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <memory>
 
+#include "base/record_replay.h"
 #include "base/task/single_thread_task_runner.h"
 #include "build/build_config.h"
 #include "cc/trees/paint_holding_reason.h"
@@ -378,7 +379,7 @@ class PLATFORM_EXPORT WidgetInputHandlerManager final
   // the input handling thread (i.e. on the compositor thread if it exists).
   bool has_seen_first_gesture_scroll_update_after_begin_ = false;
 
-  std::unique_ptr<power_scheduler::PowerModeVoter> response_power_mode_voter_;
+  recordreplay::unique_leaky_ptr<power_scheduler::PowerModeVoter> response_power_mode_voter_;
 
   // Timer for count dropped events.
   std::unique_ptr<base::OneShotTimer> dropped_event_counts_timer_;


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1227/divergence-frameschedulerimpl-destroys-powermodevoter