### PR TITLE
Add hashing functors to create dependable hash table iteration orderings

### DIFF
--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -168,19 +168,6 @@ struct CompareMemberByPointerId {
   }
 };
 
-// For use with blink WeakMember and Member.
-template <typename T>
-struct CompareMemberByRecordReplayId {
-  bool operator()(const T& a, const T& b) const {
-    if (IsRecordingOrReplaying("pointer-ids")) {
-      int ida = a.Get()->RecordReplayId();
-      int idb = b.Get()->RecordReplayId();
-      CHECK(ida && idb);
-      return ida < idb;
-    }
-    return a < b;
-  }
-};
 
 // For taking ordered locks when events might be disallowed. Passes through
 // events during the acquire to avoid generating a warning.

--- a/third_party/blink/renderer/core/animation/animation_timeline.cc
+++ b/third_party/blink/renderer/core/animation/animation_timeline.cc
@@ -198,10 +198,7 @@ Animation* AnimationTimeline::Play(AnimationEffect* child,
 void AnimationTimeline::MarkAnimationsCompositorPending(bool source_changed) {
   recordreplay::Assert("[RUN-966] AnimationTimeline::MarkAnimationsCompositorPending %d", RecordReplayId());
 
-  HeapVector<Member<Animation>> animations_vector(animations_);
-  std::sort(animations_vector.begin(), animations_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<Animation>>());
-  for (const auto& animation : animations_vector) {
+  for (const auto& animation : animations_) {
     animation->SetCompositorPending(source_changed);
   }
 

--- a/third_party/blink/renderer/core/animation/animation_timeline.h
+++ b/third_party/blink/renderer/core/animation/animation_timeline.h
@@ -14,6 +14,7 @@
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -104,7 +105,7 @@ class CORE_EXPORT AnimationTimeline : public ScriptWrappable {
   void ClearOutdatedAnimation(Animation*);
 
   virtual wtf_size_t AnimationsNeedingUpdateCount() const;
-  const HeapHashSet<WeakMember<Animation>>& GetAnimations() const {
+  const HeapHashSet<WeakMember<Animation>, WTF::MemberHashRecordReplayId<Animation>>& GetAnimations() const {
     return animations_;
   }
 
@@ -141,7 +142,7 @@ class CORE_EXPORT AnimationTimeline : public ScriptWrappable {
   // i.e. current, in effect, or had timing changed
   HeapHashSet<Member<Animation>> animations_needing_update_;
   // All animations attached to this timeline.
-  HeapHashSet<WeakMember<Animation>> animations_;
+  HeapHashSet<WeakMember<Animation>, WTF::MemberHashRecordReplayId<Animation>> animations_;
 
   // Strongly held references on animations when recording/replaying. Updating the
   // animations can interact with the recording and the animations should be consistent

--- a/third_party/blink/renderer/core/animation/document_timeline.cc
+++ b/third_party/blink/renderer/core/animation/document_timeline.cc
@@ -209,13 +209,7 @@ double DocumentTimeline::PlaybackRate() const {
 }
 
 void DocumentTimeline::InvalidateKeyframeEffects(const TreeScope& tree_scope) {
-  HeapVector<Member<Animation>> animations_vector;
   for (const auto& animation : animations_)
-    animations_vector.push_back(animation);
-  std::sort(animations_vector.begin(), animations_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<Animation>>());
-
-  for (const auto& animation : animations_vector)
     animation->InvalidateKeyframeEffect(tree_scope);
 }
 

--- a/third_party/blink/renderer/core/css/post_style_update_scope.cc
+++ b/third_party/blink/renderer/core/css/post_style_update_scope.cc
@@ -39,15 +39,10 @@ void PostStyleUpdateScope::Apply() {
   StyleEngine::InApplyAnimationUpdateScope in_apply_animation_update_scope(
       document_.GetStyleEngine());
 
-  HeapHashSet<Member<Element>> pending;
+  HeapHashSet<Member<Element>, WTF::MemberHashRecordReplayId<Element>> pending;
   std::swap(pending, animation_data_.elements_with_pending_updates_);
 
-  HeapVector<Member<Element>> pending_vector;
-  for (auto& element : pending)
-    pending_vector.push_back(element);
-  std::sort(pending_vector.begin(), pending_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<Element>>());
-  for (auto& element : pending_vector) {
+  for (auto& element : pending) {
     ElementAnimations* element_animations = element->GetElementAnimations();
     if (!element_animations)
       continue;

--- a/third_party/blink/renderer/core/css/post_style_update_scope.h
+++ b/third_party/blink/renderer/core/css/post_style_update_scope.h
@@ -63,7 +63,7 @@ class CORE_EXPORT PostStyleUpdateScope {
     friend class PostStyleUpdateScope;
     friend class ContainerQueryTest;
 
-    HeapHashSet<Member<Element>> elements_with_pending_updates_;
+    HeapHashSet<Member<Element>, WTF::MemberHashRecordReplayId<Element>> elements_with_pending_updates_;
     HeapHashMap<Member<Element>, scoped_refptr<const ComputedStyle>>
         old_styles_;
   };

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -2778,15 +2778,10 @@ void Document::UpdateUseShadowTreesIfNeeded() {
 
   // Breadth-first search since nested use elements add to the queue.
   while (!use_elements_needing_update_.empty()) {
-    HeapHashSet<Member<SVGUseElement>> elements;
+    HeapHashSet<Member<SVGUseElement>, WTF::MemberHashRecordReplayId<SVGUseElement>> elements;
     use_elements_needing_update_.swap(elements);
-    HeapVector<Member<SVGUseElement>> elements_vector;
-    for (SVGUseElement* element : elements) {
-      elements_vector.push_back(element);
-    }
-    std::sort(elements_vector.begin(), elements_vector.end(),
-              recordreplay::CompareMemberByRecordReplayId<Member<SVGUseElement>>());
-    for (SVGUseElement* element : elements_vector)
+
+    for (SVGUseElement* element : elements)
       element->BuildPendingResource();
   }
 }

--- a/third_party/blink/renderer/core/dom/document.h
+++ b/third_party/blink/renderer/core/dom/document.h
@@ -76,6 +76,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_linked_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/heap_observer_set.h"
 #include "third_party/blink/renderer/platform/instrumentation/use_counter.h"
 #include "third_party/blink/renderer/platform/scheduler/public/post_cancellable_task.h"
@@ -2447,7 +2448,7 @@ class CORE_EXPORT Document : public ContainerNode,
 
   HeapTaskRunnerTimer<Document> did_associate_form_controls_timer_;
 
-  HeapHashSet<Member<SVGUseElement>> use_elements_needing_update_;
+  HeapHashSet<Member<SVGUseElement>, WTF::MemberHashRecordReplayId<SVGUseElement>> use_elements_needing_update_;
 
   ParserSynchronizationPolicy parser_sync_policy_;
 

--- a/third_party/blink/renderer/core/dom/slot_assignment_engine.cc
+++ b/third_party/blink/renderer/core/dom/slot_assignment_engine.cc
@@ -45,15 +45,9 @@ void SlotAssignmentEngine::RecalcSlotAssignments() {
     return;
   TRACE_EVENT0("blink", "SlotAssignmentEngine::RecalcSlotAssignments");
 
-  HeapVector<Member<ShadowRoot>> shadow_roots_vector;
   for (auto& shadow_root :
-       HeapHashSet<WeakMember<ShadowRoot>>(shadow_roots_needing_recalc_)) {
-    shadow_roots_vector.push_back(shadow_root);
-  }
-  std::sort(shadow_roots_vector.begin(), shadow_roots_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<ShadowRoot>>());
-
-  for (auto& shadow_root : shadow_roots_vector) {
+       HeapHashSet<WeakMember<ShadowRoot>, WTF::MemberHashRecordReplayId<ShadowRoot>>(shadow_roots_needing_recalc_))
+  {
     DCHECK(shadow_root->isConnected());
     DCHECK(shadow_root->NeedsSlotAssignmentRecalc());
     // SlotAssignment::RecalcAssignment() will remove its shadow root from

--- a/third_party/blink/renderer/core/dom/slot_assignment_engine.h
+++ b/third_party/blink/renderer/core/dom/slot_assignment_engine.h
@@ -8,6 +8,7 @@
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -33,7 +34,7 @@ class CORE_EXPORT SlotAssignmentEngine final
   void Trace(Visitor*) const;
 
  private:
-  HeapHashSet<WeakMember<ShadowRoot>> shadow_roots_needing_recalc_;
+  HeapHashSet<WeakMember<ShadowRoot>, WTF::MemberHashRecordReplayId<ShadowRoot>> shadow_roots_needing_recalc_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/svg/animation/smil_time_container.cc
+++ b/third_party/blink/renderer/core/svg/animation/smil_time_container.cc
@@ -103,7 +103,7 @@ class SMILTimeContainer::TimingUpdate {
     return time_container_->should_dispatch_events_;
   }
 
-  using UpdatedElementsMap = HeapHashMap<Member<SVGSMILElement>, SMILInterval>;
+  using UpdatedElementsMap = HeapHashMap<Member<SVGSMILElement>, SMILInterval, WTF::MemberHashRecordReplayId<SVGSMILElement>>;
   UpdatedElementsMap& UpdatedElements() { return updated_elements_; }
 
   TimingUpdate(const TimingUpdate&) = delete;
@@ -120,16 +120,9 @@ SMILTimeContainer::TimingUpdate::~TimingUpdate() {
   if (!ShouldDispatchEvents())
     return;
   DCHECK(IsSeek() || updated_elements_.empty());
-  HeapVector<Member<SVGSMILElement>> updated_elements_vector;
   for (const auto& entry : updated_elements_) {
-    updated_elements_vector.push_back(entry.key);
-  }
-  std::sort(updated_elements_vector.begin(), updated_elements_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSMILElement>>());
-  for (const Member<SVGSMILElement>& element : updated_elements_vector) {
-    auto iter = updated_elements_.find(element);
-    CHECK(iter != updated_elements_.end());
-    if (auto events_to_dispatch = element->ComputeSeekEvents(iter->value))
+    SVGSMILElement* element = entry.key;
+    if (auto events_to_dispatch = element->ComputeSeekEvents(entry.value))
       element->DispatchEvents(events_to_dispatch);
   }
 }
@@ -598,16 +591,9 @@ void SMILTimeContainer::ApplyTimedEffects(SMILTime elapsed) {
   if (document_order_indexes_dirty_)
     UpdateDocumentOrderIndexes();
 
-  HeapVector<Member<SVGElement>> animated_targets_vector;
-  for (auto& entry : animated_targets_) {
-    animated_targets_vector.push_back(entry.key);
-  }
-  std::sort(animated_targets_vector.begin(), animated_targets_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGElement>>());
-
   bool did_apply_effects = false;
-  for (auto& entry : animated_targets_vector) {
-    ElementSMILAnimations* animations = entry->GetSMILAnimations();
+  for (auto& entry : animated_targets_) {
+    ElementSMILAnimations* animations = entry.key->GetSMILAnimations();
     if (animations && animations->Apply(elapsed))
       did_apply_effects = true;
   }

--- a/third_party/blink/renderer/core/svg/animation/smil_time_container.h
+++ b/third_party/blink/renderer/core/svg/animation/smil_time_container.h
@@ -34,6 +34,7 @@
 #include "third_party/blink/renderer/core/svg/animation/smil_time.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_counted_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/timer.h"
 
 namespace blink {
@@ -139,7 +140,7 @@ class CORE_EXPORT SMILTimeContainer final
 
   HeapTaskRunnerTimer<SMILTimeContainer> wakeup_timer_;
 
-  using AnimatedTargets = HeapHashCountedSet<WeakMember<SVGElement>>;
+  using AnimatedTargets = HeapHashCountedSet<WeakMember<SVGElement>, WTF::MemberHashRecordReplayId<SVGElement>>;
   AnimatedTargets animated_targets_;
 
   PriorityQueue<SMILTime, SVGSMILElement> priority_queue_;

--- a/third_party/blink/renderer/core/svg/animation/svg_smil_element.cc
+++ b/third_party/blink/renderer/core/svg/animation/svg_smil_element.cc
@@ -1232,10 +1232,7 @@ void SVGSMILElement::NotifyDependents(const NotifyDependentsInfo& info) {
   if (is_notifying_dependents_)
     return;
   base::AutoReset<bool> reentrancy_guard(&is_notifying_dependents_, true);
-  HeapVector<Member<SVGSMILElement>> dependents_vector(sync_base_dependents_);
-  std::sort(dependents_vector.begin(), dependents_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSMILElement>>());
-  for (SVGSMILElement* element : dependents_vector)
+  for (SVGSMILElement* element : sync_base_dependents_)
     element->CreateInstanceTimesFromSyncBase(this, info);
 }
 

--- a/third_party/blink/renderer/core/svg/animation/svg_smil_element.h
+++ b/third_party/blink/renderer/core/svg/animation/svg_smil_element.h
@@ -34,6 +34,7 @@
 #include "third_party/blink/renderer/core/svg_names.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -285,7 +286,7 @@ class CORE_EXPORT SVGSMILElement : public SVGElement, public SVGTests {
   bool is_waiting_for_first_interval_;
   bool is_scheduled_;
 
-  using TimeDependentSet = HeapHashSet<Member<SVGSMILElement>>;
+  using TimeDependentSet = HeapHashSet<Member<SVGSMILElement>, WTF::MemberHashRecordReplayId<SVGSMILElement>>;
   TimeDependentSet sync_base_dependents_;
 
   // Instance time lists

--- a/third_party/blink/renderer/core/svg/svg_document_extensions.cc
+++ b/third_party/blink/renderer/core/svg/svg_document_extensions.cc
@@ -61,10 +61,7 @@ void SVGDocumentExtensions::ServiceWebAnimationsOnAnimationFrame(
 
 bool SVGDocumentExtensions::ServiceSmilAnimations() {
   bool did_schedule_animation_frame = false;
-  HeapVector<Member<SVGSVGElement>> time_containers(time_containers_);
-  std::sort(time_containers.begin(), time_containers.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSVGElement>>());
-  for (const auto& container : time_containers) {
+  for (const auto& container : time_containers_) {
     did_schedule_animation_frame |=
         container->TimeContainer()->ServiceAnimations();
   }
@@ -92,10 +89,7 @@ void SVGDocumentExtensions::StartAnimations() {
   // FIXME: We hold a ref pointers to prevent a shadow tree from getting removed
   // out from underneath us.  In the future we should refactor the use-element
   // to avoid this. See https://webkit.org/b/53704
-  HeapVector<Member<SVGSVGElement>> time_containers(time_containers_);
-  std::sort(time_containers.begin(), time_containers.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSVGElement>>());
-  for (const auto& container : time_containers) {
+  for (const auto& container : time_containers_) {
     SMILTimeContainer* time_container = container->TimeContainer();
     if (!time_container->IsStarted())
       time_container->Start();
@@ -116,10 +110,7 @@ bool SVGDocumentExtensions::HasSmilAnimations() const {
 }
 
 void SVGDocumentExtensions::DispatchSVGLoadEventToOutermostSVGElements() {
-  HeapVector<Member<SVGSVGElement>> time_containers(time_containers_);
-  std::sort(time_containers.begin(), time_containers.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSVGElement>>());
-  for (const auto& container : time_containers) {
+  for (const auto& container : time_containers_) {
     SVGSVGElement* outer_svg = container.Get();
     if (!outer_svg->IsOutermostSVGSVGElement())
       continue;
@@ -156,13 +147,7 @@ void SVGDocumentExtensions::InvalidateSVGRootsWithRelativeLengthDescendents(
       &in_relative_length_svg_roots_invalidation_, true);
 #endif
 
-  HeapVector<Member<SVGSVGElement>> relative_length_svg_roots_vector;
   for (SVGSVGElement* element : relative_length_svg_roots_)
-    relative_length_svg_roots_vector.push_back(element);
-  std::sort(relative_length_svg_roots_vector.begin(), relative_length_svg_roots_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGSVGElement>>());
-
-  for (SVGSVGElement* element : relative_length_svg_roots_vector)
     element->InvalidateRelativeLengthClients(scope);
 }
 

--- a/third_party/blink/renderer/core/svg/svg_document_extensions.h
+++ b/third_party/blink/renderer/core/svg/svg_document_extensions.h
@@ -25,6 +25,7 @@
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/forward.h"
 #include "ui/gfx/geometry/point_f.h"
 #include "ui/gfx/geometry/vector2d_f.h"
@@ -79,11 +80,11 @@ class CORE_EXPORT SVGDocumentExtensions final
 
  private:
   Member<Document> document_;
-  HeapHashSet<Member<SVGSVGElement>> time_containers_;
-  using SVGElementSet = HeapHashSet<Member<SVGElement>>;
+  HeapHashSet<Member<SVGSVGElement>, WTF::MemberHashRecordReplayId<SVGSVGElement>> time_containers_;
+  using SVGElementSet = HeapHashSet<Member<SVGElement>, WTF::MemberHashRecordReplayId<SVGElement>>;
   SVGElementSet web_animations_pending_svg_elements_;
   // Root SVG elements with relative length descendants.
-  HeapHashSet<Member<SVGSVGElement>> relative_length_svg_roots_;
+  HeapHashSet<Member<SVGSVGElement>, WTF::MemberHashRecordReplayId<SVGSVGElement>> relative_length_svg_roots_;
   gfx::Vector2dF translate_;
 #if DCHECK_IS_ON()
   bool in_relative_length_svg_roots_invalidation_ = false;

--- a/third_party/blink/renderer/core/svg/svg_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_element.cc
@@ -549,17 +549,10 @@ void SVGElement::InvalidateRelativeLengthClients(
     }
   }
 
-  HeapVector<Member<SVGElement>> elements_with_relative_lengths_vector;
   for (SVGElement* element : elements_with_relative_lengths_) {
-    if (element != this)
-      elements_with_relative_lengths_vector.push_back(element);
-  }
-  std::sort(elements_with_relative_lengths_vector.begin(),
-            elements_with_relative_lengths_vector.end(),
-            recordreplay::CompareMemberByRecordReplayId<Member<SVGElement>>());
-
-  for (SVGElement* element : elements_with_relative_lengths_vector) {
-    element->InvalidateRelativeLengthClients(layout_scope);
+    if (element != this) {
+      element->InvalidateRelativeLengthClients(layout_scope);
+    }
   }
 }
 

--- a/third_party/blink/renderer/core/svg/svg_element.h
+++ b/third_party/blink/renderer/core/svg/svg_element.h
@@ -32,6 +32,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 #include "third_party/blink/renderer/platform/wtf/casting.h"
 
@@ -297,7 +298,7 @@ class CORE_EXPORT SVGElement : public Element {
   static SVGElementSet& GetDependencyTraversalVisitedSet();
   void UpdateWebAnimatedAttributeOnBaseValChange(const QualifiedName&);
 
-  HeapHashSet<WeakMember<SVGElement>> elements_with_relative_lengths_;
+  HeapHashSet<WeakMember<SVGElement>, WTF::MemberHashRecordReplayId<SVGElement>> elements_with_relative_lengths_;
 
   typedef HeapHashMap<QualifiedName, Member<SVGAnimatedPropertyBase>>
       AttributeToPropertyMap;

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -107,7 +107,7 @@ struct MemberHashRecordReplayRegisteredPointerId
   // Member. Prefer compressing raw pointers instead of decompressing Members,
   // assuming the former is cheaper.
   static unsigned GetHash(const T* key) {
-    if (IsRecordingOrReplaying("pointer-ids")) {
+    if (recordreplay::IsRecordingOrReplaying("pointer-ids")) {
       int ptr = recordreplay::PointerId(key);
       CHECK(ptr != 0);
       return Base::GetHash(ptr);
@@ -120,7 +120,7 @@ struct MemberHashRecordReplayRegisteredPointerId
   template <typename Member,
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
-    if (IsRecordingOrReplaying("pointer-ids")) {
+    if (recordreplay::IsRecordingOrReplaying("pointer-ids")) {
       int ptr = recordreplay::PointerId(m.Get());
       CHECK(ptr != 0);
       return Base::GetHash(ptr);
@@ -150,7 +150,7 @@ struct MemberHashRecordReplayId
   // Member. Prefer compressing raw pointers instead of decompressing Members,
   // assuming the former is cheaper.
   static unsigned GetHash(const T* key) {
-    if (IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying()) {
       return Base::GetHash(key->RecordReplayId());
     } else {
       cppgc::internal::MemberBase::RawStorage st(key);
@@ -161,7 +161,7 @@ struct MemberHashRecordReplayId
   template <typename Member,
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
-    if (IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying()) {
       return Base::GetHash(m.Get()->RecordReplayId());
     } else {
       return Base::GetHash(m.GetRawStorage().GetAsInteger());

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -5,6 +5,8 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_PLATFORM_HEAP_MEMBER_H_
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_HEAP_MEMBER_H_
 
+#include "base/check_op.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/heap/thread_state_storage.h"
 #include "third_party/blink/renderer/platform/heap/write_barrier.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
@@ -83,6 +85,69 @@ struct MemberHash
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
     return Base::GetHash(m.GetRawStorage().GetAsInteger());
+  }
+
+  template <typename U, typename V>
+  static bool Equal(const U& a, const V& b) {
+    return a == b;
+  }
+};
+
+// Replay's hashing function with Member<>-wrapped objects, using the registered 
+// pointer id.  
+template <typename T>
+struct MemberHashRecordReplayRegisteredPointerId
+    : IntHash<cppgc::internal::MemberBase::RawStorage::IntegralType> {
+  using Base = IntHash<cppgc::internal::MemberBase::RawStorage::IntegralType>;
+  STATIC_ONLY(MemberHashRecordReplayRegisteredPointerId);
+  // Heap hash containers allow to operate with raw pointers, e.g.
+  //   HeapHashSet<Member<GCed>> set;
+  //   set.find(raw_ptr);
+  // Therefore, provide two hashing functions, one for raw pointers, another for
+  // Member. Prefer compressing raw pointers instead of decompressing Members,
+  // assuming the former is cheaper.
+  static unsigned GetHash(const T* key) {
+    int ptr = recordreplay::PointerId(key);
+    CHECK(ptr != 0);
+    return Base::GetHash(ptr);
+  }
+
+  template <typename Member,
+            std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
+  static unsigned GetHash(const Member& m) {
+    int ptr = recordreplay::PointerId(m.Get());
+    CHECK(ptr != 0);
+    return Base::GetHash(ptr);
+  }
+
+  template <typename U, typename V>
+  static bool Equal(const U& a, const V& b) {
+    return a == b;
+  }
+};
+
+
+// Replay's hashing function with Member<>-wrapped objects, using the function
+// RecordReplayId for the hashing key. 
+template <typename T>
+struct MemberHashRecordReplayId
+    : IntHash<cppgc::internal::MemberBase::RawStorage::IntegralType> {
+  using Base = IntHash<cppgc::internal::MemberBase::RawStorage::IntegralType>;
+  STATIC_ONLY(MemberHashRecordReplayId);
+  // Heap hash containers allow to operate with raw pointers, e.g.
+  //   HeapHashSet<Member<GCed>> set;
+  //   set.find(raw_ptr);
+  // Therefore, provide two hashing functions, one for raw pointers, another for
+  // Member. Prefer compressing raw pointers instead of decompressing Members,
+  // assuming the former is cheaper.
+  static unsigned GetHash(const T* key) {
+    return Base::GetHash(key->RecordReplayId());
+  }
+
+  template <typename Member,
+            std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
+  static unsigned GetHash(const Member& m) {
+    return Base::GetHash(m.Get()->RecordReplayId());
   }
 
   template <typename U, typename V>

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -107,17 +107,26 @@ struct MemberHashRecordReplayRegisteredPointerId
   // Member. Prefer compressing raw pointers instead of decompressing Members,
   // assuming the former is cheaper.
   static unsigned GetHash(const T* key) {
-    int ptr = recordreplay::PointerId(key);
-    CHECK(ptr != 0);
-    return Base::GetHash(ptr);
+    if (IsRecordingOrReplaying("pointer-ids")) {
+      int ptr = recordreplay::PointerId(key);
+      CHECK(ptr != 0);
+      return Base::GetHash(ptr);
+    } else {
+      cppgc::internal::MemberBase::RawStorage st(key);
+      return Base::GetHash(st.GetAsInteger());
+    }
   }
 
   template <typename Member,
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
-    int ptr = recordreplay::PointerId(m.Get());
-    CHECK(ptr != 0);
-    return Base::GetHash(ptr);
+    if (IsRecordingOrReplaying("pointer-ids")) {
+      int ptr = recordreplay::PointerId(m.Get());
+      CHECK(ptr != 0);
+      return Base::GetHash(ptr);
+    } else {
+      return Base::GetHash(m.GetRawStorage().GetAsInteger());
+    }
   }
 
   template <typename U, typename V>
@@ -141,13 +150,22 @@ struct MemberHashRecordReplayId
   // Member. Prefer compressing raw pointers instead of decompressing Members,
   // assuming the former is cheaper.
   static unsigned GetHash(const T* key) {
-    return Base::GetHash(key->RecordReplayId());
+    if (IsRecordingOrReplaying()) {
+      return Base::GetHash(key->RecordReplayId());
+    } else {
+      cppgc::internal::MemberBase::RawStorage st(key);
+      return Base::GetHash(st.GetAsInteger());
+    }
   }
 
   template <typename Member,
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
-    return Base::GetHash(m.Get()->RecordReplayId());
+    if (IsRecordingOrReplaying()) {
+      return Base::GetHash(m.Get()->RecordReplayId());
+    } else {
+      return Base::GetHash(m.GetRawStorage().GetAsInteger());
+    }
   }
 
   template <typename U, typename V>


### PR DESCRIPTION
Add two hashing functors for objects wrapped in Member-like wrappers: one for things that have a RecordReplayId() function, and one for registered pointers.  The second is not currently being used, since (as it turns out) everything we want to be deterministically ordered already has a RecordReplayId function on it, but I'm keeping it around just in case (unless there are objections).

(Perhaps the right solution here is to make this add-hoc RecordReplayId() functionality a mixin class, and have everything we want to be orderable inherit from that?)

Remove all occurrences of CompareMemberByRecordReplayId and related container duplication.  There are other comparator functors that I will get to in subsequent PRs; submitting this now for more rapid feedback around correctness, naming, etc.