### PR TITLE
Append -buildkite to build ids from buildkite builds (for now.)

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,13 +80,16 @@ let driverString = "";
 for (let i = 0; i < driverContents.length; i++) {
   driverString += `\\${driverContents[i].toString(8)}`;
 }
+
+const buildkiteSuffix = process.env.BUILDKITE ? "-buildkite" : "";
+
 fs.writeFileSync(
   `${__dirname}/base/record_replay_driver.cc`,
   `
 namespace recordreplay {
   char gRecordReplayDriver[] = "${driverString}";
   int gRecordReplayDriverSize = ${driverContents.length};
-  char gBuildId[] = "${computeBuildId(driverDate, driverRevision)}";
+  char gBuildId[] = "${computeBuildId(driverDate, driverRevision)}${buildkiteSuffix}";
 }
 `
 );

--- a/build.js
+++ b/build.js
@@ -81,7 +81,8 @@ for (let i = 0; i < driverContents.length; i++) {
   driverString += `\\${driverContents[i].toString(8)}`;
 }
 
-const buildkiteSuffix = process.env.BUILDKITE ? "-buildkite" : "";
+const buildkiteSuffix = process.env["BUILDKITE"] ? "-buildkite" : "";
+const buildId = `${computeBuildId(driverDate, driverRevision)}${buildkiteSuffix}`;
 
 fs.writeFileSync(
   `${__dirname}/base/record_replay_driver.cc`,
@@ -89,12 +90,11 @@ fs.writeFileSync(
 namespace recordreplay {
   char gRecordReplayDriver[] = "${driverString}";
   int gRecordReplayDriverSize = ${driverContents.length};
-  char gBuildId[] = "${computeBuildId(driverDate, driverRevision)}${buildkiteSuffix}";
+  char gBuildId[] = "${buildId}";
 }
 `
 );
 
-console.log(`Preparing...`);
 const useGoma = !process.env.NO_GOMA;
 const goma_ctl = currentPlatform() == "windows" ? "goma_ctl.bat" : "goma_ctl";
 if (useGoma) {

--- a/buildLinux.js
+++ b/buildLinux.js
@@ -22,6 +22,8 @@ syncRepo(path.join(chromium, "third_party", "boringssl", "src"), deps.boringssl)
 const dockerArgs = [
   "run",
   "-e",
+  "BUILDKITE",
+  "-e",
   "GOMA_SERVER_HOST=simpsonite.goma.engflow.com",
   "-e",
   "GOMACTL_USE_PROXY=false",

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -265,14 +265,14 @@ async function buildChromiumSymbols(options) {
   }
 
   await buildSymbolsArchive(
-    buildId,
+    `${buildId}-buildkite`,
     path.join("out", "Release"),
     libraries,
     pdbs
   );
 
   log(`ChromiumSymbols Done`);
-  return buildId;
+  return `${buildId}-buildkite`;
 }
 
 

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -265,14 +265,14 @@ async function buildChromiumSymbols(options) {
   }
 
   await buildSymbolsArchive(
-    `${buildId}-buildkite`,
+    `${buildId}`,
     path.join("out", "Release"),
     libraries,
     pdbs
   );
 
   log(`ChromiumSymbols Done`);
-  return `${buildId}-buildkite`;
+  return `${buildId}`;
 }
 
 
@@ -357,7 +357,7 @@ function computeBuildId(
       ? runtimeDate
       : driverDate;
 
-  return `${currentPlatform()}-${runtimeName}-${date}-${runtimeRevision}-${driverRevision}`;
+  return `${currentPlatform()}-${runtimeName}-${date}-${runtimeRevision}-${driverRevision}-buildkite`;
 }
 
 async function buildSymbolsArchive(


### PR DESCRIPTION
We're clobbering the old build/test builds, which has caused confusion when diagnosing a bad build-related issue.