### PR TITLE
RUN-1609: enable events by default in the chromium runtime (chromium)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '92c3ee9eb60d1461d8b130f47542a800fd2bdebb',
+  'v8_revision': '910cf8a8c635300ff237dacdf8c64c152ccd7fc6',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
@@ -56,8 +56,8 @@ static void ReplayNotifyAfterEvent(const String& eventName,
 bool ShouldNotifyEvent(const String& eventName) {
   return IsRecordingOrReplaying() && !AreEventsDisallowed() &&
          !eventName.empty() &&
-         // Disabled by default (RUN-1251)
-         !FeatureEnabled("disable-collect-events") &&
+         // check for events feature flag (RUN-1609)
+         FeatureEnabled("collect-events") &&
          // Main-thread only (RUN-1392)
          IsMainThread();
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_events.cc
@@ -54,12 +54,12 @@ static void ReplayNotifyAfterEvent(const String& eventName,
                                    bool isCallback = false);
 
 bool ShouldNotifyEvent(const String& eventName) {
-  return IsRecordingOrReplaying() && !AreEventsDisallowed() &&
-         !eventName.empty() &&
+  return !AreEventsDisallowed() &&
          // check for events feature flag (RUN-1609)
-         FeatureEnabled("collect-events") &&
+         IsRecordingOrReplaying("collect-events") &&
          // Main-thread only (RUN-1392)
-         IsMainThread();
+         IsMainThread() &&
+         !eventName.empty();
 }
 
 void ReplayNotifyBeforeEvent(const String& eventName,


### PR DESCRIPTION
* Paired w/ https://github.com/replayio/chromium-v8/pull/119
* https://linear.app/replay/issue/RUN-1609/flip-the-switch-in-the-chromium-runtime-to-enable-events-everywhere-%F0%9F%98%B2