### PR TITLE
Fix match properties caching, to use a replay id instead of a pointer.

### DIFF
--- a/third_party/blink/renderer/core/css/resolver/match_result.cc
+++ b/third_party/blink/renderer/core/css/resolver/match_result.cc
@@ -44,10 +44,6 @@ MatchedProperties::MatchedProperties() {
   memset(&types_, 0, sizeof(types_));
 }
 
-RecordReplayMatchedProperties::RecordReplayMatchedProperties() {
-  memset(&types_, 0, sizeof(types_));
-}
-
 void MatchedProperties::Trace(Visitor* visitor) const {
   visitor->Trace(properties);
 }
@@ -67,21 +63,6 @@ void MatchResult::AddMatchedProperties(
   new_properties.types_.is_inline_style = options.IsInlineStyle();
   new_properties.types_.origin = current_origin_;
   new_properties.types_.tree_order = current_tree_order_;
-
-  // Create a duplicate entry for our record/replay, array, that does _not_
-  // have the properties pointer, so we avoid non-deterministic hashing values.
-  record_replay_matched_properties_.Grow(record_replay_matched_properties_.size() + 1);
-  RecordReplayMatchedProperties& new_rr_properties = record_replay_matched_properties_.back();
-  new_rr_properties.record_replay_id_properties = recordreplay::PointerId(properties);
-  new_rr_properties.types_.link_match_type = options.GetLinkMatchType();
-  new_rr_properties.types_.valid_property_filter =
-      static_cast<std::underlying_type_t<ValidPropertyFilter>>(
-          options.GetValidPropertyFilter());
-  new_rr_properties.types_.layer_order =
-      ClampTo<uint16_t>(options.GetLayerOrder());
-  new_rr_properties.types_.is_inline_style = options.IsInlineStyle();
-  new_rr_properties.types_.origin = current_origin_;
-  new_rr_properties.types_.tree_order = current_tree_order_;
 }
 
 void MatchResult::FinishAddingUARules() {

--- a/third_party/blink/renderer/core/css/resolver/match_result.cc
+++ b/third_party/blink/renderer/core/css/resolver/match_result.cc
@@ -44,6 +44,10 @@ MatchedProperties::MatchedProperties() {
   memset(&types_, 0, sizeof(types_));
 }
 
+RecordReplayMatchedProperties::RecordReplayMatchedProperties() {
+  memset(&types_, 0, sizeof(types_));
+}
+
 void MatchedProperties::Trace(Visitor* visitor) const {
   visitor->Trace(properties);
 }
@@ -63,6 +67,21 @@ void MatchResult::AddMatchedProperties(
   new_properties.types_.is_inline_style = options.IsInlineStyle();
   new_properties.types_.origin = current_origin_;
   new_properties.types_.tree_order = current_tree_order_;
+
+  // Create a duplicate entry for our record/replay, array, that does _not_
+  // have the properties pointer, so we avoid non-deterministic hashing values.
+  record_replay_matched_properties_.Grow(record_replay_matched_properties_.size() + 1);
+  RecordReplayMatchedProperties& new_rr_properties = record_replay_matched_properties_.back();
+  new_rr_properties.record_replay_id_properties = recordreplay::PointerId(properties);
+  new_rr_properties.types_.link_match_type = options.GetLinkMatchType();
+  new_rr_properties.types_.valid_property_filter =
+      static_cast<std::underlying_type_t<ValidPropertyFilter>>(
+          options.GetValidPropertyFilter());
+  new_rr_properties.types_.layer_order =
+      ClampTo<uint16_t>(options.GetLayerOrder());
+  new_rr_properties.types_.is_inline_style = options.IsInlineStyle();
+  new_rr_properties.types_.origin = current_origin_;
+  new_rr_properties.types_.tree_order = current_tree_order_;
 }
 
 void MatchResult::FinishAddingUARules() {

--- a/third_party/blink/renderer/core/css/resolver/match_result.h
+++ b/third_party/blink/renderer/core/css/resolver/match_result.h
@@ -67,13 +67,45 @@ struct CORE_EXPORT MatchedProperties {
   Data types_;
 };
 
+// This is a duplicate of the above, except that we do not have a pointer for 'properties'.
+// Instead, we store the id of the pointer, for deterministic replay.  We cannot alter
+// the above struct, because the Member<> is required for garbage collection tracing.
+struct CORE_EXPORT RecordReplayMatchedProperties {
+  DISALLOW_NEW();
+
+ public:
+  RecordReplayMatchedProperties();
+
+  int record_replay_id_properties;
+
+  struct Data {
+    unsigned link_match_type : 2;
+    unsigned valid_property_filter : 3;
+    CascadeOrigin origin;
+    // This is approximately equivalent to the 'shadow-including tree order'.
+    // It can be used to evaluate the 'Shadow Tree' criteria. Note that the
+    // number stored here is 'local' to each origin (user, author), and is
+    // not used at all for the UA origin. Hence, it is not possible to compare
+    // tree_orders from two different origins.
+    //
+    // https://drafts.csswg.org/css-scoping/#shadow-cascading
+    uint16_t tree_order;
+    // https://drafts.csswg.org/css-cascade-5/#layer-ordering
+    uint16_t layer_order;
+    bool is_inline_style;
+  };
+  Data types_;
+};
+
 }  // namespace blink
 
 WTF_ALLOW_MOVE_AND_INIT_WITH_MEM_FUNCTIONS(blink::MatchedProperties)
+WTF_ALLOW_MOVE_AND_INIT_WITH_MEM_FUNCTIONS(blink::RecordReplayMatchedProperties)
 
 namespace blink {
 
 using MatchedPropertiesVector = HeapVector<MatchedProperties, 64>;
+using RecordReplayMatchedPropertiesVector = HeapVector<RecordReplayMatchedProperties, 64>;
 
 class AddMatchedPropertiesOptions {
   STACK_ALLOCATED();
@@ -188,6 +220,10 @@ class CORE_EXPORT MatchResult {
     return matched_properties_;
   }
 
+  const RecordReplayMatchedPropertiesVector& GetRecordReplayMatchedProperties() const {
+    return record_replay_matched_properties_;
+  }
+
   // Reset the MatchResult to its initial state, as if no MatchedProperties
   // objects were added.
   void Reset();
@@ -199,6 +235,7 @@ class CORE_EXPORT MatchResult {
 
  private:
   MatchedPropertiesVector matched_properties_;
+  RecordReplayMatchedPropertiesVector record_replay_matched_properties_;
   HeapVector<Member<const TreeScope>, 4> tree_scopes_;
   bool is_cacheable_{true};
   bool depends_on_size_container_queries_{false};

--- a/third_party/blink/renderer/core/css/resolver/match_result.h
+++ b/third_party/blink/renderer/core/css/resolver/match_result.h
@@ -74,38 +74,18 @@ struct CORE_EXPORT RecordReplayMatchedProperties {
   DISALLOW_NEW();
 
  public:
-  RecordReplayMatchedProperties();
-
   int record_replay_id_properties;
-
-  struct Data {
-    unsigned link_match_type : 2;
-    unsigned valid_property_filter : 3;
-    CascadeOrigin origin;
-    // This is approximately equivalent to the 'shadow-including tree order'.
-    // It can be used to evaluate the 'Shadow Tree' criteria. Note that the
-    // number stored here is 'local' to each origin (user, author), and is
-    // not used at all for the UA origin. Hence, it is not possible to compare
-    // tree_orders from two different origins.
-    //
-    // https://drafts.csswg.org/css-scoping/#shadow-cascading
-    uint16_t tree_order;
-    // https://drafts.csswg.org/css-cascade-5/#layer-ordering
-    uint16_t layer_order;
-    bool is_inline_style;
-  };
-  Data types_;
+  MatchedProperties::Data types_;
 };
 
 }  // namespace blink
 
 WTF_ALLOW_MOVE_AND_INIT_WITH_MEM_FUNCTIONS(blink::MatchedProperties)
-WTF_ALLOW_MOVE_AND_INIT_WITH_MEM_FUNCTIONS(blink::RecordReplayMatchedProperties)
 
 namespace blink {
 
 using MatchedPropertiesVector = HeapVector<MatchedProperties, 64>;
-using RecordReplayMatchedPropertiesVector = HeapVector<RecordReplayMatchedProperties, 64>;
+using RecordReplayMatchedPropertiesVector = Vector<RecordReplayMatchedProperties, 64>;
 
 class AddMatchedPropertiesOptions {
   STACK_ALLOCATED();
@@ -220,8 +200,16 @@ class CORE_EXPORT MatchResult {
     return matched_properties_;
   }
 
-  const RecordReplayMatchedPropertiesVector& GetRecordReplayMatchedProperties() const {
-    return record_replay_matched_properties_;
+  RecordReplayMatchedPropertiesVector GetRecordReplayMatchedProperties() const {
+    RecordReplayMatchedPropertiesVector result;
+    result.resize(matched_properties_.size());
+
+    for (WTF::wtf_size_t i = 0; i < matched_properties_.size(); ++i) {
+      mempcpy(&result[i].types_, &matched_properties_[i].types_, sizeof(MatchedProperties::Data));
+      result[i].record_replay_id_properties = recordreplay::PointerId(matched_properties_[i].properties.Get());
+    }
+
+    return result;
   }
 
   // Reset the MatchResult to its initial state, as if no MatchedProperties
@@ -235,7 +223,6 @@ class CORE_EXPORT MatchResult {
 
  private:
   MatchedPropertiesVector matched_properties_;
-  RecordReplayMatchedPropertiesVector record_replay_matched_properties_;
   HeapVector<Member<const TreeScope>, 4> tree_scopes_;
   bool is_cacheable_{true};
   bool depends_on_size_container_queries_{false};

--- a/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
+++ b/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
@@ -40,9 +40,9 @@
 namespace blink {
 
 static unsigned ComputeMatchedPropertiesHash(const MatchResult& result) {
-  const MatchedPropertiesVector& vector = result.GetMatchedProperties();
+  const RecordReplayMatchedPropertiesVector& vector = result.GetRecordReplayMatchedProperties();
   return StringHasher::HashMemory(vector.data(),
-                                  sizeof(MatchedProperties) * vector.size());
+                                  sizeof(RecordReplayMatchedProperties) * vector.size());
 }
 
 void CachedMatchedProperties::Set(const ComputedStyle& style,

--- a/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
+++ b/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
@@ -40,7 +40,7 @@
 namespace blink {
 
 static unsigned ComputeMatchedPropertiesHash(const MatchResult& result) {
-  const RecordReplayMatchedPropertiesVector& vector = result.GetRecordReplayMatchedProperties();
+  const RecordReplayMatchedPropertiesVector vector = result.GetRecordReplayMatchedProperties();
   return StringHasher::HashMemory(vector.data(),
                                   sizeof(RecordReplayMatchedProperties) * vector.size());
 }

--- a/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
@@ -39,9 +39,9 @@ scoped_refptr<FontFallbackList> FontFallbackMap::Get(
 }
 
 void FontFallbackMap::Remove(const FontDescription& font_description) {
-  recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::Remove #0 %d %s",
-    record_replay_id_,
-    font_description.ToString().Utf8().data());
+  recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::Remove #0 %d %u",
+    record_replay_id_, StringHash::GetHash(font_description.ToString()));
+    
   AutoLockForParallelTextShaping guard(lock_);
   auto iter = fallback_list_for_description_.find(font_description);
   DCHECK_NE(iter, fallback_list_for_description_.end());


### PR DESCRIPTION
The hash key is computed over the vec of bits of all the matching properties, which unfortunately includes a pointer in each match.  Replace it with a record_replay id.