### PR TITLE
RUN-1335: Clear idle request callbacks upon Document::Shutdown

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'c51ba72b9c2da8890b8d43302d837e2a52763a60',
+  'v8_revision': 'd18dfa4f16f688741239ba7b5131d52377e9916e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd18dfa4f16f688741239ba7b5131d52377e9916e',
+  'v8_revision': 'f0b68e13e478fb9f2b6fd4aaff5e1925e51a9eee',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -2905,7 +2905,7 @@ void Document::Shutdown() {
 
   probe::DocumentDetached(this);
 
-  if (scripted_idle_task_controller_) {
+  if (recordreplay::IsRecordingOrReplaying("clear-idle-callbacks") && scripted_idle_task_controller_) {
     // [RUN-1335] We might have queued idle tasks, but the page got shutdown. Get rid of them!
     scripted_idle_task_controller_->ClearCallbacks();
   }

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -2905,11 +2905,9 @@ void Document::Shutdown() {
 
   probe::DocumentDetached(this);
 
-  if (scripted_idle_task_controller_ && scripted_idle_task_controller_->IdleTaskCount()) {
-    // We have queued idle tasks, but the page got shutdown.
-    // This situation is always discerning and likely to cause divergences, no matter if `EventsDisallowed` or not.
-    recordreplay::Assert("[RUN-1335-1485] Document::Shutdown IdleTaskCount=%u",
-                         scripted_idle_task_controller_->IdleTaskCount());
+  if (scripted_idle_task_controller_) {
+    // [RUN-1335] We might have queued idle tasks, but the page got shutdown. Get rid of them!
+    scripted_idle_task_controller_->ClearCallbacks();
   }
   scripted_idle_task_controller_.Clear();
 

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
@@ -100,8 +100,8 @@ class CORE_EXPORT ScriptedIdleTaskController
                      base::TimeTicks deadline,
                      IdleDeadline::CallbackType);
 
-  // [RUN-1485] Allow asserting on idle task count.
-  unsigned IdleTaskCount() const { return idle_tasks_.size(); }
+  // [RUN-1335] Allow clearing callbacks upon |Document::Shutdown|.
+  void ClearCallbacks() { idle_tasks_.clear(); }
 
  private:
   friend class internal::IdleRequestCallbackWrapper;


### PR DESCRIPTION
Paired w/ https://github.com/replayio/chromium-v8/pull/125
* Prevent executing idle task callbacks after `Document::Shutdown`.
* https://linear.app/replay/issue/RUN-1335#comment-6a4cbb7b