### PR TITLE
WIP: Deterministic HeapHashSet iteration draft

### DIFF
--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -232,6 +232,16 @@ struct ReplayRefPointerIdHash : ReplayPointerIdHash<T> {
   static bool Equal(const scoped_refptr<T>& a, T* b) { return a == b; }
 };
 
+class RecordReplayIdMixin {
+ public:
+  RecordReplayIdMixin()
+      : record_replay_id_(NewIdAnyThread("RecordReplayIdMixin")) {}
+
+  int RecordReplayId() const { return record_replay_id_; }
+
+ private:
+  int record_replay_id_ = 0;
+};
 
 // For taking ordered locks when events might be disallowed. Passes through
 // events during the acquire to avoid generating a warning.

--- a/third_party/blink/renderer/core/annotation/annotation_agent_container_impl.h
+++ b/third_party/blink/renderer/core/annotation/annotation_agent_container_impl.h
@@ -8,6 +8,7 @@
 #include "base/types/pass_key.h"
 #include "components/shared_highlighting/core/common/shared_highlighting_metrics.h"
 #include "third_party/blink/public/mojom/annotation/annotation.mojom-blink.h"
+#include "third_party/blink/renderer/core/annotation/annotation_agent_impl.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/dom/document.h"
 #include "third_party/blink/renderer/core/fragment_directive/text_fragment_selector_generator.h"
@@ -20,7 +21,7 @@
 namespace blink {
 
 class AnnotationAgentContainerImplTest;
-class AnnotationAgentImpl;
+// class AnnotationAgentImpl;
 class AnnotationSelector;
 class LocalFrame;
 class AnnotationAgentGenerator;

--- a/third_party/blink/renderer/core/annotation/annotation_agent_impl.h
+++ b/third_party/blink/renderer/core/annotation/annotation_agent_impl.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_ANNOTATION_ANNOTATION_AGENT_IMPL_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_ANNOTATION_ANNOTATION_AGENT_IMPL_H_
 
+#include "base/record_replay.h"
 #include "base/types/pass_key.h"
 #include "third_party/blink/public/mojom/annotation/annotation.mojom-blink.h"
 #include "third_party/blink/renderer/core/core_export.h"
@@ -47,7 +48,8 @@ class RangeInFlatTree;
 // closes the connection, the AnnotationAgentImpl will be removed)
 class CORE_EXPORT AnnotationAgentImpl final
     : public GarbageCollected<AnnotationAgentImpl>,
-      public mojom::blink::AnnotationAgent {
+      public mojom::blink::AnnotationAgent,
+      public recordreplay::RecordReplayIdMixin {
  public:
   using PassKey = base::PassKey<AnnotationAgentImpl>;
 

--- a/third_party/blink/renderer/core/clipboard/data_object.h
+++ b/third_party/blink/renderer/core/clipboard/data_object.h
@@ -32,6 +32,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_CLIPBOARD_DATA_OBJECT_H_
 
 #include "base/memory/scoped_refptr.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/clipboard/data_object_item.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
@@ -56,7 +57,8 @@ enum class PasteMode;
 class CORE_EXPORT DataObject : public GarbageCollected<DataObject>,
                                public Supplementable<DataObject> {
  public:
-  struct CORE_EXPORT Observer : public GarbageCollectedMixin {
+  struct CORE_EXPORT Observer : public GarbageCollectedMixin,
+                                public recordreplay::RecordReplayIdMixin {
     // Called whenever |item_list_| is modified. Note it can be called multiple
     // times for a single mutation. For example, DataObject::SetData() calls
     // both ClearData() and Add(), each of which can call this method.

--- a/third_party/blink/renderer/core/css/counter_style_map.cc
+++ b/third_party/blink/renderer/core/css/counter_style_map.cc
@@ -11,6 +11,7 @@
 #include "third_party/blink/renderer/core/css/style_engine.h"
 #include "third_party/blink/renderer/core/css/style_rule_counter_style.h"
 #include "third_party/blink/renderer/core/dom/document.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
 
 namespace blink {
@@ -275,7 +276,9 @@ void CounterStyleMap::MarkDirtyCounterStyles(
 // static
 void CounterStyleMap::MarkAllDirtyCounterStyles(
     Document& document,
-    const HeapHashSet<Member<TreeScope>>& active_tree_scopes) {
+    const HeapHashSet<Member<TreeScope>,
+                      WTF::MemberHashRecordReplayId<TreeScope>>&
+        active_tree_scopes) {
   // Traverse all CounterStyle objects in the document to mark dirtiness.
   // We assume that there are not too many CounterStyle objects, so this won't
   // be a performance bottleneck.
@@ -298,7 +301,7 @@ void CounterStyleMap::MarkAllDirtyCounterStyles(
 // static
 void CounterStyleMap::ResolveAllReferences(
     Document& document,
-    const HeapHashSet<Member<TreeScope>>& active_tree_scopes) {
+    const HeapHashSet<Member<TreeScope>, WTF::MemberHashRecordReplayId<TreeScope>>& active_tree_scopes) {
   // Traverse all counter style maps to find and update CounterStyles that are
   // dirty or have unresolved references. We assume there are not too many
   // CounterStyles, so that this won't be a performance bottleneck.

--- a/third_party/blink/renderer/core/css/counter_style_map.h
+++ b/third_party/blink/renderer/core/css/counter_style_map.h
@@ -9,6 +9,7 @@
 #include "third_party/blink/renderer/core/css/counter_style.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string_hash.h"
 
@@ -33,12 +34,16 @@ class CORE_EXPORT CounterStyleMap : public GarbageCollected<CounterStyleMap> {
   void AddCounterStyles(const RuleSet&);
 
   void ResolveReferences(HeapHashSet<Member<CounterStyleMap>>& resolved_maps);
-  static void ResolveAllReferences(Document&,
-                                   const HeapHashSet<Member<TreeScope>>&);
+  static void ResolveAllReferences(
+      Document&,
+      const HeapHashSet<Member<TreeScope>,
+                        WTF::MemberHashRecordReplayId<TreeScope>>&);
 
   void MarkDirtyCounterStyles(HeapHashSet<Member<CounterStyle>>& visited);
-  static void MarkAllDirtyCounterStyles(Document&,
-                                        const HeapHashSet<Member<TreeScope>>&);
+  static void MarkAllDirtyCounterStyles(
+      Document&,
+      const HeapHashSet<Member<TreeScope>,
+                        WTF::MemberHashRecordReplayId<TreeScope>>&);
 
   void Dispose();
 

--- a/third_party/blink/renderer/core/css/css_segmented_font_face.h
+++ b/third_party/blink/renderer/core/css/css_segmented_font_face.h
@@ -28,6 +28,7 @@
 
 #include "base/callback.h"
 #include "base/containers/lru_cache.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/fonts/font_cache_key.h"
 #include "third_party/blink/renderer/platform/fonts/font_selection_types.h"
 #include "third_party/blink/renderer/platform/fonts/segmented_font_data.h"
@@ -87,7 +88,8 @@ class FontFaceList : public GarbageCollected<FontFaceList> {
 };
 
 class CSSSegmentedFontFace final
-    : public GarbageCollected<CSSSegmentedFontFace> {
+    : public GarbageCollected<CSSSegmentedFontFace>,
+      public recordreplay::RecordReplayIdMixin {
  public:
   static CSSSegmentedFontFace* Create(FontSelectionCapabilities);
 

--- a/third_party/blink/renderer/core/css/style_engine.h
+++ b/third_party/blink/renderer/core/css/style_engine.h
@@ -60,6 +60,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/loader/fetch/render_blocking_behavior.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
@@ -449,10 +450,10 @@ class CORE_EXPORT StyleEngine final : public GarbageCollected<StyleEngine>,
                                               Element& removed_element,
                                               Element& after_element);
   void ScheduleNthPseudoInvalidations(ContainerNode&);
-  void ScheduleInvalidationsForRuleSets(TreeScope&,
-                                        const HeapHashSet<Member<RuleSet>>&,
-                                        InvalidationScope =
-                                            kInvalidateCurrentScope);
+  void ScheduleInvalidationsForRuleSets(
+      TreeScope&,
+      const HeapHashSet<Member<RuleSet>>&,
+      InvalidationScope = kInvalidateCurrentScope);
   void ScheduleCustomElementInvalidations(HashSet<AtomicString> tag_names);
   void ScheduleInvalidationsForHasPseudoAffectedByInsertion(
       Element* parent,
@@ -647,7 +648,9 @@ class CORE_EXPORT StyleEngine final : public GarbageCollected<StyleEngine>,
 
   Document& GetDocument() const { return *document_; }
 
-  typedef HeapHashSet<Member<TreeScope>> UnorderedTreeScopeSet;
+  typedef HeapHashSet<Member<TreeScope>,
+                      WTF::MemberHashRecordReplayId<TreeScope>>
+      UnorderedTreeScopeSet;
 
   bool MediaQueryAffectingValueChanged(const ActiveStyleSheetVector&,
                                        MediaValueChange);
@@ -886,7 +889,8 @@ class CORE_EXPORT StyleEngine final : public GarbageCollected<StyleEngine>,
 
   Member<CSSFontSelector> font_selector_;
 
-  HeapHashMap<AtomicString, WeakMember<StyleSheetContents>> text_to_sheet_cache_;
+  HeapHashMap<AtomicString, WeakMember<StyleSheetContents>>
+      text_to_sheet_cache_;
   HeapHashMap<WeakMember<StyleSheetContents>, AtomicString>
       sheet_to_text_cache_;
 

--- a/third_party/blink/renderer/core/display_lock/display_lock_context.h
+++ b/third_party/blink/renderer/core/display_lock/display_lock_context.h
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/css/style_recalc_change.h"
 #include "third_party/blink/renderer/core/frame/local_frame_view.h"

--- a/third_party/blink/renderer/core/dom/document_parser.h
+++ b/third_party/blink/renderer/core/dom/document_parser.h
@@ -30,12 +30,16 @@
 #include "third_party/blink/renderer/platform/bindings/name_client.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/forward.h"
+
+// For RecordReplayId
+#include "third_party/blink/renderer/core/dom/document_parser_client.h"
 
 namespace blink {
 
 class Document;
-class DocumentParserClient;
+// class DocumentParserClient;
 class ScriptableDocumentParser;
 class TextResourceDecoder;
 

--- a/third_party/blink/renderer/core/dom/document_parser_client.h
+++ b/third_party/blink/renderer/core/dom/document_parser_client.h
@@ -5,11 +5,13 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_DOCUMENT_PARSER_CLIENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_DOCUMENT_PARSER_CLIENT_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 
 namespace blink {
 
-class DocumentParserClient : public GarbageCollectedMixin {
+class DocumentParserClient : public GarbageCollectedMixin,
+                             public recordreplay::RecordReplayIdMixin {
  public:
   // This callback is called when all data pushed to parser has been consumed.
   virtual void NotifyParserStopped() = 0;

--- a/third_party/blink/renderer/core/dom/element.h
+++ b/third_party/blink/renderer/core/dom/element.h
@@ -207,6 +207,8 @@ class CORE_EXPORT Element : public ContainerNode, public Animatable {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   Element(const QualifiedName& tag_name,
           Document*,
           ConstructionType = kCreateElement);

--- a/third_party/blink/renderer/core/dom/id_target_observer.h
+++ b/third_party/blink/renderer/core/dom/id_target_observer.h
@@ -26,6 +26,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_ID_TARGET_OBSERVER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_ID_TARGET_OBSERVER_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
@@ -34,7 +35,8 @@ namespace blink {
 
 class IdTargetObserverRegistry;
 
-class IdTargetObserver : public GarbageCollected<IdTargetObserver> {
+class IdTargetObserver : public GarbageCollected<IdTargetObserver>,
+                         public recordreplay::RecordReplayIdMixin {
  public:
   virtual ~IdTargetObserver();
   virtual void Trace(Visitor*) const;

--- a/third_party/blink/renderer/core/dom/id_target_observer_registry.h
+++ b/third_party/blink/renderer/core/dom/id_target_observer_registry.h
@@ -33,9 +33,12 @@
 #include "third_party/blink/renderer/platform/wtf/forward.h"
 #include "third_party/blink/renderer/platform/wtf/text/string_hash.h"
 
+// For RecordReplayId
+#include "third_party/blink/renderer/core/dom/id_target_observer.h"
+
 namespace blink {
 
-class IdTargetObserver;
+// class IdTargetObserver;
 
 class CORE_EXPORT IdTargetObserverRegistry final
     : public GarbageCollected<IdTargetObserverRegistry> {

--- a/third_party/blink/renderer/core/dom/mutation_observer.h
+++ b/third_party/blink/renderer/core/dom/mutation_observer.h
@@ -41,6 +41,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/heap/prefinalizer.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
@@ -58,9 +59,12 @@ class Node;
 class ScriptState;
 class V8MutationCallback;
 
-using MutationObserverSet = HeapHashSet<Member<MutationObserver>>;
+using MutationObserverSet =
+    HeapHashSet<Member<MutationObserver>,
+                WTF::MemberHashRecordReplayId<MutationObserver>>;
 using MutationObserverRegistrationSet =
-    HeapHashSet<WeakMember<MutationObserverRegistration>>;
+    HeapHashSet<WeakMember<MutationObserverRegistration>,
+                WTF::MemberHashRecordReplayId<MutationObserverRegistration>>;
 using MutationObserverVector = HeapVector<Member<MutationObserver>>;
 using MutationRecordVector = HeapVector<Member<MutationRecord>>;
 
@@ -73,6 +77,8 @@ class CORE_EXPORT MutationObserver final
   USING_PRE_FINALIZER(MutationObserver, CancelInspectorAsyncTasks);
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   enum ObservationFlags { kSubtree = 1 << 3, kAttributeFilter = 1 << 4 };
 
   enum DeliveryFlags {

--- a/third_party/blink/renderer/core/dom/mutation_observer_registration.h
+++ b/third_party/blink/renderer/core/dom/mutation_observer_registration.h
@@ -31,11 +31,13 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_MUTATION_OBSERVER_REGISTRATION_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_MUTATION_OBSERVER_REGISTRATION_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/dom/mutation_observer.h"
 #include "third_party/blink/renderer/platform/bindings/name_client.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/hash_set.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string_hash.h"
@@ -46,7 +48,8 @@ class QualifiedName;
 
 class CORE_EXPORT MutationObserverRegistration final
     : public GarbageCollected<MutationObserverRegistration>,
-      public NameClient {
+      public NameClient,
+      public recordreplay::RecordReplayIdMixin {
  public:
   MutationObserverRegistration(MutationObserver&,
                                Node*,
@@ -91,7 +94,8 @@ class CORE_EXPORT MutationObserverRegistration final
   Member<MutationObserver> observer_;
   WeakMember<Node> registration_node_;
   Member<Node> registration_node_keep_alive_;
-  typedef HeapHashSet<Member<Node>> NodeHashSet;
+  typedef HeapHashSet<Member<Node>, WTF::MemberHashRecordReplayId<Node>>
+      NodeHashSet;
   Member<NodeHashSet> transient_registration_nodes_;
 
   MutationObserverOptions options_;

--- a/third_party/blink/renderer/core/dom/node.cc
+++ b/third_party/blink/renderer/core/dom/node.cc
@@ -129,6 +129,7 @@
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
 #include "third_party/blink/renderer/platform/bindings/v8_dom_wrapper.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/instrumentation/instance_counters.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/traced_value.h"
@@ -141,7 +142,9 @@
 #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
-namespace v8 { extern std::string RecordReplayGetScriptedCaller(); }
+namespace v8 {
+extern std::string RecordReplayGetScriptedCaller();
+}
 
 namespace blink {
 
@@ -1598,7 +1601,7 @@ void Node::AttachLayoutTree(AttachContext& context) {
 
 void Node::DetachLayoutTree(bool performing_reattach) {
   recordreplay::Assert("[RUN-1219-1694] Node::DetachLayoutTree %d",
-    this->RecordReplayId());
+                       this->RecordReplayId());
   DCHECK(GetDocument().Lifecycle().StateAllowsDetach() ||
          GetDocument().GetStyleEngine().InContainerQueryStyleRecalc());
   DCHECK(!performing_reattach ||
@@ -2045,9 +2048,11 @@ void Node::setTextContent(const String& text_arg) {
   // layout behavior diverges afterwards. See also Text::Create.
   if (recordreplay::IsRecordingOrReplaying("values")) {
     std::string contents = text.Utf8();
-    size_t recordedLength = recordreplay::RecordReplayValue("Node::setTextContent length", contents.length());
+    size_t recordedLength = recordreplay::RecordReplayValue(
+        "Node::setTextContent length", contents.length());
     contents.resize(recordedLength, ' ');
-    recordreplay::RecordReplayBytes("Node::setTextContent string", &contents[0], recordedLength);
+    recordreplay::RecordReplayBytes("Node::setTextContent string", &contents[0],
+                                    recordedLength);
     text = String::FromUTF8(&contents[0], recordedLength);
 
     // https://linear.app/replay/issue/RUN-809
@@ -2767,7 +2772,8 @@ Node::MutationObserverRegistry() {
   return &data->Registry();
 }
 
-const HeapHashSet<Member<MutationObserverRegistration>>*
+const HeapHashSet<Member<MutationObserverRegistration>,
+                  WTF::MemberHashRecordReplayId<MutationObserverRegistration>>*
 Node::TransientMutationObserverRegistry() {
   if (!HasRareData())
     return nullptr;
@@ -2870,8 +2876,7 @@ void Node::RegisterTransientMutationObserver(
 
 void Node::UnregisterTransientMutationObserver(
     MutationObserverRegistration* registration) {
-  const HeapHashSet<Member<MutationObserverRegistration>>* transient_registry =
-      TransientMutationObserverRegistry();
+  const auto* transient_registry = TransientMutationObserverRegistry();
   DCHECK(transient_registry);
   if (!transient_registry)
     return;

--- a/third_party/blink/renderer/core/dom/node.h
+++ b/third_party/blink/renderer/core/dom/node.h
@@ -41,6 +41,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/custom_spaces.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/text/text_direction.h"
 #include "third_party/blink/renderer/platform/wtf/wtf.h"
 
@@ -161,13 +162,14 @@ enum class LinkHighlightCandidate {
 // A Node is a base class for all objects in the DOM tree.
 // The spec governing this interface can be found here:
 // https://dom.spec.whatwg.org/#interface-node
-class CORE_EXPORT Node : public EventTarget,
-                         public recordreplay::RecordReplayIdMixin {
+class CORE_EXPORT Node : public EventTarget {
   DEFINE_WRAPPERTYPEINFO();
   friend class TreeScope;
   friend class TreeScopeAdopter;
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   enum NodeType {
     kElementNode = 1,
     kAttributeNode = 2,
@@ -1179,7 +1181,9 @@ class CORE_EXPORT Node : public EventTarget,
 
   const HeapVector<Member<MutationObserverRegistration>>*
   MutationObserverRegistry();
-  const HeapHashSet<Member<MutationObserverRegistration>>*
+  const HeapHashSet<
+      Member<MutationObserverRegistration>,
+      WTF::MemberHashRecordReplayId<MutationObserverRegistration>>*
   TransientMutationObserverRegistry();
 
   NodeRareData* DataAsNodeRareData() const {

--- a/third_party/blink/renderer/core/dom/node.h
+++ b/third_party/blink/renderer/core/dom/node.h
@@ -28,6 +28,7 @@
 
 #include "base/dcheck_is_on.h"
 #include "base/notreached.h"
+#include "base/record_replay.h"
 #include "third_party/blink/public/mojom/input/focus_type.mojom-blink-forward.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/dom/events/event_target.h"
@@ -160,7 +161,8 @@ enum class LinkHighlightCandidate {
 // A Node is a base class for all objects in the DOM tree.
 // The spec governing this interface can be found here:
 // https://dom.spec.whatwg.org/#interface-node
-class CORE_EXPORT Node : public EventTarget {
+class CORE_EXPORT Node : public EventTarget,
+                         public recordreplay::RecordReplayIdMixin {
   DEFINE_WRAPPERTYPEINFO();
   friend class TreeScope;
   friend class TreeScopeAdopter;

--- a/third_party/blink/renderer/core/dom/node_rare_data.h
+++ b/third_party/blink/renderer/core/dom/node_rare_data.h
@@ -26,6 +26,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/heap/thread_state_storage.h"
 #include "third_party/blink/renderer/platform/wtf/bit_field.h"
 #include "third_party/blink/renderer/platform/wtf/casting.h"
@@ -55,7 +56,10 @@ class NodeMutationObserverData final
     return registry_;
   }
 
-  const HeapHashSet<Member<MutationObserverRegistration>>& TransientRegistry() {
+  const HeapHashSet<
+      Member<MutationObserverRegistration>,
+      WTF::MemberHashRecordReplayId<MutationObserverRegistration>>&
+  TransientRegistry() {
     return transient_registry_;
   }
 
@@ -68,7 +72,9 @@ class NodeMutationObserverData final
 
  private:
   HeapVector<Member<MutationObserverRegistration>> registry_;
-  HeapHashSet<Member<MutationObserverRegistration>> transient_registry_;
+  HeapHashSet<Member<MutationObserverRegistration>,
+              WTF::MemberHashRecordReplayId<MutationObserverRegistration>>
+      transient_registry_;
 };
 
 class NodeData : public GarbageCollected<NodeData> {

--- a/third_party/blink/renderer/core/dom/shadow_root.h
+++ b/third_party/blink/renderer/core/dom/shadow_root.h
@@ -53,6 +53,8 @@ class CORE_EXPORT ShadowRoot final : public DocumentFragment, public TreeScope {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   ShadowRoot(Document&, ShadowRootType);
   ~ShadowRoot() override;
   ShadowRoot(const ShadowRoot&) = delete;

--- a/third_party/blink/renderer/core/dom/synchronous_mutation_observer.h
+++ b/third_party/blink/renderer/core/dom/synchronous_mutation_observer.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SYNCHRONOUS_MUTATION_OBSERVER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SYNCHRONOUS_MUTATION_OBSERVER_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/dom/container_node.h"
 #include "third_party/blink/renderer/core/dom/qualified_name.h"
@@ -39,7 +40,9 @@ class Text;
 //  - SelectionController
 //  - Range set
 //  - NodeIterator set
-class CORE_EXPORT SynchronousMutationObserver : public GarbageCollectedMixin {
+class CORE_EXPORT SynchronousMutationObserver
+    : public GarbageCollectedMixin,
+      public recordreplay::RecordReplayIdMixin {
  public:
   // TODO(yosin): We will have following member functions:
   //  - dataWillBeChanged(const CharacterData&);

--- a/third_party/blink/renderer/core/dom/tree_scope.h
+++ b/third_party/blink/renderer/core/dom/tree_scope.h
@@ -27,6 +27,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_TREE_SCOPE_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_TREE_SCOPE_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_observable_array_css_style_sheet.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/css/css_style_sheet.h"
@@ -59,7 +60,8 @@ class ScopedStyleResolver;
 // A class which inherits both Node and TreeScope must call clearRareData() in
 // its destructor so that the Node destructor no longer does problematic
 // NodeList cache manipulation in the destructor.
-class CORE_EXPORT TreeScope : public GarbageCollectedMixin {
+class CORE_EXPORT TreeScope : public GarbageCollectedMixin,
+                              public recordreplay::RecordReplayIdMixin {
  public:
   enum HitTestPointType {
     kInternal = 1 << 1,

--- a/third_party/blink/renderer/core/exported/web_plugin_container_impl.h
+++ b/third_party/blink/renderer/core/exported/web_plugin_container_impl.h
@@ -33,6 +33,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_EXPORTED_WEB_PLUGIN_CONTAINER_IMPL_H_
 
 #include "base/memory/scoped_refptr.h"
+#include "base/record_replay.h"
 #include "third_party/blink/public/common/input/web_coalesced_input_event.h"
 #include "third_party/blink/public/common/input/web_touch_event.h"
 #include "third_party/blink/public/mojom/input/focus_type.mojom-blink-forward.h"
@@ -71,7 +72,8 @@ struct WebPrintPresetOptions;
 class CORE_EXPORT WebPluginContainerImpl final
     : public GarbageCollected<WebPluginContainerImpl>,
       public EmbeddedContentView,
-      public WebPluginContainer {
+      public WebPluginContainer,
+      public recordreplay::RecordReplayIdMixin {
   USING_PRE_FINALIZER(WebPluginContainerImpl, PreFinalize);
 
  public:

--- a/third_party/blink/renderer/core/fetch/fetch_manager.cc
+++ b/third_party/blink/renderer/core/fetch/fetch_manager.cc
@@ -10,6 +10,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/numerics/safe_conversions.h"
+#include "base/record_replay.h"
 #include "base/strings/strcat.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/unguessable_token.h"
@@ -130,7 +131,8 @@ void HistogramNetErrorForTrustTokensOperation(
 
 class FetchManager::Loader final
     : public GarbageCollected<FetchManager::Loader>,
-      public ThreadableLoaderClient {
+      public ThreadableLoaderClient,
+      public recordreplay::RecordReplayIdMixin {
  public:
   Loader(ExecutionContext*,
          FetchManager*,

--- a/third_party/blink/renderer/core/fetch/fetch_manager.h
+++ b/third_party/blink/renderer/core/fetch/fetch_manager.h
@@ -10,6 +10,7 @@
 #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -39,7 +40,7 @@ class CORE_EXPORT FetchManager final
   // Removes loader from |m_loaders|.
   void OnLoaderFinished(Loader*);
 
-  HeapHashSet<Member<Loader>> loaders_;
+  HeapHashSet<Member<Loader>, WTF::MemberHashRecordReplayId<Loader>> loaders_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/frame.h
+++ b/third_party/blink/renderer/core/frame/frame.h
@@ -31,6 +31,7 @@
 
 #include "base/check_op.h"
 #include "base/i18n/rtl.h"
+#include "base/record_replay.h"
 #include "base/unguessable_token.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -98,7 +99,8 @@ enum class FrameInsertType { kInsertInConstructor, kInsertLater };
 // Frame is the base class of LocalFrame and RemoteFrame and should only contain
 // functionality shared between both. In particular, any method related to
 // input, layout, or painting probably belongs on LocalFrame.
-class CORE_EXPORT Frame : public GarbageCollected<Frame> {
+class CORE_EXPORT Frame : public GarbageCollected<Frame>,
+                          public recordreplay::RecordReplayIdMixin {
  public:
   // Returns the Frame instance for the given |frame_token|.
   // Note that this Frame can be either a LocalFrame or Remote instance.

--- a/third_party/blink/renderer/core/frame/frame_serializer.cc
+++ b/third_party/blink/renderer/core/frame/frame_serializer.cc
@@ -263,9 +263,11 @@ void SerializerMarkupAccumulator::AppendRewrittenAttribute(
   elements_with_rewritten_links_.insert(&element);
 
   if (html_names::kSrcAttr.LocalName().GetString() == attribute_name) {
-    recordreplay::Assert("[RUN-658-1438] SerializerMarkupAccumulator::AppendRewrittenAttribute %d %s",
-                         element.RecordReplayId(),
-                         attribute_value.Utf8().c_str());
+    recordreplay::Assert(
+        "[RUN-658-1438] SerializerMarkupAccumulator::AppendRewrittenAttribute "
+        "%d %s",
+        element.ScriptWrappable::RecordReplayId(),
+        attribute_value.Utf8().c_str());
   }
 
   // Append the rewritten attribute.

--- a/third_party/blink/renderer/core/frame/local_dom_window.h
+++ b/third_party/blink/renderer/core/frame/local_dom_window.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 
+#include "base/record_replay.h"
 #include "services/metrics/public/cpp/ukm_recorder.h"
 #include "services/metrics/public/cpp/ukm_source_id.h"
 #include "services/network/public/mojom/content_security_policy.mojom-blink.h"
@@ -108,7 +109,9 @@ class CORE_EXPORT LocalDOMWindow final : public DOMWindow,
   USING_PRE_FINALIZER(LocalDOMWindow, Dispose);
 
  public:
-  class CORE_EXPORT EventListenerObserver : public GarbageCollectedMixin {
+  class CORE_EXPORT EventListenerObserver
+      : public GarbageCollectedMixin,
+        public recordreplay::RecordReplayIdMixin {
    public:
     virtual void DidAddEventListener(LocalDOMWindow*, const AtomicString&) = 0;
     virtual void DidRemoveEventListener(LocalDOMWindow*,

--- a/third_party/blink/renderer/core/frame/local_frame.h
+++ b/third_party/blink/renderer/core/frame/local_frame.h
@@ -88,6 +88,9 @@
 #include "third_party/perfetto/include/perfetto/tracing/traced_value_forward.h"
 #include "ui/gfx/geometry/transform.h"
 
+// For RecordReplayId
+#include "third_party/blink/renderer/core/frame/virtual_keyboard_overlay_changed_observer.h"
+
 namespace base {
 class SingleThreadTaskRunner;
 }
@@ -142,7 +145,7 @@ class StorageKey;
 class SystemClipboard;
 class TextFragmentHandler;
 class TextSuggestionController;
-class VirtualKeyboardOverlayChangedObserver;
+// class VirtualKeyboardOverlayChangedObserver;
 class WebContentSettingsClient;
 class WebInputEventAttribution;
 class WebPluginContainerImpl;

--- a/third_party/blink/renderer/core/frame/local_frame_view.h
+++ b/third_party/blink/renderer/core/frame/local_frame_view.h
@@ -33,6 +33,7 @@
 #include "base/dcheck_is_on.h"
 #include "base/functional/function_ref.h"
 #include "base/gtest_prod_util.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "third_party/blink/public/common/metrics/document_update_reason.h"
 #include "third_party/blink/public/mojom/frame/lifecycle.mojom-blink-forward.h"
@@ -54,12 +55,16 @@
 #include "third_party/blink/renderer/platform/graphics/paint/cull_rect.h"
 #include "third_party/blink/renderer/platform/graphics/paint_invalidation_reason.h"
 #include "third_party/blink/renderer/platform/graphics/subtree_paint_property_update_reason.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/runtime_enabled_features.h"
 #include "third_party/blink/renderer/platform/scheduler/public/post_cancellable_task.h"
 #include "third_party/blink/renderer/platform/timer.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 #include "third_party/blink/renderer/platform/wtf/casting.h"
 #include "ui/gfx/geometry/rect.h"
+
+// For RecordReplayId
+#include "third_party/blink/renderer/core/exported/web_plugin_container_impl.h"
 
 template <typename T>
 class sk_sp;
@@ -72,7 +77,7 @@ class PaintOpBuffer;
 enum class PaintHoldingCommitTrigger;
 using PaintRecord = PaintOpBuffer;
 struct PaintBenchmarkResult;
-}
+}  // namespace cc
 
 namespace gfx {
 class SizeF;
@@ -115,7 +120,7 @@ class Scrollbar;
 class ScrollingCoordinator;
 class TransformState;
 class LocalFrameUkmAggregator;
-class WebPluginContainerImpl;
+// class WebPluginContainerImpl;
 struct AnnotatedRegionValue;
 struct IntrinsicSizingInfo;
 struct MobileFriendliness;
@@ -147,7 +152,8 @@ class CORE_EXPORT LocalFrameView final
 
  public:
   class CORE_EXPORT LifecycleNotificationObserver
-      : public GarbageCollectedMixin {
+      : public GarbageCollectedMixin,
+        public recordreplay::RecordReplayIdMixin {
    public:
     // These are called when the lifecycle updates start/finish.
     virtual void WillStartLifecycleUpdate(const LocalFrameView&) {}
@@ -306,7 +312,8 @@ class CORE_EXPORT LocalFrameView final
   void AdjustMediaTypeForPrinting(bool printing);
 
   typedef HeapHashSet<Member<LayoutObject>,
-                      WTF::MemberHashRecordReplayId<LayoutObject>> ObjectSet;
+                      WTF::MemberHashRecordReplayId<LayoutObject>>
+      ObjectSet;
   void AddFixedPositionObject(LayoutObject&);
   void RemoveFixedPositionObject(LayoutObject&);
   const ObjectSet* FixedPositionObjects() const {
@@ -453,7 +460,9 @@ class CORE_EXPORT LocalFrameView final
     return is_tracking_raster_invalidations_;
   }
 
-  using ScrollableAreaSet = HeapHashSet<Member<PaintLayerScrollableArea>, WTF::MemberHashRecordReplayId<PaintLayerScrollableArea>>;
+  using ScrollableAreaSet =
+      HeapHashSet<Member<PaintLayerScrollableArea>,
+                  WTF::MemberHashRecordReplayId<PaintLayerScrollableArea>>;
   void AddScrollAnchoringScrollableArea(PaintLayerScrollableArea*);
   void RemoveScrollAnchoringScrollableArea(PaintLayerScrollableArea*);
   const ScrollableAreaSet* ScrollAnchoringScrollableAreas() const {
@@ -1020,7 +1029,8 @@ class CORE_EXPORT LocalFrameView final
   LayoutSize size_;
 
   typedef HeapHashSet<Member<LayoutEmbeddedObject>,
-                      WTF::MemberHashRecordReplayId<LayoutEmbeddedObject>> EmbeddedObjectSet;
+                      WTF::MemberHashRecordReplayId<LayoutEmbeddedObject>>
+      EmbeddedObjectSet;
   EmbeddedObjectSet part_update_set_;
 
   Member<LocalFrame> frame_;
@@ -1178,7 +1188,9 @@ class CORE_EXPORT LocalFrameView final
   // possible, avoids needing to walk the tree to update them. See:
   // https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/core/paint/README.md#Transform-update-optimization
   // for more on the fast path
-  Member<HeapHashSet<Member<LayoutObject>>> pending_transform_updates_;
+  Member<HeapHashSet<Member<LayoutObject>,
+                     WTF::MemberHashRecordReplayId<LayoutObject>>>
+      pending_transform_updates_;
 
   // TODO(1370937): Currently we don't yet know how to handle soft navigation
   // UKM reporting. This flag indicates that First Contentful Paint was reported

--- a/third_party/blink/renderer/core/frame/opened_frame_tracker.cc
+++ b/third_party/blink/renderer/core/frame/opened_frame_tracker.cc
@@ -5,6 +5,7 @@
 #include "third_party/blink/renderer/core/frame/opened_frame_tracker.h"
 
 #include "third_party/blink/renderer/core/frame/frame.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -33,7 +34,8 @@ void OpenedFrameTracker::Remove(Frame* frame) {
 void OpenedFrameTracker::TransferTo(Frame* opener) const {
   // Copy the set of opened frames, since changing the owner will mutate this
   // set.
-  HeapHashSet<Member<Frame>> frames(opened_frames_);
+  HeapHashSet<Member<Frame>, WTF::MemberHashRecordReplayId<Frame>> frames(
+      opened_frames_);
   for (const auto& frame : frames)
     frame->SetOpenerDoNotNotify(opener);
 }

--- a/third_party/blink/renderer/core/frame/opened_frame_tracker.h
+++ b/third_party/blink/renderer/core/frame/opened_frame_tracker.h
@@ -7,6 +7,7 @@
 
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 
 namespace blink {
@@ -40,7 +41,8 @@ class OpenedFrameTracker {
   void Dispose();
 
  private:
-  HeapHashSet<Member<Frame>> opened_frames_;
+  HeapHashSet<Member<Frame>, WTF::MemberHashRecordReplayId<Frame>>
+      opened_frames_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/pending_beacon_dispatcher.h
+++ b/third_party/blink/renderer/core/frame/pending_beacon_dispatcher.h
@@ -6,6 +6,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_PENDING_BEACON_DISPATCHER_H_
 
 #include "base/gtest_prod_util.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "base/types/pass_key.h"
 #include "third_party/blink/public/mojom/frame/pending_beacon.mojom-blink.h"
@@ -73,7 +74,8 @@ class CORE_EXPORT PendingBeaconDispatcher
   // pending beacon object. "pending" means this beacon is ok to send.
   // PendingBeaconDispatcher uses this abstraction, instead of the entire
   // blink::PendingBeacon, to schedule tasks to send out pending beacons.
-  class CORE_EXPORT PendingBeacon : public GarbageCollectedMixin {
+  class CORE_EXPORT PendingBeacon : public GarbageCollectedMixin,
+                                    public recordreplay::RecordReplayIdMixin {
    public:
     // Returns a background timeout to help schedule calls to `Send()` when the
     // page where this beacon created enters hidden visibility state.

--- a/third_party/blink/renderer/core/frame/platform_event_controller.h
+++ b/third_party/blink/renderer/core/frame/platform_event_controller.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_PLATFORM_EVENT_CONTROLLER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_PLATFORM_EVENT_CONTROLLER_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/public/platform/task_type.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/page/page_visibility_observer.h"
@@ -20,7 +21,9 @@ class LocalDOMWindow;
 // It watches page visibility and calls stopUpdating when page is not visible.
 // It provides a DidUpdateData() callback method which is called when new data
 // it available.
-class CORE_EXPORT PlatformEventController : public PageVisibilityObserver {
+class CORE_EXPORT PlatformEventController
+    : public PageVisibilityObserver,
+      public recordreplay::RecordReplayIdMixin {
  public:
   void StartUpdating();
   void StopUpdating();

--- a/third_party/blink/renderer/core/frame/platform_event_dispatcher.h
+++ b/third_party/blink/renderer/core/frame/platform_event_dispatcher.h
@@ -10,8 +10,11 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/member.h"
 
+// For RecordReplayId.
+#include "third_party/blink/renderer/core/frame/platform_event_controller.h"
+
 namespace blink {
-class PlatformEventController;
+// class PlatformEventController;
 class LocalDOMWindow;
 
 class CORE_EXPORT PlatformEventDispatcher : public GarbageCollectedMixin {

--- a/third_party/blink/renderer/core/frame/use_counter_impl.h
+++ b/third_party/blink/renderer/core/frame/use_counter_impl.h
@@ -27,6 +27,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_USE_COUNTER_IMPL_H_
 
 #include <bitset>
+#include "base/record_replay.h"
 #include "third_party/blink/public/common/use_counter/use_counter_feature_tracker.h"
 #include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/mojom/permissions_policy/permissions_policy_feature.mojom-blink-forward.h"
@@ -102,7 +103,8 @@ class CORE_EXPORT UseCounterImpl final {
   // An interface to observe UseCounterImpl changes. Note that this is never
   // notified when the counter is disabled by |m_muteCount| or when |m_context|
   // is kDisabledContext.
-  class Observer : public GarbageCollected<Observer> {
+  class Observer : public GarbageCollected<Observer>,
+                   public recordreplay::RecordReplayIdMixin {
    public:
     // Notified when a feature is counted for the first time. This should return
     // true if it no longer needs to observe changes so that the counter can

--- a/third_party/blink/renderer/core/frame/virtual_keyboard_overlay_changed_observer.h
+++ b/third_party/blink/renderer/core/frame/virtual_keyboard_overlay_changed_observer.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_VIRTUAL_KEYBOARD_OVERLAY_CHANGED_OBSERVER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_VIRTUAL_KEYBOARD_OVERLAY_CHANGED_OBSERVER_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 
@@ -21,7 +22,8 @@ class LocalFrame;
 // Browser process receives these VK showing/hiding events from the OS input
 // services. It is reported as a rectangle that occludes the web content.
 class CORE_EXPORT VirtualKeyboardOverlayChangedObserver
-    : public GarbageCollectedMixin {
+    : public GarbageCollectedMixin,
+      public recordreplay::RecordReplayIdMixin {
  public:
   // This is used to fire a VK overlay geometry change JS event.
   // The |Rect| is the VK rectangle that occludes the web content.

--- a/third_party/blink/renderer/core/html/anchor_element_metrics_sender.h
+++ b/third_party/blink/renderer/core/html/anchor_element_metrics_sender.h
@@ -14,10 +14,13 @@
 #include "third_party/blink/renderer/platform/supplementable.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
+// For RecordReplayId.
+#include "third_party/blink/renderer/core/html/html_anchor_element.h"
+
 namespace blink {
 
 class Document;
-class HTMLAnchorElement;
+// class HTMLAnchorElement;
 class IntersectionObserver;
 class IntersectionObserverEntry;
 class AnchorElementMetrics;

--- a/third_party/blink/renderer/core/html/canvas/canvas_draw_listener.h
+++ b/third_party/blink/renderer/core/html/canvas/canvas_draw_listener.h
@@ -6,6 +6,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_HTML_CANVAS_CANVAS_DRAW_LISTENER_H_
 
 #include "base/memory/ref_counted.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/platform/graphics/static_bitmap_image.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
@@ -16,7 +17,9 @@ class VideoFrame;
 
 namespace blink {
 
-class CORE_EXPORT CanvasDrawListener : public GarbageCollectedMixin {
+class CORE_EXPORT CanvasDrawListener
+    : public GarbageCollectedMixin,
+      public recordreplay::RecordReplayIdMixin {
  public:
   virtual ~CanvasDrawListener();
   // GetNewFrameCallback returns a once-callback to be made with a VideoFrame

--- a/third_party/blink/renderer/core/html/canvas/html_canvas_element.h
+++ b/third_party/blink/renderer/core/html/canvas/html_canvas_element.h
@@ -53,13 +53,16 @@
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/geometry/size.h"
 
+// For RecordReplayId
+#include "third_party/blink/renderer/core/html/canvas/canvas_draw_listener.h"
+
 #define CanvasDefaultInterpolationQuality kInterpolationLow
 
 namespace blink {
 
 class Canvas2DLayerBridge;
 class CanvasContextCreationAttributesCore;
-class CanvasDrawListener;
+// class CanvasDrawListener;
 class CanvasHighDynamicRangeOptions;
 class CanvasRenderingContext;
 class CanvasRenderingContextFactory;

--- a/third_party/blink/renderer/core/html/custom/custom_element_registry.h
+++ b/third_party/blink/renderer/core/html/custom/custom_element_registry.h
@@ -13,6 +13,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string_hash.h"
 
@@ -86,7 +87,8 @@ class CORE_EXPORT CustomElementRegistry final : public ScriptWrappable {
 
   Member<const LocalDOMWindow> owner_;
 
-  using UpgradeCandidateSet = HeapHashSet<WeakMember<Element>>;
+  using UpgradeCandidateSet =
+      HeapHashSet<WeakMember<Element>, WTF::MemberHashRecordReplayId<Element>>;
   using UpgradeCandidateMap =
       HeapHashMap<AtomicString, Member<UpgradeCandidateSet>>;
   Member<UpgradeCandidateMap> upgrade_candidates_;

--- a/third_party/blink/renderer/core/html/custom/custom_element_upgrade_sorter.h
+++ b/third_party/blink/renderer/core/html/custom/custom_element_upgrade_sorter.h
@@ -9,6 +9,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 
 namespace blink {
@@ -35,7 +36,8 @@ class CORE_EXPORT CustomElementUpgradeSorter {
   void Sorted(HeapVector<Member<Element>>* result, Node* parent);
 
  private:
-  using ChildSet = HeapHashSet<Member<Node>>;
+  using ChildSet =
+      HeapHashSet<Member<Node>, WTF::MemberHashRecordReplayId<Node>>;
   using ParentChildMap = HeapHashMap<Member<Node>, Member<ChildSet>>;
 
   enum AddResult { kParentAlreadyExistsInMap, kParentAddedToMap };

--- a/third_party/blink/renderer/core/html/custom/custom_state_set.cc
+++ b/third_party/blink/renderer/core/html/custom/custom_state_set.cc
@@ -4,13 +4,15 @@
 
 #include "third_party/blink/renderer/core/html/custom/custom_state_set.h"
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/css/css_selector.h"
 #include "third_party/blink/renderer/core/css/parser/css_parser_idioms.h"
 #include "third_party/blink/renderer/core/dom/element.h"
 
 namespace blink {
 
-class CustomStateIterationSource : public CustomStateSet::IterationSource {
+class CustomStateIterationSource : public CustomStateSet::IterationSource,
+                                   public recordreplay::RecordReplayIdMixin {
  public:
   explicit CustomStateIterationSource(CustomStateSet& states)
       : states_(states) {}

--- a/third_party/blink/renderer/core/html/custom/custom_state_set.h
+++ b/third_party/blink/renderer/core/html/custom/custom_state_set.h
@@ -8,6 +8,7 @@
 #include "third_party/blink/renderer/bindings/core/v8/iterable.h"
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 
 namespace blink {
@@ -52,7 +53,9 @@ class CustomStateSet final : public ScriptWrappable,
   // If the O(size()) operations are problematic, we should change the type of
   // the following data member.
   Vector<String> list_;
-  HeapHashSet<WeakMember<CustomStateIterationSource>> iterators_;
+  HeapHashSet<WeakMember<CustomStateIterationSource>,
+              WTF::MemberHashRecordReplayId<CustomStateIterationSource>>
+      iterators_;
 
   friend class CustomStateIterationSource;
 };

--- a/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
+++ b/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
@@ -159,9 +159,8 @@ scoped_refptr<FontData> PopupMenuCSSFontSelector::GetFontData(
 void PopupMenuCSSFontSelector::FontsNeedUpdate(FontSelector* font_selector,
                                                FontInvalidationReason reason) {
   recordreplay::Assert(
-    "[RUN-1219-1728] PopupMenuCSSFontSelector::FontsNeedUpdate %d",
-    this->RecordReplayId()
-  );
+      "[RUN-1219-1728] PopupMenuCSSFontSelector::FontsNeedUpdate %d",
+      this->FontSelectorClient::RecordReplayId());
   DispatchInvalidationCallbacks(reason);
 }
 

--- a/third_party/blink/renderer/core/html/media/html_media_element.h
+++ b/third_party/blink/renderer/core/html/media/html_media_element.h
@@ -112,6 +112,8 @@ class CORE_EXPORT HTMLMediaElement
   USING_PRE_FINALIZER(HTMLMediaElement, Dispose);
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   // Limits the range of media playback rate.
   static constexpr double kMinPlaybackRate = 0.0625;
   static constexpr double kMaxPlaybackRate = 16.0;

--- a/third_party/blink/renderer/core/html/media/remote_playback_controller.h
+++ b/third_party/blink/renderer/core/html/media/remote_playback_controller.h
@@ -9,9 +9,11 @@
 #include "third_party/blink/renderer/core/html/media/html_media_element.h"
 #include "third_party/blink/renderer/platform/supplementable.h"
 
+// For visibility of `RecordReplayId()`.
+#include "third_party/blink/renderer/core/html/media/remote_playback_observer.h"
 namespace blink {
 
-class RemotePlaybackObserver;
+// class RemotePlaybackObserver;
 
 // Interface exposing RemotePlayback to core/. It is meant to replace
 // WebRemotePlaybackClient in the long run when there will be no need to expose

--- a/third_party/blink/renderer/core/html/media/remote_playback_observer.h
+++ b/third_party/blink/renderer/core/html/media/remote_playback_observer.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_HTML_MEDIA_REMOTE_PLAYBACK_OBSERVER_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_HTML_MEDIA_REMOTE_PLAYBACK_OBSERVER_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/public/mojom/presentation/presentation.mojom-blink.h"
 
 namespace blink {
@@ -12,7 +13,8 @@ namespace blink {
 // Interface to be implemented by objects that intend to be notified by remote
 // playback status changes on an HTMLMediaElement. The object should self-add
 // itself to the RemotePlaybackController using the add/remove observer methods.
-class RemotePlaybackObserver : public GarbageCollectedMixin {
+class RemotePlaybackObserver : public GarbageCollectedMixin,
+                               public recordreplay::RecordReplayIdMixin {
  public:
   // Called when the remote playback state is changed. The state is related to
   // the connection to a remote device.

--- a/third_party/blink/renderer/core/html/track/text_track.h
+++ b/third_party/blink/renderer/core/html/track/text_track.h
@@ -43,7 +43,7 @@ class ExceptionState;
 class ExecutionContext;
 class HTMLMediaElement;
 class HTMLElement;
-class TextTrack;
+// class TextTrack;
 class TextTrackCue;
 class TextTrackCueList;
 class TextTrackList;

--- a/third_party/blink/renderer/core/layout/depth_ordered_layout_object_list.cc
+++ b/third_party/blink/renderer/core/layout/depth_ordered_layout_object_list.cc
@@ -9,6 +9,7 @@
 #include "third_party/blink/renderer/core/frame/local_frame_view.h"
 #include "third_party/blink/renderer/core/layout/layout_object.h"
 #include "third_party/blink/renderer/core/layout/ng/legacy_layout_tree_walking.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 
 namespace blink {
 
@@ -24,7 +25,11 @@ class DepthOrderedLayoutObjectListData
   HeapVector<LayoutObjectWithDepth>& ordered_objects() {
     return ordered_objects_;
   }
-  HeapHashSet<Member<LayoutObject>>& objects() { return objects_; }
+  HeapHashSet<Member<LayoutObject>,
+              WTF::MemberHashRecordReplayId<LayoutObject>>&
+  objects() {
+    return objects_;
+  }
 
   // LayoutObjects sorted by depth (deepest first). This structure is only
   // populated at the beginning of enumerations. See ordered().
@@ -33,7 +38,8 @@ class DepthOrderedLayoutObjectListData
   // Outside of layout, LayoutObjects can be added and removed as needed such
   // as when style was changed or destroyed. They're kept in this hashset to
   // keep those operations fast.
-  HeapHashSet<Member<LayoutObject>> objects_;
+  HeapHashSet<Member<LayoutObject>, WTF::MemberHashRecordReplayId<LayoutObject>>
+      objects_;
 };
 
 DepthOrderedLayoutObjectList::DepthOrderedLayoutObjectList()
@@ -107,7 +113,8 @@ unsigned LayoutObjectWithDepth::DetermineDepth(LayoutObject* object) {
   return depth;
 }
 
-const HeapHashSet<Member<LayoutObject>>&
+const HeapHashSet<Member<LayoutObject>,
+                  WTF::MemberHashRecordReplayId<LayoutObject>>&
 DepthOrderedLayoutObjectList::Unordered() const {
   return data_->objects();
 }

--- a/third_party/blink/renderer/core/layout/depth_ordered_layout_object_list.h
+++ b/third_party/blink/renderer/core/layout/depth_ordered_layout_object_list.h
@@ -9,6 +9,7 @@
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_vector.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 #include "third_party/blink/renderer/platform/wtf/vector_traits.h"
@@ -62,7 +63,9 @@ class DepthOrderedLayoutObjectList {
   int size() const;
   CORE_EXPORT bool IsEmpty() const;
 
-  const HeapHashSet<Member<LayoutObject>>& Unordered() const;
+  const HeapHashSet<Member<LayoutObject>,
+                    WTF::MemberHashRecordReplayId<LayoutObject>>&
+  Unordered() const;
   const HeapVector<LayoutObjectWithDepth>& Ordered();
 
  private:

--- a/third_party/blink/renderer/core/layout/hit_test_result.h
+++ b/third_party/blink/renderer/core/layout/hit_test_result.h
@@ -39,6 +39,9 @@
 #include "ui/gfx/geometry/quad_f.h"
 #include "ui/gfx/geometry/rect_f.h"
 
+// For RecordReplayId
+#include "third_party/blink/renderer/core/scroll/scrollbar.h"
+
 namespace cc {
 class Region;
 }
@@ -55,7 +58,7 @@ class MediaSourceHandle;
 class MediaStreamDescriptor;
 class NGPhysicalBoxFragment;
 class Node;
-class Scrollbar;
+// class Scrollbar;
 struct PhysicalOffset;
 
 // List-based hit test testing can continue even after a hit has been found.

--- a/third_party/blink/renderer/core/layout/layout_object.h
+++ b/third_party/blink/renderer/core/layout/layout_object.h
@@ -280,7 +280,8 @@ struct RecalcLayoutOverflowResult {
 // See the individual getters below for more details about what each width is.
 class CORE_EXPORT LayoutObject : public GarbageCollected<LayoutObject>,
                                  public ImageResourceObserver,
-                                 public DisplayItemClient {
+                                 public DisplayItemClient,
+                                 public recordreplay::RecordReplayIdMixin {
   friend class LayoutObjectChildList;
   FRIEND_TEST_ALL_PREFIXES(LayoutObjectTest, MutableForPaintingClearPaintFlags);
   FRIEND_TEST_ALL_PREFIXES(

--- a/third_party/blink/renderer/core/loader/long_task_detector.h
+++ b/third_party/blink/renderer/core/loader/long_task_detector.h
@@ -16,7 +16,8 @@
 
 namespace blink {
 
-class CORE_EXPORT LongTaskObserver : public GarbageCollectedMixin {
+class CORE_EXPORT LongTaskObserver : public GarbageCollectedMixin,
+                                     public recordreplay::RecordReplayIdMixin {
  public:
   LongTaskObserver() {
     // Pointer registration is needed for sorting in LongTaskDetector methods.

--- a/third_party/blink/renderer/core/page/page.h
+++ b/third_party/blink/renderer/core/page/page.h
@@ -27,6 +27,7 @@
 
 #include "base/check_op.h"
 #include "base/dcheck_is_on.h"
+#include "base/record_replay.h"
 #include "base/types/pass_key.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/public/common/features.h"
@@ -102,7 +103,8 @@ typedef uint64_t LinkHash;
 class CORE_EXPORT Page final : public GarbageCollected<Page>,
                                public Supplementable<Page>,
                                public SettingsDelegate,
-                               public PageScheduler::Delegate {
+                               public PageScheduler::Delegate,
+                               public recordreplay::RecordReplayIdMixin {
   friend class Settings;
 
  public:

--- a/third_party/blink/renderer/core/page/page.h
+++ b/third_party/blink/renderer/core/page/page.h
@@ -144,6 +144,7 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
     }
 
     static const bool safe_to_compare_to_empty_or_deleted = true;
+    static constexpr bool kIsRecordReplayDeterministicHash = true;
   };
 
   using PageSet = HeapHashSet<WeakMember<Page>, PageHash>;

--- a/third_party/blink/renderer/core/scroll/scrollbar.h
+++ b/third_party/blink/renderer/core/scroll/scrollbar.h
@@ -26,6 +26,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_SCROLL_SCROLLBAR_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_SCROLL_SCROLLBAR_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
 #include "third_party/blink/public/mojom/frame/color_scheme.mojom-blink-forward.h"
 #include "third_party/blink/renderer/core/core_export.h"
@@ -53,7 +54,8 @@ class WebMouseEvent;
 class WebPointerEvent;
 
 class CORE_EXPORT Scrollbar : public GarbageCollected<Scrollbar>,
-                              public DisplayItemClient {
+                              public DisplayItemClient,
+                              public recordreplay::RecordReplayIdMixin {
  public:
   // Theme object ownership remains with the caller and it must outlive the
   // scrollbar.

--- a/third_party/blink/renderer/core/svg/svg_element.h
+++ b/third_party/blink/renderer/core/svg/svg_element.h
@@ -52,13 +52,15 @@ class SVGPropertyBase;
 class SVGSVGElement;
 class SVGUseElement;
 
-typedef HeapHashSet<Member<SVGElement>> SVGElementSet;
+typedef HeapHashSet<Member<SVGElement>, WTF::MemberHashRecordReplayId<SVGElement>> SVGElementSet;
 
 class CORE_EXPORT SVGElement : public Element {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
   ~SVGElement() override;
+
+  using ScriptWrappable::RecordReplayId;
 
   bool SupportsFocus() const override { return false; }
 

--- a/third_party/blink/renderer/core/svg/svg_svg_element.h
+++ b/third_party/blink/renderer/core/svg/svg_svg_element.h
@@ -50,6 +50,8 @@ class SVGSVGElement final : public SVGGraphicsElement,
   explicit SVGSVGElement(Document&);
   ~SVGSVGElement() override;
 
+  using ScriptWrappable::RecordReplayId;
+
   absl::optional<float> IntrinsicWidth() const;
   absl::optional<float> IntrinsicHeight() const;
   gfx::SizeF CurrentViewportSize() const;

--- a/third_party/blink/renderer/modules/geolocation/geo_notifier.h
+++ b/third_party/blink/renderer/modules/geolocation/geo_notifier.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_GEOLOCATION_GEO_NOTIFIER_H_
 #define THIRD_PARTY_BLINK_RENDERER_MODULES_GEOLOCATION_GEO_NOTIFIER_H_
 
+#include "base/record_replay.h"
 #include "base/task/single_thread_task_runner.h"
 #include "third_party/blink/renderer/bindings/modules/v8/v8_position_callback.h"
 #include "third_party/blink/renderer/bindings/modules/v8/v8_position_error_callback.h"
@@ -20,7 +21,8 @@ class GeolocationPositionError;
 class Geoposition;
 
 class GeoNotifier final : public GarbageCollected<GeoNotifier>,
-                          public NameClient {
+                          public NameClient,
+                          public recordreplay::RecordReplayIdMixin {
  public:
   GeoNotifier(Geolocation*,
               V8PositionCallback*,

--- a/third_party/blink/renderer/modules/mediacapturefromelement/html_media_element_capture.cc
+++ b/third_party/blink/renderer/modules/mediacapturefromelement/html_media_element_capture.cc
@@ -147,7 +147,9 @@ class MediaElementEventListener final : public NativeEventListener {
  private:
   Member<HTMLMediaElement> media_element_;
   Member<MediaStream> media_stream_;
-  HeapHashSet<WeakMember<MediaStreamSource>> sources_;
+  HeapHashSet<WeakMember<MediaStreamSource>,
+              WTF::MemberHashRecordReplayId<MediaStreamSource>>
+      sources_;
 };
 
 MediaElementEventListener::MediaElementEventListener(HTMLMediaElement* element,

--- a/third_party/blink/renderer/modules/nfc/ndef_reader.h
+++ b/third_party/blink/renderer/modules/nfc/ndef_reader.h
@@ -33,6 +33,7 @@ class MODULES_EXPORT NDEFReader : public EventTargetWithInlineData,
   DEFINE_WRAPPERTYPEINFO();
 
  public:
+  using ScriptWrappable::RecordReplayId;
   static NDEFReader* Create(ExecutionContext*);
 
   NDEFReader(ExecutionContext*);

--- a/third_party/blink/renderer/modules/nfc/nfc_proxy.h
+++ b/third_party/blink/renderer/modules/nfc/nfc_proxy.h
@@ -9,6 +9,7 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/device/public/mojom/nfc.mojom-blink.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
+#include "third_party/blink/renderer/modules/nfc/ndef_reader.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_receiver.h"
@@ -18,7 +19,7 @@
 namespace blink {
 
 class LocalDOMWindow;
-class NDEFReader;
+// class NDEFReader;
 
 // This is a proxy class used by NDEFReader(s) to connect
 // to implementation of device::mojom::blink::NFC interface.

--- a/third_party/blink/renderer/modules/storage/inspector_dom_storage_agent.h
+++ b/third_party/blink/renderer/modules/storage/inspector_dom_storage_agent.h
@@ -29,6 +29,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_STORAGE_INSPECTOR_DOM_STORAGE_AGENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_MODULES_STORAGE_INSPECTOR_DOM_STORAGE_AGENT_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/inspector/inspector_base_agent.h"
 #include "third_party/blink/renderer/core/inspector/protocol/dom_storage.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
@@ -41,7 +42,8 @@ class BlinkStorageKey;
 class InspectedFrames;
 
 class MODULES_EXPORT InspectorDOMStorageAgent final
-    : public InspectorBaseAgent<protocol::DOMStorage::Metainfo> {
+    : public InspectorBaseAgent<protocol::DOMStorage::Metainfo>,
+      public recordreplay::RecordReplayIdMixin {
  public:
   explicit InspectorDOMStorageAgent(InspectedFrames*);
   ~InspectorDOMStorageAgent() override;

--- a/third_party/blink/renderer/modules/storage/storage_namespace.h
+++ b/third_party/blink/renderer/modules/storage/storage_namespace.h
@@ -35,6 +35,7 @@
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_wrapper_mode.h"
 #include "third_party/blink/renderer/platform/storage/blink_storage_key.h"
@@ -122,7 +123,9 @@ class MODULES_EXPORT StorageNamespace final
  private:
   void EnsureConnected();
 
-  HeapHashSet<WeakMember<InspectorDOMStorageAgent>> inspector_agents_;
+  HeapHashSet<WeakMember<InspectorDOMStorageAgent>,
+              WTF::MemberHashRecordReplayId<InspectorDOMStorageAgent>>
+      inspector_agents_;
 
   // Lives globally.
   StorageController* controller_;

--- a/third_party/blink/renderer/modules/wake_lock/wake_lock_manager.h
+++ b/third_party/blink/renderer/modules/wake_lock/wake_lock_manager.h
@@ -12,14 +12,23 @@
 #include "third_party/blink/renderer/modules/wake_lock/wake_lock_type.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_wrapper_mode.h"
+
+// For visibility into `recordreplay::RecordReplayId()`.
+#include "third_party/blink/renderer/modules/wake_lock/wake_lock_sentinel.h"
 
 namespace blink {
 
 class ExecutionContext;
 class ScriptPromiseResolver;
-class WakeLockSentinel;
+// class WakeLockSentinel;
+
+void Foo() {
+  WakeLockSentinel* sentinel = nullptr;
+  sentinel->RecordReplayId();
+}
 
 // https://w3c.github.io/screen-wake-lock/#dfn-activelocks
 // Per-document and per-wake lock type internal data.
@@ -39,6 +48,7 @@ class MODULES_EXPORT WakeLockManager final
   // Handle connection errors from |wake_lock_|.
   void OnWakeLockConnectionError();
 
+  static_assert(WTF::has_record_replay_id<WakeLockSentinel>);
   // A set with all WakeLockSentinel instances belonging to this
   // Navigator/WorkerNavigator.
   HeapHashSet<Member<WakeLockSentinel>> wake_lock_sentinels_;

--- a/third_party/blink/renderer/modules/wake_lock/wake_lock_sentinel.h
+++ b/third_party/blink/renderer/modules/wake_lock/wake_lock_sentinel.h
@@ -29,6 +29,8 @@ class MODULES_EXPORT WakeLockSentinel final
   DEFINE_WRAPPERTYPEINFO();
 
  public:
+  using ScriptWrappable::RecordReplayId;
+
   WakeLockSentinel(ScriptState* script_state,
                    V8WakeLockType::Enum type,
                    WakeLockManager* manager);

--- a/third_party/blink/renderer/modules/webaudio/async_audio_decoder.h
+++ b/third_party/blink/renderer/modules/webaudio/async_audio_decoder.h
@@ -29,6 +29,9 @@
 #include "third_party/blink/renderer/bindings/modules/v8/v8_decode_error_callback.h"
 #include "third_party/blink/renderer/bindings/modules/v8/v8_decode_success_callback.h"
 
+// Included for `RecordReplayId()`.
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+
 namespace base {
 class SingleThreadTaskRunner;
 }
@@ -39,7 +42,8 @@ class AudioBuffer;
 class AudioBus;
 class BaseAudioContext;
 class DOMArrayBuffer;
-class ScriptPromiseResolver;
+// Replaced with #include directive.
+// class ScriptPromiseResolver;
 class ExceptionContext;
 class ExceptionState;
 

--- a/third_party/blink/renderer/modules/webaudio/audio_graph_tracer.h
+++ b/third_party/blink/renderer/modules/webaudio/audio_graph_tracer.h
@@ -9,15 +9,19 @@
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/supplementable.h"
 #include "third_party/blink/renderer/platform/wtf/forward.h"
+
+// Included for `RecordReplayId` visibility.
+#include "third_party/blink/renderer/modules/webaudio/base_audio_context.h"
 
 namespace blink {
 
 class AudioListener;
 class AudioNode;
 class AudioParam;
-class BaseAudioContext;
+// class BaseAudioContext;
 class Document;
 class InspectorWebAudioAgent;
 class Page;
@@ -75,7 +79,9 @@ class MODULES_EXPORT AudioGraphTracer final
 
  private:
   Member<InspectorWebAudioAgent> inspector_agent_;
-  HeapHashSet<WeakMember<BaseAudioContext>> contexts_;
+  HeapHashSet<WeakMember<BaseAudioContext>,
+              WTF::MemberHashRecordReplayId<ScriptWrappable>>
+      contexts_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/webaudio/base_audio_context.h
+++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.h
@@ -27,6 +27,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_MODULES_WEBAUDIO_BASE_AUDIO_CONTEXT_H_
 
 #include "base/memory/scoped_refptr.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/bindings/core/v8/active_script_wrappable.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
 #include "third_party/blink/renderer/bindings/modules/v8/v8_decode_error_callback.h"

--- a/third_party/blink/renderer/modules/webshare/navigator_share.cc
+++ b/third_party/blink/renderer/modules/webshare/navigator_share.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/files/safe_base_name.h"
+#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "third_party/blink/public/common/browser_interface_broker_proxy.h"
 #include "third_party/blink/public/mojom/devtools/console_message.mojom-blink.h"
@@ -109,7 +110,8 @@ bool CanShareInternal(const LocalDOMWindow& window,
 }  // namespace
 
 class NavigatorShare::ShareClientImpl final
-    : public GarbageCollected<ShareClientImpl> {
+    : public GarbageCollected<ShareClientImpl>,
+      public recordreplay::RecordReplayIdMixin {
  public:
   ShareClientImpl(NavigatorShare*, bool has_files, ScriptPromiseResolver*);
 

--- a/third_party/blink/renderer/modules/webshare/navigator_share.h
+++ b/third_party/blink/renderer/modules/webshare/navigator_share.h
@@ -15,6 +15,7 @@
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/heap/member.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
 #include "third_party/blink/renderer/platform/supplementable.h"
 
@@ -60,7 +61,9 @@ class MODULES_EXPORT NavigatorShare final
   // This set must have at most 1 element on non-Android platforms. This is a
   // set, and not just and object in order to work around an Android specific
   // bug in opposition to the web-share spec.
-  HeapHashSet<Member<ShareClientImpl>> clients_;
+  HeapHashSet<Member<ShareClientImpl>,
+              WTF::MemberHashRecordReplayId<ShareClientImpl>>
+      clients_;
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/webtransport/web_transport.h
+++ b/third_party/blink/renderer/modules/webtransport/web_transport.h
@@ -17,6 +17,7 @@
 #include "third_party/blink/public/mojom/webtransport/web_transport_connector.mojom-blink.h"
 #include "third_party/blink/renderer/bindings/core/v8/active_script_wrappable.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
@@ -38,7 +39,7 @@ class IncomingStream;
 class OutgoingStream;
 class ReadableStream;
 class ScriptPromise;
-class ScriptPromiseResolver;
+// class ScriptPromiseResolver;
 class ScriptState;
 class WebTransportCloseInfo;
 class WebTransportOptions;

--- a/third_party/blink/renderer/modules/webusb/usb.h
+++ b/third_party/blink/renderer/modules/webusb/usb.h
@@ -22,11 +22,15 @@
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_wrapper_mode.h"
 #include "third_party/blink/renderer/platform/supplementable.h"
 
+// Included for visibility into `recordreplay::RecordReplayId()`.
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+
 namespace blink {
 
 class ExceptionState;
 class NavigatorBase;
-class ScriptPromiseResolver;
+// Replaced with #include directive.
+// class ScriptPromiseResolver;
 class ScriptState;
 class USBDevice;
 class USBDeviceRequestOptions;

--- a/third_party/blink/renderer/modules/xr/xr_frame_provider.h
+++ b/third_party/blink/renderer/modules/xr/xr_frame_provider.h
@@ -28,10 +28,12 @@ class XRWebGLLayer;
 
 // This class manages requesting and dispatching frame updates, which includes
 // pose information for a given XRDevice.
-class XRFrameProvider final : public GarbageCollected<XRFrameProvider> {
+class XRFrameProvider final : public GarbageCollected<XRFrameProvider>,
+                              public recordreplay::RecordReplayIdMixin {
  public:
   // Class
-  class ImmersiveSessionObserver : public GarbageCollectedMixin {
+  class ImmersiveSessionObserver : public GarbageCollectedMixin,
+                                   public recordreplay::RecordReplayIdMixin {
    public:
     virtual void OnImmersiveSessionStart() = 0;
     virtual void OnImmersiveSessionEnd() = 0;

--- a/third_party/blink/renderer/platform/context_lifecycle_observer.h
+++ b/third_party/blink/renderer/platform/context_lifecycle_observer.h
@@ -6,6 +6,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_CONTEXT_LIFECYCLE_OBSERVER_H_
 
 #include "base/dcheck_is_on.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/member.h"
 
@@ -15,7 +16,9 @@ class ContextLifecycleNotifier;
 
 // Observer that gets notified when the context is destroyed. Used to observe
 // ExecutionContext from platform/.
-class PLATFORM_EXPORT ContextLifecycleObserver : public GarbageCollectedMixin {
+class PLATFORM_EXPORT ContextLifecycleObserver
+    : public GarbageCollectedMixin,
+      public recordreplay::RecordReplayIdMixin {
  public:
   virtual ~ContextLifecycleObserver();
   void NotifyContextDestroyed();

--- a/third_party/blink/renderer/platform/fonts/font_cache_client.h
+++ b/third_party/blink/renderer/platform/fonts/font_cache_client.h
@@ -31,13 +31,15 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_PLATFORM_FONTS_FONT_CACHE_CLIENT_H_
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_FONTS_FONT_CACHE_CLIENT_H_
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/platform_export.h"
 
 namespace blink {
 
 class PLATFORM_EXPORT FontCacheClient
-    : public GarbageCollected<FontCacheClient> {
+    : public GarbageCollected<FontCacheClient>,
+      public recordreplay::RecordReplayIdMixin {
  public:
   virtual ~FontCacheClient() = default;
 

--- a/third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h
+++ b/third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h
@@ -9,6 +9,7 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/heap_allocator_impl.h"
 #include "third_party/blink/renderer/platform/wtf/hash_set.h"
+#include "third_party/blink/renderer/platform/wtf/type_traits.h"
 
 namespace blink {
 
@@ -25,6 +26,11 @@ class HeapHashSet final
 
   void Trace(Visitor* visitor) const {
     HashSet<ValueArg, HashArg, TraitsArg, HeapAllocator>::Trace(visitor);
+  }
+
+  HashSet<ValueArg, HashArg, TraitsArg, HeapAllocator>::iterator begin() const {
+    static_assert(WTF::IsRecordReplayDeterministicHashV<HashArg>);
+    return HashSet<ValueArg, HashArg, TraitsArg, HeapAllocator>::begin();
   }
 
  private:

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -176,7 +176,7 @@ struct MemberHashRecordReplayId
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
     if (recordreplay::IsRecordingOrReplaying()) {
-      int id = static_cast<T*>(m.Get())->RecordReplayId();
+      int id = m.Get()->T::RecordReplayId();
       // Ids are allowed to be zero if we've diverged from the recording.
       if (recordreplay::HasDivergedFromRecording()) {
         if (id > 0) {

--- a/third_party/blink/renderer/platform/heap/member.h
+++ b/third_party/blink/renderer/platform/heap/member.h
@@ -176,7 +176,7 @@ struct MemberHashRecordReplayId
             std::enable_if_t<WTF::IsAnyMemberType<Member>::value>* = nullptr>
   static unsigned GetHash(const Member& m) {
     if (recordreplay::IsRecordingOrReplaying()) {
-      int id = m.Get()->RecordReplayId();
+      int id = static_cast<T*>(m.Get())->RecordReplayId();
       // Ids are allowed to be zero if we've diverged from the recording.
       if (recordreplay::HasDivergedFromRecording()) {
         if (id > 0) {
@@ -201,15 +201,31 @@ struct MemberHashRecordReplayId
   static constexpr bool kIsRecordReplayDeterministicHash = true;
 };
 
+// template <typename T>
+// class HasRecordReplayId {
+//   template <typename U>
+//   static auto Check(U* u) -> decltype(u->RecordReplayId(), std::true_type());
+//   template <typename>
+//   static std::false_type Check(...);
+
+//  public:
+//   static constexpr bool value = decltype(Check<T>(nullptr))::value;
+// };
+
 template <typename T>
 class HasRecordReplayId {
-  template <typename U>
-  static auto Check(U* u) -> decltype(u->RecordReplayId(), std::true_type());
-  template <typename>
-  static std::false_type Check(...);
+  typedef char one;
+  struct two {
+    char x[2];
+  };
+
+  template <typename C>
+  static one test(decltype(&C::RecordReplayId));
+  template <typename C>
+  static two test(...);
 
  public:
-  static constexpr bool value = decltype(Check<T>(nullptr))::value;
+  enum { value = sizeof(test<T>(0)) == sizeof(char) };
 };
 
 template <typename T>

--- a/third_party/blink/renderer/platform/heap_observer_set.h
+++ b/third_party/blink/renderer/platform/heap_observer_set.h
@@ -72,7 +72,8 @@ class PLATFORM_EXPORT HeapObserverSet {
   void Trace(Visitor* visitor) const { visitor->Trace(observers_); }
 
  private:
-  using ObserverSet = HeapHashSet<WeakMember<ObserverType>>;
+  using ObserverSet = HeapHashSet<WeakMember<ObserverType>,
+                                  WTF::MemberHashRecordReplayId<ObserverType>>;
 
   // TODO(keishi): Clean up iteration state once transition from
   // LifecycleObserver is complete.

--- a/third_party/blink/renderer/platform/instrumentation/memory_pressure_listener.h
+++ b/third_party/blink/renderer/platform/instrumentation/memory_pressure_listener.h
@@ -6,6 +6,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_PLATFORM_INSTRUMENTATION_MEMORY_PRESSURE_LISTENER_H_
 
 #include "base/memory/memory_pressure_listener.h"
+#include "base/record_replay.h"
 #include "base/synchronization/lock.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
@@ -17,7 +18,9 @@ namespace blink {
 
 class NonMainThread;
 
-class PLATFORM_EXPORT MemoryPressureListener : public GarbageCollectedMixin {
+class PLATFORM_EXPORT MemoryPressureListener
+    : public GarbageCollectedMixin,
+      public recordreplay::RecordReplayIdMixin {
  public:
   virtual ~MemoryPressureListener() = default;
 

--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/record_replay.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/unguessable_token.h"
 #include "services/metrics/public/cpp/mojo_ukm_recorder.h"
@@ -92,7 +93,8 @@ struct ResourceLoaderOptions;
 // keep a ResourceFetcher alive past detach if scripts still reference the
 // Document.
 class PLATFORM_EXPORT ResourceFetcher
-    : public GarbageCollected<ResourceFetcher> {
+    : public GarbageCollected<ResourceFetcher>,
+      public recordreplay::RecordReplayIdMixin {
   USING_PRE_FINALIZER(ResourceFetcher, ClearPreloads);
 
  public:

--- a/third_party/blink/renderer/platform/mediastream/media_stream_source.h
+++ b/third_party/blink/renderer/platform/mediastream/media_stream_source.h
@@ -35,6 +35,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/record_replay.h"
 #include "base/synchronization/lock.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/public/platform/modules/mediastream/web_media_stream_source.h"
@@ -58,7 +59,8 @@ class WebAudioDestinationConsumer;
 // GarbageCollected wrapper of a WebPlatformMediaStreamSource, which acts as a
 // source backing one or more MediaStreamTracks.
 class PLATFORM_EXPORT MediaStreamSource final
-    : public GarbageCollected<MediaStreamSource> {
+    : public GarbageCollected<MediaStreamSource>,
+      public recordreplay::RecordReplayIdMixin {
   USING_PRE_FINALIZER(MediaStreamSource, Dispose);
 
  public:


### PR DESCRIPTION
Work in progress toward getting all uses of `HeapHashSet` iteration to have stable ordering between record and replay.

There's a lot to be improved here but it mostly demonstrates what kind of changes might be required to get more coverage using compile-time techniques.

After working through these changes over the past few days, I think @oridb's upcoming container changes (iteration order based on insertion order) might be a more maintainable path toward consistent ordering, in general.

Some of the challenges with the compile-time techniques:
- Forward declarations are pervasive in the Chromium codebase. This makes it difficult to understand where cyclic dependencies may potentially exist between types.
- When a cyclic dependency does exist, I don't think there's a better solution than manually specifying the hash type to use.
- Adding a `static_assert` to `HeapHashSet::begin` was the most reliable way that I found to easily identify forward declaration issues. But there's no good way to disambiguate between types that are *actually* missing a `RecordReplayId` method and incomplete types that already have a `RecordReplayId` method.
- The use of `recordreplay::RecordReplayIdMixin` across a large number of header files does significantly increase compile times after changing `base/record_replay.h`.