### PR TITLE
Remove checkout step in build/test action

### DIFF
--- a/.github/actions/release/main.js
+++ b/.github/actions/release/main.js
@@ -2,7 +2,6 @@
 const {
   getLatestRevision,
   sendBuildTestRequest,
-  spawnChecked,
   newTask,
 } = require("../utils");
 

--- a/.github/actions/utils.js
+++ b/.github/actions/utils.js
@@ -3,12 +3,8 @@ const http = require("http");
 const https = require("https");
 const { spawnSync } = require("child_process");
 
-const chromium = `${__dirname}/../..`;
-
 function getLatestRevision() {
-  return spawnChecked("git", ["rev-parse", "--short=12", "HEAD"], { cwd: chromium })
-    .stdout.toString()
-    .trim();
+  return process.env.GITHUB_SHA.substring(12);
 }
 
 function sendBuildTestRequest(contents) {

--- a/.github/actions/utils.js
+++ b/.github/actions/utils.js
@@ -4,7 +4,7 @@ const https = require("https");
 const { spawnSync } = require("child_process");
 
 function getLatestRevision() {
-  return process.env.GITHUB_SHA.substring(12);
+  return process.env.GITHUB_SHA.substring(0, 12);
 }
 
 function sendBuildTestRequest(contents) {

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: Bhacaz/checkout-files@v2
         with:
           files: .github
+          branch: ${{ github.head_ref || github.ref_name }}
       - uses: ./.github/actions/build-test-branch
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
           version: 1.28.0
+      - uses: Bhacaz/checkout-files@v2
+        with:
+          files: .github
       - uses: ./.github/actions/build-test-branch
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
           version: 1.28.0
-      - uses: actions/checkout@v2
       - uses: ./.github/actions/build-test-branch
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
           version: 1.28.0
-      - uses: actions/checkout@v2
+      - uses: Bhacaz/checkout-files@v2
+        with:
+          files: .github
+          branch: ${{ github.head_ref || github.ref_name }}
       - uses: ./.github/actions/build-test
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
           version: 1.28.0
-      - uses: actions/checkout@v2
+      - uses: Bhacaz/checkout-files@v2
+        with:
+          files: .github
+          branch: ${{ github.head_ref || github.ref_name }}
       - uses: ./.github/actions/release
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}


### PR DESCRIPTION
Build/test actions always checkout the latest version of chromium, which takes a few minutes.  I don't know if we need this for anything, let's try removing it.