### PR TITLE
Don't close (instead, leak) the IndexedDB connection, to avoid recording during a GC.

### DIFF
--- a/third_party/blink/renderer/modules/indexeddb/idb_database.cc
+++ b/third_party/blink/renderer/modules/indexeddb/idb_database.cc
@@ -117,7 +117,7 @@ IDBDatabase::~IDBDatabase() {
   if (!close_pending_ && backend_) {
     // Explicitly leak the database proxy, as we are likely in a GC, and
     // closing will issue IPC messages that need to be recorded.
-    if (!recordreplay::IsRecordingOrReplaying()) {
+    if (!recordreplay::IsRecordingOrReplaying("IDBDatabase::~IDBDatabase")) {
       backend_->Close();
     }
   }

--- a/third_party/blink/renderer/modules/indexeddb/idb_database.cc
+++ b/third_party/blink/renderer/modules/indexeddb/idb_database.cc
@@ -114,8 +114,13 @@ IDBDatabase::IDBDatabase(
 }
 
 IDBDatabase::~IDBDatabase() {
-  if (!close_pending_ && backend_)
-    backend_->Close();
+  if (!close_pending_ && backend_) {
+    // Explicitly leak the database proxy, as we are likely in a GC, and
+    // closing will issue IPC messages that need to be recorded.
+    if (!recordreplay::IsRecordingOrReplaying()) {
+      backend_->Close();
+    }
+  }
 }
 
 void IDBDatabase::Trace(Visitor* visitor) const {

--- a/third_party/blink/renderer/modules/indexeddb/idb_database.cc
+++ b/third_party/blink/renderer/modules/indexeddb/idb_database.cc
@@ -117,7 +117,7 @@ IDBDatabase::~IDBDatabase() {
   if (!close_pending_ && backend_) {
     // Explicitly leak the database proxy, as we are likely in a GC, and
     // closing will issue IPC messages that need to be recorded.
-    if (!recordreplay::IsRecordingOrReplaying("IDBDatabase::~IDBDatabase")) {
+    if (!recordreplay::IsRecordingOrReplaying("leak-references ")) {
       backend_->Close();
     }
   }


### PR DESCRIPTION
Otherwise, IndexedDB sends IPC messages which we record.