### PR TITLE
Make StyleEngine::text_to_sheet_cache_ more deterministic.

### DIFF
--- a/third_party/blink/renderer/core/css/style_engine.cc
+++ b/third_party/blink/renderer/core/css/style_engine.cc
@@ -800,6 +800,19 @@ CSSStyleSheet* StyleEngine::CreateSheet(
 
   AtomicString text_content(text);
 
+  // RecordReplay: Clear the cache deterministically once it grows too large
+  // or is accessed too many times.
+  int text_content_length = text_content.length();
+  if (
+    (record_replay_text_to_sheet_cache_weight_ + text_content_length >= kRecordReplayTextToSheetCacheMaxWeight) ||
+    (record_replay_text_to_sheet_cache_access_count_ >= kRecordReplayTextToSheetCacheMaxAccessCount)
+  ) {
+    text_to_sheet_cache_.clear();
+    sheet_to_text_cache_.clear();
+    record_replay_text_to_sheet_cache_weight_ = 0;
+    record_replay_text_to_sheet_cache_access_count_ = 0;
+  }
+
   auto result = text_to_sheet_cache_.insert(text_content, nullptr);
   StyleSheetContents* contents = result.stored_value->value;
 
@@ -814,6 +827,10 @@ CSSStyleSheet* StyleEngine::CreateSheet(
     result.stored_value->value = nullptr;
     style_sheet =
         ParseSheet(element, text, start_position, render_blocking_behavior);
+
+    record_replay_text_to_sheet_cache_weight_ += text_content_length;
+    record_replay_text_to_sheet_cache_access_count_++;
+
     if (style_sheet->Contents()->IsCacheableForStyleElement()) {
       result.stored_value->value = style_sheet->Contents();
       sheet_to_text_cache_.insert(style_sheet->Contents(), text_content);

--- a/third_party/blink/renderer/core/css/style_engine.h
+++ b/third_party/blink/renderer/core/css/style_engine.h
@@ -886,9 +886,20 @@ class CORE_EXPORT StyleEngine final : public GarbageCollected<StyleEngine>,
 
   Member<CSSFontSelector> font_selector_;
 
-  HeapHashMap<AtomicString, WeakMember<StyleSheetContents>>
+  // RecordReplay: We use strong pointers to StyleSheetContents objects so that
+  // GC doesn't clean them up non-deterministically.
+  //
+  // Instead, the cache is cleared deterministically once its size exceeds a
+  // fixed threshold, or a certain number of accesses are made.
+  static const unsigned kRecordReplayTextToSheetCacheMaxWeight = 1000 * 1000;
+  unsigned record_replay_text_to_sheet_cache_weight_{0};
+
+  static const unsigned kRecordReplayTextToSheetCacheMaxAccessCount = 100;
+  unsigned record_replay_text_to_sheet_cache_access_count_{0};
+
+  HeapHashMap<AtomicString, Member<StyleSheetContents>>
       text_to_sheet_cache_;
-  HeapHashMap<WeakMember<StyleSheetContents>, AtomicString>
+  HeapHashMap<Member<StyleSheetContents>, AtomicString>
       sheet_to_text_cache_;
 
   std::unique_ptr<StyleResolverStats> style_resolver_stats_;


### PR DESCRIPTION
Fixes #RUN-1249 (https://linear.app/replay/issue/RUN-1249)

This is a stab at making the cache access more deterministic without getting rid of the cache itself.