### PR TITLE
Handle `FontFallbackIterator::Next` returning null in `HarfBuzzShaper::ShapeSegment`

### DIFF
--- a/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
+++ b/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
@@ -789,7 +789,15 @@ void HarfBuzzShaper::ShapeSegment(
 
       current_font_data_for_range_set =
           fallback_iterator.Next(fallback_chars_hint);
-      if (!current_font_data_for_range_set->FontData()) {
+
+      // [RecordReplay] https://linear.app/replay/issue/RUN-1302#comment-0930eb4f
+      // When replaying and diverged from the recording, the `fallback_iterator.Next()`
+      // call can return null.
+      bool skipCheck =
+        recordreplay::HasDivergedFromRecording() &&
+        !current_font_data_for_range_set;
+
+      if (skipCheck || !current_font_data_for_range_set->FontData()) {
         DCHECK(range_data->reshape_queue.empty());
         break;
       }


### PR DESCRIPTION
See https://linear.app/replay/issue/RUN-1302#comment-0930eb4f