### PR TITLE
Optimize React DevTools unmount handling

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -890,6 +890,10 @@ function registerRrpCpdId(rrpId, cdpId, cdpObject = null) {
 
 
 // Strings longer than this will be truncated when creating protocol values.
+// TODO This limit creates problems when we try to evaluate large strings in routines,
+// such as stringifying a large object/array (like 2000+ unmounted fiber IDs).
+// The RDT routine works around this by splitting the string into chunks, but
+// we should find a better long-term solution (like bypassing the limit for evals).
 const MaxStringLength = 10000;
 
 const cdpRefTypes = ['object', 'function'];
@@ -2824,6 +2828,7 @@ const char* gReactDevtoolsScript = R""""(
 (() => {
 
 const stubFiberRoots = {};
+const unmountedFibersByRenderer = {};
 
 const stubHook = {
   isStub: true,
@@ -2836,14 +2841,20 @@ const stubHook = {
 };
 
 
-function stubGetFiberRoots(rendererID) {
-  const roots = stubFiberRoots;
-
-  if (!roots[rendererID]) {
-    roots[rendererID] = new Set();
+function getFiberRootsSetForRenderer(rendererID) {
+  if (!stubFiberRoots[rendererID]) {
+    stubFiberRoots[rendererID] = new Set();
   }
 
-  return roots[rendererID];
+  return stubFiberRoots[rendererID];
+}
+
+function getUnmountedFibersSetForRenderer(rendererID) {
+  if (!unmountedFibersByRenderer[rendererID]) {
+    unmountedFibersByRenderer[rendererID] = new Set();
+  }
+
+  return unmountedFibersByRenderer[rendererID];
 }
 
 window.__REACT_DEVTOOLS_SAVED_RENDERERS__ = [];
@@ -2860,33 +2871,57 @@ Object.defineProperty(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
 let uidCounter = 0;
 
 function inject(renderer) {
+  // Declare these enum strings in scope for later routine use
+  const annotationType = "inject";
+
   const id = ++uidCounter;
-  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "inject");
+  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook:v1:" + annotationType, "");
   window.__REACT_DEVTOOLS_SAVED_RENDERERS__.push(renderer);
   return id;
 }
 
 function onCommitFiberUnmount(rendererID, fiber) {
-  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "commit-fiber-unmount");
+  const annotationType = "commit-fiber-unmount"
+
+  // Unmounts are always one fiber at a time during the commit phase.
+  // Stash the unmounted fibers here, so we can map them to persistent 
+  // object IDs inside of `onCommitFiberRoot` processing in the routine.
+  const unmountedFibersSet = getUnmountedFibersSetForRenderer(rendererID);
+  unmountedFibersSet.add(fiber);
+
+  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook:v1:" + annotationType, "");
 }
 
 function onCommitFiberRoot(rendererID, root, priorityLevel) {
-  const mountedRoots = stubGetFiberRoots(rendererID);
+  // The "commit" handler should be the only one the routine needs to do the work as of 2023-05-01.
+  // We capture unmounted fibers in the unmount handler above, and the routine
+  // will process them when we evaluate at the commit annotation point.
+  // The others mostly exist for hypothetical completeness.
+  const annotationType = "commit-fiber-root";
+
+  const mountedRoots = getFiberRootsSetForRenderer(rendererID);
   const current = root.current;
   const isKnownRoot = mountedRoots.has(root);
-  const isUnmounting = current.memoizedState == null || current.memoizedState.element == null; // Keep track of mounted roots so we can hydrate when DevTools connect.
+  // Keep track of mounted roots so we can hydrate when DevTools connect.
+  const isUnmounting = current.memoizedState == null || current.memoizedState.element == null; 
 
   if (!isKnownRoot && !isUnmounting) {
     mountedRoots.add(root);
   } else if (isKnownRoot && isUnmounting) {
     mountedRoots.delete(root);
   }
+
+  // Get these so it's in scope in the routine eval, and we can clear it after the annotation
+  const unmountedFibersSet = getUnmountedFibersSetForRenderer(rendererID);
   
-  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "commit-fiber-root");
+  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook:v1:" + annotationType, "");
+
+  unmountedFibersSet.clear();
 }
 
 function onPostCommitFiberRoot(rendererID, root) {
-  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook", "post-commit-fiber-root");
+  const annotationType = "post-commit-fiber-root";
+  window.__RECORD_REPLAY_ANNOTATION_HOOK__("react-devtools-hook:v1:" + annotationType, "");
 }
 
 })();


### PR DESCRIPTION
This PR:

- Reworks the React DevTools stub logic to capture all unmounted React Fiber objects in a `Set`, which is then brought into scope in the next `onCommitFiberRoot` call.  This allows the routine to run the unmount handling for each fiber inside the `"commit"` eval step, thus batching up the processing and eliminating the need to evaluate the 80-90% of the points that were `"unmount"` annotations.