### PR TITLE
Narrowing assertions for RUN-1219.

### DIFF
--- a/third_party/blink/renderer/core/layout/ng/ng_block_layout_algorithm.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_layout_algorithm.cc
@@ -273,9 +273,16 @@ void NGBlockLayoutAlgorithm::SetBoxType(NGPhysicalFragment::NGBoxType type) {
 
 MinMaxSizesResult NGBlockLayoutAlgorithm::ComputeMinMaxSizes(
     const MinMaxSizesFloatInput& float_input) {
+  recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #0 node=%d left=%d right=%d",
+    Node().RecordReplayId(),
+    float_input.float_left_inline_size.RawValue(),
+    float_input.float_right_inline_size.RawValue());
   if (auto result =
-          CalculateMinMaxSizesIgnoringChildren(node_, BorderScrollbarPadding()))
+          CalculateMinMaxSizesIgnoringChildren(node_, BorderScrollbarPadding())) {
+    recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #1");
     return *result;
+  }
+  recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #2");
 
   MinMaxSizes sizes;
   bool depends_on_block_constraints = false;
@@ -286,6 +293,8 @@ MinMaxSizesResult NGBlockLayoutAlgorithm::ComputeMinMaxSizes(
 
   for (NGLayoutInputNode child = Node().FirstChild(); child;
        child = child.NextSibling()) {
+    recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #3 child=%d",
+      child.RecordReplayId());
     // We don't check IsRubyText() here intentionally. RubyText width should
     // affect this width.
     if (child.IsOutOfFlowPositioned() ||

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.h
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.h
@@ -89,6 +89,8 @@ class PLATFORM_EXPORT FontFallbackList : public RefCounted<FontFallbackList> {
 
   const SimpleFontData* PrimarySimpleFontData(
       const FontDescription& font_description) {
+    recordreplay::Assert("[RUN-1219-1406] FontFallbackList::PrimarySimpleFontData %d",
+      (int) !!cached_primary_simple_font_data_);
     if (!cached_primary_simple_font_data_) {
       cached_primary_simple_font_data_ =
           DeterminePrimarySimpleFontData(font_description);


### PR DESCRIPTION
Add assertions in FontFallbackList::PrimarySimpleFontData and NGBlockLayoutAlgorithm::ComputeMinMaxSizes.

For RUN-1406 (https://linear.app/replay/issue/RUN-1406/add-assertions-in-fontfallbacklistprimarysimplefontdata-and)