### PR TITLE
Order CSSFontSelector::clients_ and add assertions

### DIFF
--- a/third_party/blink/renderer/core/css/css_font_selector.cc
+++ b/third_party/blink/renderer/core/css/css_font_selector.cc
@@ -26,6 +26,7 @@
 
 #include "third_party/blink/renderer/core/css/css_font_selector.h"
 
+#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "third_party/blink/renderer/core/css/css_segmented_font_face.h"
 #include "third_party/blink/renderer/core/css/css_value_list.h"
@@ -68,12 +69,20 @@ UseCounter* CSSFontSelector::GetUseCounter() const {
 void CSSFontSelector::RegisterForInvalidationCallbacks(
     FontSelectorClient* client) {
   CHECK(client);
+  recordreplay::Assert("[RUN-1219-1728] CSSFontSelector::RegisterForInvalidationCallbacks");
   clients_.insert(client);
+  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers")) {
+    record_replay_strong_clients_.insert(client);
+  }
 }
 
 void CSSFontSelector::UnregisterForInvalidationCallbacks(
     FontSelectorClient* client) {
+  recordreplay::Assert("[RUN-1219-1728] CSSFontSelector::UnregisterForInvalidationCallbacks");
   clients_.erase(client);
+  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers")) {
+    record_replay_strong_clients_.erase(client);
+  }
 }
 
 void CSSFontSelector::DispatchInvalidationCallbacks(
@@ -176,6 +185,7 @@ bool CSSFontSelector::IsAlive() const {
 void CSSFontSelector::Trace(Visitor* visitor) const {
   visitor->Trace(tree_scope_);
   visitor->Trace(clients_);
+  visitor->Trace(record_replay_strong_clients_);
   CSSFontSelectorBase::Trace(visitor);
 }
 

--- a/third_party/blink/renderer/core/css/css_font_selector.h
+++ b/third_party/blink/renderer/core/css/css_font_selector.h
@@ -91,7 +91,8 @@ class CORE_EXPORT CSSFontSelector : public CSSFontSelectorBase {
   // currently leak because ComputedStyle and its data are not on the heap.
   // See crbug.com/383860 for details.
   WeakMember<const TreeScope> tree_scope_;
-  HeapHashSet<WeakMember<FontSelectorClient>> clients_;
+  HeapHashSet<WeakMember<FontSelectorClient>, WTF::MemberHashRecordReplayId<FontSelectorClient>> clients_;
+  HeapHashSet<Member<FontSelectorClient>> record_replay_strong_clients_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/css/style_engine.cc
+++ b/third_party/blink/renderer/core/css/style_engine.cc
@@ -963,6 +963,10 @@ void StyleEngine::MarkCounterStylesNeedUpdate() {
 }
 
 void StyleEngine::FontsNeedUpdate(FontSelector*, FontInvalidationReason) {
+  recordreplay::Assert(
+    "[RUN-1219-1728] StyleEngine::FontsNeedUpdate %d",
+    this->RecordReplayId()
+  );
   if (!GetDocument().IsActive())
     return;
 

--- a/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
+++ b/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
@@ -4,6 +4,7 @@
 
 #include "third_party/blink/renderer/core/html/forms/internal_popup_menu.h"
 
+#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "third_party/blink/public/common/input/web_mouse_event.h"
 #include "third_party/blink/public/platform/platform.h"
@@ -157,6 +158,10 @@ scoped_refptr<FontData> PopupMenuCSSFontSelector::GetFontData(
 
 void PopupMenuCSSFontSelector::FontsNeedUpdate(FontSelector* font_selector,
                                                FontInvalidationReason reason) {
+  recordreplay::Assert(
+    "[RUN-1219-1728] PopupMenuCSSFontSelector::FontsNeedUpdate %d",
+    this->RecordReplayId()
+  );
   DispatchInvalidationCallbacks(reason);
 }
 

--- a/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d_state.cc
+++ b/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d_state.cc
@@ -172,6 +172,10 @@ CanvasRenderingContext2DState::~CanvasRenderingContext2DState() = default;
 
 void CanvasRenderingContext2DState::FontsNeedUpdate(FontSelector* font_selector,
                                                     FontInvalidationReason) {
+  recordreplay::Assert(
+    "[RUN-1219-1728] CanvasRenderingContext2DState::FontNeedsUpdate %d",
+    this->RecordReplayId()
+  );
   DCHECK_EQ(font_selector, font_.GetFontSelector());
   DCHECK(realized_font_);
 

--- a/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
@@ -79,6 +79,10 @@ void FontFallbackMap::InvalidateInternal(Predicate predicate) {
 
 void FontFallbackMap::FontsNeedUpdate(FontSelector*,
                                       FontInvalidationReason reason) {
+  recordreplay::Assert(
+    "[RUN-1219-1728] FontFallbackMap::FontNeedsUpdate %d",
+    this->RecordReplayId()
+  );
   AutoLockForParallelTextShaping guard(lock_);
   switch (reason) {
     case FontInvalidationReason::kFontFaceLoaded:

--- a/third_party/blink/renderer/platform/fonts/font_selector_client.h
+++ b/third_party/blink/renderer/platform/fonts/font_selector_client.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_PLATFORM_FONTS_FONT_SELECTOR_CLIENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_FONTS_FONT_SELECTOR_CLIENT_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/fonts/font_invalidation_reason.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 
@@ -14,11 +15,21 @@ class FontSelector;
 
 class FontSelectorClient : public GarbageCollectedMixin {
  public:
+  FontSelectorClient()
+    :record_replay_id_(
+      recordreplay::NewIdAnyThread("FontSelectorClient"))
+  {}
+
   virtual ~FontSelectorClient() = default;
 
   virtual void FontsNeedUpdate(FontSelector*, FontInvalidationReason) = 0;
 
   void Trace(Visitor* visitor) const override {}
+
+  int RecordReplayId() const { return record_replay_id_; }
+
+ private:
+  int record_replay_id_;
 };
 
 }  // namespace blink


### PR DESCRIPTION
For RUN-1728 (https://linear.app/replay/issue/RUN-1728/order-cssfontselectorclients-and-add-more-assertions-around-it)

Bucket issue RUN-1219