### PR TITLE
[Run-1333] Add additional assertions to `ImageLoader`

### DIFF
--- a/third_party/blink/renderer/core/loader/image_loader.cc
+++ b/third_party/blink/renderer/core/loader/image_loader.cc
@@ -134,7 +134,10 @@ class ImageLoader::Task {
   void Run() {
     if (!loader_)
       return;
-    ExecutionContext* context = loader_->GetElement()->GetExecutionContext();
+    Element* element = loader_->GetElement();
+    recordreplay::Assert("[Run-1333] ImageLoader::Run %d",
+                         element->RecordReplayId());
+    ExecutionContext* context = element->GetExecutionContext();
     probe::AsyncTask async_task(context, &async_task_context_);
     loader_->DoUpdateFromElement(world_, update_behavior_, referrer_policy_);
   }
@@ -422,6 +425,9 @@ inline void ImageLoader::EnqueueImageLoadingMicroTask(
     network::mojom::ReferrerPolicy referrer_policy) {
   auto task = std::make_unique<Task>(this, update_behavior, referrer_policy);
   pending_task_ = task->GetWeakPtr();
+  recordreplay::Assert(
+      "[RUN-1333] ImageLoader::EnqueueImageLoadingMicroTask %d",
+      element_->RecordReplayId());
   element_->GetDocument().GetAgent()->event_loop()->EnqueueMicrotask(
       WTF::BindOnce(&Task::Run, std::move(task)));
   delay_until_do_update_from_element_ =
@@ -675,6 +681,8 @@ void ImageLoader::UpdateFromElement(
   }
 
   if (ShouldLoadImmediately(ImageSourceToKURL(image_source_url))) {
+    recordreplay::Assert("[Run-1333] ImageLoader::UpdateFromElement %d",
+                         element_->RecordReplayId());
     DoUpdateFromElement(element_->GetExecutionContext()->GetCurrentWorld(),
                         update_behavior, referrer_policy, UpdateType::kSync,
                         force_blocking);


### PR DESCRIPTION
This PR adds additional assertions to `ImageLoader`
to convert the call stack mismatch to an assertion mismatch.

[Analysis](https://linear.app/replay/issue/RUN-1333/call-stack-mismatch-imageloaderdoupdatefromelement#comment-13503c0c)

## Open Questions

* Is it okay/a good idea to use `RecordReplayId` on `_element` or is using the id over restrictive?
* Is it okay to add assertions to `EnqueueImageLoadingMicroTask` and `Task::Run` to get a better understanding if the non-determinism comes from the scheduling or queuing, when the assertion in `Task::Run` would be sufficient to convert the failure to an assertion failure