### PR TITLE
[RUN-1385] Assert `layers_that_should_push_properties` mutations

### DIFF
--- a/cc/trees/layer_tree_host.cc
+++ b/cc/trees/layer_tree_host.cc
@@ -1623,7 +1623,11 @@ void LayerTreeHost::UnregisterLayer(Layer* layer) {
   DCHECK(IsMainThread());
   DCHECK(LayerById(layer->id()));
   DCHECK(!in_paint_layer_contents_);
-  pending_commit_state()->layers_that_should_push_properties.erase(layer);
+
+  auto commit_state = pending_commit_state();
+  recordreplay::Assert("[Run-1229-1385] LayerTreeHost::UnregisterLayer %d %d",
+                       commit_state->source_frame_number, layer->id());
+  commit_state->layers_that_should_push_properties.erase(layer);
   layer_id_map_.erase(layer->id());
 }
 
@@ -1660,7 +1664,13 @@ void LayerTreeHost::RemoveSurfaceRange(const viz::SurfaceRange& surface_range) {
 }
 
 void LayerTreeHost::AddLayerShouldPushProperties(Layer* layer) {
-  pending_commit_state()->layers_that_should_push_properties.insert(layer);
+  auto commit_state = pending_commit_state();
+
+  recordreplay::Assert(
+      "[Run-1229-1385] LayerTreeHost::AddLayerShouldPushProperties %d %d",
+      commit_state->source_frame_number, layer->id());
+
+  commit_state->layers_that_should_push_properties.insert(layer);
 }
 
 void LayerTreeHost::SetPageScaleFromImplSide(float page_scale) {


### PR DESCRIPTION
This PR asserts that to the code paths modifying `CommitState::layers_that_should_push_properties` execute identically when recording and replaying. Adding these assertions will help us understand why the `commit_state.layers_that_should_push_properties` in `TreeSynchronizer::PushLayerProperties` differs between recording and replay. 

Asserting that the mutations are identical between recording and replay is more restrictive than strictly necessary because we only require that the layers are identical, not that they're added/removed in the same order. The new assertion is justified because we already have strong proof that the layers differ; we now need to figure out why and this is best done by looking at the mutation of the `layers_that_should_push_properties`

[Analysis](https://linear.app/replay/issue/RUN-1229/mismatch-in-ccpicturelayerdroprecordingsourcecontentifinvalid#comment-0c911b42)