### PR TITLE
RUN-1347: undo my previous change and leak `PageScheduler` properly instead

### DIFF
--- a/third_party/blink/renderer/core/page/page.cc
+++ b/third_party/blink/renderer/core/page/page.cc
@@ -1022,6 +1022,15 @@ void Page::WillBeDestroyed() {
       });
   page_visibility_observer_set_.Clear();
 
+  if (recordreplay::AreEventsDisallowed() &&
+      recordreplay::IsRecordingOrReplaying("leak-references")) {
+    // If the dtor is called during GC (usually from |~SVGImage|),
+    // we leak the scheduler, so the finalizer does not touch the recording
+    // stream.
+    // https://linear.app/replay/issue/RUN-1347#comment-bc4e3f9d
+    page_scheduler_.release();
+  }
+
   page_scheduler_ = nullptr;
 }
 

--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -209,9 +209,6 @@ SVGImage::SVGImage(ImageObserver* observer, bool is_multipart)
                                  ->CreateAgentGroupScheduler()),
       has_pending_timeline_rewind_(false) {}
 
-// RUN-1347
-static std::vector<std::unique_ptr<PageScheduler>>* gReplayLeakedSchedulers = nullptr;
-
 SVGImage::~SVGImage() {
   AllowDestroyingLayoutObjectInFinalizerScope scope;
 
@@ -219,19 +216,6 @@ SVGImage::~SVGImage() {
     frame_client_->ClearImage();
 
   if (page_) {
-
-    if (recordreplay::IsRecordingOrReplaying()) {
-      // Since the dtor is called by the GC, we leak the scheduler, so it won't
-      // try touching the recording stream during `WillBeDestroyed` below.
-      // https://linear.app/replay/issue/RUN-1347#comment-73b7832e
-      CHECK(IsMainThread());
-      if (!gReplayLeakedSchedulers) {
-        gReplayLeakedSchedulers = new std::vector<std::unique_ptr<PageScheduler>>();
-      }
-      std::unique_ptr<PageScheduler> scheduler(page_->GetPageScheduler());
-      gReplayLeakedSchedulers->push_back(std::move(scheduler));
-    }
-
     // It is safe to allow UA events within this scope, because event
     // dispatching inside the SVG image's document doesn't trigger JavaScript
     // execution. All script execution is forbidden when an SVG is loaded as an


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1347#comment-bc4e3f9d
* NOTE: This fully reverts [this previous PR](https://github.com/replayio/chromium/pull/531/files)