### PR TITLE
RUN-1680: prevent cross-origin errors (+ RUN-1682)

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -392,6 +392,14 @@ int NewIdAnyThread(const char* name) {
   return 0;
 }
 
+bool AllowCrossDomainAccesses() {
+  // Allow cross-origin accesses from the replaying script installed to inspect
+  // DOM state. Events are disallowed when running replaying specific scripts.
+  // FIXME Use a separate API for this https://linear.app/replay/issue/RUN-1502
+  return IsReplaying() && AreEventsDisallowed();
+}
+
+
 void RecordReplayString(const char* why, std::string& str) {
   size_t length = RecordReplayValue(why, str.length());
   str.resize(length);

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -404,7 +404,7 @@ int NewIdAnyThread(const char* name) {
   return 0;
 }
 
-bool AllowCrossDomainAccesses() {
+bool IsInReplayCode() {
   // Allow cross-origin accesses from the replaying script installed to inspect
   // DOM state. Events are disallowed when running replaying specific scripts.
   // FIXME Use a separate API for this https://linear.app/replay/issue/RUN-1502

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -48,6 +48,9 @@ namespace recordreplay {
   Macro(V8RecordReplayDiagnosticVA,                                     \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
+  Macro(V8RecordReplayWarning,                                          \
+        (const char* format, va_list args),                             \
+        (format, args))                                                 \
   Macro(V8RecordReplayBytes,                                            \
         (const char* why, void* buf, size_t size),                      \
         (why, buf, size))                                               \
@@ -185,6 +188,15 @@ void Diagnostic(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   V8RecordReplayDiagnosticVA(format, ap);
+  va_end(ap);
+#endif
+}
+
+void Warning(const char* format, ...) {
+#ifndef NACL_TC_REV
+  va_list ap;
+  va_start(ap, format);
+  V8RecordReplayWarning(format, ap);
   va_end(ap);
 #endif
 }

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -28,6 +28,7 @@ char* GetRecordingId();
 
 void Print(const char* format, ...);
 void Diagnostic(const char* format, ...);
+void Warning(const char* format, ...);
 void Assert(const char* format, ...);
 void AssertBytes(const char* why, const void* buf, size_t size);
 

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -97,7 +97,7 @@ void OnNavigationEvent(const char* kind, const char* url);
 int NewIdMainThread(const char* name);
 int NewIdAnyThread(const char* name);
 
-
+bool AllowCrossDomainAccesses();
 
 // stl comparator that uses pointer IDs to compare elements when recording/replaying,
 // giving a deterministic sort order.

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -98,7 +98,7 @@ void OnNavigationEvent(const char* kind, const char* url);
 int NewIdMainThread(const char* name);
 int NewIdAnyThread(const char* name);
 
-bool AllowCrossDomainAccesses();
+bool IsInReplayCode();
 
 // stl comparator that uses pointer IDs to compare elements when recording/replaying,
 // giving a deterministic sort order.

--- a/third_party/blink/renderer/bindings/core/v8/binding_security.cc
+++ b/third_party/blink/renderer/bindings/core/v8/binding_security.cc
@@ -114,13 +114,6 @@ void ReportOrThrowSecurityError(
   }
 }
 
-static bool RecordReplayAllowCrossDomainAccesses() {
-  // Allow cross-origin accesses from the replaying script installed to inspect
-  // DOM state. Events are disallowed when running replaying specific scripts.
-  // FIXME Use a separate API for this https://linear.app/replay/issue/RUN-1502
-  return recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed();
-}
-
 bool CanAccessWindowInternal(
     const LocalDOMWindow* accessing_window,
     const DOMWindow* target_window,
@@ -130,7 +123,7 @@ bool CanAccessWindowInternal(
   DCHECK_EQ(DOMWindow::CrossDocumentAccessPolicy::kAllowed,
             *cross_document_access);
 
-  if (RecordReplayAllowCrossDomainAccesses())
+  if (recordreplay::AllowCrossDomainAccesses())
     return true;
 
   // It's important to check that target_window is a LocalDOMWindow: it's
@@ -263,7 +256,7 @@ bool BindingSecurity::ShouldAllowAccessTo(
     ErrorReportOption reporting_option) {
   DCHECK(target);
 
-  if (RecordReplayAllowCrossDomainAccesses())
+  if (recordreplay::AllowCrossDomainAccesses())
     return true;
 
   // TODO(https://crbug.com/723057): This is intended to match the legacy
@@ -396,7 +389,7 @@ bool ShouldAllowAccessToV8ContextInternal(
   // Workers and worklets do not support multiple contexts, so both of
   // |accessing_context| and |target_context| must be windows at this point.
 
-  if (RecordReplayAllowCrossDomainAccesses())
+  if (recordreplay::AllowCrossDomainAccesses())
     return true;
 
   // remote_object->GetCreationContext() returns the empty handle. Remote

--- a/third_party/blink/renderer/bindings/core/v8/binding_security.cc
+++ b/third_party/blink/renderer/bindings/core/v8/binding_security.cc
@@ -123,7 +123,7 @@ bool CanAccessWindowInternal(
   DCHECK_EQ(DOMWindow::CrossDocumentAccessPolicy::kAllowed,
             *cross_document_access);
 
-  if (recordreplay::AllowCrossDomainAccesses())
+  if (recordreplay::IsInReplayCode())
     return true;
 
   // It's important to check that target_window is a LocalDOMWindow: it's
@@ -256,7 +256,7 @@ bool BindingSecurity::ShouldAllowAccessTo(
     ErrorReportOption reporting_option) {
   DCHECK(target);
 
-  if (recordreplay::AllowCrossDomainAccesses())
+  if (recordreplay::IsInReplayCode())
     return true;
 
   // TODO(https://crbug.com/723057): This is intended to match the legacy
@@ -389,7 +389,7 @@ bool ShouldAllowAccessToV8ContextInternal(
   // Workers and worklets do not support multiple contexts, so both of
   // |accessing_context| and |target_context| must be windows at this point.
 
-  if (recordreplay::AllowCrossDomainAccesses())
+  if (recordreplay::IsInReplayCode())
     return true;
 
   // remote_object->GetCreationContext() returns the empty handle. Remote

--- a/third_party/blink/renderer/bindings/core/v8/custom/v8_window_custom.cc
+++ b/third_party/blink/renderer/bindings/core/v8/custom/v8_window_custom.cc
@@ -245,15 +245,6 @@ void V8Window::NamedPropertyGetterCustom(
       return;
     }
 
-    if (recordreplay::IsReplaying()) {
-      auto* local_dom_window = CurrentDOMWindow(info.GetIsolate());
-      recordreplay::Print(
-          "DDBG V8Window::NamedPropertyGetterCustom FailedAccessCheckFor %d %s",
-          recordreplay::AreEventsDisallowed(),
-          local_dom_window->GetSecurityOrigin()->ToString().Utf8().c_str());
-      CHECK(false && "ddbg intentional crash");
-    }
-
     BindingSecurity::FailedAccessCheckFor(
         info.GetIsolate(), window->GetWrapperTypeInfo(), info.Holder());
     return;

--- a/third_party/blink/renderer/bindings/core/v8/custom/v8_window_custom.cc
+++ b/third_party/blink/renderer/bindings/core/v8/custom/v8_window_custom.cc
@@ -245,6 +245,15 @@ void V8Window::NamedPropertyGetterCustom(
       return;
     }
 
+    if (recordreplay::IsReplaying()) {
+      auto* local_dom_window = CurrentDOMWindow(info.GetIsolate());
+      recordreplay::Print(
+          "DDBG V8Window::NamedPropertyGetterCustom FailedAccessCheckFor %d %s",
+          recordreplay::AreEventsDisallowed(),
+          local_dom_window->GetSecurityOrigin()->ToString().Utf8().c_str());
+      CHECK(false && "ddbg intentional crash");
+    }
+
     BindingSecurity::FailedAccessCheckFor(
         info.GetIsolate(), window->GetWrapperTypeInfo(), info.Holder());
     return;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -515,6 +515,7 @@ function Pause_evaluateInGlobal({ expression }) {
 }
 
 function Pause_getAllFrames() {
+  log(`DDBG Pause_getAllFrames start`);
   const frames = getStackFrames().map((frame, index) => {
     // Use our own IDs for frames.
     const id = (index++).toString();
@@ -1275,7 +1276,7 @@ function previewBlinkNode(node) {
   }
 
   let childNodes;
-  if (node.nodeName == "IFRAME") {
+  if (node.nodeName == "IFRAME" && node.contentDocument) {
     // Treat an iframe's content document as one of its child nodes.
     childNodes = [registerPlainObject(node.contentDocument)];
   } else if (node.childNodes.length) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -194,7 +194,24 @@ let gCurrentMessageResult;
 function sendMessage(method, params) {
   const id = gNextMessageId++;
   gCurrentMessageId = id;
-  sendCDPMessage(JSON_stringify({ method, params, id }));
+  gCurrentMessageResult = undefined;
+  try {
+    sendCDPMessage(JSON_stringify({ method, params, id }));
+  }
+  catch (err) {
+    if (!gCurrentMessageResult) {
+      throw err;
+    }
+    else {
+      // Work around "ghostly" cross-origin (and maybe other?) errors:
+      // Generally speaking, CDP commands should not throw.
+      // If they do, there is a chance that the error was triggered by user JS
+      // and only happens to still be pending when Replay commands were 
+      // triggered.
+      // E.g.: https://linear.app/replay/issue/RUN-1680#comment-1dfa142b
+      log(`[RuntimeError][RUN-1680] sendCDPMessage(${method}) failed: ${err?.message}`);
+    }
+  }
   gCurrentMessageId = undefined;
   if (gCurrentMessageResult?.result) {
     return gCurrentMessageResult.result;
@@ -515,20 +532,7 @@ function Pause_evaluateInGlobal({ expression }) {
 }
 
 function Pause_getAllFrames() {
-  let frames;
-  try {
-    frames = getStackFrames();
-  }
-  catch (err) {
-    // Work around "ghostly" cross-origin errors.
-    // https://linear.app/replay/issue/RUN-1680#comment-1dfa142b
-    log(`[RuntimeError] getStackFrames failed (${err.message})`);
-    return {
-      frames: [],
-      data: { frames: [] },
-    };
-  }
-  frames = frames.map((frame, index) => {
+  const frames = getStackFrames().map((frame, index) => {
     // Use our own IDs for frames.
     const id = (index++).toString();
     return createProtocolFrame(id, frame);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -286,7 +286,7 @@ function commandCallback(method, params) {
     // that decision.
     return {
       is_error: true,
-      message: e?.message || e.toString(),
+      message: e?.message || (e + ''),
       stack: e?.stack?.split?.("\n") || e?.stack || [],
     };
   }
@@ -515,8 +515,20 @@ function Pause_evaluateInGlobal({ expression }) {
 }
 
 function Pause_getAllFrames() {
-  log(`DDBG Pause_getAllFrames start`);
-  const frames = getStackFrames().map((frame, index) => {
+  let frames;
+  try {
+    frames = getStackFrames();
+  }
+  catch (err) {
+    // Work around "ghostly" cross-origin errors.
+    // https://linear.app/replay/issue/RUN-1680#comment-1dfa142b
+    log(`[RuntimeError] getStackFrames failed (${err.message})`);
+    return {
+      frames: [],
+      data: { frames: [] },
+    };
+  }
+  frames = frames.map((frame, index) => {
     // Use our own IDs for frames.
     const id = (index++).toString();
     return createProtocolFrame(id, frame);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -195,8 +195,9 @@ function sendMessage(method, params) {
   const id = gNextMessageId++;
   gCurrentMessageId = id;
   gCurrentMessageResult = undefined;
+  const cdpArgs = JSON_stringify({ method, params, id });
   try {
-    sendCDPMessage(JSON_stringify({ method, params, id }));
+    sendCDPMessage(cdpArgs);
   }
   catch (err) {
     if (!gCurrentMessageResult) {

--- a/third_party/blink/renderer/platform/weborigin/security_origin.cc
+++ b/third_party/blink/renderer/platform/weborigin/security_origin.cc
@@ -53,6 +53,8 @@
 #include "url/url_canon_ip.h"
 #include "url/url_util.h"
 
+#include "base/record_replay.h"
+
 namespace blink {
 
 namespace {
@@ -323,6 +325,10 @@ const base::UnguessableToken* SecurityOrigin::GetNonceForSerialization() const {
 bool SecurityOrigin::CanAccess(const SecurityOrigin* other,
                                AccessResultDomainDetail& detail) const {
   if (universal_access_) {
+    detail = AccessResultDomainDetail::kDomainNotRelevant;
+    return true;
+  }
+  if (recordreplay::AllowCrossDomainAccesses()) {
     detail = AccessResultDomainDetail::kDomainNotRelevant;
     return true;
   }

--- a/third_party/blink/renderer/platform/weborigin/security_origin.cc
+++ b/third_party/blink/renderer/platform/weborigin/security_origin.cc
@@ -328,7 +328,7 @@ bool SecurityOrigin::CanAccess(const SecurityOrigin* other,
     detail = AccessResultDomainDetail::kDomainNotRelevant;
     return true;
   }
-  if (recordreplay::AllowCrossDomainAccesses()) {
+  if (recordreplay::IsInReplayCode()) {
     detail = AccessResultDomainDetail::kDomainNotRelevant;
     return true;
   }


### PR DESCRIPTION
* Fix for: https://linear.app/replay/issue/RUN-1680#comment-ac407129
* Added `IsInReplayCode` API function to replace `RecordReplayAllowAccesses` (https://linear.app/replay/issue/RUN-1502/new-runtime-api-isinreplaycode)
* Sneaky changes:
  * RUN-1682 (one line): https://linear.app/replay/issue/RUN-1682/js-exception-in-pages-with-iframes
  * Added `recordreplay::Warning` (because I used it temporarily)
* Tests look good ✔


### Previous tests
* Tests: 100+ tests passed. Only `weather.com` failed. But that is beign flakey in general. ✔