### PR TITLE
RUN-1561: fix some getObjectPreview bugs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9e2f70e12d103270595a3838a75fa120e791a211',
+  'v8_revision': '5cf314403ee6e9578721d43668cd804bfae7aea3',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '5cf314403ee6e9578721d43668cd804bfae7aea3',
+  'v8_revision': 'e7ef54990f575889ea5d21d02d3dd6e972089281',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e7ef54990f575889ea5d21d02d3dd6e972089281',
+  'v8_revision': '9e2f70e12d103270595a3838a75fa120e791a211',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -962,15 +962,6 @@ function isObjectPropertyBlacklisted(cdpObj, name) {
   if (isPropNameInObjectBase(name)) {
     return true;
   }
-  switch (`${cdpObj.className}.${name}`) {
-    // NOTE: these are from gecko. Chromium will probably need some adjustments.
-    case "Window.localStorage":
-    case "Window.sysinfo":
-    case "Navigator.hardwareConcurrency":
-    case "XPCWrappedNative_NoHelper.isParentWindowMainWidgetVisible":
-    case "XPCWrappedNative_NoHelper.systemFont":
-      return true;
-  }
   switch (name) {
     case "__proto__":
       // Accessing __proto__ doesn't cause problems, but is redundant with the
@@ -1023,14 +1014,20 @@ ProtocolObjectPreview.prototype = {
     return true;
   },
 
-  addProperty(property, force) {
+  addProperty(ownerCdpObject, rrpProp, force) {
+    if (isObjectPropertyBlacklisted(ownerCdpObject, rrpProp.name)) {
+      return;
+    }
+    if (this.getterValues?.has(rrpProp.name)) {
+      return;
+    }
     if (!this.startAddItem(force)) {
       return;
     }
     if (!this.properties) {
       this.properties = [];
     }
-    this.properties.push(property);
+    this.properties.push(rrpProp);
   },
 
   addGetterValue(propKey, ownerCdpObject, force = false) {
@@ -1120,6 +1117,7 @@ ProtocolObjectPreview.prototype = {
           entry.call(this, cdpProperties);
         }
         else {
+          // entry should be string
           this.addGetterValue(entry, this.cdpObj, /* force */ true);
         }
       }
@@ -1146,8 +1144,11 @@ ProtocolObjectPreview.prototype = {
 
       // only add complete prop data for own props
       const rrpProp = createRrpPropertyDescriptor(cdpProp);
-      const force = false;
-      this.addProperty(rrpProp, force);
+      if (rrpProp.get || Object.hasOwn(this.raw, propKey)) {
+        // only add own props or prototype's getters
+        const force = false;
+        this.addProperty(this.cdpObj, rrpProp, force);
+      }
     }
 
     let prototypeCdp = getInternalProp(cdpProperties, '[[Prototype]]')?.value;
@@ -1314,6 +1315,7 @@ function previewTypedArray() {
   this.addGetterValue('length', this.cdpObj, /* force */ true);
   this.addGetterValue('byteLength', this.cdpObj, /* force */ true);
   this.addGetterValue('byteOffset', this.cdpObj, /* force */ true);
+  this.addGetterValue('buffer', this.cdpObj, /* force */ true);
 }
 
 function previewSetMap(cdpProperties) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -939,27 +939,9 @@ function isObjectBlacklisted(cdpObj) {
   return false;
 }
 
-const ObjectPropNames = new Set([
-  '__defineGetter__', '__defineSetter__', '__lookupGetter__', '__lookupSetter__',
-  'constructor', 'hasOwnProperty', 'isPrototypeOf', 'parentProp',
-  'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf'
-]);
-
-/**
- * Runtime.getProperties, for some reason, adds basic `Object` props, that we don't want.
- * Hackfix: There is no easy way to identify `Object` props, 
- *   so we have to reject certain names categorically :/
- */
-function isPropNameInObjectBase(name) {
-  return ObjectPropNames.has(name);
-}
-
 // Return whether an object's property should be ignored when generating previews.
 function isObjectPropertyBlacklisted(cdpObj, name) {
   if (isObjectBlacklisted(cdpObj)) {
-    return true;
-  }
-  if (isPropNameInObjectBase(name)) {
     return true;
   }
   switch (name) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1561/object-previews-contain-properties-from-the-objects-prototype
* Test [here](https://github.com/replayio/build-test-dashboard/blob/master/88342674-c6f2-4acc-b7e9-b9cc271f0cb3): 25 pass vs. 5 fail
  * 0 command crashes visible [here](https://ui.honeycomb.io/replay/datasets/backend/result/32U3Kzejsmf)