### PR TITLE
RUN-1293: Fix RemoveFence During GC

### DIFF
--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -1040,7 +1040,7 @@ void TaskQueueImpl::RemoveFence() {
   front_task_unblocked |= main_thread_only().delayed_work_queue->RemoveFence();
 
   {
-    base::internal::CheckedAutoLock lock(any_thread_lock_);
+    recordreplay::AutoLockMaybeEventsDisallowed lock(any_thread_lock_);
     if (!front_task_unblocked && previous_fence) {
       if (!any_thread_.immediate_incoming_queue.empty() &&
           any_thread_.immediate_incoming_queue.front().task_order() >


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1286#comment-c645417d
* https://linear.app/replay/issue/RUN-1286/crash-with-disallowed-events-value-trylock-under-basesequence