### PR TITLE
Assert values in AudioDeviceThread::ThreadMain socket loop.

### DIFF
--- a/media/audio/audio_device_thread.cc
+++ b/media/audio/audio_device_thread.cc
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "base/check_op.h"
+#include "base/record_replay.h"
 #include "base/system/sys_info.h"
 #include "build/build_config.h"
 
@@ -78,10 +79,19 @@ void AudioDeviceThread::ThreadMain() {
   base::PlatformThread::SetName(thread_name_);
   callback_->InitializeOnAudioThread();
 
+  uint32_t record_replay_iteration_idx = 0;
   uint32_t buffer_index = 0;
   while (true) {
     uint32_t pending_data = 0;
     size_t bytes_read = socket_.Receive(&pending_data, sizeof(pending_data));
+    recordreplay::Assert(
+      "[RUN-1667-1674] AudioDeviceThread::ThreadMain %u %u %u %u",
+      (unsigned) record_replay_iteration_idx,
+      (unsigned) buffer_index,
+      (unsigned) pending_data,
+      (unsigned) bytes_read
+    );
+    record_replay_iteration_idx++;
     if (bytes_read != sizeof(pending_data))
       break;
 


### PR DESCRIPTION
For RUN-1674 https://linear.app/replay/issue/RUN-1674/assert-values-in-audiodevicethreadthreadmain-socket-loop

Bucket issue RUN-1667.