### PR TITLE
RUN-1415: fix buildid timestamp regression (1/3)

### DIFF
--- a/build.js
+++ b/build.js
@@ -138,8 +138,8 @@ function driverExtension() {
 }
 
 /**
- * WARNING: This is a copy-and-paste from `backend` here.
- * When changing: always keep the two in sync, or else, builds will break.
+ * WARNING: This is a copy-and-paste from `backend`.
+ * When changing: always keep all versions of this in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
  * @see https://github.com/replayio/backend/blob/eda247aacb2ade5481b9fb73d751171576197eba/src/shared/linkerVersion.ts#L23
  */
@@ -172,10 +172,10 @@ function computeBuildId(driverDate, driverRevision) {
     .stdout.toString()
     .trim();
 
-  const chromiumDate = getLinkerRevisionDate();
+  const runtimeDate = getLinkerRevisionDate();
 
   // Use the later of the two dates in the build ID.
-  const date = +chromiumDate >= +driverDate ? chromiumDate : driverDate;
+  const date = +runtimeDate >= +driverDate ? runtimeDate : driverDate;
 
   return `${currentPlatform()}-chromium-${date}-${chromiumRevision}-${driverRevision}`;
 }

--- a/build.js
+++ b/build.js
@@ -83,7 +83,7 @@ fs.writeFileSync(
 namespace recordreplay {
   char gRecordReplayDriver[] = "${driverString}";
   int gRecordReplayDriverSize = ${driverContents.length};
-  char gBuildId[] = "${computeBuildId()}";
+  char gBuildId[] = "${computeBuildId(driverDate, driverRevision)}";
 }
 `
 );
@@ -137,7 +137,29 @@ function driverExtension() {
   return currentPlatform() == "windows" ? "dll" : "so";
 }
 
-function computeBuildId() {
+/**
+ * WARNING: This is a copy-and-paste from `backend` here.
+ * When changing: always keep the two in sync, or else, builds will break.
+ * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
+ */
+function getLinkerRevisionDate(
+  revision = "HEAD",
+  spawnOptions
+) {
+  const dateString = spawnChecked(
+    "git",
+    ["show", revision, "--pretty=%cd", "--date=iso-strict", "--no-patch"],
+    spawnOptions
+  )
+    .stdout.toString()
+    .trim();
+
+  // convert to UTC -> then get the date only
+  // explanations: https://github.com/replayio/backend/pull/7115#issue-1587869475
+  return new Date(dateString).toISOString().substring(0, 10).replace(/-/g, "");
+}
+
+function computeBuildId(driverDate, driverRevision) {
   // Note: this build ID doesn't include revision etc. information for v8 or other inner git
   // repositories. It would be good to either fix this or enforce that the chromium revision
   // gets bumped whenever an inner repository changes.
@@ -148,16 +170,8 @@ function computeBuildId() {
   ])
     .stdout.toString()
     .trim();
-  const chromiumDate = spawnChecked("git", [
-    "show",
-    "HEAD",
-    "--pretty=%cd",
-    "--date=short",
-    "--no-patch",
-  ])
-    .stdout.toString()
-    .trim()
-    .replace(/-/g, "");
+
+  const chromiumDate = getLinkerRevisionDate();
 
   // Use the later of the two dates in the build ID.
   const date = +chromiumDate >= +driverDate ? chromiumDate : driverDate;

--- a/build.js
+++ b/build.js
@@ -141,6 +141,7 @@ function driverExtension() {
  * WARNING: This is a copy-and-paste from `backend` here.
  * When changing: always keep the two in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
+ * @see https://github.com/replayio/backend/blob/eda247aacb2ade5481b9fb73d751171576197eba/src/shared/linkerVersion.ts#L23
  */
 function getLinkerRevisionDate(
   revision = "HEAD",

--- a/build.js
+++ b/build.js
@@ -138,8 +138,6 @@ function driverExtension() {
 }
 
 /**
- * WARNING: We have copy-and-pasted `getLinkerRevisionDate` into all our runtimes and `backend`.
- * When changing this: always keep all versions of this in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
  */
 function getRevisionDate(
@@ -159,6 +157,10 @@ function getRevisionDate(
   return new Date(dateString).toISOString().substring(0, 10).replace(/-/g, "");
 }
 
+/**
+ * WARNING: We have copy-and-pasted `computeBuildId` into all our runtimes and `backend`.
+ * When changing this: always keep all versions of this in sync, or else, builds will break.
+ */
 function computeBuildId(driverDate, driverRevision) {
   // Note: this build ID doesn't include revision etc. information for v8 or other inner git
   // repositories. It would be good to either fix this or enforce that the chromium revision

--- a/build.js
+++ b/build.js
@@ -138,8 +138,8 @@ function driverExtension() {
 }
 
 /**
- * WARNING: This is a copy-and-paste from `backend`.
- * When changing: always keep all versions of this in sync, or else, builds will break.
+ * WARNING: We have copy-and-pasted the same code in all our runtimes and `backend`.
+ * When changing this: always keep all versions of this in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
  * @see https://github.com/replayio/backend/blob/eda247aacb2ade5481b9fb73d751171576197eba/src/shared/linkerVersion.ts#L23
  */

--- a/build.js
+++ b/build.js
@@ -142,7 +142,7 @@ function driverExtension() {
  * When changing this: always keep all versions of this in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
  */
-function getLinkerRevisionDate(
+function getRevisionDate(
   revision = "HEAD",
   spawnOptions
 ) {
@@ -171,7 +171,7 @@ function computeBuildId(driverDate, driverRevision) {
     .stdout.toString()
     .trim();
 
-  const runtimeDate = getLinkerRevisionDate();
+  const runtimeDate = getRevisionDate();
 
   // Use the later of the two dates in the build ID.
   const date = +runtimeDate >= +driverDate ? runtimeDate : driverDate;

--- a/build.js
+++ b/build.js
@@ -138,10 +138,9 @@ function driverExtension() {
 }
 
 /**
- * WARNING: We have copy-and-pasted the same code in all our runtimes and `backend`.
+ * WARNING: We have copy-and-pasted `getLinkerRevisionDate` into all our runtimes and `backend`.
  * When changing this: always keep all versions of this in sync, or else, builds will break.
  * @returns {string} "YYYYMMDD" format of UTC timestamp of given revision.
- * @see https://github.com/replayio/backend/blob/eda247aacb2ade5481b9fb73d751171576197eba/src/shared/linkerVersion.ts#L23
  */
 function getLinkerRevisionDate(
   revision = "HEAD",


### PR DESCRIPTION
* Explanation: https://linear.app/replay/issue/RUN-1328#comment-c49a7744
* https://linear.app/replay/issue/RUN-1415/fix-buildid-timestamp-regression-build-server-failing