### PR TITLE
Assert that the web audio device callback buffer size is identical.

### DIFF
--- a/third_party/blink/renderer/platform/audio/audio_destination.cc
+++ b/third_party/blink/renderer/platform/audio/audio_destination.cc
@@ -113,7 +113,7 @@ AudioDestination::AudioDestination(AudioIOCallback& callback,
 
   callback_buffer_size_ = web_audio_device_->FramesPerBuffer();
   
-  recordreplay::Assert("[RUN-1345] callback_buffer_size_: %d", callback_buffer_size_);
+  recordreplay::Assert("[RUN-1345] callback_buffer_size_ is big: %d", (callback_buffer_size_ > RenderQuantumFrames() * 2));
   
   SendLogMessage(String::Format("%s => (device callback buffer size=%u frames)",
                                 __func__, callback_buffer_size_));

--- a/third_party/blink/renderer/platform/audio/audio_destination.cc
+++ b/third_party/blink/renderer/platform/audio/audio_destination.cc
@@ -112,6 +112,9 @@ AudioDestination::AudioDestination(AudioIOCallback& callback,
   DCHECK(web_audio_device_);
 
   callback_buffer_size_ = web_audio_device_->FramesPerBuffer();
+  
+  recordreplay::Assert("[RUN-1345] callback_buffer_size_: %d", callback_buffer_size_);
+  
   SendLogMessage(String::Format("%s => (device callback buffer size=%u frames)",
                                 __func__, callback_buffer_size_));
   SendLogMessage(String::Format("%s => (device sample rate=%.0f Hz)", __func__,


### PR DESCRIPTION
See https://linear.app/replay/issue/RUN-1345#comment-0e8c8a54 for details.  Differing `callback_buffer_size_` values would lead to different branches being taken; assert this.