### PR TITLE
Assert on worker thread stack size.

### DIFF
--- a/base/task/thread_pool/worker_thread_stack.cc
+++ b/base/task/thread_pool/worker_thread_stack.cc
@@ -20,7 +20,7 @@ WorkerThreadStack::~WorkerThreadStack() = default;
 void WorkerThreadStack::Push(WorkerThread* worker) {
   DCHECK(!Contains(worker)) << "WorkerThread already on stack";
 
-  if (recordreplay::IsRecordingOrReplaying() && !recordreplay::AreEventsDisallowed()) {
+  if (!recordreplay::AreEventsDisallowed()) {
     recordreplay::Assert("[RUN-597] WorkerThreadStack::Push %d", IsEmpty());
   }
 

--- a/base/task/thread_pool/worker_thread_stack.cc
+++ b/base/task/thread_pool/worker_thread_stack.cc
@@ -7,6 +7,7 @@
 #include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/ranges/algorithm.h"
+#include "base/record_replay.h"
 #include "base/task/thread_pool/worker_thread.h"
 
 namespace base {
@@ -18,6 +19,11 @@ WorkerThreadStack::~WorkerThreadStack() = default;
 
 void WorkerThreadStack::Push(WorkerThread* worker) {
   DCHECK(!Contains(worker)) << "WorkerThread already on stack";
+
+  if (recordreplay::IsRecordingOrReplaying() && !recordreplay::AreEventsDisallowed()) {
+    recordreplay::Assert("[RUN-597] WorkerThreadStack::Push %d", IsEmpty());
+  }
+
   if (!IsEmpty())
     stack_.back()->BeginUnusedPeriod();
   stack_.push_back(worker);


### PR DESCRIPTION
More detail in https://linear.app/replay/issue/RUN-597#comment-dd16b598.  Add an assert to confirm we're seeing a divergence in the contents of the worker stack.