### PR TITLE
Add RecordReplayHadMismatch API.

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -33,7 +33,8 @@ namespace recordreplay {
   Macro(V8RecordReplayIdPointer, (int id), (id), void*, nullptr)        \
   Macro(V8RecordReplayFeatureEnabled,                                   \
         (const char* feature), (feature), bool, false)                  \
-  Macro(V8IsMainThread, (), (), bool, false)
+  Macro(V8IsMainThread, (), (), bool, false)                            \
+  Macro(V8RecordReplayHadMismatch, (), (), bool, false)
 
 #define ForEachV8APIVoid(Macro)                                         \
   Macro(V8RecordReplayAssertVA,                                         \
@@ -172,6 +173,10 @@ bool IsReplaying() {
 
 char* GetRecordingId() {
   return V8GetRecordingId();
+}
+
+bool HadMismatch() {
+  return V8RecordReplayHadMismatch();
 }
 
 void Assert(const char* format, ...) {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -26,6 +26,8 @@ bool IsRecording();
 bool IsReplaying();
 char* GetRecordingId();
 
+bool HadMismatch();
+
 void Print(const char* format, ...);
 void Diagnostic(const char* format, ...);
 void Warning(const char* format, ...);


### PR DESCRIPTION
For RUN-1796 (https://linear.app/replay/issue/RUN-1796/add-recordreplayhadmismatch-api-to-linkerdriver)