### PR TITLE
Add confirmation to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,16 @@ name: Release Latest Browsers
 on:
   workflow_dispatch:
     inputs:
+      confirmed:
+        description: This action is deprecated. Do you mean to do this?
+        type: boolean
       revision:
         description: SHA (first 12 chars) to release
         type: string
 
 jobs:
   release:
+    if: inputs.confirmed
     name: Trigger release run
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
We can close this if we don't want it but a nudge seems helpful to move us over to buildkite.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/788456/235525701-e4983c90-9098-459f-839a-198b9af51130.png">
