### PR TITLE
Return an jso of the command error, instead of an actual error object.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9e2f70e12d103270595a3838a75fa120e791a211',
+  'v8_revision': 'd6b78ab16a2e191673bff5d9e7f15e50a9b76924',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -283,7 +283,11 @@ function commandCallback(method, params) {
     // Pass the error up to V8; it can (for now) decide how to handle itself, whether
     // it should crash or not, etc.  Eventually, the caller of the command should make
     // that decision.
-    return e;
+    return {
+      is_error: true,
+      message: e?.message || e.toString(),
+      stack: e?.stack?.split?.("\n") || e?.stack || [],
+    };
   }
 }
 


### PR DESCRIPTION
This is the chromium half of reporting js command error stacks; the v8 half was committed in https://github.com/replayio/chromium-v8/pull/118 .