### PR TITLE
RUN-1644: fix getObjectPreview to not accidentally call into user JS

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1083,6 +1083,9 @@ ProtocolObjectPreview.prototype = {
     if (!this.startAddItem(force)) {
       return;
     }
+    if (!this.getterValues) {
+      this.getterValues = new Map();
+    }
     this.getterValues.set(key, { name: key, ...valueObject });
   },
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -26,13 +26,13 @@
 #include "third_party/blink/renderer/core/inspector/inspector_css_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_dom_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h"
-#include "third_party/blink/renderer/core/inspector/inspector_dom_debugger_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_network_agent.h"
 #include "third_party/blink/renderer/core/inspector/inspector_resource_container.h"
 #include "third_party/blink/renderer/core/inspector/inspector_resource_content_loader.h"
 #include "third_party/blink/renderer/core/inspector/resolve_node.h"
 #include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
 #include "third_party/blink/renderer/platform/bindings/v8_binding.h"
+#include "third_party/blink/renderer/platform/bindings/v8_dom_wrapper.h"
 #include "third_party/inspector_protocol/crdtp/maybe.h"
 #include "v8/include/v8-inspector.h"
 
@@ -98,6 +98,7 @@ const {
   fromJsMakeDebuggeeValue,
   fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
+  fromJsIsNativeObject,
   fromJsGetNodeId,
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForNode,
@@ -561,39 +562,15 @@ function Graphics_getDevicePixelRatio() {
 // Utilities
 ///////////////////////////////////////////////////////////////////////////////
 
-/**
- * NOTE: this is not a guarantee, since `toString()` can be overridden.
- * NOTE2: v8 debugger has `CalculateNativeAccessorFlags` but is expensive and cached and annoying.
- */
-function isProbablyNativeFunction(f) {
-  return isNativeFunctionDescription(f.toString());
-}
-
-function isNativeFunctionDescription(functionString) {
-  return functionString?.endsWith('() { [native code] }') || false;
-}
-
 function isPrototype(x) {
   return x === x?.constructor?.prototype;
 }
 
-
 /**
- * Check whether given object `x` has what looks like a native ctor.
+ * Check whether given object `x` is a native object.
  */
-function isProbablyInstanceOfNativeClass(x) {
-  // hackfix: check if its ctor has a native toString
-  try {
-    return x?.constructor &&
-      // avoid false positives for prototypes (see https://linear.app/replay/issue/RUN-1067)
-      x.constructor === x.__proto__?.constructor &&
-      isProbablyNativeFunction(x.constructor);
-  }
-  catch (err) {
-    // Note: there can be some errors here, e.g.:
-    // "Error: Blocked a frame with origin ... from accessing a cross-origin frame."
-    log(`[RuntimeError] isProbablyInstanceOfNativeClass err: ${err?.stack || err}`);
-  }
+function isNativeObject(x) {
+  return fromJsIsNativeObject(x);
 }
 
 /**
@@ -601,23 +578,21 @@ function isProbablyInstanceOfNativeClass(x) {
  * is not a plain object or array.
  * @see https://linear.app/replay/issue/RUN-1592#comment-4011cec0
  */
-function isProbablyInstanceOfSpecificNativeClass(plainObject, cdpObj) {
-  return isProbablyInstanceOfNativeClass(plainObject) && 
+function isBlinkObject(plainObject, cdpObj) {
+  return isNativeObject(plainObject) && 
     cdpObj.subtype !== 'array' &&
     cdpObj.subtype !== 'typedarray' &&
     cdpObj.className !== 'Object';
 }
 
 /**
- * Check whether given object `x` is instance of class of given `target.name`,
- * and also has what looks like a native ctor.
+ * Check whether given object `x` is native object and its 
+ * class name is `target.name`.
  */
 function isInstanceOfNative(x, target) {
-  // hackfix: check if its native, and has `name` in inheritance chain
-  const name = target?.name;
-  return name &&
-    isProbablyInstanceOfNativeClass(x) &&
-    hasInProtoChain(x.constructor, name);
+  return isNativeObject(x) &&
+    target?.name &&
+    hasInProtoChain(x.constructor, target.name);
 }
 
 /**
@@ -1137,7 +1112,7 @@ ProtocolObjectPreview.prototype = {
   get pageIndex() { return 0; },
 
   get pageSize() {
-    if (isProbablyInstanceOfSpecificNativeClass(this.raw, this.cdpObj)) {
+    if (isBlinkObject(this.raw, this.cdpObj)) {
       // Don't limit native objects because in gecko, we add all native getters,
       // independent of prop limits.
       return 0;
@@ -3317,17 +3292,9 @@ extern "C" void V8RecordReplayFinishRecording();
 // associated with a given API object.
 static int GetAPIObjectIdCallback(v8::Local<v8::Object> object) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  const WrapperTypeInfo* infos[] = {
-    // ScriptWrappable itself doesn't have wrapper type info, so check subclasses.
-    Node::GetStaticWrapperTypeInfo(),
-    Event::GetStaticWrapperTypeInfo(),
-    CSSStyleDeclaration::GetStaticWrapperTypeInfo()
-  };
-  for (const WrapperTypeInfo* info : infos) {
-    if (V8PerIsolateData::From(isolate)->HasInstance(info, object)) {
-      ScriptWrappable* wrappable = ToScriptWrappable(object);
-      return wrappable->RecordReplayId();
-    }
+  if (V8DOMWrapper::IsWrapper(isolate, object)) {
+    ScriptWrappable* wrappable = ToScriptWrappable(object);
+    return wrappable->RecordReplayId();
   }
   return 0;
 }
@@ -3661,6 +3628,26 @@ static void fromJsGetObjectByCdpId(
   } else {
     args.GetReturnValue().SetNull();
   }
+}
+
+/**
+ * Whether a given value is a native object.
+ * 
+ * WARNING: We currently don't have a general solution to this.
+ * This effectively only checks whether the given value is a **blink** object.
+ * If we want to generalize, we probably have to expose |v8::internal::Script::type|,
+ * which is also used by |CallSiteInfo::IsNative| for that purpose.
+ */
+static void fromJsIsNativeObject(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && 
+        "[RuntimeError] must be called with a single value");
+
+  v8::Isolate* isolate = args.GetIsolate();
+  
+  bool result = V8DOMWrapper::IsWrapper(isolate, args[0]);
+  
+  args.GetReturnValue().Set(result);
 }
 
 /** ###########################################################################
@@ -4508,13 +4495,15 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "setCommandCallback",
                       v8::FunctionCallbackRecordReplaySetCommandCallback);
 
-  // Object Management
+  // Object Util
   SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
                       fromJsMakeDebuggeeValue);
   SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
                       fromJsGetArgumentsInFrame);
   SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
                       fromJsGetObjectByCdpId);
+  SetFunctionProperty(isolate, args, "fromJsIsNativeObject",
+                      fromJsIsNativeObject);
 
   // networking
   SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -98,7 +98,7 @@ const {
   fromJsMakeDebuggeeValue,
   fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
-  fromJsIsNativeObject,
+  fromJsIsBlinkObject,
   fromJsGetNodeId,
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForNode,
@@ -569,28 +569,16 @@ function isPrototype(x) {
 /**
  * Check whether given object `x` is a native object.
  */
-function isNativeObject(x) {
-  return fromJsIsNativeObject(x);
+function isBlinkObject(x) {
+  return fromJsIsBlinkObject(x);
 }
 
 /**
- * Check whether the object has what looks like a native ctor and
- * is not a plain object or array.
- * @see https://linear.app/replay/issue/RUN-1592#comment-4011cec0
- */
-function isBlinkObject(plainObject, cdpObj) {
-  return isNativeObject(plainObject) && 
-    cdpObj.subtype !== 'array' &&
-    cdpObj.subtype !== 'typedarray' &&
-    cdpObj.className !== 'Object';
-}
-
-/**
- * Check whether given object `x` is native object and its 
+ * Check whether given object `x` is a blink object and its 
  * class name is `target.name`.
  */
-function isInstanceOfNative(x, target) {
-  return isNativeObject(x) &&
+function isBlinkInstanceOf(x, target) {
+  return isBlinkObject(x) &&
     target?.name &&
     hasInProtoChain(x.constructor, target.name);
 }
@@ -1112,9 +1100,9 @@ ProtocolObjectPreview.prototype = {
   get pageIndex() { return 0; },
 
   get pageSize() {
-    if (isBlinkObject(this.raw, this.cdpObj)) {
-      // Don't limit native objects because in gecko, we add all native getters,
-      // independent of prop limits.
+    if (isBlinkObject(this.raw, this.cdpObj) || CustomPreviewers[this.cdpObj.className]) {
+      // Don't limit props of native objects, and ignore prop limits.
+      // (Because that is how we do it in gecko.)
       return 0;
     }
     return MaxItems[this.level] || 10;
@@ -1156,8 +1144,12 @@ ProtocolObjectPreview.prototype = {
             entry.call(this, cdpProperties);
           }
           else {
-            // entry should be string
-            this.addGetterValue(entry, this.cdpObj, /* force */ true);
+            // entry should be string -> Look it up in results
+            const cdpEntry = cdpProperties.result.find(prop => prop.name === entry);
+            if (cdpEntry) {
+              const rrpEntry = buildRrpObjectFromCdpObject(cdpEntry);
+              this.setGetterValue(entry, rrpEntry);
+            }
           }
         }
       }
@@ -1230,13 +1222,13 @@ function previewBlinkObject(cdpObject, cdpProperties) {
   assert(rrpId);
   const plainObject = getPlainObjectByRrpId(rrpId);
 
-  if (isInstanceOfNative(plainObject, Node)) {
+  if (isBlinkInstanceOf(plainObject, Node)) {
     return {
       node: previewBlinkNode(plainObject)
     }
   }
 
-  if (isInstanceOfNative(plainObject, CSSStyleDeclaration)) {
+  if (isBlinkInstanceOf(plainObject, CSSStyleDeclaration)) {
     return {
       style: previewBlinkStyle(plainObject)
     }
@@ -1245,7 +1237,7 @@ function previewBlinkObject(cdpObject, cdpProperties) {
 
 function previewBlinkNode(node) {
   let attributes, pseudoType;
-  if (isInstanceOfNative(node, Element)) {
+  if (isBlinkInstanceOf(node, Element)) {
     attributes = [];
     for (const { name, value } of node.attributes) {
       attributes.push({ name, value });
@@ -1840,7 +1832,7 @@ function CSS_getComputedStyle({ node }) {
   const nodeObj = getPlainObjectByRrpId(node);
 
   const computedStyle = [];
-  if (isInstanceOfNative(nodeObj, Element)) {
+  if (isBlinkInstanceOf(nodeObj, Element)) {
     // NOTE: tested successfully for same-CSP elements of different iframes
     const ownerGlobal = window;
 
@@ -2114,7 +2106,7 @@ function CSS_getAppliedRules({ node: nodeRrpId }) {
   let rules = gCssRulesByNodeRrpId.get(nodeRrpId);
   const data = {};
 
-  if (!rules && isInstanceOfNative(nodeObj, Element)) {
+  if (!rules && isBlinkInstanceOf(nodeObj, Element)) {
     const nodeId = getBlinkNodeIdByRrpId(nodeRrpId);
 
     // NOTE: CSS domain commands are not accessible via `sendMessage`, so we have to get the data indirectly.
@@ -3631,14 +3623,13 @@ static void fromJsGetObjectByCdpId(
 }
 
 /**
- * Whether a given value is a native object.
+ * Whether a given value is a blink object.
  * 
- * WARNING: We currently don't have a general solution to this.
- * This effectively only checks whether the given value is a **blink** object.
- * If we want to generalize, we probably have to expose |v8::internal::Script::type|,
- * which is also used by |CallSiteInfo::IsNative| for that purpose.
+ * NOTE: If we want a generalized |isNativeObject| function, 
+ * we probably have to expose |v8::internal::Script::type|
+ * (which is also used by |CallSiteInfo::IsNative|).
  */
-static void fromJsIsNativeObject(
+static void fromJsIsBlinkObject(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && 
         "[RuntimeError] must be called with a single value");
@@ -4502,8 +4493,8 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
                       fromJsGetArgumentsInFrame);
   SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
                       fromJsGetObjectByCdpId);
-  SetFunctionProperty(isolate, args, "fromJsIsNativeObject",
-                      fromJsIsNativeObject);
+  SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
+                      fromJsIsBlinkObject);
 
   // networking
   SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1644/fix-getobjectpreview-to-not-accidentally-call-into-user-js
* New CI tests are passing ✔
  * I also checked manually that all kinds of objects, including POD, blink and native objects show props correctly ✔