### PR TITLE
Assertions for divergences in PictureLayerImpl.

### DIFF
--- a/cc/layers/picture_layer_impl.cc
+++ b/cc/layers/picture_layer_impl.cc
@@ -601,11 +601,11 @@ void PictureLayerImpl::AppendQuads(viz::CompositorRenderPass* render_pass,
 
 bool PictureLayerImpl::UpdateTiles() {
   // https://linear.app/replay/issue/RUN-550
-  recordreplay::Assert("PictureLayerImpl::UpdateTiles Start %d", id());
+  recordreplay::Assert("[RUN-550] PictureLayerImpl::UpdateTiles Start %d", id());
 
   if (!CanHaveTilings()) {
     // https://linear.app/replay/issue/RUN-550
-    recordreplay::Assert("PictureLayerImpl::UpdateTiles #1");
+    recordreplay::Assert("[RUN-550] PictureLayerImpl::UpdateTiles #1");
 
     ideal_page_scale_ = 0.f;
     ideal_device_scale_ = 0.f;
@@ -620,12 +620,18 @@ bool PictureLayerImpl::UpdateTiles() {
   // only have one or two tilings (high and low res), so only clean up the
   // active layer. This cleans it up here in case AppendQuads didn't run.
   // If it did run, this would not remove any additional tilings.
+
+  // https://linear.app/replay/issue/RUN-550
+  recordreplay::Assert("[RUN-550-1409] PictureLayerImpl::UpdateTiles #2 %d",
+    (int) layer_tree_impl()->IsActiveTree());
   if (layer_tree_impl()->IsActiveTree())
     CleanUpTilingsOnActiveLayer(last_append_quads_tilings_);
 
   UpdateIdealScales();
 
   const bool should_adjust_raster_scale = ShouldAdjustRasterScale();
+  recordreplay::Assert("[RUN-550-1409] PictureLayerImpl::UpdateTiles #3 %d",
+    (int) should_adjust_raster_scale);
   if (should_adjust_raster_scale)
     RecalculateRasterScales();
   UpdateTilingsForRasterScaleAndTranslation(should_adjust_raster_scale);
@@ -686,7 +692,7 @@ bool PictureLayerImpl::UpdateTiles() {
   SanityCheckTilingState();
 
   // https://linear.app/replay/issue/RUN-550
-  recordreplay::Assert("PictureLayerImpl::UpdateTiles Done %d", updated);
+  recordreplay::Assert("[RUN-550] PictureLayerImpl::UpdateTiles Done %d", updated);
 
   return updated;
 }
@@ -1692,6 +1698,11 @@ void PictureLayerImpl::AdjustRasterScaleForTransformAnimation(
 
 void PictureLayerImpl::CleanUpTilingsOnActiveLayer(
     const std::vector<PictureLayerTiling*>& used_tilings) {
+
+  // https://linear.app/replay/issue/RUN-550
+  recordreplay::Assert("[RUN-550-1409] PictureLayerImpl::CleanUpTilingsOnActiveLayer Start %u",
+    (unsigned) tilings_->num_tilings());
+
   DCHECK(layer_tree_impl()->IsActiveTree());
   if (tilings_->num_tilings() == 0)
     return;

--- a/cc/trees/layer_tree_impl.cc
+++ b/cc/trees/layer_tree_impl.cc
@@ -1575,7 +1575,7 @@ bool LayerTreeImpl::UpdateDrawProperties(
   // update draw properties flag is set again.
   if (!host_impl_->layer_tree_frame_sink()) {
     // https://linear.app/replay/issue/RUN-550
-    recordreplay::Assert("LayerTreeImpl::UpdateDrawProperties #2");
+    recordreplay::Assert("[RUN-550] LayerTreeImpl::UpdateDrawProperties #2");
     return false;
   }
 
@@ -1585,7 +1585,7 @@ bool LayerTreeImpl::UpdateDrawProperties(
 
   if (layer_list_.empty()) {
     // https://linear.app/replay/issue/RUN-550
-    recordreplay::Assert("LayerTreeImpl::UpdateDrawProperties #3");
+    recordreplay::Assert("[RUN-550] LayerTreeImpl::UpdateDrawProperties #3");
     return false;
   }
 
@@ -1706,7 +1706,7 @@ bool LayerTreeImpl::UpdateDrawProperties(
   }
 
   // https://linear.app/replay/issue/RUN-550
-  recordreplay::Assert("LayerTreeImpl::UpdateDrawProperties Done");
+  recordreplay::Assert("[RUN-550] LayerTreeImpl::UpdateDrawProperties Done");
 
   device_viewport_rect_changed_ = false;
 


### PR DESCRIPTION
Asserts in `PictureLayerImpl::UpdateTiles` and `PictureLayerImpl::CleanUpTilingsOnActiveLayer`.

For RUN-1409 (https://linear.app/replay/issue/RUN-1409/asserts-in-picturelayerimplupdatetiles-and)