### PR TITLE
Don't build on non-linux platforms by default

### DIFF
--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -11,8 +11,8 @@ sendBuildTestRequest({
   name: `Chromium Build/Test ${revision}`,
   tasks: [
     ...platformTasks("linux"),
-    ...platformTasks("macOS"),
-    ...platformTasks("windows"),
+    //...platformTasks("macOS"),
+    //...platformTasks("windows"),
   ],
 });
 

--- a/.github/actions/release/main.js
+++ b/.github/actions/release/main.js
@@ -11,7 +11,8 @@ sendBuildTestRequest({
   name: `Chromium Release ${revision}`,
   tasks: [
     ...platformTasks("linux"),
-    ...platformTasks("macOS"),
+    //...platformTasks("macOS"),
+    //...platformTasks("windows"),
   ],
 });
 

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -11,12 +11,12 @@ on:
         description: "Build and run tests on macOS"
         type: boolean
         required: false
-        default: "true"
+        default: "false"
       windows_build:
         description: "Build and run tests on windows"
         type: boolean
         required: false
-        default: "true"
+        default: "false"
       driver_revision:
         description: "Driver revision to use, if not the latest"
         required: false


### PR DESCRIPTION
Until we have goma set up for mac / windows builds we want to minimize the amount of building we do on these platforms.