### PR TITLE
RUN-1347: Leak SVG PageSchedulers

### DIFF
--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -224,6 +224,7 @@ SVGImage::~SVGImage() {
       // Since the dtor is called by the GC, we leak the scheduler, so it won't
       // try touching the recording stream during `WillBeDestroyed` below.
       // https://linear.app/replay/issue/RUN-1347#comment-73b7832e
+      CHECK(IsMainThread());
       if (!gReplayLeakedSchedulers) {
         gReplayLeakedSchedulers = new std::vector<std::unique_ptr<PageScheduler>>();
       }

--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -209,6 +209,9 @@ SVGImage::SVGImage(ImageObserver* observer, bool is_multipart)
                                  ->CreateAgentGroupScheduler()),
       has_pending_timeline_rewind_(false) {}
 
+// RUN-1347
+static std::vector<std::unique_ptr<PageScheduler>>* gReplayLeakedSchedulers = nullptr;
+
 SVGImage::~SVGImage() {
   AllowDestroyingLayoutObjectInFinalizerScope scope;
 
@@ -216,6 +219,18 @@ SVGImage::~SVGImage() {
     frame_client_->ClearImage();
 
   if (page_) {
+
+    if (recordreplay::IsRecordingOrReplaying()) {
+      // Since the dtor is called by the GC, we leak the scheduler, so it won't
+      // try touching the recording stream during `WillBeDestroyed` below.
+      // https://linear.app/replay/issue/RUN-1347#comment-73b7832e
+      if (!gReplayLeakedSchedulers) {
+        gReplayLeakedSchedulers = new std::vector<std::unique_ptr<PageScheduler>>();
+      }
+      std::unique_ptr<PageScheduler> scheduler(page_->GetPageScheduler());
+      gReplayLeakedSchedulers->push_back(std::move(scheduler));
+    }
+
     // It is safe to allow UA events within this scope, because event
     // dispatching inside the SVG image's document doesn't trigger JavaScript
     // execution. All script execution is forbidden when an SVG is loaded as an


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1347#comment-73b7832e