### PR TITLE
Narrower asserts in `NGInlineNode::ShapeTextIncludingFirstLine`

### DIFF
--- a/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
@@ -1259,8 +1259,8 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
                              const Font* override_font) const {
 
   // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText id=%d",
-    RecordReplayId());
+  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText id=%d items=%u",
+    RecordReplayId(), (unsigned) data->items.size());
 
   TRACE_EVENT0("fonts", "NGInlineNode::ShapeText");
   const String& text_content = data->text_content;
@@ -1274,12 +1274,15 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
          data->segments->EndOffset() == text_content.length());
 
   for (unsigned index = 0; index < items->size();) {
+    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #1 index=%u", index);
     NGInlineItem& start_item = (*items)[index];
 
     if (start_item.Type() != NGInlineItem::kText || !start_item.Length()) {
       index++;
       continue;
     }
+    // https://linear.app/replay/issue/RUN-1219
+    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #2");
 
     const ComputedStyle& start_style = *start_item.Style();
     const Font& font =
@@ -1310,6 +1313,8 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
       index++;
       continue;
     }
+    // https://linear.app/replay/issue/RUN-1219
+    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #3");
 
     // Scan forward until an item is encountered that should trigger a shaping
     // break. This ensures that adjacent text items are shaped together whenever
@@ -1363,6 +1368,8 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
       index++;
       continue;
     }
+    // https://linear.app/replay/issue/RUN-1219
+    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #4");
 
     // Results may only be reused if all items in the range remain valid.
     if (previous_text) {
@@ -1390,11 +1397,15 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
         continue;
       }
     }
+    // https://linear.app/replay/issue/RUN-1219
+    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #5");
 
     // Shape each item with the full context of the entire node.
     scoped_refptr<ShapeResult> shape_result;
     if (MutableData() && MutableData()->IsShapingDeferred() &&
         font.PrimaryFont()) {
+      // https://linear.app/replay/issue/RUN-1219
+      recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #6");
       unsigned length = end_offset - start_item.StartOffset();
       shape_result = ShapeResult::CreateForSpacesWithPerGlyphWidth(
           &font, TextDirection::kLtr, start_item.StartOffset(), length,
@@ -1527,6 +1538,10 @@ void NGInlineNode::ShapeTextIncludingFirstLine(
 #endif
 
   ShapeText(data, previous_text, previous_items);
+
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextIncludingFirstLine #2");
+
   if (new_state == NGInlineNodeData::kShapingDone)
     ShapeTextForFirstLineIfNeeded(data);
 }

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
@@ -93,6 +93,9 @@ bool FontFallbackList::ShouldSkipDrawing() const {
 
 const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontData(
     const FontDescription& font_description) {
+  // https://linear.app/replay/issue/RUN-1219
+  recordreplay::Assert("[RUN-1219] FontFallbackList::DeterminePrimarySimpleFontData");
+
   base::ElapsedTimer timer;
   const SimpleFontData* result =
       DeterminePrimarySimpleFontDataCore(font_description);


### PR DESCRIPTION
For #RUN-1261 (https://linear.app/replay/issue/RUN-1261/add-counter-to-nginlinenode-and-assert-in-shapetextincludingfirstline)

