### PR TITLE
RUN-1716: ContextLifecycle HeapObserverSet

### DIFF
--- a/third_party/blink/renderer/core/animation/animation.h
+++ b/third_party/blink/renderer/core/animation/animation.h
@@ -317,7 +317,9 @@ class CORE_EXPORT Animation : public EventTargetWithInlineData,
   bool AtScrollTimelineBoundary();
 
   // RUN-1716
-  int RecordReplayId() const override { return recordreplay::PointerId(this); }
+  int RecordReplayId() const override {
+    return ScriptWrappable::RecordReplayId();
+  }
 
  protected:
   DispatchEventResult DispatchEventInternal(Event&) override;

--- a/third_party/blink/renderer/core/animation/animation.h
+++ b/third_party/blink/renderer/core/animation/animation.h
@@ -316,6 +316,9 @@ class CORE_EXPORT Animation : public EventTargetWithInlineData,
   bool AnimationHasNoEffect() const { return animation_has_no_effect_; }
   bool AtScrollTimelineBoundary();
 
+  // RUN-1716
+  int RecordReplayId() const override { return recordreplay::PointerId(this); }
+
  protected:
   DispatchEventResult DispatchEventInternal(Event&) override;
   void AddedEventListener(const AtomicString& event_type,

--- a/third_party/blink/renderer/core/animation/animation.h
+++ b/third_party/blink/renderer/core/animation/animation.h
@@ -317,6 +317,8 @@ class CORE_EXPORT Animation : public EventTargetWithInlineData,
   bool AtScrollTimelineBoundary();
 
   // RUN-1716
+  // Disambiguate between ScriptWrappable::RecordReplayId and
+  // ContextLifecycleObserver::RecordReplayId.
   int RecordReplayId() const override {
     return ScriptWrappable::RecordReplayId();
   }

--- a/third_party/blink/renderer/core/execution_context/execution_context.cc
+++ b/third_party/blink/renderer/core/execution_context/execution_context.cc
@@ -192,7 +192,7 @@ void ExecutionContext::CountDeprecation(WebFeature feature) {
   Deprecation::CountDeprecation(this, feature);
 }
 
-HeapObserverSet<ContextLifecycleObserver>&
+ContextLifecycleHeapObserverSet&
 ExecutionContext::ContextLifecycleObserverSet() {
   return ContextLifecycleNotifier::observers();
 }

--- a/third_party/blink/renderer/core/execution_context/execution_context.h
+++ b/third_party/blink/renderer/core/execution_context/execution_context.h
@@ -386,7 +386,7 @@ class CORE_EXPORT ExecutionContext : public Supplementable<ExecutionContext>,
       const String& message = g_empty_string,
       const String& source_file = g_empty_string) const {}
 
-  HeapObserverSet<ContextLifecycleObserver>& ContextLifecycleObserverSet();
+  ContextLifecycleHeapObserverSet& ContextLifecycleObserverSet();
   unsigned ContextLifecycleStateObserverCountForTesting() const;
 
   // Implementation of WindowOrWorkerGlobalScope.crossOriginIsolated.

--- a/third_party/blink/renderer/platform/context_lifecycle_notifier.h
+++ b/third_party/blink/renderer/platform/context_lifecycle_notifier.h
@@ -9,7 +9,9 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap_observer_set.h"
 
+#include "third_party/blink/renderer/platform/context_lifecycle_observer.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
+
 
 namespace blink {
 
@@ -32,13 +34,13 @@ class PLATFORM_EXPORT ContextLifecycleNotifier : public GarbageCollectedMixin {
   // destroyed.
   void NotifyContextDestroyed();
 
-  const HeapObserverSet<ContextLifecycleObserver>& observers() const {
+  const ContextLifecycleHeapObserverSet& observers() const {
     return observers_;
   }
-  HeapObserverSet<ContextLifecycleObserver>& observers() { return observers_; }
+  ContextLifecycleHeapObserverSet& observers() { return observers_; }
 
  private:
-  HeapObserverSet<ContextLifecycleObserver> observers_;
+  ContextLifecycleHeapObserverSet observers_;
   bool context_destroyed_ = false;
 
   // When replaying, strong references are held on all observers, which are

--- a/third_party/blink/renderer/platform/context_lifecycle_observer.h
+++ b/third_party/blink/renderer/platform/context_lifecycle_observer.h
@@ -9,6 +9,8 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/member.h"
 
+#include "third_party/blink/renderer/platform/heap_observer_set.h"
+
 namespace blink {
 
 class ContextLifecycleNotifier;
@@ -29,6 +31,8 @@ class PLATFORM_EXPORT ContextLifecycleObserver : public GarbageCollectedMixin {
 
   void Trace(Visitor*) const override;
 
+  int RecordReplayId() const { return recordreplay::PointerId(this); }
+
  protected:
   ContextLifecycleObserver();
 
@@ -40,6 +44,13 @@ class PLATFORM_EXPORT ContextLifecycleObserver : public GarbageCollectedMixin {
   bool waiting_for_context_destroyed_ = false;
 #endif
 };
+
+// RUN-1716
+typedef HeapObserverSet<
+    ContextLifecycleObserver,
+    HeapHashSet<WeakMember<ContextLifecycleObserver>,
+                WTF::MemberHashRecordReplayId<ContextLifecycleObserver>>>
+    ContextLifecycleHeapObserverSet;
 
 }  // namespace blink
 

--- a/third_party/blink/renderer/platform/context_lifecycle_observer.h
+++ b/third_party/blink/renderer/platform/context_lifecycle_observer.h
@@ -46,11 +46,10 @@ class PLATFORM_EXPORT ContextLifecycleObserver : public GarbageCollectedMixin {
 };
 
 // RUN-1716
-typedef HeapObserverSet<
+using ContextLifecycleHeapObserverSet = HeapObserverSet<
     ContextLifecycleObserver,
     HeapHashSet<WeakMember<ContextLifecycleObserver>,
-                WTF::MemberHashRecordReplayId<ContextLifecycleObserver>>>
-    ContextLifecycleHeapObserverSet;
+                WTF::MemberHashRecordReplayId<ContextLifecycleObserver>>>;
 
 }  // namespace blink
 

--- a/third_party/blink/renderer/platform/context_lifecycle_observer.h
+++ b/third_party/blink/renderer/platform/context_lifecycle_observer.h
@@ -31,7 +31,7 @@ class PLATFORM_EXPORT ContextLifecycleObserver : public GarbageCollectedMixin {
 
   void Trace(Visitor*) const override;
 
-  int RecordReplayId() const { return recordreplay::PointerId(this); }
+  virtual int RecordReplayId() const { return recordreplay::PointerId(this); }
 
  protected:
   ContextLifecycleObserver();

--- a/third_party/blink/renderer/platform/heap_observer_set.h
+++ b/third_party/blink/renderer/platform/heap_observer_set.h
@@ -14,7 +14,8 @@ namespace blink {
 
 // A set of observers. Ensures list is not mutated while iterating. Observers
 // are not retained.
-template <class ObserverType>
+template <typename ObserverType,
+          typename ObserverSet = HeapHashSet<WeakMember<ObserverType>>>
 class PLATFORM_EXPORT HeapObserverSet {
   DISALLOW_NEW();
 
@@ -72,8 +73,6 @@ class PLATFORM_EXPORT HeapObserverSet {
   void Trace(Visitor* visitor) const { visitor->Trace(observers_); }
 
  private:
-  using ObserverSet = HeapHashSet<WeakMember<ObserverType>>;
-
   // TODO(keishi): Clean up iteration state once transition from
   // LifecycleObserver is complete.
   enum IterationState {

--- a/third_party/blink/renderer/platform/heap_observer_set.h
+++ b/third_party/blink/renderer/platform/heap_observer_set.h
@@ -14,6 +14,8 @@ namespace blink {
 
 // A set of observers. Ensures list is not mutated while iterating. Observers
 // are not retained.
+// [Replay] We made some changes to allow for deterministic hash functions for
+// a subset of all |ObserverType|s.
 template <typename ObserverType,
           typename ObserverSet = HeapHashSet<WeakMember<ObserverType>>>
 class PLATFORM_EXPORT HeapObserverSet {


### PR DESCRIPTION
* Another round of making set iterations deterministic.
* https://linear.app/replay/issue/RUN-1716/mismatch-in-blinkexecutioncontextsetlifecyclestate