### PR TITLE
Fix: Assert in PostImmediateTaskImpl causes many unwanted warnings

### DIFF
--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -453,8 +453,13 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
 
     bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
     TimeTicks queue_time;
-    recordreplay::Assert("[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d",
-                         add_queue_time_to_tasks || delayed_fence_allowed_);
+
+    if (!events_disallowed) {
+      recordreplay::Assert(
+          "[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d",
+          add_queue_time_to_tasks || delayed_fence_allowed_);
+    }
+    
     if (add_queue_time_to_tasks || delayed_fence_allowed_)
       queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
 


### PR DESCRIPTION
-> Don't generate unwanted warnings.
Let's account for the fact that `PostImmediateTaskImpl` might be called in `EventsDisallowed` regions

* https://linear.app/replay/issue/RUN-1264/add-asserts-in-arm-and-cancel