### PR TITLE
RUN-1469: Assert PictureLayerImpl::CleanUpTilings + Layer::SetTransformTreeIndex

### DIFF
--- a/cc/layers/layer.cc
+++ b/cc/layers/layer.cc
@@ -120,8 +120,6 @@ Layer::Layer()
       ignore_set_needs_commit_for_test_(false),
       bitflags_(0u),
       subtree_property_changed_(false) {
-  // https://linear.app/replay/issue/RUN-1229
-  recordreplay::Assert("Layer::Layer %d", this->layer_id_);
 }
 
 Layer::~Layer() {
@@ -1236,6 +1234,10 @@ void Layer::SetTransformTreeIndex(int index) {
   if (transform_tree_index_.Read(*this) == index)
     return;
   SetHasTransformNode(index != kInvalidPropertyNodeId);
+
+  recordreplay::Assert("[RUN-550-1469] Layer::SetTransformTreeIndex %d %d",
+                       layer_id_, index);
+
   transform_tree_index_.Write(*this) = index;
   SetNeedsPushProperties();
 }

--- a/cc/layers/picture_layer_impl.cc
+++ b/cc/layers/picture_layer_impl.cc
@@ -1699,10 +1699,6 @@ void PictureLayerImpl::AdjustRasterScaleForTransformAnimation(
 void PictureLayerImpl::CleanUpTilingsOnActiveLayer(
     const std::vector<PictureLayerTiling*>& used_tilings) {
 
-  // https://linear.app/replay/issue/RUN-550
-  recordreplay::Assert("[RUN-550-1409] PictureLayerImpl::CleanUpTilingsOnActiveLayer Start %u",
-    (unsigned) tilings_->num_tilings());
-
   DCHECK(layer_tree_impl()->IsActiveTree());
   if (tilings_->num_tilings() == 0)
     return;
@@ -1721,6 +1717,12 @@ void PictureLayerImpl::CleanUpTilingsOnActiveLayer(
         {max_acceptable_high_res_scale, twin->raster_contents_scale_key(),
          twin->ideal_contents_scale_key()});
   }
+
+  recordreplay::Assert(
+      "[RUN-550-1469] PictureLayerImpl::CleanUpTilingsOnActiveLayer %zu %f %f",
+      tilings_->num_tilings(),
+      min_acceptable_high_res_scale,
+      max_acceptable_high_res_scale);
 
   PictureLayerTilingSet* twin_set = twin ? twin->tilings_.get() : nullptr;
   tilings_->CleanUpTilings(min_acceptable_high_res_scale,

--- a/cc/tiles/picture_layer_tiling_set.cc
+++ b/cc/tiles/picture_layer_tiling_set.cc
@@ -256,6 +256,14 @@ void PictureLayerTilingSet::CleanUpTilings(
   std::vector<PictureLayerTiling*> to_remove;
   for (const auto& tiling : tilings_) {
     // Keep all tilings within the min/max scales.
+
+    auto rect = tiling->GetCurrentVisibleRectForTesting();
+    recordreplay::Assert(
+        "[RUN-550-1469] PictureLayerTilingSet::CleanUpTilings A %f, %d %d, %d %d %d %d",
+        tiling->contents_scale_key(),
+        (int)tiling->resolution(), base::Contains(needed_tilings, tiling.get()),
+        rect.x(), rect.y(), rect.width(), rect.height());
+
     if (tiling->contents_scale_key() >= min_acceptable_high_res_scale_key &&
         tiling->contents_scale_key() <= max_acceptable_high_res_scale_key) {
       continue;
@@ -272,6 +280,8 @@ void PictureLayerTilingSet::CleanUpTilings(
 
     to_remove.push_back(tiling.get());
   }
+
+  recordreplay::Assert("[RUN-550-1469] PictureLayerTilingSet::CleanUpTilings B %zu", to_remove.size());
 
   for (auto* tiling : to_remove) {
     DCHECK_NE(HIGH_RESOLUTION, tiling->resolution());


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-550#comment-b5d291e4
* NOTE: I ran a test [here](https://github.com/replayio/build-test-dashboard/blob/master/dbb49b49-8af2-4ae0-b9ed-d7152725cbdb): 2 failed vs. 48 passed