### PR TITLE
RUN-1540 + RUN-1539

### DIFF
--- a/mojo/core/ports/node.cc
+++ b/mojo/core/ports/node.cc
@@ -280,6 +280,7 @@ int Node::ClosePort(const PortRef& port_ref) {
   if (recordreplay::AreEventsDisallowed()) {
     return OK;
   }
+  recordreplay::Assert("[RUN-1307-1539] Node::ClosePort");
 
   std::vector<std::unique_ptr<UserMessageEvent>> undelivered_messages;
   NodeName peer_node_name;

--- a/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
+++ b/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
@@ -706,11 +706,6 @@ void PaintArtifactCompositor::Update(
 
     cc::Layer& layer = pending_layer.CcLayer();
 
-    // NOTE: This `Assert` must come after `UpdateCompositedLayer`, since that one sets `pending_layer.CcLayer`.
-    recordreplay::Assert(
-        "[RUN-1229-1434] PaintArtifactCompositor::Update %d %d",
-        host->GetId(), layer.id());
-
     const auto& property_state = pending_layer.GetPropertyTreeState();
     const auto& transform = property_state.Transform();
     const auto& clip = property_state.Clip();
@@ -750,7 +745,8 @@ void PaintArtifactCompositor::Update(
     bool backface_hidden = transform.IsBackfaceHidden();
     layer.SetShouldCheckBackfaceVisibility(backface_hidden);
 
-    recordreplay::Assert("[RUN-1470-1471] %d", layer.subtree_property_changed());
+    recordreplay::Assert("[RUN-1470-1471] PaintArtifactCompositor::Update %d",
+                         layer.subtree_property_changed());
 
     if (layer.subtree_property_changed())
       root_layer_->SetNeedsCommit();
@@ -762,6 +758,8 @@ void PaintArtifactCompositor::Update(
           .AddTransitionPseudoElementEffectId(effect_id);
     }
   }
+
+  recordreplay::Assert("[RUN-657-1540] PaintArtifactCompositor::Update");
 
   root_layer_->layer_tree_host()->RegisterSelection(layer_selection);
 

--- a/third_party/blink/renderer/platform/graphics/compositing/pending_layer.cc
+++ b/third_party/blink/renderer/platform/graphics/compositing/pending_layer.cc
@@ -17,6 +17,8 @@
 #include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/geometry/vector2d_conversions.h"
 
+#include "cc/trees/layer_tree_host.h"
+
 namespace blink {
 
 namespace {
@@ -522,6 +524,13 @@ void PendingLayer::UpdateCompositedLayer(PendingLayer* old_pending_layer,
                                          cc::LayerSelection& layer_selection,
                                          bool tracks_raster_invalidations,
                                          cc::LayerTreeHost* layer_tree_host) {
+  recordreplay::Assert(
+      "[RUN-657-1540] PendingLayer::UpdateCompositedLayer %d %d %d",
+      layer_tree_host ? layer_tree_host->GetId() : 0,
+      old_pending_layer && old_pending_layer->cc_layer_
+          ? old_pending_layer->cc_layer_->id()
+          : 0,
+      cc_layer_ ? cc_layer_->id() : 0);
   switch (compositing_type_) {
     case PendingLayer::kForeignLayer:
       UpdateForeignLayer();


### PR DESCRIPTION
* This is mostly for RUN-657: https://linear.app/replay/issue/RUN-657#comment-23d3ba3d
* + Sneaky change for `Node::ClosePort` for RUN-1307: https://linear.app/replay/issue/RUN-1539/assert-nodecloseport
* + some small cleanup