### PR TITLE
These changes are breaking the buildkite build, and are wrong.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,14 +17,6 @@ steps:
       - "queue=runtime"
     artifact_paths:
       - "build_id/**"
-
   - trigger: "testing-runtime-e2e"
     label: ":hammer: Trigger Runtime Tests"
     depends_on: "build-chromium"
-    message: "${BUILDKITE_MESSAGE}"
-    commit: "${BUILDKITE_COMMIT}"
-    branch: "${BUILDKITE_BRANCH}"
-    env:
-      BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
-      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-      BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"


### PR DESCRIPTION
The testing part of the build takes place on `backend`, not on `chromium`, and so should always happen on `backend`'s `master`.  We find the right build from s3 via the buildkite build_id artifact.  (These changes break because they should actually be nested under 'build'.)