### PR TITLE
build: build using ubuntu user

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,6 +3,11 @@ FROM ubuntu:bionic
 RUN apt-get update && \
     apt-get install -y wget python clang llvm python3 mercurial git python3-distutils python3-pip nasm-mozilla curl make glib-2.0 glib2.0-dev libgtk-3-dev libdbus-glib-1-dev libxt-dev libpulse-dev unzip zip nodejs gperf python-setuptools lsof
 
+RUN groupadd -o -g 1000 ubuntu
+RUN useradd -o -m -s /bin/bash -g 1000 -u 10000 ubuntu 
+
+USER ubuntu
+
 ENV PATH=$PATH:/depot_tools
 
 WORKDIR /chromium/src

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,11 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && \
     apt-get install -y wget python clang llvm python3 mercurial git python3-distutils python3-pip nasm-mozilla curl make glib-2.0 glib2.0-dev libgtk-3-dev libdbus-glib-1-dev libxt-dev libpulse-dev unzip zip nodejs gperf python-setuptools lsof
 
-RUN groupadd -o -g 997 build
-RUN useradd -o -m -s /bin/bash -g 997 -u 997 build
-
-USER build
-
 ENV PATH=$PATH:/depot_tools
 
 WORKDIR /chromium/src

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y wget python clang llvm python3 mercurial git python3-distutils python3-pip nasm-mozilla curl make glib-2.0 glib2.0-dev libgtk-3-dev libdbus-glib-1-dev libxt-dev libpulse-dev unzip zip nodejs gperf python-setuptools lsof
 
 RUN groupadd -o -g 1000 ubuntu
-RUN useradd -o -m -s /bin/bash -g 1000 -u 10000 ubuntu 
+RUN useradd -o -m -s /bin/bash -g 1000 -u 1000 ubuntu 
 
 USER ubuntu
 

--- a/buildLinux.js
+++ b/buildLinux.js
@@ -50,7 +50,7 @@ const dockerArgs = [
   `${path.join(
     process.env.HOME,
     ".goma_client_oauth2_config"
-  )}:/home/build/.goma_client_oauth2_config`,
+  )}:/home/ubuntu/.goma_client_oauth2_config`,
   "-p",
   "9098:9099",
   "chromium-build-new",


### PR DESCRIPTION
Rather than run buildkite as the `buildkite-agent` user, just use the default `ubuntu` user. This makes it a lot easier to setup a new EC2 instance that can build chromium.