### PR TITLE
Record/replay the visited link state.

### DIFF
--- a/content/renderer/renderer_blink_platform_impl.cc
+++ b/content/renderer/renderer_blink_platform_impl.cc
@@ -298,7 +298,8 @@ uint64_t RendererBlinkPlatformImpl::VisitedLinkHash(const char* canonical_url,
 }
 
 bool RendererBlinkPlatformImpl::IsLinkVisited(uint64_t link_hash) {
-  return GetContentClient()->renderer()->IsLinkVisited(link_hash);
+  return (bool)recordreplay::RecordReplayValue("RendererBlinkPlatformImpl::IsLinkVisited", 
+    GetContentClient()->renderer()->IsLinkVisited(link_hash));
 }
 
 blink::WebString RendererBlinkPlatformImpl::UserAgent() {

--- a/content/renderer/renderer_blink_platform_impl.cc
+++ b/content/renderer/renderer_blink_platform_impl.cc
@@ -298,6 +298,8 @@ uint64_t RendererBlinkPlatformImpl::VisitedLinkHash(const char* canonical_url,
 }
 
 bool RendererBlinkPlatformImpl::IsLinkVisited(uint64_t link_hash) {
+  // Link status is something we want to record, to match playback.  See RUN-1442
+  // for details.
   return (bool)recordreplay::RecordReplayValue("RendererBlinkPlatformImpl::IsLinkVisited", 
     GetContentClient()->renderer()->IsLinkVisited(link_hash));
 }


### PR DESCRIPTION
This fixes some(?) asserts related to RUN-966 that I managed to repro locally, due to the divergent computed styles that would result.