### PR TITLE
RUN-1665: Add trait utilities to help identify non-deterministic iteration order

### DIFF
--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -133,8 +133,9 @@ struct MemberHashRecordReplayRegisteredPointerId
   static bool Equal(const U& a, const V& b) {
     return a == b;
   }
-};
 
+  static constexpr bool kIsRecordReplayDeterministicHash = true;
+};
 
 // Replay's hashing function with Member<>-wrapped objects, using the function
 // RecordReplayId for the hashing key.
@@ -195,6 +196,8 @@ struct MemberHashRecordReplayId
   static bool Equal(const U& a, const V& b) {
     return a == b;
   }
+
+  static constexpr bool kIsRecordReplayDeterministicHash = true;
 };
 
 template <typename T>
@@ -329,6 +332,12 @@ class ConstructTraits<blink::Member<T>, Traits, Allocator> final
 template <typename T, typename Traits, typename Allocator>
 class ConstructTraits<blink::WeakMember<T>, Traits, Allocator> final
     : public MemberConstructTraits<blink::WeakMember<T>> {};
+
+template <typename T>
+struct IsPointerType<blink::WeakMember<T>> : std::true_type {};
+
+template <typename T>
+struct IsPointerType<blink::Member<T>> : std::true_type {};
 
 }  // namespace WTF
 

--- a/third_party/blink/renderer/platform/heap/persistent.h
+++ b/third_party/blink/renderer/platform/heap/persistent.h
@@ -285,4 +285,16 @@ struct MaybeValidTraits<blink::WeakPersistent<T>> {
 
 }  // namespace base
 
+namespace WTF {
+
+// Some type trait implementations for Persistent<> and WeakPersistent<>.
+
+template <typename T>
+struct IsPointerType<blink::Persistent<T>> : std::true_type {};
+
+template <typename T>
+struct IsPointerType<blink::WeakPersistent<T>> : std::true_type {};
+
+}  // namespace WTF
+
 #endif  // THIRD_PARTY_BLINK_RENDERER_PLATFORM_HEAP_PERSISTENT_H_

--- a/third_party/blink/renderer/platform/wtf/hash_set.h
+++ b/third_party/blink/renderer/platform/wtf/hash_set.h
@@ -27,6 +27,7 @@
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/partition_allocator.h"
 #include "third_party/blink/renderer/platform/wtf/hash_table.h"
+#include "third_party/blink/renderer/platform/wtf/type_traits.h"
 #include "third_party/blink/renderer/platform/wtf/wtf_size_t.h"
 
 namespace WTF {

--- a/third_party/blink/renderer/platform/wtf/type_traits.h
+++ b/third_party/blink/renderer/platform/wtf/type_traits.h
@@ -23,9 +23,13 @@
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_WTF_TYPE_TRAITS_H_
 
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 #include <utility>
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "build/build_config.h"
 #include "v8/include/cppgc/type-traits.h"  // nogncheck
 
@@ -103,6 +107,59 @@ struct IsSubclassOfTemplateTypenameSizeTypename {
  public:
   static const bool value = sizeof(SubclassCheck(t_)) == sizeof(YesType);
 };
+
+template <typename T, typename = void>
+struct IsRecordReplayDeterministicHash : std::false_type {};
+
+template <typename T>
+struct IsRecordReplayDeterministicHash<
+    T,
+    std::enable_if_t<T::kIsRecordReplayDeterministicHash>> : std::true_type {};
+
+template <typename T>
+constexpr bool IsRecordReplayDeterministicHashV =
+    IsRecordReplayDeterministicHash<T>::value;
+
+template <typename T>
+struct IsPointerType : std::false_type {};
+
+template <typename T>
+struct IsPointerType<T*> : std::true_type {};
+
+template <typename T>
+struct IsPointerType<const T*> : std::true_type {};
+
+template <typename T, typename U>
+struct IsPointerType<std::unique_ptr<T, U>> : std::true_type {};
+
+template <typename T>
+struct IsPointerType<scoped_refptr<T>> : std::true_type {};
+
+template <typename T>
+struct IsPointerType<base::WeakPtr<T>> : std::true_type {};
+
+template <>
+struct IsPointerType<base::internal::WeakPtrBase> : std::true_type {};
+
+template <typename T, typename U>
+struct IsPointerType<raw_ptr<T, U>> : std::true_type {};
+
+template <typename T>
+constexpr bool IsPointerTypeV = IsPointerType<T>::value;
+
+// This is a helper template to check if iteration over a container might
+// have non-deterministic ordering due to hashing pointer values.
+//
+// Example usage:
+//   inline typename HashSet<T, U, V, W>::iterator HashSet<T, U, V, W>::begin()
+//       const {
+//     static_assert(!IsRecordReplayNonDeterministicContainerV<T, U>,
+//                   "Using non-deterministic pointer hash");
+//     return impl_.begin();
+//   }
+template <typename Key, typename Hash>
+constexpr bool IsRecordReplayNonDeterministicContainerV =
+    !IsRecordReplayDeterministicHashV<Hash> && IsPointerTypeV<Key>;
 
 template <typename T>
 struct IsTraceable : cppgc::internal::IsTraceable<T> {};


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-1665/detect-and-automatically-make-all-instances-of-wtf-set-and-map

Start of some static analysis utilities for identifying cases of iteration over containers that may have different iteration orders between runs.