### PR TITLE
RUN-1667: make audio_destination lock ordered

### DIFF
--- a/third_party/blink/renderer/modules/webaudio/audio_node_output.h
+++ b/third_party/blink/renderer/modules/webaudio/audio_node_output.h
@@ -151,7 +151,7 @@ class MODULES_EXPORT AudioNodeOutput final {
   // AudioNode::makeConnection when we add an AudioNodeInput to this, and must
   // call AudioNode::breakConnection() when we remove an AudioNodeInput from
   // this.
-  HashSet<AudioNodeInput*> inputs_;
+  HashSet<AudioNodeInput*, WTF::MemberHashRecordReplayRegisteredPointerId<AudioNodeInput>> inputs_;
   bool is_enabled_ = true;
 
   bool did_call_dispose_ = false;

--- a/third_party/blink/renderer/platform/audio/audio_destination.cc
+++ b/third_party/blink/renderer/platform/audio/audio_destination.cc
@@ -100,6 +100,7 @@ AudioDestination::AudioDestination(AudioIOCallback& callback,
           AudioBus::Create(number_of_output_channels, render_quantum_frames)),
       callback_(callback),
       frames_elapsed_(0),
+      state_change_lock_("AudioDestination"),
       device_state_(DeviceState::kStopped) {
   SendLogMessage(String::Format("%s({output_channels=%u})", __func__,
                                 number_of_output_channels));


### PR DESCRIPTION
And make the audio output node's input set deterministic (not actually a part of this bug, but I ran into a divergence here when attempting to repro.)