### PR TITLE
[Run 1229] Assert identical commit ordering between recorded and replay

### DIFF
--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -795,6 +795,9 @@ void ProxyImpl::ScheduledActionCommit() {
 
   auto* commit_state = data_for_commit_->commit_state.get();
   auto* unsafe_state = data_for_commit_->unsafe_state.get();
+  recordreplay::Assert("[Run-1229] ProxyImpl::ScheduledActionCommit %d %d",
+                       commit_state->source_frame_number,
+                       commit_state->trace_id);
   host_impl_->BeginCommit(commit_state->source_frame_number,
                           commit_state->trace_id);
   host_impl_->FinishCommit(*commit_state, *unsafe_state);

--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -795,7 +795,7 @@ void ProxyImpl::ScheduledActionCommit() {
 
   auto* commit_state = data_for_commit_->commit_state.get();
   auto* unsafe_state = data_for_commit_->unsafe_state.get();
-  recordreplay::Assert("[Run-1229] ProxyImpl::ScheduledActionCommit %d %d",
+  recordreplay::Assert("[Run-1229] ProxyImpl::ScheduledActionCommit %d %llu",
                        commit_state->source_frame_number,
                        commit_state->trace_id);
   host_impl_->BeginCommit(commit_state->source_frame_number,

--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -795,9 +795,13 @@ void ProxyImpl::ScheduledActionCommit() {
 
   auto* commit_state = data_for_commit_->commit_state.get();
   auto* unsafe_state = data_for_commit_->unsafe_state.get();
-  recordreplay::Assert("[Run-1229] ProxyImpl::ScheduledActionCommit %d %llu",
+
+  // NOTE: Both, RUN-1229 and RUN-550 are hitting a divergence in layers/trees.
+  recordreplay::Assert("[RUN-1229-1342] ProxyImpl::ScheduledActionCommit %d %d %llu",
                        commit_state->source_frame_number,
+                       unsafe_state->property_trees.sequence_number(),
                        commit_state->trace_id);
+
   host_impl_->BeginCommit(commit_state->source_frame_number,
                           commit_state->trace_id);
   host_impl_->FinishCommit(*commit_state, *unsafe_state);

--- a/cc/trees/tree_synchronizer.cc
+++ b/cc/trees/tree_synchronizer.cc
@@ -219,9 +219,9 @@ void TreeSynchronizer::PushLayerProperties(
       commit_state.layers_that_should_push_properties.end();
   for (auto it = source_layers_begin; it != source_layers_end; ++it) {
     auto* source_layer = *it;
-    // https://linear.app/replay/issue/RUN-1229
     recordreplay::Assert(
-        "TreeSynchronizer::PushLayerProperties source_layer %d",
+        "[RUN-1229-1342] TreeSynchronizer::PushLayerProperties source_layer %lld %d",
+        (long long)(it - source_layers_begin),
         source_layer->id());
 
     LayerImpl* target_layer = impl_tree->LayerById(source_layer->id());


### PR DESCRIPTION
This PR adds an assertion to `ProxyImpl::ScheduledActionCommit` verifying that the replay and recorded agree on the performed commits (and the source frames in which the commits happen).

This assertion should help us understand if the commits diverge (in case this assertion hits) or if the same commits are happening, but the commits contain different layers (old assertion keeps hitting).

[Analysis](https://linear.app/replay/issue/RUN-1229/mismatch-in-ccpicturelayerdroprecordingsourcecontentifinvalid#comment-ee7abca4)