### PR TITLE
Use a record-replay deterministic hash for Member types that contain ScriptWrappable objects

### DIFF
--- a/third_party/blink/renderer/core/dom/popup_animation_finished_event_listener.h
+++ b/third_party/blink/renderer/core/dom/popup_animation_finished_event_listener.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_POPUP_ANIMATION_FINISHED_EVENT_LISTENER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_POPUP_ANIMATION_FINISHED_EVENT_LISTENER_H_
 
+#include "third_party/blink/renderer/core/dom/events/event_target.h"
 #include "third_party/blink/renderer/core/dom/events/native_event_listener.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
@@ -16,7 +17,6 @@
 namespace blink {
 
 class Element;
-class EventTarget;
 
 // Helper class used to manage popup hide animations.
 class PopupAnimationFinishedEventListener : public NativeEventListener {

--- a/third_party/blink/renderer/core/dom/slot_assignment.h
+++ b/third_party/blink/renderer/core/dom/slot_assignment.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SLOT_ASSIGNMENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SLOT_ASSIGNMENT_H_
 
+#include "third_party/blink/renderer/core/dom/node.h"
 #include "third_party/blink/renderer/core/dom/tree_ordered_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
@@ -14,7 +15,6 @@
 namespace blink {
 
 class HTMLSlotElement;
-class Node;
 class ShadowRoot;
 
 class SlotAssignment final : public GarbageCollected<SlotAssignment> {

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -7,6 +7,7 @@
 
 #include "base/check_op.h"
 #include "base/record_replay.h"
+#include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
 #include "third_party/blink/renderer/platform/heap/thread_state_storage.h"
 #include "third_party/blink/renderer/platform/heap/write_barrier.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
@@ -135,7 +136,6 @@ struct MemberHashRecordReplayRegisteredPointerId
   }
 };
 
-
 // Replay's hashing function with Member<>-wrapped objects, using the function
 // RecordReplayId for the hashing key.
 template <typename T>
@@ -174,7 +174,8 @@ struct MemberHashRecordReplayId
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
     if (recordreplay::IsRecordingOrReplaying()) {
-      int id = m.Get()->RecordReplayId();
+      T* ptr = m.Get();
+      int id = ptr->RecordReplayId();
       // Ids are allowed to be zero if we've diverged from the recording.
       if (recordreplay::HasDivergedFromRecording()) {
         if (id > 0) {
@@ -198,21 +199,27 @@ struct MemberHashRecordReplayId
 };
 
 template <typename T>
+using DefaultHashTypeForMember =
+    std::conditional_t<IsSubclass<T, blink::ScriptWrappable>::value,
+                       MemberHashRecordReplayId<blink::ScriptWrappable>,
+                       MemberHash<T>>;
+
+template <typename T>
 struct DefaultHash<blink::Member<T>> {
   STATIC_ONLY(DefaultHash);
-  using Hash = MemberHash<T>;
+  using Hash = DefaultHashTypeForMember<T>;
 };
 
 template <typename T>
 struct DefaultHash<blink::WeakMember<T>> {
   STATIC_ONLY(DefaultHash);
-  using Hash = MemberHash<T>;
+  using Hash = DefaultHashTypeForMember<T>;
 };
 
 template <typename T>
 struct DefaultHash<blink::UntracedMember<T>> {
   STATIC_ONLY(DefaultHash);
-  using Hash = MemberHash<T>;
+  using Hash = DefaultHashTypeForMember<T>;
 };
 
 template <typename T>

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -174,8 +174,7 @@ struct MemberHashRecordReplayId
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
     if (recordreplay::IsRecordingOrReplaying()) {
-      T* ptr = m.Get();
-      int id = ptr->RecordReplayId();
+      int id = m.Get()->RecordReplayId();
       // Ids are allowed to be zero if we've diverged from the recording.
       if (recordreplay::HasDivergedFromRecording()) {
         if (id > 0) {
@@ -201,7 +200,7 @@ struct MemberHashRecordReplayId
 template <typename T>
 using DefaultHashTypeForMember =
     std::conditional_t<IsSubclass<T, blink::ScriptWrappable>::value,
-                       MemberHashRecordReplayId<blink::ScriptWrappable>,
+                       MemberHashRecordReplayId<T>,
                        MemberHash<T>>;
 
 template <typename T>


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-1665/detect-and-automatically-make-all-instances-of-wtf-set-and-map

This change makes the hash functions that @klochek added the default for `Member`'s that contain subclasses of `ScriptWrappable`.

Once this and #545 are merged, I can go back through the containers where a record-replay deterministic hash was set manually and validate that the default hash should now have the behavior that we want.