### PR TITLE
RUN-1384: Assert NGBlockNode::CachedLayoutResultForOutOfFlowPositioned

### DIFF
--- a/third_party/blink/renderer/core/layout/layout_box.cc
+++ b/third_party/blink/renderer/core/layout/layout_box.cc
@@ -3497,6 +3497,11 @@ const NGLayoutResult* LayoutBox::GetCachedLayoutResult(
     const NGBlockBreakToken* break_token) const {
   NOT_DESTROYED();
   wtf_size_t index = FragmentIndex(break_token);
+
+  recordreplay::Assert(
+      "[RUN-1239-1384] LayoutBox::GetCachedLayoutResult %lu %lu", index,
+      layout_results_.size());
+
   if (index >= layout_results_.size())
     return nullptr;
   const NGLayoutResult* result = layout_results_[index];

--- a/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
@@ -810,6 +810,11 @@ const NGLayoutResult* NGBlockNode::CachedLayoutResultForOutOfFlowPositioned(
     LogicalSize container_content_size) const {
   DCHECK(IsOutOfFlowPositioned());
 
+  recordreplay::Assert(
+      "[RUN-1239-1384] NGBlockNode::CachedLayoutResultForOutOfFlowPositioned A %d %lu",
+      box_->NeedsLayout(),
+      box_->PhysicalFragmentCount());
+
   if (box_->NeedsLayout())
     return nullptr;
 
@@ -825,6 +830,11 @@ const NGLayoutResult* NGBlockNode::CachedLayoutResultForOutOfFlowPositioned(
 
   // The containing-block may have borders/scrollbars which might change
   // between passes affecting the final position.
+  
+  recordreplay::Assert(
+      "[RUN-1239-1384] NGBlockNode::CachedLayoutResultForOutOfFlowPositioned C %d",
+      cached_layout_result->CanUseOutOfFlowPositionedFirstTierCache());
+
   if (!cached_layout_result->CanUseOutOfFlowPositionedFirstTierCache())
     return nullptr;
 
@@ -834,6 +844,16 @@ const NGLayoutResult* NGBlockNode::CachedLayoutResultForOutOfFlowPositioned(
   // are in the correct writing mode (htb-ltr), and we have a fixed width.
   const NGConstraintSpace& space =
       cached_layout_result->GetConstraintSpaceForCaching();
+
+  recordreplay::Assert(
+      "[RUN-1239-1384] NGBlockNode::CachedLayoutResultForOutOfFlowPositioned D %d %d %d %d %d %d",
+      space.PercentageResolutionSize().inline_size.RawValue(),
+      space.PercentageResolutionSize().block_size.RawValue(),
+      container_content_size.inline_size.RawValue(),
+      container_content_size.block_size.RawValue(),
+      (Style().Left().IsAuto() && Style().Right().IsAuto()),
+      (Style().Top().IsAuto() && Style().Bottom().IsAuto()));
+
   if (space.PercentageResolutionSize() != container_content_size)
     return nullptr;
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1239#comment-9347cb03