### PR TITLE
re-enable events behind `disable-collect-events` feature flag (for use in our own test suites)

### DIFF
--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -962,24 +962,44 @@ static String MakeReplayEventType(const String& eventTypeRaw,
   return builder.ToString();
 }
 
+static bool gIsEventInFlight = false;
+
 void ReplayNotifyBeforeEvent(const String& eventName, 
-                      EventTarget* eventTarget,
-                      bool isCallback) {
-  String qualifiedEventName =
+                             EventTarget* eventTarget,
+                             bool isCallback) {
+  String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
-  // Disabled, see https://linear.app/replay/issue/RUN-1206
-  //recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), true);
-  (void)qualifiedEventName;
+  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
+  if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::FeatureEnabled("disable-collect-events")) {
+    recordreplay::Print("[RUN-1251] DEBUG-EVENTS event START %d %d %s",
+                        recordreplay::AreEventsDisallowed(),
+                        gIsEventInFlight,
+                        replayEventType.Ascii().c_str());
+    if (!recordreplay::AreEventsDisallowed()) {
+      recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
+      gIsEventInFlight = true;
+    }
+  }
 }
 
 void ReplayNotifyAfterEvent(const String& eventName,
-                     EventTarget* eventTarget,
-                     bool isCallback) {
-  String qualifiedEventName =
+                            EventTarget* eventTarget,
+                            bool isCallback) {
+  String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
-  // Disabled, see https://linear.app/replay/issue/RUN-1206
-  //recordreplay::OnEvent(qualifiedEventName.Ascii().c_str(), false);
-  (void)qualifiedEventName;
+  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
+  if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::FeatureEnabled("disable-collect-events")) {
+    recordreplay::Print("[RUN-1251] DEBUG-EVENTS event END %d %d %s",
+                        recordreplay::AreEventsDisallowed(),
+                        gIsEventInFlight,
+                        replayEventType.Ascii().c_str());
+    if (gIsEventInFlight) {
+      recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
+      gIsEventInFlight = false;
+    }
+  }
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -738,12 +738,10 @@ static void ReplayNotifyAfterEvent(const String& eventName,
                             bool isCallback = false);
 
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
-  ReplayNotifyBeforeEvent("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
-  ReplayNotifyAfterEvent("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 
@@ -970,12 +968,11 @@ void ReplayNotifyBeforeEvent(const String& eventName,
   String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
+  recordreplay::Assert("[RUN-1226] ReplayNotifyBeforeEvent %d %s",
+                       gIsEventInFlight,
+                       replayEventType.Ascii().c_str());
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
-    recordreplay::Print("[RUN-1251] DEBUG-EVENTS event START %d %d %s",
-                        recordreplay::AreEventsDisallowed(),
-                        gIsEventInFlight,
-                        replayEventType.Ascii().c_str());
     if (!recordreplay::AreEventsDisallowed()) {
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
       ++gIsEventInFlight;
@@ -991,10 +988,6 @@ void ReplayNotifyAfterEvent(const String& eventName,
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
-    recordreplay::Print("[RUN-1251] DEBUG-EVENTS event END %d %d %s",
-                        recordreplay::AreEventsDisallowed(),
-                        gIsEventInFlight,
-                        replayEventType.Ascii().c_str());
     if (gIsEventInFlight) {
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
       --gIsEventInFlight;

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -962,7 +962,7 @@ static String MakeReplayEventType(const String& eventTypeRaw,
   return builder.ToString();
 }
 
-static bool gIsEventInFlight = false;
+static int gIsEventInFlight = 0;
 
 void ReplayNotifyBeforeEvent(const String& eventName, 
                              EventTarget* eventTarget,
@@ -978,7 +978,7 @@ void ReplayNotifyBeforeEvent(const String& eventName,
                         replayEventType.Ascii().c_str());
     if (!recordreplay::AreEventsDisallowed()) {
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
-      gIsEventInFlight = true;
+      ++gIsEventInFlight;
     }
   }
 }
@@ -997,7 +997,7 @@ void ReplayNotifyAfterEvent(const String& eventName,
                         replayEventType.Ascii().c_str());
     if (gIsEventInFlight) {
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
-      gIsEventInFlight = false;
+      --gIsEventInFlight;
     }
   }
 }

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -967,10 +967,8 @@ void ReplayNotifyBeforeEvent(const String& eventName,
                              bool isCallback) {
   String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
+
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
-  recordreplay::Assert("[RUN-1226] ReplayNotifyBeforeEvent %d %s",
-                       gIsEventInFlight,
-                       replayEventType.Ascii().c_str());
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
     if (!recordreplay::AreEventsDisallowed()) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1251/add-an-eventsenabled-feature-flag-to-chromium

After some first tests, I can see that:

1. Multiple events can be in-flight at the same time (which might be problematic for other reasons).
2. None are hitting `recordreplay::AreEventsDisallowed()` thus far.
