### PR TITLE
Use an integer id for PictureLayerTilings, to fix pointer re-use bug.

### DIFF
--- a/cc/layers/picture_layer_impl.cc
+++ b/cc/layers/picture_layer_impl.cc
@@ -571,10 +571,10 @@ void PictureLayerImpl::AppendQuads(viz::CompositorRenderPass* render_pass,
       only_used_low_res_last_append_quads_ = false;
 
     if (last_append_quads_tilings_.empty() ||
-        last_append_quads_tilings_.back() != iter.CurrentTiling()) {
+        last_append_quads_tilings_.back() != iter.CurrentTiling()->tile_id) {
       recordreplay::Assert("[RUN-550-1536] PictureLayerImpl::AppendQuads B %d",
                            iter.CurrentTiling()->record_replay_id_);
-      last_append_quads_tilings_.push_back(iter.CurrentTiling());
+      last_append_quads_tilings_.push_back(iter.CurrentTiling()->tile_id);
     }
   }
   recordreplay::Assert("[RUN-550-1536] PictureLayerImpl::AppendQuads C");
@@ -1701,7 +1701,7 @@ void PictureLayerImpl::AdjustRasterScaleForTransformAnimation(
 }
 
 void PictureLayerImpl::CleanUpTilingsOnActiveLayer(
-    const std::vector<PictureLayerTiling*>& used_tilings) {
+    const std::vector<int>& used_tilings) {
 
   DCHECK(layer_tree_impl()->IsActiveTree());
   if (tilings_->num_tilings() == 0)

--- a/cc/layers/picture_layer_impl.h
+++ b/cc/layers/picture_layer_impl.h
@@ -177,7 +177,7 @@ class CC_EXPORT PictureLayerImpl
   }
 
   void AddLastAppendQuadsTilingForTesting(PictureLayerTiling* tiling) {
-    last_append_quads_tilings_.push_back(tiling);
+    last_append_quads_tilings_.push_back(tiling->tile_id);
   }
 
  protected:
@@ -198,7 +198,7 @@ class CC_EXPORT PictureLayerImpl
   // Returns false if raster translation is not applicable.
   bool CalculateRasterTranslation(gfx::Vector2dF& raster_translation) const;
   void CleanUpTilingsOnActiveLayer(
-      const std::vector<PictureLayerTiling*>& used_tilings);
+      const std::vector<int>& used_tilings);
   float MinimumContentsScale() const;
   float MaximumContentsScale() const;
   void UpdateViewportRectForTilePriorityInContentSpace();
@@ -315,10 +315,8 @@ class CC_EXPORT PictureLayerImpl
 
   // List of tilings that were used last time we appended quads. This can be
   // used as an optimization not to remove tilings if they are still being
-  // drawn. Note that accessing this vector should only be done in the context
-  // of comparing pointers, since objects pointed to are not guaranteed to
-  // exist.
-  std::vector<PictureLayerTiling*> last_append_quads_tilings_;
+  // drawn.
+  std::vector<int> last_append_quads_tilings_;
 
   // The set of PaintWorkletInputs that are part of this PictureLayerImpl, and
   // their painted results (if any). During commit, Blink hands us a set of

--- a/cc/tiles/picture_layer_tiling.cc
+++ b/cc/tiles/picture_layer_tiling.cc
@@ -29,6 +29,8 @@
 
 #include "base/record_replay.h"
 
+static int tile_id_ = 1;
+
 namespace cc {
 
 PictureLayerTiling::PictureLayerTiling(
@@ -47,6 +49,7 @@ PictureLayerTiling::PictureLayerTiling(
       max_preraster_distance_(max_preraster_distance),
       can_use_lcd_text_(can_use_lcd_text) {
   record_replay_id_ = recordreplay::NewIdAnyThread("PictureLayerTiling");
+  tile_id = tile_id_++;
   
   DCHECK(!raster_source->IsSolidColor());
   DCHECK_GE(raster_transform.translation().x(), 0.f);

--- a/cc/tiles/picture_layer_tiling.h
+++ b/cc/tiles/picture_layer_tiling.h
@@ -330,6 +330,9 @@ class CC_EXPORT PictureLayerTiling {
   // See https://linear.app/replay/issue/RUN-550#comment-60ba884e
   int record_replay_id_ = 0;
 
+  // Fix for use after free bug.
+  int tile_id = 0;
+
  protected:
   friend class CoverageIterator;
   friend class PrioritizedTile;

--- a/cc/tiles/picture_layer_tiling_set.cc
+++ b/cc/tiles/picture_layer_tiling_set.cc
@@ -251,7 +251,7 @@ void PictureLayerTilingSet::VerifyTilings(
 void PictureLayerTilingSet::CleanUpTilings(
     float min_acceptable_high_res_scale_key,
     float max_acceptable_high_res_scale_key,
-    const std::vector<PictureLayerTiling*>& needed_tilings,
+    const std::vector<int>& needed_tilings,
     PictureLayerTilingSet* twin_set) {
   std::vector<PictureLayerTiling*> to_remove;
   for (const auto& tiling : tilings_) {
@@ -261,7 +261,7 @@ void PictureLayerTilingSet::CleanUpTilings(
     recordreplay::Assert(
         "[RUN-550-1469] PictureLayerTilingSet::CleanUpTilings A %f, %d %d, %d %d %d %d",
         tiling->contents_scale_key(),
-        (int)tiling->resolution(), base::Contains(needed_tilings, tiling.get()),
+        (int)tiling->resolution(), base::Contains(needed_tilings, tiling.get()->tile_id),
         rect.x(), rect.y(), rect.width(), rect.height());
 
     if (tiling->contents_scale_key() >= min_acceptable_high_res_scale_key &&
@@ -274,7 +274,7 @@ void PictureLayerTilingSet::CleanUpTilings(
       continue;
 
     // Don't remove tilings that are required.
-    if (base::Contains(needed_tilings, tiling.get())) {
+    if (base::Contains(needed_tilings, tiling.get()->tile_id)) {
       continue;
     }
 

--- a/cc/tiles/picture_layer_tiling_set.h
+++ b/cc/tiles/picture_layer_tiling_set.h
@@ -58,7 +58,7 @@ class CC_EXPORT PictureLayerTilingSet {
 
   void CleanUpTilings(float min_acceptable_high_res_scale_key,
                       float max_acceptable_high_res_scale_key,
-                      const std::vector<PictureLayerTiling*>& needed_tilings,
+                      const std::vector<int>& needed_tilings,
                       PictureLayerTilingSet* twin_set);
   void RemoveNonIdealTilings();
 


### PR DESCRIPTION
As per my comment in https://linear.app/replay/issue/RUN-550#comment-7ecba77d, Chromium uses a vector of pointers for testing to see if a picture layer tiling is part of a running list of needed tilings for painting.  These layer tiling objects come and go, though, and somewhat frequently a new object will re-use a pointer that a previous object was at, leading to a subtle-reuse bug, and divergent behaviour.  Given that the code is lock-free and (I think) thread-safe, just use a simple static id in place of the pointer.