### PR TITLE
Assert layer ordering in `layers_that_should_push_properties`

### DIFF
--- a/cc/layers/layer.cc
+++ b/cc/layers/layer.cc
@@ -120,13 +120,11 @@ Layer::Layer()
       ignore_set_needs_commit_for_test_(false),
       bitflags_(0u),
       subtree_property_changed_(false) {
-  // https://linear.app/replay/issue/RUN-885
-  recordreplay::RegisterPointer("Layer", this);
+  // https://linear.app/replay/issue/RUN-1229
+  recordreplay::Assert("Layer::Layer %d", this->layer_id_);
 }
 
 Layer::~Layer() {
-  recordreplay::UnregisterPointer(this);
-
   // Our parent should be holding a reference to us so there should be no
   // way for us to be destroyed while we still have a parent.
   DCHECK(!parent());

--- a/cc/layers/picture_layer.cc
+++ b/cc/layers/picture_layer.cc
@@ -281,7 +281,7 @@ void PictureLayer::DropRecordingSourceContentIfInvalid(
     int source_frame_number) {
   // https://linear.app/replay/issue/RUN-885
   recordreplay::Assert("PictureLayer::DropRecordingSourceContentIfInvalid %d %d",
-                       recordreplay::PointerId(this), source_frame_number);
+                       this->id(), source_frame_number);
 
   gfx::Size recording_source_bounds = recording_source_.Read(*this)->GetSize();
 

--- a/cc/trees/tree_synchronizer.cc
+++ b/cc/trees/tree_synchronizer.cc
@@ -219,6 +219,11 @@ void TreeSynchronizer::PushLayerProperties(
       commit_state.layers_that_should_push_properties.end();
   for (auto it = source_layers_begin; it != source_layers_end; ++it) {
     auto* source_layer = *it;
+    // https://linear.app/replay/issue/RUN-1229
+    recordreplay::Assert(
+        "TreeSynchronizer::PushLayerProperties source_layer %d",
+        source_layer->id());
+
     LayerImpl* target_layer = impl_tree->LayerById(source_layer->id());
     DCHECK(target_layer);
     source_layer->PushPropertiesTo(target_layer, commit_state, unsafe_state);


### PR DESCRIPTION
This PR adds two new assertion:

* `TreeSynchronizer::PushLayerProperties` that verifies that the source layers are iterated in a stable order. 
* `Layer::Layer`: to assert that the layer ids are generated in the same order.

It further changes the assertion in `PictureLayer::DropRecordingSourceContentIfInvalid` to use the `Layer->id()` instead of the pointer to avoid having to track two identifiers for `Layer` that must be stable (`Layer::id` is used to sort the layers in `TreeSynchronizer`). 

Part of https://linear.app/replay/issue/RUN-1229
[In detail analysis](https://linear.app/replay/issue/RUN-1229/mismatch-in-ccpicturelayerdroprecordingsourcecontentifinvalid#comment-0b38e10e)