### PR TITLE
Make scrollable area hash sets deterministic.

### DIFF
--- a/third_party/blink/renderer/core/frame/local_frame_view.h
+++ b/third_party/blink/renderer/core/frame/local_frame_view.h
@@ -452,7 +452,7 @@ class CORE_EXPORT LocalFrameView final
     return is_tracking_raster_invalidations_;
   }
 
-  using ScrollableAreaSet = HeapHashSet<Member<PaintLayerScrollableArea>>;
+  using ScrollableAreaSet = HeapHashSet<Member<PaintLayerScrollableArea>, WTF::MemberHashRecordReplayId<PaintLayerScrollableArea>>;
   void AddScrollAnchoringScrollableArea(PaintLayerScrollableArea*);
   void RemoveScrollAnchoringScrollableArea(PaintLayerScrollableArea*);
   const ScrollableAreaSet* ScrollAnchoringScrollableAreas() const {

--- a/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.cc
+++ b/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.cc
@@ -156,6 +156,9 @@ PaintLayerScrollableArea::PaintLayerScrollableArea(PaintLayer& layer)
       resizer_(nullptr),
       scroll_anchor_(this),
       non_composited_main_thread_scrolling_reasons_(0) {
+  // For RUN-550, to ensure that we iterate over the scrollable area sets in the same order.
+  record_replay_id_ = recordreplay::NewIdAnyThread("PaintLayerScrollableArea");
+
   if (auto* element = DynamicTo<Element>(GetLayoutBox()->GetNode())) {
     // We save and restore only the scrollOffset as the other scroll values are
     // recalculated.

--- a/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.h
+++ b/third_party/blink/renderer/core/paint/paint_layer_scrollable_area.h
@@ -628,6 +628,10 @@ class CORE_EXPORT PaintLayerScrollableArea final
     return last_cull_rect_update_scroll_offset_;
   }
 
+  int RecordReplayId() const { 
+    return record_replay_id_; 
+  }
+
  private:
   // This also updates main thread scrolling reasons and the LayoutBox's
   // background paint location.
@@ -804,6 +808,8 @@ class CORE_EXPORT PaintLayerScrollableArea final
   gfx::Rect scroll_corner_and_resizer_visual_rect_;
 
   ScrollOffset last_cull_rect_update_scroll_offset_;
+
+  int record_replay_id_ = 0;
 
   class ScrollingBackgroundDisplayItemClient final
       : public GarbageCollected<ScrollingBackgroundDisplayItemClient>,


### PR DESCRIPTION
In many RUN-550 stacks, we see `EnsureCompositorScrollNodes` being called.  This leads to iteration over a vec of `PaintLayerScrollableArea` pointers, which is built from a non-deterministic hash set of `PaintLayerScrollableAreas`.  (The iteration to produce the vector occurs in `LocalFrameView::GetUserScrollTranslationNodes`.)  This makes these sets deterministic.