### PR TITLE
Enable React DevTools support for Cypress tests

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -79,6 +79,7 @@ using RemoteObjectIdType = WTF::String;
 // Script which defines handlers for recorder commands, and is only loaded while
 // replaying.
 const char* gReplayScript = R""""(
+//js
 (() => {
 
 const EmptyArray = Object.freeze([]); // reduce unnecessary mem churn
@@ -2593,7 +2594,7 @@ function shiftRect(rect, offset) {
 // Script which sets a handler for collecting source maps from scripts in the
 // recording. Runs when recording/replaying if source map collection is enabled.
 const char* gSourceMapScript = R""""(
-
+//js
 (() => {
 
 const {
@@ -2812,12 +2813,13 @@ function isValidBaseURL(url) {
 // Script that injects React DevTools "stub" functions to capture 
 // marker annotations while recording, for use in later processing
 const char* gReactDevtoolsScript = R""""(
-
+//js 
 (() => {
 
 const stubFiberRoots = {};
 
 const stubHook = {
+  isStub: true,
   supportsFiber: true,
   inject,
   onCommitFiberUnmount,
@@ -2889,7 +2891,7 @@ function onPostCommitFiberRoot(rendererID, root) {
 // Script that injects Redux DevTools "stub" functions to capture 
 // marker annotations while recording, for use in later processing
 const char* gReduxDevtoolsScript = R""""(
-
+//js
 (() => { // webpackBootstrap
 /******/ 	"use strict";
 var __webpack_exports__ = {};
@@ -3102,6 +3104,120 @@ function reduxDevtoolsExtensionCompose(...funcs) {
 }
 window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = reduxDevtoolsExtensionCompose;
 /******/ })()
+
+)"""";
+
+
+
+// Script that copies the React and Redux DevTools global variables into
+// each iframe that gets added to the page.
+// This is primarily to support React DevTools in Cypress tests, as Cypress
+// runs the user's app in an iframe, but it should be a general solution for
+// other iframe usages in any application as well.
+const char* gDevtoolsIframeSetupScript = R""""(
+//js
+;(() => {
+  // TODO This _shouldn't_ be needed now that we allow cross-domain access at the C++ level
+  function canAccessIframe(iframe) {
+    try {
+      if (!iframe.src || iframe.src === 'about:blank') {
+        return false
+      }
+
+      const url = new URL(iframe.src)
+      const sameHost = url.hostname === window?.location?.hostname
+      const contentDocExists = !!iframe.contentDocument
+      return sameHost && contentDocExists
+    } catch (e) {
+      return false
+    }
+  }
+
+  function watchForIframeSrcChanges(iframe) {
+    let oldSrc = iframe.src
+    const iframeSrcObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes') {
+          const changedAttrName = mutation.attributeName
+          // Cypress has changed the blank iframe src to the app url.
+          if (changedAttrName === 'src') {
+            const oldLocation = iframe.contentWindow.location.href
+
+            let counter = 0
+
+            // Once the `src` has changed, it still takes time for the browser
+            // to navigate inside the iframe. We need to mutate the iframe's `window`
+            // _after_ it has navigated to the new page, but _before_ any JS starts running
+            // (such as ReactDOM initializing itself).
+            // This `setTimeout` loop is a brute-force hack, but it appears to work consistently.
+            function checkForLocationChange() {
+              try {
+                const newLocation = iframe.contentWindow.location.href
+                if (newLocation !== oldLocation) {
+                  iframeSrcObserver.disconnect()
+                  addDevtoolsToIframe(iframe)
+                  return
+                }
+              } catch (err) {
+              }
+
+              counter++
+
+              // Arbitrary limit to prevent infinite loops.
+              if (counter < 100) {
+                setTimeout(checkForLocationChange, 0)
+              }
+            }
+
+            setTimeout(checkForLocationChange, 0)
+
+            oldSrc = iframe.src
+          }
+        }
+      })
+    })
+
+    iframeSrcObserver.observe(iframe, {
+      attributes: true,
+    })
+  }
+
+  function addDevtoolsToIframe(iframe) {
+    // React DevTools especially cannot see React code in an iframe by default.
+    // It needs the main window's "global hook" reference to be copied into an iframe.
+    // That way React in the iframe attaches itself correctly, and the extension code
+    // can see the render updates. Redux likely needs the same kind of setup.
+    if (canAccessIframe(iframe)) {
+      iframe.contentWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.__REACT_DEVTOOLS_GLOBAL_HOOK__
+      iframe.contentWindow.__REDUX_DEVTOOLS_EXTENSION__ = window.__REDUX_DEVTOOLS_EXTENSION__
+      iframe.contentWindow.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', (event) => {
+    const initialIframes = document.querySelectorAll('iframe')
+    initialIframes.forEach(function (iframe) {
+      addDevtoolsToIframe(iframe)
+      watchForIframeSrcChanges(iframe)
+    })
+
+    const iframeAddedObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        ;[].filter
+          .call(mutation.addedNodes, function (node) {
+            return node.nodeName === 'IFRAME'
+          })
+          .forEach(function (iframe) {
+            watchForIframeSrcChanges(iframe)
+          })
+      })
+    })
+    iframeAddedObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+  })
+})()
 
 )"""";
 
@@ -4634,6 +4750,7 @@ void RunInitialRecordReplayScripts(v8::Isolate* isolate) {
     // its frames.
     RunScript(isolate, context, gReactDevtoolsScript, "record-replay-react-devtools");
     RunScript(isolate, context, gReduxDevtoolsScript, "record-replay-redux-devtools");
+    RunScript(isolate, context, gDevtoolsIframeSetupScript, "record-replay-devtools-iframes");
   }
 }
 


### PR DESCRIPTION
This PR:

- Tries to enable React DevTools support for Cypress tests by watching for all `<iframe>`s added to the app, and copying the RDT "global hook" object reference into each iframe
- Adds `//js` comments to all JS code-in-string blocks in `record_replay_interface.cc`, to enable actual JS syntax highlighting via the https://marketplace.visualstudio.com/items?itemName=iuyoy.highlight-string-code extension