### PR TITLE
Replay assertions in LayoutBox::CachedLayoutResult

### DIFF
--- a/third_party/blink/renderer/core/layout/layout_box_hot.cc
+++ b/third_party/blink/renderer/core/layout/layout_box_hot.cc
@@ -102,11 +102,20 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   NOT_DESTROYED();
   *out_cache_status = NGLayoutCacheStatus::kNeedsLayout;
 
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult Start %d %d %d",
+    (int) new_space.CacheSlot(), layout_results_.empty());
+
   const bool use_layout_cache_slot =
       new_space.CacheSlot() == NGCacheSlot::kLayout && !layout_results_.empty();
   const NGLayoutResult* cached_layout_result =
       use_layout_cache_slot ? GetCachedLayoutResult(break_token)
                             : GetCachedMeasureResult();
+
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #1 %d %d %d %d",
+    (int) new_space.CacheSlot(),
+    (int) use_layout_cache_slot,
+    (int) !!cached_layout_result,
+    (int) !!early_break);
 
   if (!cached_layout_result)
     return nullptr;
@@ -136,20 +145,33 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       (break_token && break_token->IsRepeated()))
     return nullptr;
 
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2");
+
   if (SelfNeedsLayoutForStyle() || child_needs_layout_unless_locked ||
       NeedsSimplifiedNormalFlowLayout() ||
       (NeedsPositionedMovementLayout() &&
        !NeedsPositionedMovementLayoutOnly())) {
+
+    recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.1");
+
     if (!ChildrenInline()) {
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.1.1");
+
       // Check if we only need "simplified" layout. We don't abort yet, as we
       // need to check if other things (like floats) will require us to perform
       // a full layout.
       if (!NeedsSimplifiedLayoutOnly())
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.1.2");
+
       cache_status = NGLayoutCacheStatus::kNeedsSimplifiedLayout;
     } else if (!NeedsSimplifiedLayoutOnly() ||
                NeedsSimplifiedNormalFlowLayout()) {
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.1");
+
       // We don't regenerate any lineboxes during our "simplified" layout pass.
       // If something needs "simplified" layout within a linebox, (e.g. an
       // atomic-inline) we miss the cache.
@@ -161,15 +183,23 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (!use_layout_cache_slot)
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.2");
+
       if (SelfNeedsLayout())
         return nullptr;
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.3");
 
       if (!physical_fragment.HasItems())
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.4");
+
       // Propagating OOF needs re-layout.
       if (physical_fragment.NeedsOOFPositionedInfoPropagation())
         return nullptr;
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.5");
 
       // Any floats might need to move, causing lines to wrap differently,
       // needing re-layout, either in cached result or in new constraint space.
@@ -177,8 +207,13 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           new_space.HasFloats())
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.2.6");
+
       cache_status = NGLayoutCacheStatus::kCanReuseLines;
     } else {
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #2.3");
+
       cache_status = NGLayoutCacheStatus::kNeedsSimplifiedLayout;
     }
   }
@@ -193,6 +228,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   if (size_cache_status == NGLayoutCacheStatus::kNeedsLayout)
     return nullptr;
 
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #3");
+
   // If we need simplified layout, but the cached fragment's children are not
   // valid (see comment in `SetCachedLayoutResult`), don't return the fragment,
   // since it will be used to iteration the invalid children when running
@@ -201,6 +238,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       (size_cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout ||
        cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout))
     return nullptr;
+
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #4");
 
   // Update our temporary cache status, if the size cache check indicated we
   // might need simplified layout.
@@ -213,11 +252,15 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
     if (IsLayoutReplaced())
       return nullptr;
 
+    recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #4.1");
+
     // Simplified layout requires children to have a cached layout result. If
     // the current box has no cached layout result, its children might not,
     // either.
     if (!use_layout_cache_slot && !GetCachedLayoutResult(break_token))
       return nullptr;
+
+    recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #4.2");
   }
 
   LayoutUnit bfc_line_offset = new_space.BfcOffset().line_offset;
@@ -262,6 +305,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
     if (!is_new_formatting_context &&
         (!are_bfc_offsets_equal || !is_exclusion_space_equal ||
          !is_margin_strut_equal || !is_clearance_offset_equal)) {
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #5.1");
       DCHECK(!CreatesNewFormattingContext());
 
       // If we have a different BFC offset, or exclusion space we can't perform
@@ -275,15 +320,22 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           cache_status == NGLayoutCacheStatus::kCanReuseLines)
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #5.2");
+
       DCHECK_EQ(cache_status, NGLayoutCacheStatus::kHit);
 
       if (!MaySkipLayoutWithinBlockFormattingContext(
               *cached_layout_result, new_space, &bfc_block_offset,
               &block_offset_delta, &end_margin_strut))
         return nullptr;
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #5.3");
     }
 
     if (UNLIKELY(new_space.HasBlockFragmentation())) {
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.1");
+
       DCHECK(old_space.HasBlockFragmentation());
 
       // Sometimes we perform simplified layout on a block-flow which is just
@@ -291,6 +343,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       // cache for these cases as we may grow past the fragmentation line.
       if (cache_status != NGLayoutCacheStatus::kHit)
         return nullptr;
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.2");
 
       // Miss the cache if we have nested multicol containers inside that also
       // have OOF descendants. OOFs in nested multicol containers are handled in
@@ -302,6 +356,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (UNLIKELY(physical_fragment.HasNestedMulticolsWithOOFs()))
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.3");
+
       // Any fragmented out-of-flow positioned items will be placed once we
       // reach the fragmentation context root rather than the containing block,
       // so we should miss the cache in this case to ensure that such OOF
@@ -309,8 +365,12 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (physical_fragment.HasOutOfFlowFragmentChild())
         return nullptr;
 
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.4");
+
       if (column_spanner_path || cached_layout_result->ColumnSpannerPath())
         return nullptr;
+
+      recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5");
 
       // If the node didn't break into multiple fragments, we might be able to
       // re-use the result. If the fragmentainer block-size has changed, or if
@@ -319,6 +379,9 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       // be sure that this is the case, we need to miss the cache.
       if (new_space.IsInitialColumnBalancingPass()) {
         if (!old_space.IsInitialColumnBalancingPass()) {
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.1");
+
           // If the previous result was generated with a known fragmentainer
           // size (i.e. not in the initial column balancing pass),
           // TallestUnbreakableBlockSize() won't be stored in the layout result,
@@ -343,12 +406,17 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
                      old_space.FragmentainerBlockSize() ||
                  new_space.FragmentainerOffset() !=
                      old_space.FragmentainerOffset()) {
+
+        recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.2");
+
         // The fragment block-offset will either change, or the fragmentainer
         // block-size has changed. If the node is fragmented, we're going to
         // have to refragment, since the fragmentation line has moved,
         // relatively to the fragment.
         if (is_fragmented)
           return nullptr;
+
+        recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.3");
 
         // Fragmentation inside a nested multicol container depends on the
         // amount of remaining space in the outer fragmentation context, so if
@@ -358,11 +426,15 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         if (physical_fragment.IsFragmentationContextRoot())
           return nullptr;
 
+        recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.4");
+
         // If the fragment was forced to stay in a fragmentainer (even if it
         // overflowed), BlockSizeForFragmentation() cannot be used for cache
         // testing.
         if (cached_layout_result->IsBlockSizeForFragmentationClamped())
           return nullptr;
+
+        recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.5");
 
         // If the fragment was truncated at the fragmentation line, and since we
         // have now moved relatively to the fragmentation line, we cannot re-use
@@ -370,11 +442,14 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         if (cached_layout_result->IsTruncatedByFragmentationLine())
           return nullptr;
 
+        recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.6");
+
         // TODO(layout-dev): This likely shouldn't be scoped to just OOFs, but
         // scoping it more widely results in several perf regressions[1].
         //
         // [1] https://bugs.chromium.org/p/chromium/issues/detail?id=1362550
         if (node.IsOutOfFlowPositioned()) {
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.6.1");
           // If the fragmentainer size has changed, and there previously was
           // space shortage reported, we should re-run layout to avoid reporting
           // the same space shortage again.
@@ -382,6 +457,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
               cached_layout_result->MinimalSpaceShortage();
           if (space_shortage && *space_shortage > LayoutUnit())
             return nullptr;
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.6.2");
         }
 
         // Returns true if there are any floats added by |cached_layout_result|
@@ -400,6 +477,9 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         };
 
         if (!bfc_block_offset && cached_layout_result->IsSelfCollapsing()) {
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.7.1");
+
           // Self-collapsing blocks may have floats and OOF descendants.
           // Checking if floats cross the fragmentation line is easy enough
           // (check the exclusion space), but we currently have no way of
@@ -410,16 +490,29 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           if (old_space.IsInitialColumnBalancingPass())
             return nullptr;
 
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.7.2");
+
           if (DoFloatsCrossFragmentationLine())
             return nullptr;
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.7.3");
+
         } else {
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.8.1");
+
           // If floats were added inside an inline formatting context, they
           // might extrude (and not included within the block-size for
           // fragmentation calculation above, unlike block formatting contexts).
           if (physical_fragment.IsInlineFormattingContext() &&
               !is_new_formatting_context) {
+
+            recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.8.1.1");
+
             if (DoFloatsCrossFragmentationLine())
               return nullptr;
+
+            recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.8.1.2");
           }
 
           // Check if we have content which might cross the fragmentation line.
@@ -438,6 +531,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
               block_size_for_fragmentation;
           if (block_end_offset > new_space.FragmentainerBlockSize())
             return nullptr;
+
+          recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.8.2");
         }
 
         // Multi-cols behave differently between the initial column balancing
@@ -447,18 +542,26 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           if (physical_fragment.HasOutOfFlowInFragmentainerSubtree())
             return nullptr;
           if (auto* block = DynamicTo<LayoutBlock>(this)) {
+
+            recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.9.1");
+
             if (block->IsFragmentationContextRoot())
               return nullptr;
+
+            recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #6.5.9.2");
           }
         }
       }
     }
   }
 
+
   // Simplified layout doesn't support fragmented nodes.
   if (is_fragmented &&
       cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout)
     return nullptr;
+
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #7");
 
   // We've performed all of the cache checks at this point. If we need
   // "simplified" layout then abort now.
@@ -466,6 +569,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   if (cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout ||
       cache_status == NGLayoutCacheStatus::kCanReuseLines)
     return cached_layout_result;
+
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #8");
 
   physical_fragment.CheckType();
 
@@ -525,12 +630,17 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   // were equal.
   if (are_bfc_offsets_equal && is_exclusion_space_equal &&
       is_margin_strut_equal && !needs_cached_result_update) {
+
+    recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #9.1");
+
     // In order not to rebuild the internal derived-geometry "cache" of float
     // data, we need to move this to the new "output" exclusion space.
     cached_layout_result->ExclusionSpace().MoveAndUpdateDerivedGeometry(
         new_space.ExclusionSpace());
     return cached_layout_result;
   }
+
+  recordreplay::Assert("[RUN-1219-1440] LayoutBox::CachedLayoutResult #10");
 
   const NGLayoutResult* new_result = MakeGarbageCollected<NGLayoutResult>(
       *cached_layout_result, new_space, end_margin_strut, bfc_line_offset,

--- a/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
@@ -417,8 +417,9 @@ const NGLayoutResult* NGBlockNode::Layout(
     const NGEarlyBreak* early_break,
     const NGColumnSpannerPath* column_spanner_path) const {
   // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGBlockNode::Layout Start %d",
-                       GetLayoutBox()->RecordReplayId());
+  recordreplay::Assert("[RUN-1219] NGBlockNode::Layout Start %d cs=%d",
+                       GetLayoutBox()->RecordReplayId(),
+                       constraint_space.CacheSlot());
 
   // Use the old layout code and synthesize a fragment.
   if (!CanUseNewLayout())


### PR DESCRIPTION
For RUN-1440 (https://linear.app/replay/issue/RUN-1440/)

Divergence symptoms are happening somewhere inside LayoutBox::CachedLayoutResult.  Source of it is _probably_ the fields storing cached info, but we can't be 100% sure of that, so we're carpeting this method's control flow to make sure.

Should trigger again quickly since this is hitting in livetests.