### PR TITLE
RUN-1593: Divergence in `PerformMicrotaskCheckpoint`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '92c3ee9eb60d1461d8b130f47542a800fd2bdebb',
+  'v8_revision': '419d73d1e24fb5e0090f30948adf8968a64c496d',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0adbdb23af36600620fbcfed3515c681015d6a6e',
+  'v8_revision': 'be3e2a5fae7a75504bb6e532694fda64fdfc83ab',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/core/animation/animation_timeline.cc
+++ b/third_party/blink/renderer/core/animation/animation_timeline.cc
@@ -31,7 +31,6 @@ void AnimationTimeline::AnimationAttached(Animation* animation) {
 
 void AnimationTimeline::AnimationDetached(Animation* animation) {
   animations_.erase(animation);
-
   if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers"))
     record_replay_animations_strong_.erase(animation);
 

--- a/third_party/blink/renderer/core/animation/animation_timeline.cc
+++ b/third_party/blink/renderer/core/animation/animation_timeline.cc
@@ -31,7 +31,10 @@ void AnimationTimeline::AnimationAttached(Animation* animation) {
 
 void AnimationTimeline::AnimationDetached(Animation* animation) {
   animations_.erase(animation);
-  record_replay_animations_strong_.erase(animation);
+
+  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers"))
+    record_replay_animations_strong_.erase(animation);
+
   animations_needing_update_.erase(animation);
   if (animation->Outdated())
     outdated_animation_count_--;

--- a/third_party/blink/renderer/core/execution_context/agent.cc
+++ b/third_party/blink/renderer/core/execution_context/agent.cc
@@ -39,7 +39,9 @@ Agent::Agent(v8::Isolate* isolate,
       origin_keyed_because_of_inheritance_(false),
       is_origin_agent_cluster_(is_origin_agent_cluster),
       origin_agent_cluster_left_as_default_(
-          origin_agent_cluster_left_as_default) {}
+          origin_agent_cluster_left_as_default) {
+  record_replay_id_ = recordreplay::NewIdMainThread("blink::Agent");
+}
 
 Agent::~Agent() = default;
 

--- a/third_party/blink/renderer/core/execution_context/agent.h
+++ b/third_party/blink/renderer/core/execution_context/agent.h
@@ -125,6 +125,8 @@ class CORE_EXPORT Agent : public GarbageCollected<Agent>,
         bool is_origin_agent_cluster,
         bool origin_agent_cluster_left_as_default);
 
+  int record_replay_id_ = 0;
+
  private:
   scoped_refptr<RejectedPromises> rejected_promises_;
   scoped_refptr<scheduler::EventLoop> event_loop_;
@@ -132,7 +134,6 @@ class CORE_EXPORT Agent : public GarbageCollected<Agent>,
   bool origin_keyed_because_of_inheritance_;
   const bool is_origin_agent_cluster_;
   const bool origin_agent_cluster_left_as_default_;
-  int record_replay_id_ = 0;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/execution_context/agent.h
+++ b/third_party/blink/renderer/core/execution_context/agent.h
@@ -114,6 +114,10 @@ class CORE_EXPORT Agent : public GarbageCollected<Agent>,
 
   RejectedPromises& GetRejectedPromises();
 
+  virtual int RecordReplayId() const {
+    return record_replay_id_;
+  }
+
  protected:
   Agent(v8::Isolate* isolate,
         const base::UnguessableToken& cluster_id,
@@ -128,6 +132,7 @@ class CORE_EXPORT Agent : public GarbageCollected<Agent>,
   bool origin_keyed_because_of_inheritance_;
   const bool is_origin_agent_cluster_;
   const bool origin_agent_cluster_left_as_default_;
+  int record_replay_id_ = 0;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/execution_context/window_agent.h
+++ b/third_party/blink/renderer/core/execution_context/window_agent.h
@@ -50,6 +50,8 @@ class WindowAgent final : public Agent, public AgentGroupScheduler::Agent {
   void PerformMicrotaskCheckpoint() override;
   void SchedulerDestroyed() override;
 
+  int RecordReplayId() const override { return record_replay_id_; }
+
   scheduler::WebAgentGroupScheduler& GetAgentGroupScheduler();
 
  private:

--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
@@ -49,7 +49,8 @@ AgentGroupSchedulerImpl::AgentGroupSchedulerImpl(
       main_thread_scheduler_(main_thread_scheduler) {
   DCHECK(!default_task_queue_->GetFrameScheduler());
   DCHECK_EQ(default_task_queue_->GetAgentGroupScheduler(), this);
-  agents_ = MakeGarbageCollected<HeapHashSet<WeakMember<Agent>>>();
+  agents_ = MakeGarbageCollected<HeapHashSet<WeakMember<Agent>, WTF::MemberHashRecordReplayId<Agent>>>();
+  replay_agents_strong_ = MakeGarbageCollected<HeapHashSet<Member<Agent>>>();
 }
 
 AgentGroupSchedulerImpl::~AgentGroupSchedulerImpl() {

--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
@@ -121,11 +121,16 @@ v8::Isolate* AgentGroupSchedulerImpl::Isolate() {
 void AgentGroupSchedulerImpl::AddAgent(Agent* agent) {
   DCHECK(agents_->find(agent) == agents_->end());
   agents_->insert(agent);
+  
+  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers"))
+    replay_agents_strong_->insert(agent);
 }
 
 void AgentGroupSchedulerImpl::RemoveAgent(Agent* agent) {
   DCHECK(agents_->find(agent) != agents_->end());
   agents_->erase(agent);
+  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers"))
+    replay_agents_strong_->erase(agent);
 }
 
 void AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint() {

--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.h
@@ -58,7 +58,12 @@ class PLATFORM_EXPORT AgentGroupSchedulerImpl : public AgentGroupScheduler {
   scoped_refptr<MainThreadTaskQueue> compositor_task_queue_;
   scoped_refptr<base::SingleThreadTaskRunner> compositor_task_runner_;
   MainThreadSchedulerImpl& main_thread_scheduler_;  // Not owned.
-  Persistent<HeapHashSet<WeakMember<Agent>>> agents_;
+  Persistent<
+      HeapHashSet<WeakMember<Agent>, WTF::MemberHashRecordReplayId<Agent>>>
+      agents_;
+  Persistent<
+      HeapHashSet<Member<Agent>>>
+      replay_agents_strong_;
 
   BrowserInterfaceBrokerProxy broker_;
 };

--- a/third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h
+++ b/third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h
@@ -23,6 +23,7 @@ class BLINK_PLATFORM_EXPORT AgentGroupScheduler
    public:
     virtual void PerformMicrotaskCheckpoint() = 0;
     virtual void SchedulerDestroyed() = 0;
+
     virtual int RecordReplayId() const = 0;
   };
 

--- a/third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h
+++ b/third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h
@@ -23,6 +23,7 @@ class BLINK_PLATFORM_EXPORT AgentGroupScheduler
    public:
     virtual void PerformMicrotaskCheckpoint() = 0;
     virtual void SchedulerDestroyed() = 0;
+    virtual int RecordReplayId() const = 0;
   };
 
   // Creates a new PageScheduler for a given Page. Must be called from the


### PR DESCRIPTION
Paired w/ https://github.com/replayio/chromium-v8/pull/120

* Fix hash set iteration order
* Fix WeakMember divergence

→ https://linear.app/replay/issue/RUN-1593/divergence-in-performmicrotaskcheckpoint


# Tests
* Pending: Running tests in `edeb6bfacc18` ([main.md](https://github.com/replayio/build-test-dashboard/blob/master/main.md))
  * Link: [Honeycomb Crashes](https://ui.honeycomb.io/replay/datasets/backend/result/w7mf4JFcQBK)