### PR TITLE
Make more audio locks ordered; record the delay params from the audio output buffer.

### DIFF
--- a/media/audio/audio_output_device_thread_callback.cc
+++ b/media/audio/audio_output_device_thread_callback.cc
@@ -61,7 +61,9 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
                      "callback_num", callback_num_, "frames skipped",
                      frames_skipped);
 
-  base::TimeDelta delay = base::Microseconds(recordreplay::RecordReplayValue("audioparams::delay_us", buffer->params.delay_us));
+  // RUN-1667: Record the delay_us param from the shared memory buffer (this is mutated by the other end.)
+  base::TimeDelta delay = base::Microseconds(
+    recordreplay::RecordReplayValue("audioparams::delay_us", buffer->params.delay_us));
 
   base::TimeTicks delay_timestamp =
       base::TimeTicks() + base::Microseconds(buffer->params.delay_timestamp_us);

--- a/media/audio/audio_output_device_thread_callback.cc
+++ b/media/audio/audio_output_device_thread_callback.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "base/record_replay.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/trace_event/trace_event.h"
@@ -60,7 +61,7 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
                      "callback_num", callback_num_, "frames skipped",
                      frames_skipped);
 
-  base::TimeDelta delay = base::Microseconds(buffer->params.delay_us);
+  base::TimeDelta delay = base::Microseconds(recordreplay::RecordReplayValue("audioparams::delay_us", buffer->params.delay_us));
 
   base::TimeTicks delay_timestamp =
       base::TimeTicks() + base::Microseconds(buffer->params.delay_timestamp_us);

--- a/media/base/silent_sink_suspender.cc
+++ b/media/base/silent_sink_suspender.cc
@@ -22,6 +22,7 @@ SilentSinkSuspender::SilentSinkSuspender(
       task_runner_(base::ThreadTaskRunnerHandle::Get()),
       silence_timeout_(silence_timeout),
       fake_sink_(std::move(worker), params_),
+      transition_lock_("SilentSinkSuspender"),
       sink_transition_callback_(
           base::BindRepeating(&SilentSinkSuspender::TransitionSinks,
                               base::Unretained(this))) {

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_destination_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_destination_handler.cc
@@ -31,6 +31,7 @@ MediaStreamAudioDestinationHandler::MediaStreamAudioDestinationHandler(
                                  node,
                                  node.context()->sampleRate()),
       source_(static_cast<MediaStreamAudioDestinationNode&>(node).source()),
+      process_lock_("MediaStreamAudioDestinationHandler"),
       mix_bus_(
           AudioBus::Create(number_of_channels,
                            GetDeferredTaskHandler().RenderQuantumFrames())) {

--- a/third_party/blink/renderer/platform/mediastream/media_stream_source.cc
+++ b/third_party/blink/renderer/platform/mediastream/media_stream_source.cc
@@ -149,7 +149,8 @@ MediaStreamSource::MediaStreamSource(const String& id,
       name_(name),
       remote_(remote),
       ready_state_(ready_state),
-      requires_consumer_(requires_consumer) {
+      requires_consumer_(requires_consumer),
+      audio_consumer_lock_("MediaStreamSource") {
   SendLogMessage(
       String::Format(
           "MediaStreamSource({id=%s}, {type=%s}, {name=%s}, {remote=%d}, "

--- a/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
+++ b/third_party/blink/renderer/platform/peerconnection/webrtc_audio_sink.cc
@@ -169,7 +169,8 @@ WebRtcAudioSink::Adapter::Adapter(
       label_(label),
       source_(std::move(source)),
       signaling_task_runner_(std::move(signaling_task_runner)),
-      main_task_runner_(std::move(main_task_runner)) {
+      main_task_runner_(std::move(main_task_runner)),
+      lock_("WebRtcAudioSink::Adapter") {
   DCHECK(signaling_task_runner_);
   DCHECK(main_task_runner_);
   SendLogMessage(


### PR DESCRIPTION
@bhackett1024 I'm recording the `delay_us` from the audio output buffer's params to the recording stream, because that is coming from ipc shared memory (my sleuthing isn't turning up where that is coming from, but I'm guessing we're getting down to the os.)  I'm a bit leery of doing this given that I don't fully understand it, but something is definitely writing values to that buffer that seems outside of chromium, and I'm hoping that us recording those values won't create a bomb somewhere down the line.  ([Here's a codesearch link if you want to dig more.](https://source.chromium.org/chromium/chromium/src/+/main:media/audio/audio_output_device_thread_callback.cc;l=18;drc=19f3c214cd4f78e0fe47b2ccafaca406aaacd42f;bpv=1;bpt=1?q=AudioOutputDeviceThreadCallback&ss=chromium%2Fchromium%2Fsrc))

The rest is just adding some much-needed ordering to more audio locks.  This resolves the repro of RUN-1667 in the WPT test I was examining.