### PR TITLE
RUN-1271: Capture events without InspectorDOMDebuggerAgent

### DIFF
--- a/third_party/blink/renderer/bindings/bindings.gni
+++ b/third_party/blink/renderer/bindings/bindings.gni
@@ -70,6 +70,8 @@ blink_core_sources_bindings =
                     "core/v8/profiler_trace_builder.h",
                     "core/v8/record_replay_interface.cc",
                     "core/v8/record_replay_interface.h",
+                    "core/v8/record_replay_events.cc",
+                    "core/v8/record_replay_events.h",
                     "core/v8/referrer_script_info.cc",
                     "core/v8/referrer_script_info.h",
                     "core/v8/rejected_promises.cc",

--- a/third_party/blink/renderer/bindings/core/v8/module_record.cc
+++ b/third_party/blink/renderer/bindings/core/v8/module_record.cc
@@ -21,6 +21,8 @@
 #include "third_party/blink/renderer/platform/wtf/text/text_position.h"
 #include "third_party/blink/renderer/platform/wtf/wtf.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 ModuleRecordProduceCacheData::ModuleRecordProduceCacheData(
@@ -121,6 +123,9 @@ ScriptValue ModuleRecord::Instantiate(ScriptState* script_state,
                                      record->IsSourceTextModule()
                                  ? record->ScriptId()
                                  : v8::UnboundScript::kNoScriptId);
+
+  recordreplay::UserEventProbe replayEvent;
+
   bool success;
   if (!record->InstantiateModule(context, &ResolveModuleCallback)
            .To(&success) ||

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
@@ -59,22 +59,21 @@ void ReplayNotifyBeforeEvent(const String& eventName,
   String replayEventType =
     MakeReplayEventType(eventName, eventTarget, isCallback);
 
-  recordreplay::Assert("[RUN-1271] ReplayNotifyBeforeEvent %d %s",
+  Assert("[RUN-1271] ReplayNotifyBeforeEvent %d %s",
                         gIsEventInFlight, replayEventType.Ascii().c_str());
-  recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
+  OnEvent(replayEventType.Ascii().c_str(), true);
   ++gIsEventInFlight;
 }
 
 void ReplayNotifyAfterEvent(const String& eventName,
                             EventTarget* eventTarget,
                             bool isCallback) {
-  String replayEventType =
-      MakeReplayEventType(eventName, eventTarget, isCallback);
-
   if (gIsEventInFlight) {
-    recordreplay::Assert("[RUN-1271] ReplayNotifyAfterEvent %d %s",
+    String replayEventType =
+      MakeReplayEventType(eventName, eventTarget, isCallback);
+    Assert("[RUN-1271] ReplayNotifyAfterEvent %d %s",
                          gIsEventInFlight, replayEventType.Ascii().c_str());
-    recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
+    OnEvent(replayEventType.Ascii().c_str(), false);
     --gIsEventInFlight;
   }
 }
@@ -87,9 +86,9 @@ UserEventProbe::UserEventProbe(const char* name,
       event_target_(event_target),
       is_callback_(is_callback) {
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
-  if (recordreplay::IsRecordingOrReplaying() &&
-      !recordreplay::FeatureEnabled("disable-collect-events") &&
-      !recordreplay::AreEventsDisallowed()) {
+  if (IsRecordingOrReplaying() &&
+      !FeatureEnabled("disable-collect-events") &&
+      !AreEventsDisallowed()) {
     ReplayNotifyBeforeEvent(name_, event_target_, is_callback);
   }
 }
@@ -101,13 +100,17 @@ UserEventProbe::UserEventProbe(const char* name,
 { }
 
 UserEventProbe::UserEventProbe()
-    : UserEventProbe("scriptFirstStatement", AtomicString(), nullptr, false) {}
+    // NOTE: This is used for capturing script run events but it does not work.
+    // TODO: uncomment - https://linear.app/replay/issue/RUN-1271
+    // UserEventProbe("scriptFirstStatement", AtomicString(), nullptr, false) 
+    {}
 
 UserEventProbe::~UserEventProbe() {
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
-  if (recordreplay::IsRecordingOrReplaying() &&
-      !recordreplay::FeatureEnabled("disable-collect-events")) {
-      ReplayNotifyAfterEvent(name_, event_target_, is_callback_);
+  if (name_ &&
+      IsRecordingOrReplaying() &&
+      !FeatureEnabled("disable-collect-events")) {
+    ReplayNotifyAfterEvent(name_, event_target_, is_callback_);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
@@ -1,0 +1,114 @@
+// Copyright 2023 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/record_replay.h"
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+#include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
+
+using namespace blink;
+
+namespace recordreplay {
+/** ###########################################################################
+ * User event probing and handling
+ * ##########################################################################*/
+
+static int gIsEventInFlight = 0;
+
+// This gathers and encodes the data points necessary for the "event breakpoint
+// matching logic" of CDT. Based on DOMDebuggerModel:
+// https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L958
+static String MakeReplayEventType(const String& eventTypeRaw,
+                                  EventTarget* eventTarget,
+                                  bool isCallback) {
+  // build final name
+  StringBuilder builder;
+  builder.Append(eventTypeRaw);
+  if (isCallback) {
+    builder.Append(".callback");
+  }
+
+  if (eventTarget) {
+    // Sadly, this is necessary because the lookup logic needs to distinguish
+    // between event and target name:
+    // The event name itself is ambiguous. To resolve it, sometimes the target
+    // name needs to be used, sometimes it needs to be omitted.
+    // Thus, we need to keep them logically separate.
+    Node* node = eventTarget->ToNode();
+    auto targetName = node ? node->nodeName() : eventTarget->InterfaceName();
+    builder.Append(",");
+    builder.Append(targetName);
+  }
+
+  return builder.ToString();
+}
+
+// Call `ReplayOnEvent` for the given event *before* it happened.
+static void ReplayNotifyBeforeEvent(const String& eventName,
+                                    EventTarget* eventTarget = nullptr,
+                                    bool isCallback = false);
+
+// Call `ReplayOnEvent` for the given event *after* it happened.
+static void ReplayNotifyAfterEvent(const String& eventName,
+                                   EventTarget* eventTarget = nullptr,
+                                   bool isCallback = false);
+
+void ReplayNotifyBeforeEvent(const String& eventName,
+                             EventTarget* eventTarget,
+                             bool isCallback) {
+  String replayEventType =
+    MakeReplayEventType(eventName, eventTarget, isCallback);
+
+  recordreplay::Assert("[RUN-1271] ReplayNotifyBeforeEvent %d %s",
+                        gIsEventInFlight, replayEventType.Ascii().c_str());
+  recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
+  ++gIsEventInFlight;
+}
+
+void ReplayNotifyAfterEvent(const String& eventName,
+                            EventTarget* eventTarget,
+                            bool isCallback) {
+  String replayEventType =
+      MakeReplayEventType(eventName, eventTarget, isCallback);
+
+  if (gIsEventInFlight) {
+    recordreplay::Assert("[RUN-1271] ReplayNotifyAfterEvent %d %s",
+                         gIsEventInFlight, replayEventType.Ascii().c_str());
+    recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
+    --gIsEventInFlight;
+  }
+}
+
+UserEventProbe::UserEventProbe(const char* name,
+                               const AtomicString& atomic_name,
+                               EventTarget* event_target,
+                               bool is_callback)
+    : name_(name ? String(name) : atomic_name),
+      event_target_(event_target),
+      is_callback_(is_callback) {
+  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
+  if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::FeatureEnabled("disable-collect-events") &&
+      !recordreplay::AreEventsDisallowed()) {
+    ReplayNotifyBeforeEvent(name_, event_target_, is_callback);
+  }
+}
+
+UserEventProbe::UserEventProbe(const char* name,
+                               const AtomicString& atomic_name,
+                               EventTarget* event_target) : 
+                               UserEventProbe(name, atomic_name, event_target, !event_target)
+{ }
+
+UserEventProbe::UserEventProbe()
+    : UserEventProbe("scriptFirstStatement", AtomicString(), nullptr, false) {}
+
+UserEventProbe::~UserEventProbe() {
+  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
+  if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::FeatureEnabled("disable-collect-events")) {
+      ReplayNotifyAfterEvent(name_, event_target_, is_callback_);
+  }
+}
+
+}  // namespace recordreplay

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_events.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_events.h
@@ -1,0 +1,38 @@
+#ifndef THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_EVENTS_H_
+#define THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_EVENTS_H_
+
+#include "base/values.h"
+#include "third_party/blink/renderer/core/events/error_event.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+#include "v8/include/v8.h"
+
+namespace recordreplay {
+
+// Emulate probe::UserCallback (but without InspectorDOMDebuggerAgent).
+struct UserEventProbe {
+  String name_;
+  blink::EventTarget* event_target_;
+  bool is_callback_;
+
+  UserEventProbe(const char* name,
+                 const AtomicString& atomic_name,
+                 blink::EventTarget* event_target,
+                 bool is_callback);
+
+  // Used for probes::UserCallback.
+  // see: https://source.chromium.org/chromium/chromium/src/+/main:out/android-Debug/gen/third_party/blink/renderer/core/core_probes_impl.cc;l=2090;drc=0c4306fc554c80506eb0f9b833a5d2a5fdd452d5;bpv=1;bpt=1
+  UserEventProbe(const char* name,
+                 const AtomicString& atomic_name,
+                 blink::EventTarget* event_target = nullptr);
+
+  // Primarily used for probes::ExecuteScript.
+  // see: https://source.chromium.org/search?q=%22ExecuteScript%20probe%22&sq=&ss=chromium%2Fchromium%2Fsrc
+  UserEventProbe();
+
+  ~UserEventProbe();
+};
+
+}  // namespace recordreplay
+
+#endif // THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_EVENTS_H_

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4449,10 +4449,6 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
     recordreplay::AutoDisallowEvents disallow("SetupRecordReplayCommands");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
   }
-  if (recordreplay::IsRecordingOrReplaying()) {
-    // initialize InspectorDOMDebuggerAgent, so it can pick up user events
-    getOrCreateInspectorDOMDebuggerAgent(isolate);
-  }
 }
 
 void RunInitialRecordReplayScripts(v8::Isolate* isolate) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4445,7 +4445,8 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   if (recordreplay::IsReplaying()) {
     recordreplay::AutoDisallowEvents disallow("SetupRecordReplayCommands");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
-
+  }
+  if (recordreplay::IsRecordingOrReplaying()) {
     // initialize InspectorDOMDebuggerAgent, so it can pick up user events
     getOrCreateInspectorDOMDebuggerAgent(isolate);
   }

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -60,6 +60,8 @@
 #include "third_party/blink/renderer/platform/scheduler/public/event_loop.h"
 #include "third_party/blink/renderer/platform/wtf/text/text_encoding.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 namespace {
@@ -406,6 +408,9 @@ v8::MaybeLocal<v8::Value> V8ScriptRunner::RunCompiledScript(
     probe::ExecuteScript probe(context, isolate->GetCurrentContext(),
                                ToCoreString(script_url),
                                script->GetUnboundScript()->GetId());
+
+  recordreplay::UserEventProbe replayEvent;
+
     result = script->Run(isolate->GetCurrentContext(), host_defined_options);
   }
 
@@ -808,6 +813,8 @@ ScriptEvaluationResult V8ScriptRunner::EvaluateModule(
                                        record->IsSourceTextModule()
                                    ? record->ScriptId()
                                    : v8::UnboundScript::kNoScriptId);
+
+    recordreplay::UserEventProbe replayEvent;
 
     TRACE_EVENT0("v8,devtools.timeline", "v8.evaluateModule");
     RUNTIME_CALL_TIMER_SCOPE(isolate, RuntimeCallStats::CounterId::kV8);

--- a/third_party/blink/renderer/core/dom/events/event_target.cc
+++ b/third_party/blink/renderer/core/dom/events/event_target.cc
@@ -67,6 +67,8 @@
 #include "third_party/blink/renderer/platform/wtf/threading.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 namespace {
 
@@ -904,6 +906,8 @@ bool EventTarget::FireEventListeners(Event& event,
     probe::AsyncTask async_task(context, listener->async_task_context(),
                                 "event",
                                 IsInstrumentedForAsyncStack(event.type()));
+
+    recordreplay::UserEventProbe replayEvent(nullptr, event.type(), this);
 
     // To match Mozilla, the AT_TARGET phase fires both capturing and bubbling
     // event listeners, even though that violates some versions of the DOM spec.

--- a/third_party/blink/renderer/core/dom/frame_request_callback_collection.cc
+++ b/third_party/blink/renderer/core/dom/frame_request_callback_collection.cc
@@ -9,6 +9,8 @@
 #include "third_party/blink/renderer/core/probe/core_probes.h"
 #include "third_party/blink/renderer/platform/instrumentation/use_counter.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 FrameRequestCallbackCollection::FrameRequestCallbackCollection(
@@ -89,6 +91,10 @@ void FrameRequestCallbackCollection::ExecuteFrameCallbacks(
     probe::AsyncTask async_task(context_, callback->async_task_context());
     probe::UserCallback probe(context_, "requestAnimationFrame", AtomicString(),
                               true);
+
+    recordreplay::UserEventProbe replayEvent("requestAnimationFrame",
+                                             AtomicString());
+
     if (callback->GetUseLegacyTimeBase())
       callback->Invoke(high_res_now_ms_legacy);
     else

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -17,6 +17,8 @@
 #include "third_party/blink/renderer/platform/wtf/functional.h"
 #include "third_party/blink/renderer/platform/wtf/ref_counted.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 namespace internal {
@@ -204,6 +206,9 @@ void ScriptedIdleTaskController::RunCallback(
                               idle_task->async_task_context());
   probe::UserCallback probe(GetExecutionContext(), "requestIdleCallback",
                             AtomicString(), true);
+
+  recordreplay::UserEventProbe replayEvent("requestIdleCallback",
+                                           AtomicString());
 
   bool cross_origin_isolated_capability =
       GetExecutionContext()

--- a/third_party/blink/renderer/core/frame/dom_timer.cc
+++ b/third_party/blink/renderer/core/frame/dom_timer.cc
@@ -38,6 +38,8 @@
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
 #include "third_party/blink/renderer/platform/scheduler/public/scheduling_policy.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 namespace {
@@ -182,6 +184,8 @@ void DOMTimer::Fired() {
                             g_null_atom, true);
   probe::AsyncTask async_task(context, &async_task_context_,
                               is_interval ? "fired" : nullptr);
+
+  recordreplay::UserEventProbe replayEvent(is_interval ? "setInterval" : "setTimeout", g_null_atom);
 
   // Simple case for non-one-shot timers.
   if (IsActive()) {

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -972,6 +972,8 @@ void ReplayNotifyBeforeEvent(const String& eventName,
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
     if (!recordreplay::AreEventsDisallowed()) {
+      recordreplay::Assert("[RUN-1226] ReplayNotifyBeforeEvent %d %s",
+                           gIsEventInFlight, replayEventType.Ascii().c_str());
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
       ++gIsEventInFlight;
     }
@@ -983,10 +985,13 @@ void ReplayNotifyAfterEvent(const String& eventName,
                             bool isCallback) {
   String replayEventType =
       MakeReplayEventType(eventName, eventTarget, isCallback);
+
   // Disabled by default, see https://linear.app/replay/issue/RUN-1251
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::FeatureEnabled("disable-collect-events")) {
     if (gIsEventInFlight) {
+      recordreplay::Assert("[RUN-1226] ReplayNotifyAfterEvent %d %s",
+                           gIsEventInFlight, replayEventType.Ascii().c_str());
       recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
       --gIsEventInFlight;
     }

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -738,10 +738,12 @@ static void ReplayNotifyAfterEvent(const String& eventName,
                             bool isCallback = false);
 
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
+  ReplayNotifyBeforeEvent("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
+  ReplayNotifyAfterEvent("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 

--- a/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.cc
@@ -727,23 +727,11 @@ void InspectorDOMDebuggerAgent::ScriptExecutionBlockedByCSP(
   PauseOnNativeEventIfNeeded(std::move(event_data), true);
 }
 
-// Call `ReplayOnEvent` for the given event *before* it happened.
-static void ReplayNotifyBeforeEvent(const String& eventName,
-                              EventTarget* eventTarget = nullptr,
-                              bool isCallback = false);
-
-// Call `ReplayOnEvent` for the given event *after* it happened.
-static void ReplayNotifyAfterEvent(const String& eventName,
-                            EventTarget* eventTarget = nullptr,
-                            bool isCallback = false);
-
 void InspectorDOMDebuggerAgent::Will(const probe::ExecuteScript& probe) {
-  ReplayNotifyBeforeEvent("scriptFirstStatement");
   AllowNativeBreakpoint("scriptFirstStatement", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::ExecuteScript& probe) {
-  ReplayNotifyAfterEvent("scriptFirstStatement");
   CancelNativeBreakpoint();
 }
 
@@ -754,23 +742,14 @@ void InspectorDOMDebuggerAgent::Will(const probe::UserCallback& probe) {
     Node* node = probe.event_target->ToNode();
     String target_name =
         node ? node->nodeName() : probe.event_target->InterfaceName();
-    ReplayNotifyBeforeEvent(name, probe.event_target, false);
     AllowNativeBreakpoint(name, &target_name, false);
     return;
   }
-  ReplayNotifyBeforeEvent(name, nullptr, true);
   AllowNativeBreakpoint(name + ".callback", nullptr, false);
 }
 
 void InspectorDOMDebuggerAgent::Did(const probe::UserCallback& probe) {
   String name = probe.name ? String(probe.name) : probe.atomic_name;
-
-  if (probe.event_target) {
-    ReplayNotifyAfterEvent(name, probe.event_target, false);
-  } else {
-    ReplayNotifyAfterEvent(name, nullptr, true);
-  }
-
   CancelNativeBreakpoint();
 }
 
@@ -929,75 +908,6 @@ void InspectorDOMDebuggerAgent::OnContentSecurityPolicyViolation(
       v8_inspector::protocol::Debugger::API::Paused::ReasonEnum::CSPViolation);
 
   v8_session_->breakProgram(listener, json_view);
-}
-
-
-// [replay]
-
-// This gathers and encodes the data points necessary for the "event breakpoint
-// matching logic" of CDT. Based on DOMDebuggerModel:
-// https://chromium.googlesource.com/devtools/devtools-frontend/+/3a80260722c77d984a637b923cad4883857e57dc/front_end/core/sdk/DOMDebuggerModel.ts#L958
-static String MakeReplayEventType(const String& eventTypeRaw,
-                                         EventTarget* eventTarget,
-                                         bool isCallback) {
-  // build final name
-  StringBuilder builder;
-  builder.Append(eventTypeRaw);
-  if (isCallback) {
-    builder.Append(".callback");
-  }
-
-  if (eventTarget) {
-    // Sadly, this is necessary because the lookup logic needs to distinguish
-    // between event and target name:
-    // The event name itself is ambiguous. To resolve it, sometimes the target
-    // name needs to be used, sometimes it needs to be omitted.
-    // Thus, we need to keep them logically separate.
-    Node* node = eventTarget->ToNode();
-    auto targetName = node ? node->nodeName() : eventTarget->InterfaceName();
-    builder.Append(",");
-    builder.Append(targetName);
-  }
-
-  return builder.ToString();
-}
-
-static int gIsEventInFlight = 0;
-
-void ReplayNotifyBeforeEvent(const String& eventName, 
-                             EventTarget* eventTarget,
-                             bool isCallback) {
-  String replayEventType =
-      MakeReplayEventType(eventName, eventTarget, isCallback);
-
-  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
-  if (recordreplay::IsRecordingOrReplaying() &&
-      !recordreplay::FeatureEnabled("disable-collect-events")) {
-    if (!recordreplay::AreEventsDisallowed()) {
-      recordreplay::Assert("[RUN-1226] ReplayNotifyBeforeEvent %d %s",
-                           gIsEventInFlight, replayEventType.Ascii().c_str());
-      recordreplay::OnEvent(replayEventType.Ascii().c_str(), true);
-      ++gIsEventInFlight;
-    }
-  }
-}
-
-void ReplayNotifyAfterEvent(const String& eventName,
-                            EventTarget* eventTarget,
-                            bool isCallback) {
-  String replayEventType =
-      MakeReplayEventType(eventName, eventTarget, isCallback);
-
-  // Disabled by default, see https://linear.app/replay/issue/RUN-1251
-  if (recordreplay::IsRecordingOrReplaying() &&
-      !recordreplay::FeatureEnabled("disable-collect-events")) {
-    if (gIsEventInFlight) {
-      recordreplay::Assert("[RUN-1226] ReplayNotifyAfterEvent %d %s",
-                           gIsEventInFlight, replayEventType.Ascii().c_str());
-      recordreplay::OnEvent(replayEventType.Ascii().c_str(), false);
-      --gIsEventInFlight;
-    }
-  }
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/script/pending_script.cc
+++ b/third_party/blink/renderer/core/script/pending_script.cc
@@ -81,9 +81,6 @@ void PendingScript::Dispose() {
   starting_position_ = TextPosition::BelowRangePosition();
   parser_blocking_load_start_time_ = base::TimeTicks();
 
-  recordreplay::Assert("[RUN-1271] PendingScript::Dispose 1 %d",
-                       starting_position_);
-
   DisposeInternal();
   element_ = nullptr;
 }
@@ -139,7 +136,6 @@ void PendingScript::MarkParserBlockingLoadStartTime() {
 void PendingScript::ExecuteScriptBlock() {
   TRACE_EVENT0("blink", "PendingScript::ExecuteScriptBlock");
   ExecutionContext* context = element_->GetExecutionContext();
-
   if (!context) {
     Dispose();
     return;
@@ -186,12 +182,6 @@ void PendingScript::ExecuteScriptBlock() {
   const bool is_controlled_by_script_runner = IsControlledByScriptRunner();
   ScriptElementBase* element = element_;
   Dispose();
-
-  recordreplay::Assert(
-      "[RUN-1271] PendingScript::ExecuteScriptBlock 3 %d %s %d",
-      script ? (int)script->GetScriptType() : -1,
-      script ? script->SourceUrl().GetString().Utf8().c_str() : "",
-      was_canceled);
 
   // ExecuteScriptBlockInternal() is split just in order to prevent accidential
   // access to |this| after Dispose().
@@ -298,10 +288,6 @@ void PendingScript::ExecuteScriptBlockInternal(
     //
     // <spec step="4.B.2">Run the module script given by the script's
     // script.</spec>
-    recordreplay::Assert(
-        "[RUN-1271] PendingScript::ExecuteScriptBlockInternal %d %s",
-        !!current_script,
-        current_script ? current_script->ChildTextContent().Utf8().c_str() : "");
     script->RunScript(context_document->domWindow());
 
     // <spec step="4.A.4">Set the script element's node document's currentScript

--- a/third_party/blink/renderer/modules/scheduler/dom_task.cc
+++ b/third_party/blink/renderer/modules/scheduler/dom_task.cc
@@ -26,6 +26,8 @@
 #include "third_party/blink/renderer/platform/wtf/casting.h"
 #include "third_party/perfetto/include/perfetto/tracing/traced_value_forward.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 #define QUEUEING_TIME_PER_PRIORITY_METRIC_NAME \
@@ -138,6 +140,8 @@ void DOMTask::InvokeInternal(ScriptState* script_state) {
   DCHECK(context);
   probe::AsyncTask async_task(context, &async_task_context_);
   probe::UserCallback probe(context, "postTask", AtomicString(), true);
+
+  recordreplay::UserEventProbe replayEvent("postTask", AtomicString());
 
   ScriptValue result;
   if (callback_->Invoke(nullptr).To(&result))

--- a/third_party/blink/renderer/modules/xr/xr_frame_request_callback_collection.cc
+++ b/third_party/blink/renderer/modules/xr/xr_frame_request_callback_collection.cc
@@ -12,6 +12,8 @@
 #include "third_party/blink/renderer/modules/xr/xr_session.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
+#include "third_party/blink/renderer/bindings/core/v8/record_replay_events.h"
+
 namespace blink {
 
 XRFrameRequestCallbackCollection::XRFrameRequestCallbackCollection(
@@ -76,6 +78,9 @@ void XRFrameRequestCallbackCollection::ExecuteCallbacks(XRSession* session,
 
     probe::AsyncTask async_task(context_, it_async_task->value.get());
     probe::UserCallback probe(context_, "XRRequestFrame", AtomicString(), true);
+
+    recordreplay::UserEventProbe replayEvent("XRRequestFrame", AtomicString());
+
     it_frame_request->value->InvokeAndReportException(session, timestamp,
                                                       frame);
   }


### PR DESCRIPTION
* We can now capture events without `InspectorDOMDebuggerAgent`, so there are no more mismatch crashes.
* As of now, we are getting `Progress counter mismatch at checkpoint` warnings ([see here](https://linear.app/replay/issue/RUN-1271#comment-d421112d))
* https://linear.app/replay/issue/RUN-1271/capture-events-without-inspectordomdebuggeragent