### PR TITLE
[RUN-1672] update to skia that uses a baseline CPU.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '9f4116d92ab3e0f74671bfff63db7c26bef168eb',
+  'skia_revision': '38e32536f0458b7bc30439abbf31cb1d72f583ab',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '38e32536f0458b7bc30439abbf31cb1d72f583ab',
+  'skia_revision': 'a405f63fc707397afe38592249d7feb51cba0f09',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.


### PR DESCRIPTION
Fixes https://linear.app/replay/issue/RUN-1672