### PR TITLE
RUN-1335 (part 2): Make IdleTaskFired not divergent

### DIFF
--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -37,26 +37,33 @@ class IdleRequestCallbackWrapper
       scoped_refptr<IdleRequestCallbackWrapper> callback_wrapper,
       base::TimeTicks deadline) {
 
-    recordreplay::Assert("[RUN-1335-1336] IdleTaskFired A %d",
-                          callback_wrapper->Id());
+    // [RUN-1335] This might execute even after the controller has been marked
+    // for collection. We avoid possible divergence by checking for whether 
+    // it is still registered first.
+    bool hasCallback = callback_wrapper->Controller()
+                            && callback_wrapper->Controller()
+                               ->ContainsCallback(callback_wrapper->Id());
+    recordreplay::Assert("[RUN-1335-1336] IdleTaskFired A %d %d",
+                         callback_wrapper->Id(),
+                         hasCallback);
 
-    if (ScriptedIdleTaskController* controller =
-            callback_wrapper->Controller()) {
-      // If we are going to yield immediately, reschedule the callback for
-      // later.
+    if (hasCallback)
+      if (ScriptedIdleTaskController* controller =
+              callback_wrapper->Controller()) {
+        // If we are going to yield immediately, reschedule the callback for
+        // later.
+        recordreplay::Assert("[RUN-1335-1456] IdleTaskFired B %d",
+                             callback_wrapper->Id());
 
-      recordreplay::Assert("[RUN-1335-1456] IdleTaskFired B %d",
-                           callback_wrapper->Id());
-
-      if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
-        controller->ScheduleCallback(std::move(callback_wrapper),
-                                     /* timeout_millis */ 0);
-        return;
+        if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
+          controller->ScheduleCallback(std::move(callback_wrapper),
+                                       /* timeout_millis */ 0);
+          return;
+        }
+        controller->CallbackFired(callback_wrapper->Id(), deadline,
+                                  IdleDeadline::CallbackType::kCalledWhenIdle);
       }
-      controller->CallbackFired(callback_wrapper->Id(), deadline,
-                                IdleDeadline::CallbackType::kCalledWhenIdle);
-    }
-    
+
     recordreplay::Assert("[RUN-1335-1456] IdleTaskFired C %d",
                          callback_wrapper->Id());
 

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -50,11 +50,12 @@ class IdleRequestCallbackWrapper
     if (hasCallback)
       if (ScriptedIdleTaskController* controller =
               callback_wrapper->Controller()) {
-        // If we are going to yield immediately, reschedule the callback for
-        // later.
+
         recordreplay::Assert("[RUN-1335-1456] IdleTaskFired B %d",
                              callback_wrapper->Id());
 
+        // If we are going to yield immediately, reschedule the callback for
+        // later.
         if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
           controller->ScheduleCallback(std::move(callback_wrapper),
                                        /* timeout_millis */ 0);

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -40,9 +40,8 @@ class IdleRequestCallbackWrapper
     // [RUN-1335] This might execute even after the controller has been marked
     // for collection. We avoid possible divergence by checking for whether 
     // it is still registered first.
-    bool hasCallback = callback_wrapper->Controller()
-                            && callback_wrapper->Controller()
-                               ->ContainsCallback(callback_wrapper->Id());
+    bool hasCallback = callback_wrapper->Controller() &&
+                         callback_wrapper->Controller()->ContainsCallback(callback_wrapper->Id());
     recordreplay::Assert("[RUN-1335-1336] IdleTaskFired A %d %d",
                          callback_wrapper->Id(),
                          hasCallback);

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -40,13 +40,15 @@ class IdleRequestCallbackWrapper
     // [RUN-1335] This might execute even after the controller has been marked
     // for collection. We avoid possible divergence by checking for whether 
     // it is still registered first.
-    bool hasCallback = callback_wrapper->Controller() &&
-                         callback_wrapper->Controller()->ContainsCallback(callback_wrapper->Id());
+    bool check = !recordreplay::IsRecordingOrReplaying("clear-idle-callbacks") ||
+                   (callback_wrapper->Controller() &&
+                   callback_wrapper->Controller()->ContainsCallback(
+                     callback_wrapper->Id()));
     recordreplay::Assert("[RUN-1335-1336] IdleTaskFired A %d %d",
                          callback_wrapper->Id(),
-                         hasCallback);
+                         check);
 
-    if (hasCallback)
+    if (check)
       if (ScriptedIdleTaskController* controller =
               callback_wrapper->Controller()) {
 

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
@@ -102,6 +102,8 @@ class CORE_EXPORT ScriptedIdleTaskController
 
   // [RUN-1335] Allow clearing callbacks upon |Document::Shutdown|.
   void ClearCallbacks() { idle_tasks_.clear(); }
+  // [RUN-1335] We want to check for callback existence before firing.
+  bool ContainsCallback(CallbackId id) { return idle_tasks_.Contains(id); }
 
  private:
   friend class internal::IdleRequestCallbackWrapper;


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1335#comment-fa00829e
* NOTE: When comparing, it helps to hide whitespace changes - [direct link](https://github.com/replayio/chromium/pull/526/files?diff=split&w=1)