### PR TITLE
Guard asserts in LayoutObjectChildList on !EventsDisallowed

### DIFF
--- a/third_party/blink/renderer/core/layout/layout_object_child_list.cc
+++ b/third_party/blink/renderer/core/layout/layout_object_child_list.cc
@@ -98,10 +98,12 @@ LayoutObject* LayoutObjectChildList::RemoveChildNode(
   DCHECK_EQ(this, owner->VirtualChildren());
 
   // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert(
-    "[RUN-1219] LayoutObjectChildList::RemoveChildNode owner=%d child=%d",
-    owner ? owner->RecordReplayId() : -1,
-    old_child ? old_child->RecordReplayId() : -1);
+  if (!recordreplay::AreEventsDisallowed()) {
+    recordreplay::Assert(
+      "[RUN-1219] LayoutObjectChildList::RemoveChildNode owner=%d child=%d",
+      owner ? owner->RecordReplayId() : -1,
+      old_child ? old_child->RecordReplayId() : -1);
+  }
 
   if (old_child->IsFloatingOrOutOfFlowPositioned())
     To<LayoutBox>(old_child)->RemoveFloatingOrPositionedChildFromBlockLists();
@@ -175,11 +177,13 @@ void LayoutObjectChildList::InsertChildNode(LayoutObject* owner,
                                             LayoutObject* before_child,
                                             bool notify_layout_object) {
   // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert(
-    "[RUN-1219] LayoutObjectChildList::InsertChildNode owner=%d new_child=%d before_child=%d",
-    owner ? owner->RecordReplayId() : -1,
-    new_child ? new_child->RecordReplayId() : -1,
-    before_child ? before_child->RecordReplayId() : -1);
+  if (!recordreplay::AreEventsDisallowed()) {
+    recordreplay::Assert(
+      "[RUN-1219] LayoutObjectChildList::InsertChildNode owner=%d new_child=%d before_child=%d",
+      owner ? owner->RecordReplayId() : -1,
+      new_child ? new_child->RecordReplayId() : -1,
+      before_child ? before_child->RecordReplayId() : -1);
+  }
 
   DCHECK(!new_child->Parent());
   DCHECK_EQ(this, owner->VirtualChildren());


### PR DESCRIPTION
For #RUN-1287 (https://linear.app/replay/issue/RUN-1287/guard-asserts-in-layoutobjectchildlist-with-eventsdisallowed)

@klochek  @MichaReiser Basic example of just not doing the asserts when we're in events-disallowed mode.