### PR TITLE
Combine build/test branch inputs

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -33,13 +33,9 @@ const slotInput = process.env.INPUT_SLOT;
 console.log("Slot", slotInput);
 const slot = slotInput ? +slotInput : undefined;
 
-const runStaticTestsInput = process.env.INPUT_RUN_STATIC_TESTS;
-console.log("RunStaticTests", runStaticTestsInput);
-const runStaticTests = runStaticTestsInput == "true";
-
 const numStaticTestsInput = process.env.INPUT_NUM_STATIC_TESTS;
 console.log("NumStaticTests", numStaticTestsInput);
-const numStaticTests = numStaticTestsInput ? +numStaticTestsInput : undefined;
+const numStaticTests = numStaticTestsInput ? +numStaticTestsInput : 30;
 
 const runTestSuitesInput = process.env.INPUT_RUN_TEST_SUITES;
 console.log("RunTestSuites", runTestSuitesInput);
@@ -90,7 +86,7 @@ function platformTasks(platform) {
 
   const tasks = [buildTask];
 
-  if (runStaticTests) {
+  if (numStaticTests) {
     const testStaticTask = newTask(
       `Chromium Static Tests ${platform}`,
       {

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -27,13 +27,9 @@ on:
       slot:
         description: "Checked out repository slot to use"
         required: false
-      run_static_tests:
-        description: "Run static tests"
-        type: boolean
-        required: false
-        default: "true"
       num_static_tests:
         description: "Number of static tests to run"
+        default: "30"
         required: false
       run_test_suites:
         description: "Run test suites"
@@ -74,7 +70,6 @@ jobs:
           INPUT_DRIVER_REVISION: ${{ github.event.inputs.driver_revision }}
           INPUT_CLOBBER: ${{ github.event.inputs.clobber }}
           INPUT_SLOT: ${{ github.event.inputs.slot }}
-          INPUT_RUN_STATIC_TESTS: ${{ github.event.inputs.run_static_tests }}
           INPUT_NUM_STATIC_TESTS: ${{ github.event.inputs.num_static_tests }}
           INPUT_RUN_TEST_SUITES: ${{ github.event.inputs.run_test_suites }}
           INPUT_TEST_SUITES_FILTER: ${{ github.event.inputs.test_suites_filter }}


### PR DESCRIPTION
Github has a (ridiculous) limit of 10 inputs in workflows, this combines two of the inputs to workaround this.  Apparently there is a repository_dispatch mechanism without this restriction but switching things to that would be more involved.