### PR TITLE
RUN-1271: divergence due to InspectorDOMDebuggerAgent

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4445,7 +4445,8 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   if (recordreplay::IsReplaying()) {
     recordreplay::AutoDisallowEvents disallow("SetupRecordReplayCommands");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
-
+  }
+  if (recordreplay::IsRecordingOrReplaying()) {
     // initialize InspectorDOMDebuggerAgent, so it can pick up user events
     getOrCreateInspectorDOMDebuggerAgent(isolate);
   }

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -972,6 +972,8 @@ void ReplayNotifyBeforeEvent(const String& eventName,
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
     if (!recordreplay::AreEventsDisallowed()) {
+      recordreplay::Assert("[RUN-1226] ReplayNotifyBeforeEvent %d %s",
+                           gIsEventInFlight, replayEventType.Ascii().c_str());
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
       ++gIsEventInFlight;
     }
@@ -983,10 +985,13 @@ void ReplayNotifyAfterEvent(const String& eventName,
                             bool isCallback) {
   String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
+
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
     if (gIsEventInFlight) {
+      recordreplay::Assert("[RUN-1226] ReplayNotifyAfterEvent %d %s",
+                           gIsEventInFlight, replayEventType.Ascii().c_str());
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
       --gIsEventInFlight;
     }

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -738,10 +738,12 @@ static void ReplayNotifyAfterEvent(const String& eventName,
                             bool isCallback = false);
 
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
+  ReplayNotifyBeforeEvent("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
+  ReplayNotifyAfterEvent("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 

--- a/third_party/blink/renderer/core/script/pending_script.cc
+++ b/third_party/blink/renderer/core/script/pending_script.cc
@@ -81,9 +81,6 @@ void PendingScript::Dispose() {
   starting_position_ = TextPosition::BelowRangePosition();
   parser_blocking_load_start_time_ = base::TimeTicks();
 
-  recordreplay::Assert("[RUN-1271] PendingScript::Dispose 1 %d",
-                       starting_position_);
-
   DisposeInternal();
   element_ = nullptr;
 }
@@ -139,7 +136,6 @@ void PendingScript::MarkParserBlockingLoadStartTime() {
 void PendingScript::ExecuteScriptBlock() {
   TRACE_EVENT0("blink", "PendingScript::ExecuteScriptBlock");
   ExecutionContext* context = element_->GetExecutionContext();
-
   if (!context) {
     Dispose();
     return;
@@ -186,12 +182,6 @@ void PendingScript::ExecuteScriptBlock() {
   const bool is_controlled_by_script_runner = IsControlledByScriptRunner();
   ScriptElementBase* element = element_;
   Dispose();
-
-  recordreplay::Assert(
-      "[RUN-1271] PendingScript::ExecuteScriptBlock 3 %d %s %d",
-      script ? (int)script->GetScriptType() : -1,
-      script ? script->SourceUrl().GetString().Utf8().c_str() : "",
-      was_canceled);
 
   // ExecuteScriptBlockInternal() is split just in order to prevent accidential
   // access to |this| after Dispose().
@@ -298,10 +288,6 @@ void PendingScript::ExecuteScriptBlockInternal(
     //
     // <spec step="4.B.2">Run the module script given by the script's
     // script.</spec>
-    recordreplay::Assert(
-        "[RUN-1271] PendingScript::ExecuteScriptBlockInternal %d %s",
-        !!current_script,
-        current_script ? current_script->ChildTextContent().Utf8().c_str() : "");
     script->RunScript(context_document->domWindow());
 
     // <spec step="4.A.4">Set the script element's node document's currentScript


### PR DESCRIPTION
@bhackett1024 Let me know what you think? 

* This PR makes sure that we also have the `InspectorDOMDebuggerAgent` active during recording.
* Ideally, we do want to support this type of divergence, but until we have a better framework with proper safeguards in place, a little bit of extra overhead might be warranted?
* With the new `events` feature flag, we can also compare performance of events enabled vs. disabled, if it makes any difference at all.

https://linear.app/replay/issue/RUN-1271/divergence-in-pendingscriptexecutescriptblock