### PR TITLE
RUN-1642: move asserts from RUN-966 to RUN-1436 and RUN-1641

### DIFF
--- a/third_party/blink/renderer/core/animation/animation.cc
+++ b/third_party/blink/renderer/core/animation/animation.cc
@@ -2380,8 +2380,7 @@ absl::optional<AnimationTimeDelta> Animation::TimeToEffectChange() {
 }
 
 void Animation::cancel() {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-1641] Animation::cancel %d", RecordReplayId());
+    recordreplay::Assert("[RUN-1641] Animation::cancel %d", RecordReplayId());
 
   AnimationTimeDelta current_time_before_cancel =
       CurrentTimeInternal().value_or(AnimationTimeDelta());

--- a/third_party/blink/renderer/core/animation/animation.cc
+++ b/third_party/blink/renderer/core/animation/animation.cc
@@ -2164,7 +2164,7 @@ void Animation::StartAnimationOnCompositor(
 // composited and non-composited animations. The use of 'compositor' in the name
 // is confusing.
 void Animation::SetCompositorPending(bool effect_changed) {
-  recordreplay::Assert("[RUN-966] Animation::SetCompositorPending %d", RecordReplayId());
+  recordreplay::Assert("[RUN-1641] Animation::SetCompositorPending %d", RecordReplayId());
 
   // FIXME: KeyframeEffect could notify this directly?
   if (!HasActiveAnimationsOnCompositor()) {
@@ -2381,7 +2381,7 @@ absl::optional<AnimationTimeDelta> Animation::TimeToEffectChange() {
 
 void Animation::cancel() {
   // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] Animation::cancel %d", RecordReplayId());
+  recordreplay::Assert("[RUN-1641] Animation::cancel %d", RecordReplayId());
 
   AnimationTimeDelta current_time_before_cancel =
       CurrentTimeInternal().value_or(AnimationTimeDelta());

--- a/third_party/blink/renderer/core/animation/animation_timeline.cc
+++ b/third_party/blink/renderer/core/animation/animation_timeline.cc
@@ -198,13 +198,13 @@ Animation* AnimationTimeline::Play(AnimationEffect* child,
 }
 
 void AnimationTimeline::MarkAnimationsCompositorPending(bool source_changed) {
-  recordreplay::Assert("[RUN-966] AnimationTimeline::MarkAnimationsCompositorPending %d", RecordReplayId());
+  recordreplay::Assert("[RUN-1641] AnimationTimeline::MarkAnimationsCompositorPending %d", RecordReplayId());
 
   for (const auto& animation : animations_) {
     animation->SetCompositorPending(source_changed);
   }
 
-  recordreplay::Assert("[RUN-966] AnimationTimeline::MarkAnimationsCompositorPending Done");
+  recordreplay::Assert("[RUN-1641] AnimationTimeline::MarkAnimationsCompositorPending Done");
 }
 
 void AnimationTimeline::MarkPendingIfCompositorPropertyAnimationChanges(

--- a/third_party/blink/renderer/core/animation/css/css_animation_update.h
+++ b/third_party/blink/renderer/core/animation/css/css_animation_update.h
@@ -156,6 +156,8 @@ class CORE_EXPORT CSSAnimationUpdate final {
     suppressed_animations_.insert(animation);
   }
   void UpdateCompositorKeyframes(Animation* animation) {
+    recordreplay::Assert(
+        "[RUN-1641] CSSAnimationUpdate::UpdateCompositorKeyframes %d", animation->RecordReplayId());
     updated_compositor_keyframes_.push_back(animation);
   }
 

--- a/third_party/blink/renderer/core/animation/css/css_animations.cc
+++ b/third_party/blink/renderer/core/animation/css/css_animations.cc
@@ -1285,7 +1285,7 @@ void CSSAnimations::UpdateAnimationFlags(Element& animating_element,
 
 void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
   // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] CSSAnimations::MaybeApplyPendingUpdate %d",
+  recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate %d",
                        element->RecordReplayId());
 
   previous_active_interpolations_for_animations_.clear();
@@ -1353,7 +1353,7 @@ void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
         *running_animations_[cancelled_indices[i]]->animation;
 
     // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] CSSAnimations::MaybeApplyPendingUpdate #5 %d",
+    recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #5 %d",
                          animation.RecordReplayId());
 
     animation.ClearOwningElement();
@@ -1394,7 +1394,7 @@ void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
     Animation* animation = transitions_.Take(property)->animation;
 
     // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] CSSAnimations::MaybeApplyPendingUpdate #10 %d",
+    recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #10 %d",
                          animation->RecordReplayId());
 
     auto* effect = To<KeyframeEffect>(animation->effect());

--- a/third_party/blink/renderer/core/animation/css/css_animations.cc
+++ b/third_party/blink/renderer/core/animation/css/css_animations.cc
@@ -1284,8 +1284,7 @@ void CSSAnimations::UpdateAnimationFlags(Element& animating_element,
 }
 
 void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate %d",
+    recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate %d",
                        element->RecordReplayId());
 
   previous_active_interpolations_for_animations_.clear();
@@ -1352,8 +1351,7 @@ void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
     Animation& animation =
         *running_animations_[cancelled_indices[i]]->animation;
 
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #5 %d",
+        recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #5 %d",
                          animation.RecordReplayId());
 
     animation.ClearOwningElement();
@@ -1393,8 +1391,7 @@ void CSSAnimations::MaybeApplyPendingUpdate(Element* element) {
 
     Animation* animation = transitions_.Take(property)->animation;
 
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #10 %d",
+        recordreplay::Assert("[RUN-1641] CSSAnimations::MaybeApplyPendingUpdate #10 %d",
                          animation->RecordReplayId());
 
     auto* effect = To<KeyframeEffect>(animation->effect());

--- a/third_party/blink/renderer/core/animation/document_timeline.cc
+++ b/third_party/blink/renderer/core/animation/document_timeline.cc
@@ -188,7 +188,7 @@ void DocumentTimeline::PauseAnimationsForTesting(
 }
 
 void DocumentTimeline::SetPlaybackRate(double playback_rate) {
-  recordreplay::Assert("[RUN-966] DocumentTimeline::SetPlaybackRate");
+  recordreplay::Assert("[RUN-1436] DocumentTimeline::SetPlaybackRate");
 
   if (!IsActive())
     return;

--- a/third_party/blink/renderer/core/animation/pending_animations.cc
+++ b/third_party/blink/renderer/core/animation/pending_animations.cc
@@ -41,7 +41,7 @@
 namespace blink {
 
 void PendingAnimations::Add(Animation* animation) {
-  recordreplay::Assert("[RUN-966] PendingAnimations::Add");
+  recordreplay::Assert("[RUN-1641] PendingAnimations::Add");
 
   DCHECK(animation);
   DCHECK_EQ(pending_.Find(animation), kNotFound);

--- a/third_party/blink/renderer/core/dom/container_node.cc
+++ b/third_party/blink/renderer/core/dom/container_node.cc
@@ -1401,7 +1401,7 @@ void ContainerNode::RecalcDescendantStyles(
   StyleRecalcChange local_change = change;
   for (Node* child = firstChild(); child; child = child->nextSibling()) {
     recordreplay::Assert(
-        "[RUN-966] ContainerNode::RecalcDescendantStyles #1 %d",
+        "[RUN-1436] ContainerNode::RecalcDescendantStyles #1 %d",
         child->RecordReplayId());
 
     if (!local_change.TraverseChild(*child))

--- a/third_party/blink/renderer/core/dom/element.cc
+++ b/third_party/blink/renderer/core/dom/element.cc
@@ -5832,7 +5832,7 @@ bool Element::IsBaseElementFocusable() const {
 }
 
 bool Element::IsFocusable() const {
-    recordreplay::Assert("[RUN-966] Element::IsFocusable %d", RecordReplayId());
+    recordreplay::Assert("[RUN-1436] Element::IsFocusable %d", RecordReplayId());
 
   return IsMouseFocusable() || IsKeyboardFocusable();
 }

--- a/third_party/blink/renderer/core/dom/element.cc
+++ b/third_party/blink/renderer/core/dom/element.cc
@@ -5832,8 +5832,7 @@ bool Element::IsBaseElementFocusable() const {
 }
 
 bool Element::IsFocusable() const {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] Element::IsFocusable %d", RecordReplayId());
+    recordreplay::Assert("[RUN-966] Element::IsFocusable %d", RecordReplayId());
 
   return IsMouseFocusable() || IsKeyboardFocusable();
 }

--- a/third_party/blink/renderer/core/dom/events/event_target.cc
+++ b/third_party/blink/renderer/core/dom/events/event_target.cc
@@ -833,10 +833,11 @@ DispatchEventResult EventTarget::FireEventListeners(Event& event) {
 
   bool fired_event_listeners = false;
   recordreplay::Assert(
-      "[RUN-1260] EventTarget::FireEventListeners 2 %d %d %d",
+      "[RUN-1260] EventTarget::FireEventListeners 2 %d %d %d %d %s",
       listeners_vector ? listeners_vector->size() : -1,
       legacy_listeners_vector ? legacy_listeners_vector->size() : -1,
-      event.isTrusted());
+      event.isTrusted(), HasJSBasedEventListeners(event.type()),
+      GetHumanReadableName());
   if (listeners_vector) {
     fired_event_listeners = FireEventListeners(event, d, *listeners_vector);
   } else if (event.isTrusted() && legacy_listeners_vector) {
@@ -980,10 +981,7 @@ void EventTarget::RemoveAllEventListeners() {
   if (!d)
     return;
 
-  if (!recordreplay::AreEventsDisallowed()) {
-    // don't Assert during GC
-    recordreplay::Assert("[RUN-1260-1332] EventTarget::RemoveAllEventListeners");
-  }
+  recordreplay::Assert("[RUN-1260-1332] EventTarget::RemoveAllEventListeners");
 
   d->event_listener_map.Clear();
 

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -1607,8 +1607,7 @@ void LocalFrame::ScheduleVisualUpdateUnlessThrottled() {
   if (ShouldThrottleRendering())
     return;
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LocalFrame::ScheduleVisualUpdateUnlessThrottled #1");
+    recordreplay::Assert("[RUN-966] LocalFrame::ScheduleVisualUpdateUnlessThrottled #1");
 
   GetPage()->Animator().ScheduleVisualUpdate(this);
 }

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -1607,7 +1607,7 @@ void LocalFrame::ScheduleVisualUpdateUnlessThrottled() {
   if (ShouldThrottleRendering())
     return;
 
-    recordreplay::Assert("[RUN-966] LocalFrame::ScheduleVisualUpdateUnlessThrottled #1");
+    recordreplay::Assert("[RUN-1436] LocalFrame::ScheduleVisualUpdateUnlessThrottled #1");
 
   GetPage()->Animator().ScheduleVisualUpdate(this);
 }

--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
@@ -1712,7 +1712,7 @@ void LocalFrameView::SetBaseBackgroundColor(const Color& background_color) {
 
 void LocalFrameView::SetUseColorAdjustBackground(UseColorAdjustBackground use,
                                                  bool color_scheme_changed) {
-    recordreplay::Assert("[RUN-966] LocalFrameView::SetUseColorAdjustBackground %d",
+    recordreplay::Assert("[RUN-1436] LocalFrameView::SetUseColorAdjustBackground %d",
                        recordreplay::PointerId(this));
 
   if (use_color_adjust_background_ == use && !color_scheme_changed)
@@ -2158,7 +2158,7 @@ void LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded() {
   // We need a full lifecycle update to clear pending paint invalidations.
   if (local_frame_root.View()->target_state_ < DocumentLifecycle::kPaintClean ||
       Lifecycle().GetState() >= DocumentLifecycle::kPrePaintClean) {
-        recordreplay::Assert("[RUN-966] LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded #1");
+        recordreplay::Assert("[RUN-1436] LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded #1");
 
     // Schedule visual update to process the paint invalidation in the next
     // cycle.

--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
@@ -3662,7 +3662,7 @@ void LocalFrameView::ServiceScriptedAnimations(base::TimeTicks start_time) {
 
 void LocalFrameView::ScheduleAnimation(base::TimeDelta delay,
                                        base::Location location) {
-  recordreplay::Assert("[RUN-966] LocalFrameView::ScheduleAnimation");
+  recordreplay::Assert("[RUN-1641] LocalFrameView::ScheduleAnimation");
 
   TRACE_EVENT("cc", "LocalFrameView::ScheduleAnimation", "frame", GetFrame(),
               "delay", delay, "location", location);

--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
@@ -1712,8 +1712,7 @@ void LocalFrameView::SetBaseBackgroundColor(const Color& background_color) {
 
 void LocalFrameView::SetUseColorAdjustBackground(UseColorAdjustBackground use,
                                                  bool color_scheme_changed) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LocalFrameView::SetUseColorAdjustBackground %d",
+    recordreplay::Assert("[RUN-966] LocalFrameView::SetUseColorAdjustBackground %d",
                        recordreplay::PointerId(this));
 
   if (use_color_adjust_background_ == use && !color_scheme_changed)
@@ -2159,8 +2158,7 @@ void LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded() {
   // We need a full lifecycle update to clear pending paint invalidations.
   if (local_frame_root.View()->target_state_ < DocumentLifecycle::kPaintClean ||
       Lifecycle().GetState() >= DocumentLifecycle::kPrePaintClean) {
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded #1");
+        recordreplay::Assert("[RUN-966] LocalFrameView::ScheduleVisualUpdateForPaintInvalidationIfNeeded #1");
 
     // Schedule visual update to process the paint invalidation in the next
     // cycle.

--- a/third_party/blink/renderer/core/inspector/devtools_session.cc
+++ b/third_party/blink/renderer/core/inspector/devtools_session.cc
@@ -254,7 +254,7 @@ void DevToolsSession::DidFailProvisionalLoad(LocalFrame* frame) {
 }
 
 void DevToolsSession::DidCommitLoad(LocalFrame* frame, DocumentLoader*) {
-  recordreplay::Assert("[RUN-966] DevToolsSession::DidCommitLoad");
+  recordreplay::Assert("[RUN-1436] DevToolsSession::DidCommitLoad");
 
   for (wtf_size_t i = 0; i < agents_.size(); i++)
     agents_[i]->DidCommitLoadForLocalFrame(frame);

--- a/third_party/blink/renderer/core/inspector/inspector_animation_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_animation_agent.cc
@@ -103,7 +103,7 @@ Response InspectorAnimationAgent::disable() {
 }
 
 void InspectorAnimationAgent::DidCommitLoadForLocalFrame(LocalFrame* frame) {
-  recordreplay::Assert("[RUN-966] InspectorAnimationAgent::DidCommitLoadForLocalFrame");
+  recordreplay::Assert("[RUN-1641] InspectorAnimationAgent::DidCommitLoadForLocalFrame");
 
   if (frame == inspected_frames_->Root()) {
     id_to_animation_.clear();
@@ -231,7 +231,7 @@ Response InspectorAnimationAgent::getPlaybackRate(double* playback_rate) {
 }
 
 Response InspectorAnimationAgent::setPlaybackRate(double playback_rate) {
-  recordreplay::Assert("[RUN-966] InspectorAnimationAgent::setPlaybackRate");
+  recordreplay::Assert("[RUN-1641] InspectorAnimationAgent::setPlaybackRate");
 
   for (LocalFrame* frame : *inspected_frames_)
     frame->GetDocument()->Timeline().SetPlaybackRate(playback_rate);

--- a/third_party/blink/renderer/core/layout/layout_block.cc
+++ b/third_party/blink/renderer/core/layout/layout_block.cc
@@ -229,7 +229,7 @@ static double ComputeSquaredLocalFontSizeScalingFactor(
 
 void LayoutBlock::StyleDidChange(StyleDifference diff,
                                  const ComputedStyle* old_style) {
-    recordreplay::Assert("[RUN-966] LayoutBlock::StyleDidChange %d",
+    recordreplay::Assert("[RUN-1436] LayoutBlock::StyleDidChange %d",
                        RecordReplayId());
 
   NOT_DESTROYED();

--- a/third_party/blink/renderer/core/layout/layout_block.cc
+++ b/third_party/blink/renderer/core/layout/layout_block.cc
@@ -229,8 +229,7 @@ static double ComputeSquaredLocalFontSizeScalingFactor(
 
 void LayoutBlock::StyleDidChange(StyleDifference diff,
                                  const ComputedStyle* old_style) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutBlock::StyleDidChange %d",
+    recordreplay::Assert("[RUN-966] LayoutBlock::StyleDidChange %d",
                        RecordReplayId());
 
   NOT_DESTROYED();

--- a/third_party/blink/renderer/core/layout/layout_object.cc
+++ b/third_party/blink/renderer/core/layout/layout_object.cc
@@ -2504,8 +2504,7 @@ void LayoutObject::SetPseudoElementStyle(
 DISABLE_CFI_PERF
 void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
                             ApplyStyleChanges apply_changes) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetStyle %d %d %d",
+    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle %d %d %d",
                        RecordReplayId(), style_ == style, (int)apply_changes);
 
   NOT_DESTROYED();
@@ -2671,8 +2670,7 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
 #endif
   }
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #9 %d %d %d",
+    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #9 %d %d %d",
                        diff.NeedsPaintInvalidation(),
                        updated_diff.NeedsPaintInvalidation(),
                        IsSVGRoot());
@@ -2682,8 +2680,7 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
       // LayoutSVGRoot::LocalVisualRect() depends on some styles.
       SetShouldDoFullPaintInvalidation();
     } else {
-      // https://linear.app/replay/issue/RUN-966
-      recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #10");
+            recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #10");
 
       // We'll set needing geometry change later if the style change does cause
       // possible layout change or visual overflow change.
@@ -2715,14 +2712,12 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
   }
 
   if (!IsText() && diff.CompositablePaintEffectChanged()) {
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #15");
+        recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #15");
 
     SetShouldDoFullPaintInvalidationWithoutGeometryChange();
   }
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetStyle Done");
+    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle Done");
 }
 
 void LayoutObject::UpdateFirstLineImageObservers(
@@ -4559,8 +4554,7 @@ void LayoutObject::
     return;
   }
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal #1");
+    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal #1");
 
   SetShouldCheckForPaintInvalidationWithoutGeometryChange();
   if (reason == PaintInvalidationReason::kFull) {
@@ -4593,16 +4587,14 @@ void LayoutObject::SetShouldCheckForPaintInvalidation() {
 }
 
 void LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange() {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange %d",
+    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange %d",
                        RecordReplayId());
 
   NOT_DESTROYED();
   if (ShouldCheckForPaintInvalidation())
     return;
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange #1 %d",
+    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange #1 %d",
                        RecordReplayId());
 
   GetFrameView()->ScheduleVisualUpdateForPaintInvalidationIfNeeded();
@@ -4630,8 +4622,7 @@ void LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage() {
   if (MayNeedPaintInvalidationAnimatedBackgroundImage())
     return;
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-1641] LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage #1");
+    recordreplay::Assert("[RUN-1641] LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage #1");
 
   bitfields_.SetMayNeedPaintInvalidationAnimatedBackgroundImage(true);
   SetShouldCheckForPaintInvalidationWithoutGeometryChange();
@@ -4644,8 +4635,7 @@ void LayoutObject::SetShouldDelayFullPaintInvalidation() {
 
   bitfields_.SetShouldDelayFullPaintInvalidation(true);
   if (!ShouldCheckForPaintInvalidation()) {
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDelayFullPaintInvalidation #1");
+        recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDelayFullPaintInvalidation #1");
 
     // This will also schedule a visual update.
     SetShouldCheckForPaintInvalidationWithoutGeometryChange();

--- a/third_party/blink/renderer/core/layout/layout_object.cc
+++ b/third_party/blink/renderer/core/layout/layout_object.cc
@@ -2504,7 +2504,7 @@ void LayoutObject::SetPseudoElementStyle(
 DISABLE_CFI_PERF
 void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
                             ApplyStyleChanges apply_changes) {
-    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle %d %d %d",
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetStyle %d %d %d",
                        RecordReplayId(), style_ == style, (int)apply_changes);
 
   NOT_DESTROYED();
@@ -2670,7 +2670,7 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
 #endif
   }
 
-    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #9 %d %d %d",
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetStyle #9 %d %d %d",
                        diff.NeedsPaintInvalidation(),
                        updated_diff.NeedsPaintInvalidation(),
                        IsSVGRoot());
@@ -2680,7 +2680,7 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
       // LayoutSVGRoot::LocalVisualRect() depends on some styles.
       SetShouldDoFullPaintInvalidation();
     } else {
-            recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #10");
+            recordreplay::Assert("[RUN-1436] LayoutObject::SetStyle #10");
 
       // We'll set needing geometry change later if the style change does cause
       // possible layout change or visual overflow change.
@@ -2712,12 +2712,12 @@ void LayoutObject::SetStyle(scoped_refptr<const ComputedStyle> style,
   }
 
   if (!IsText() && diff.CompositablePaintEffectChanged()) {
-        recordreplay::Assert("[RUN-966] LayoutObject::SetStyle #15");
+        recordreplay::Assert("[RUN-1436] LayoutObject::SetStyle #15");
 
     SetShouldDoFullPaintInvalidationWithoutGeometryChange();
   }
 
-    recordreplay::Assert("[RUN-966] LayoutObject::SetStyle Done");
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetStyle Done");
 }
 
 void LayoutObject::UpdateFirstLineImageObservers(
@@ -4554,7 +4554,7 @@ void LayoutObject::
     return;
   }
 
-    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal #1");
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetShouldDoFullPaintInvalidationWithoutGeometryChangeInternal #1");
 
   SetShouldCheckForPaintInvalidationWithoutGeometryChange();
   if (reason == PaintInvalidationReason::kFull) {
@@ -4587,14 +4587,14 @@ void LayoutObject::SetShouldCheckForPaintInvalidation() {
 }
 
 void LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange() {
-    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange %d",
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange %d",
                        RecordReplayId());
 
   NOT_DESTROYED();
   if (ShouldCheckForPaintInvalidation())
     return;
 
-    recordreplay::Assert("[RUN-966] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange #1 %d",
+    recordreplay::Assert("[RUN-1436] LayoutObject::SetShouldCheckForPaintInvalidationWithoutGeometryChange #1 %d",
                        RecordReplayId());
 
   GetFrameView()->ScheduleVisualUpdateForPaintInvalidationIfNeeded();
@@ -4635,7 +4635,7 @@ void LayoutObject::SetShouldDelayFullPaintInvalidation() {
 
   bitfields_.SetShouldDelayFullPaintInvalidation(true);
   if (!ShouldCheckForPaintInvalidation()) {
-        recordreplay::Assert("[RUN-966] LayoutObject::SetShouldDelayFullPaintInvalidation #1");
+        recordreplay::Assert("[RUN-1436] LayoutObject::SetShouldDelayFullPaintInvalidation #1");
 
     // This will also schedule a visual update.
     SetShouldCheckForPaintInvalidationWithoutGeometryChange();

--- a/third_party/blink/renderer/core/layout/layout_object.cc
+++ b/third_party/blink/renderer/core/layout/layout_object.cc
@@ -4631,7 +4631,7 @@ void LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage() {
     return;
 
   // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage #1");
+  recordreplay::Assert("[RUN-1641] LayoutObject::SetMayNeedPaintInvalidationAnimatedBackgroundImage #1");
 
   bitfields_.SetMayNeedPaintInvalidationAnimatedBackgroundImage(true);
   SetShouldCheckForPaintInvalidationWithoutGeometryChange();

--- a/third_party/blink/renderer/core/layout/layout_object_hot.cc
+++ b/third_party/blink/renderer/core/layout/layout_object_hot.cc
@@ -136,7 +136,7 @@ void LayoutObject::SetNeedsOverflowRecalc(
 }
 
 void LayoutObject::PropagateStyleToAnonymousChildren() {
-    recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren %d",
+    recordreplay::Assert("[RUN-1436] LayoutObject::PropagateStyleToAnonymousChildren %d",
                        RecordReplayId());
 
   NOT_DESTROYED();
@@ -144,7 +144,7 @@ void LayoutObject::PropagateStyleToAnonymousChildren() {
   // properties.
   for (LayoutObject* child = SlowFirstChild(); child;
        child = child->NextSibling()) {
-        recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren #1 %d",
+        recordreplay::Assert("[RUN-1436] LayoutObject::PropagateStyleToAnonymousChildren #1 %d",
                          child->RecordReplayId());
 
     if (!child->IsAnonymous() || child->StyleRef().StyleType() != kPseudoIdNone)

--- a/third_party/blink/renderer/core/layout/layout_object_hot.cc
+++ b/third_party/blink/renderer/core/layout/layout_object_hot.cc
@@ -136,8 +136,7 @@ void LayoutObject::SetNeedsOverflowRecalc(
 }
 
 void LayoutObject::PropagateStyleToAnonymousChildren() {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren %d",
+    recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren %d",
                        RecordReplayId());
 
   NOT_DESTROYED();
@@ -145,8 +144,7 @@ void LayoutObject::PropagateStyleToAnonymousChildren() {
   // properties.
   for (LayoutObject* child = SlowFirstChild(); child;
        child = child->NextSibling()) {
-    // https://linear.app/replay/issue/RUN-966
-    recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren #1 %d",
+        recordreplay::Assert("[RUN-966] LayoutObject::PropagateStyleToAnonymousChildren #1 %d",
                          child->RecordReplayId());
 
     if (!child->IsAnonymous() || child->StyleRef().StyleType() != kPseudoIdNone)

--- a/third_party/blink/renderer/core/loader/document_loader.cc
+++ b/third_party/blink/renderer/core/loader/document_loader.cc
@@ -1886,7 +1886,7 @@ void DocumentLoader::WillCommitNavigation() {
 }
 
 void DocumentLoader::DidCommitNavigation() {
-  recordreplay::Assert("[RUN-966] DocumentLoader::DidCommitNavigation");
+  recordreplay::Assert("[RUN-1436] DocumentLoader::DidCommitNavigation");
 
   if (commit_reason_ != CommitReason::kRegular)
     return;
@@ -1926,7 +1926,7 @@ void DocumentLoader::DidCommitNavigation() {
   DEVTOOLS_TIMELINE_TRACE_EVENT("CommitLoad", inspector_commit_load_event::Data,
                                 frame_);
 
-  recordreplay::Assert("[RUN-966] DocumentLoader::DidCommitNavigation #1");
+  recordreplay::Assert("[RUN-1436] DocumentLoader::DidCommitNavigation #1");
 
   // Needs to run before dispatching preloads, as it may evict the memory cache.
   probe::DidCommitLoad(frame_, this);

--- a/third_party/blink/renderer/core/loader/resource/image_resource.cc
+++ b/third_party/blink/renderer/core/loader/resource/image_resource.cc
@@ -517,8 +517,7 @@ void ImageResource::UpdateImage(
                                           update_image_option,
                                           all_data_received, is_multipart);
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("ImageResource::UpdateImage #1 %d", (int)result);
+    recordreplay::Assert("[RUN-1436] ImageResource::UpdateImage #1 %d", (int)result);
 
   if (result == ImageResourceContent::UpdateImageResult::kShouldDecodeError) {
     // In case of decode error, we call imageNotifyFinished() iff we don't

--- a/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -502,8 +502,7 @@ void ChromeClientImpl::InvalidateContainer() {
 
 void ChromeClientImpl::ScheduleAnimation(const LocalFrameView* frame_view,
                                          base::TimeDelta delay) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-1641] ChromeClientImpl::ScheduleAnimation");
+    recordreplay::Assert("[RUN-1641] ChromeClientImpl::ScheduleAnimation");
 
   LocalFrame& frame = frame_view->GetFrame();
   // If the frame is still being created, it might not yet have a WebWidget.

--- a/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -503,7 +503,7 @@ void ChromeClientImpl::InvalidateContainer() {
 void ChromeClientImpl::ScheduleAnimation(const LocalFrameView* frame_view,
                                          base::TimeDelta delay) {
   // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] ChromeClientImpl::ScheduleAnimation");
+  recordreplay::Assert("[RUN-1641] ChromeClientImpl::ScheduleAnimation");
 
   LocalFrame& frame = frame_view->GetFrame();
   // If the frame is still being created, it might not yet have a WebWidget.

--- a/third_party/blink/renderer/core/page/page_animator.cc
+++ b/third_party/blink/renderer/core/page/page_animator.cc
@@ -144,8 +144,7 @@ void PageAnimator::SetHasSharedElementTransition(
 
 DISABLE_CFI_PERF
 void PageAnimator::ScheduleVisualUpdate(LocalFrame* frame) {
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-1641] PageAnimator::ScheduleVisualUpdate %d %d %d",
+    recordreplay::Assert("[RUN-1641] PageAnimator::ScheduleVisualUpdate %d %d %d",
                        servicing_animations_, updating_layout_and_style_for_painting_,
                        suppress_frame_requests_workaround_for704763_only_);
 

--- a/third_party/blink/renderer/core/page/page_animator.cc
+++ b/third_party/blink/renderer/core/page/page_animator.cc
@@ -145,7 +145,7 @@ void PageAnimator::SetHasSharedElementTransition(
 DISABLE_CFI_PERF
 void PageAnimator::ScheduleVisualUpdate(LocalFrame* frame) {
   // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] PageAnimator::ScheduleVisualUpdate %d %d %d",
+  recordreplay::Assert("[RUN-1641] PageAnimator::ScheduleVisualUpdate %d %d %d",
                        servicing_animations_, updating_layout_and_style_for_painting_,
                        suppress_frame_requests_workaround_for704763_only_);
 

--- a/third_party/blink/renderer/core/page/scrolling/element_fragment_anchor.cc
+++ b/third_party/blink/renderer/core/page/scrolling/element_fragment_anchor.cc
@@ -133,7 +133,7 @@ bool ElementFragmentAnchor::Invoke() {
 void ElementFragmentAnchor::Installed() {
   DCHECK(frame_->GetDocument());
 
-    recordreplay::Assert("[RUN-966] ElementFragmentAnchor::Installed");
+    recordreplay::Assert("[RUN-1436] ElementFragmentAnchor::Installed");
 
   // If rendering isn't ready yet, we'll focus and scroll as part of the
   // document lifecycle.

--- a/third_party/blink/renderer/core/page/scrolling/element_fragment_anchor.cc
+++ b/third_party/blink/renderer/core/page/scrolling/element_fragment_anchor.cc
@@ -133,8 +133,7 @@ bool ElementFragmentAnchor::Invoke() {
 void ElementFragmentAnchor::Installed() {
   DCHECK(frame_->GetDocument());
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("[RUN-966] ElementFragmentAnchor::Installed");
+    recordreplay::Assert("[RUN-966] ElementFragmentAnchor::Installed");
 
   // If rendering isn't ready yet, we'll focus and scroll as part of the
   // document lifecycle.

--- a/third_party/blink/renderer/core/style/style_difference.h
+++ b/third_party/blink/renderer/core/style/style_difference.h
@@ -80,7 +80,7 @@ class StyleDifference {
 
   bool NeedsPaintInvalidation() const { return needs_paint_invalidation_; }
   void SetNeedsPaintInvalidation() {
-    recordreplay::Assert("[RUN-966] StyleDifference::SetNeedsPaintInvalidation");
+    recordreplay::Assert("[RUN-1436] StyleDifference::SetNeedsPaintInvalidation");
     needs_paint_invalidation_ = true;
   }
 

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
@@ -1269,8 +1269,7 @@ void ResourceLoader::DidStartLoadingResponseBody(
 void ResourceLoader::DidReceiveData(const char* data, int length) {
   CHECK_GE(length, 0);
 
-  // https://linear.app/replay/issue/RUN-966
-  recordreplay::Assert("ResourceLoader::DidReceiveData %d", length);
+  recordreplay::Assert("[RUN-1436] ResourceLoader::DidReceiveData %d", length);
 
   if (PermitRecordReplayBrowserEvents()) {
     base::DictionaryValue dict;

--- a/third_party/blink/renderer/platform/scheduler/common/throttling/budget_pool.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/throttling/budget_pool.cc
@@ -52,7 +52,7 @@ void BudgetPool::UnregisterThrottler(TaskQueueThrottler* throttler) {
 void BudgetPool::RemoveThrottler(base::TimeTicks now,
                                  TaskQueueThrottler* throttler) {
   if (!recordreplay::AreEventsDisallowed()) {
-    recordreplay::Assert("[RUN-966] BudgetPool::RemoveThrottler %d %d",
+    recordreplay::Assert("[RUN-1436] BudgetPool::RemoveThrottler %d %d",
                          recordreplay::PointerId(this),
                          recordreplay::PointerId(throttler));
   }

--- a/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/frame_scheduler_impl.cc
@@ -265,7 +265,7 @@ void FrameSchedulerImpl::RemoveThrottleableQueueFromBudgetPools(
 }
 
 void FrameSchedulerImpl::MoveTaskQueuesToCorrectWakeUpBudgetPool() {
-  recordreplay::Assert("[RUN-966] FrameSchedulerImpl::MoveTaskQueuesToCorrectWakeUpBudgetPool");
+  recordreplay::Assert("[RUN-1436] FrameSchedulerImpl::MoveTaskQueuesToCorrectWakeUpBudgetPool");
 
   base::LazyNow lazy_now(main_thread_scheduler_->GetTickClock());
 

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
@@ -212,7 +212,7 @@ PageSchedulerImpl::~PageSchedulerImpl() {
 constexpr base::TimeDelta PageSchedulerImpl::kRecentAudioDelay;
 
 void PageSchedulerImpl::SetPageVisible(bool page_visible) {
-  recordreplay::Assert("[RUN-966] PageSchedulerImpl::SetPageVisible %d", page_visible);
+  recordreplay::Assert("[RUN-1436] PageSchedulerImpl::SetPageVisible %d", page_visible);
 
   PageVisibilityState page_visibility = page_visible
                                             ? PageVisibilityState::kVisible


### PR DESCRIPTION
Move `Assert`s to new issues. 3 goals:
* Make RUN-966 disappear from triage
* Clean up
* Improve focus by splitting things up

https://linear.app/replay/issue/RUN-966#comment-32e2f3dc