### PR TITLE
RUN-1456: remove useless, noisy Assert

### DIFF
--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -114,7 +114,6 @@ ScriptedIdleTaskController::ScriptedIdleTaskController(
       paused_(false) {}
 
 ScriptedIdleTaskController::~ScriptedIdleTaskController() {
-  recordreplay::Assert("[RUN-1335-1456] ScriptedIdleTaskController::~ScriptedIdleTaskController");
 }
 
 void ScriptedIdleTaskController::Trace(Visitor* visitor) const {


### PR DESCRIPTION
* This pops up everywhere and it should not.
* https://linear.app/replay/issue/RUN-1335/mismatch-in-singlethreadidletaskrunnerruntask