### PR TITLE
Remove all RUN-1219 assertions.

### DIFF
--- a/third_party/blink/renderer/core/css/css_font_selector.cc
+++ b/third_party/blink/renderer/core/css/css_font_selector.cc
@@ -69,7 +69,6 @@ UseCounter* CSSFontSelector::GetUseCounter() const {
 void CSSFontSelector::RegisterForInvalidationCallbacks(
     FontSelectorClient* client) {
   CHECK(client);
-  recordreplay::Assert("[RUN-1219-1728] CSSFontSelector::RegisterForInvalidationCallbacks");
   clients_.insert(client);
   if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers")) {
     record_replay_strong_clients_.insert(client);
@@ -78,7 +77,6 @@ void CSSFontSelector::RegisterForInvalidationCallbacks(
 
 void CSSFontSelector::UnregisterForInvalidationCallbacks(
     FontSelectorClient* client) {
-  recordreplay::Assert("[RUN-1219-1728] CSSFontSelector::UnregisterForInvalidationCallbacks");
   clients_.erase(client);
   if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers")) {
     record_replay_strong_clients_.erase(client);

--- a/third_party/blink/renderer/core/css/resolver/font_builder.cc
+++ b/third_party/blink/renderer/core/css/resolver/font_builder.cc
@@ -481,12 +481,10 @@ FontSelector* FontBuilder::ComputeFontSelector(const ComputedStyle& style) {
 
 void FontBuilder::CreateFont(ComputedStyle& style,
                              const ComputedStyle* parent_style) {
-  recordreplay::Assert("[RUN-1219-1708] FontBuilder::CreateFont #0");
   DCHECK(document_);
 
   if (!flags_)
     return;
-  recordreplay::Assert("[RUN-1219-1708] FontBuilder::CreateFont #1");
 
   FontDescription description = style.GetFontDescription();
 
@@ -497,10 +495,7 @@ void FontBuilder::CreateFont(ComputedStyle& style,
   FontSelector* font_selector = ComputeFontSelector(style);
   UpdateAdjustedSize(description, style, font_selector);
 
-  recordreplay::Assert("[RUN-1219-1708] FontBuilder::CreateFont #2 sel=%d",
-    (int) !!font_selector);
   style.SetFontInternal(Font(description, font_selector));
-  recordreplay::Assert("[RUN-1219-1708] FontBuilder::CreateFont #3");
   flags_ = 0;
 }
 

--- a/third_party/blink/renderer/core/css/resolver/style_cascade.cc
+++ b/third_party/blink/renderer/core/css/resolver/style_cascade.cc
@@ -172,7 +172,6 @@ void StyleCascade::AddInterpolations(const ActiveInterpolationsMap* map,
 }
 
 void StyleCascade::Apply(CascadeFilter filter) {
-  recordreplay::Assert("[RUN-1219-1708] StyleCascade::Apply #0");
   AnalyzeIfNeeded();
 
   CascadeResolver resolver(filter, ++generation_);
@@ -204,7 +203,6 @@ void StyleCascade::Apply(CascadeFilter filter) {
   }
 
   ApplyHighPriority(resolver);
-  recordreplay::Assert("[RUN-1219-1708] StyleCascade::Apply #1");
 
   if (map_.NativeBitset().Has(CSSPropertyID::kLineHeight)) {
     LookupAndApply(GetCSSPropertyLineHeight(), resolver);

--- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
+++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
@@ -919,10 +919,6 @@ scoped_refptr<ComputedStyle> StyleResolver::ResolveStyle(
     Element* element,
     const StyleRecalcContext& style_recalc_context,
     const StyleRequest& style_request) {
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ResolveStyle #0 elem=%d",
-    element ? element->RecordReplayId() : -1
-  );
   if (!element) {
     DCHECK(style_request.IsPseudoStyleRequest());
     return nullptr;
@@ -946,10 +942,6 @@ scoped_refptr<ComputedStyle> StyleResolver::ResolveStyle(
   // style computation itself, also also where the caching for the base
   // computed style optimization happens.
   ApplyBaseStyle(element, style_recalc_context, style_request, state, cascade);
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ResolveStyle #1 elem=%d",
-    element->RecordReplayId()
-  );
 
   if (style_request.IsPseudoStyleRequest() && state.HadNoMatchedProperties()) {
     DCHECK(!cascade.InlineStyleLost());
@@ -1262,10 +1254,6 @@ void StyleResolver::ApplyBaseStyleNoCache(
     const StyleRequest& style_request,
     StyleResolverState& state,
     StyleCascade& cascade) {
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyleNoCache #0 elem=%d",
-    element->RecordReplayId()
-  );
   InitStyleAndApplyInheritance(*element, style_request, state);
 
   // For some very special elements (e.g. <video>): Ensure internal UA style
@@ -1321,11 +1309,6 @@ void StyleResolver::ApplyBaseStyleNoCache(
     }
   }
 
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyleNoCache #1 elem=%d",
-    element->RecordReplayId()
-  );
-
   // Preserve the text autosizing multiplier on style recalc. Autosizer will
   // update it during layout if needed.
   // NOTE: This must occur before CascadeAndApplyMatchedProperties for correct
@@ -1333,11 +1316,6 @@ void StyleResolver::ApplyBaseStyleNoCache(
   PreserveTextAutosizingMultiplierIfNeeded(state, style_request);
 
   CascadeAndApplyMatchedProperties(state, cascade);
-
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyleNoCache #2 elem=%d",
-    element->RecordReplayId()
-  );
 
   if (collector.MatchedResult().DependsOnSizeContainerQueries())
     state.Style()->SetDependsOnSizeContainerQueries(true);
@@ -1381,15 +1359,7 @@ void StyleResolver::ApplyBaseStyle(
     StyleCascade& cascade) {
   DCHECK(style_request.pseudo_id != kPseudoIdFirstLineInherited);
 
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyle #0 elem=%d",
-    element->RecordReplayId()
-  );
   if (state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)) {
-    recordreplay::Assert(
-      "[RUN-1219-1708] StyleResolver::ApplyBaseStyle #1 elem=%d",
-      element->RecordReplayId()
-    );
     const ComputedStyle* animation_base_computed_style =
         CachedAnimationBaseComputedStyle(state);
     DCHECK(animation_base_computed_style);
@@ -1423,10 +1393,6 @@ void StyleResolver::ApplyBaseStyle(
 
   if (!style_recalc_context.parent_forces_recalc &&
       CanApplyInlineStyleIncrementally(element, state, style_request)) {
-    recordreplay::Assert(
-      "[RUN-1219-1708] StyleResolver::ApplyBaseStyle #2 elem=%d",
-      element->RecordReplayId()
-    );
     // We are in a situation where we can reuse the old style
     // and just apply the element's inline style on top of it
     // (see the function comment).
@@ -1494,19 +1460,9 @@ void StyleResolver::ApplyBaseStyle(
     return;
   }
 
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyle #3 elem=%d",
-    element->RecordReplayId()
-  );
-
   // None of the caches applied, so we need a full recalculation.
   ApplyBaseStyleNoCache(element, style_recalc_context, style_request, state,
                         cascade);
-
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::ApplyBaseStyle #4 elem=%d",
-    element->RecordReplayId()
-  );
 }
 
 CompositorKeyframeValue* StyleResolver::CreateCompositorKeyframeValueSnapshot(
@@ -2152,10 +2108,6 @@ StyleResolver::BeforeChangeStyleForTransitionUpdate(
 
 void StyleResolver::CascadeAndApplyMatchedProperties(StyleResolverState& state,
                                                      StyleCascade& cascade) {
-
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::CascadeAndApplyMatchedProperties #0"
-  );
   const MatchResult& result = cascade.GetMatchResult();
 
   CacheSuccess cache_success = ApplyMatchedCache(state, result);
@@ -2163,9 +2115,6 @@ void StyleResolver::CascadeAndApplyMatchedProperties(StyleResolverState& state,
   if (cache_success.IsFullCacheHit())
     return;
 
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::CascadeAndApplyMatchedProperties #1"
-  );
   auto apply = [&state, &cascade, &cache_success](CascadeFilter filter) {
     if (cache_success.ShouldApplyInheritedOnly()) {
       cascade.Apply(filter.Add(CSSProperty::kInherited, false));
@@ -2183,22 +2132,12 @@ void StyleResolver::CascadeAndApplyMatchedProperties(StyleResolverState& state,
   // again to get the correct result.
   apply(CascadeFilter(CSSProperty::kLegacyOverlapping, true));
 
-  recordreplay::Assert(
-    "[RUN-1219-1708] StyleResolver::CascadeAndApplyMatchedProperties #2"
-  );
-
   if (state.RejectedLegacyOverlapping()) {
     scoped_refptr<ComputedStyle> non_legacy_style =
         ComputedStyle::Clone(state.StyleRef());
-    recordreplay::Assert(
-      "[RUN-1219-1708] StyleResolver::CascadeAndApplyMatchedProperties #3"
-    );
     // Re-apply all overlapping properties (both legacy and non-legacy).
     apply(CascadeFilter(CSSProperty::kOverlapping, false));
 
-    recordreplay::Assert(
-      "[RUN-1219-1708] StyleResolver::CascadeAndApplyMatchedProperties #4"
-    );
     UseCountLegacyOverlapping(GetDocument(), *non_legacy_style,
                               state.StyleRef());
   }

--- a/third_party/blink/renderer/core/css/resolver/style_resolver_state.cc
+++ b/third_party/blink/renderer/core/css/resolver/style_resolver_state.cc
@@ -244,9 +244,7 @@ const CSSValue& StyleResolverState::ResolveLightDarkPair(
 }
 
 void StyleResolverState::UpdateFont() {
-  recordreplay::Assert("[RUN-1219-1708] StyleResolverState::UpdateFont #0");
   GetFontBuilder().CreateFont(StyleRef(), ParentStyle());
-  recordreplay::Assert("[RUN-1219-1708] StyleResolverState::UpdateFont #1");
   SetConversionFontSizes(
       CSSToLengthConversionData::FontSizes(Style(), RootElementStyle()));
   SetConversionZoom(Style()->EffectiveZoom());

--- a/third_party/blink/renderer/core/css/style_engine.cc
+++ b/third_party/blink/renderer/core/css/style_engine.cc
@@ -963,10 +963,6 @@ void StyleEngine::MarkCounterStylesNeedUpdate() {
 }
 
 void StyleEngine::FontsNeedUpdate(FontSelector*, FontInvalidationReason) {
-  recordreplay::Assert(
-    "[RUN-1219-1728] StyleEngine::FontsNeedUpdate %d",
-    this->RecordReplayId()
-  );
   if (!GetDocument().IsActive())
     return;
 

--- a/third_party/blink/renderer/core/css/style_recalc_change.cc
+++ b/third_party/blink/renderer/core/css/style_recalc_change.cc
@@ -29,42 +29,23 @@ bool StyleRecalcChange::TraverseChild(const Node& node) const {
 }
 
 bool StyleRecalcChange::ShouldRecalcStyleFor(const Node& node) const {
-  recordreplay::Assert("[RUN-1219-1706] StyleRecalcChange::ShouldRecalcStyleFor #0 %d",
-    node.RecordReplayId());
   if (flags_ & kSuppressRecalc) {
-    recordreplay::Assert("StyleRecalcChange::ShouldRecalcStyleFor %d suppressRecalc",
-      node.RecordReplayId());
     return false;
   }
   if (RecalcChildren()) {
-    recordreplay::Assert("[RUN-1219-1706] StyleRecalcChange::ShouldRecalcStyleFor %d recalcChildren",
-      node.RecordReplayId());
     return true;
   }
   if (node.NeedsStyleRecalc()) {
-    recordreplay::Assert("[RUN-1219-1706] StyleRecalcChange::ShouldRecalcStyleFor %d needsStyleRecalc",
-      node.RecordReplayId());
     return true;
   }
   // Early exit before getting the computed style.
   if (!RecalcContainerQueryDependent()) {
-    recordreplay::Assert("[RUN-1219-1706] StyleRecalcChange::ShouldRecalcStyleFor %d needsStyleRecalc",
-      node.RecordReplayId());
     return false;
   }
   const ComputedStyle* old_style = node.GetComputedStyle();
   // Container queries may affect display:none elements, and we since we store
   // that dependency on ComputedStyle we need to recalc style for display:none
   // subtree roots.
-  recordreplay::Assert(
-    "[RUN-1219-1706] StyleRecalcChange::ShouldRecalcStyleFor END %d old=%d sz=%d dsz=%d st=%d dst=%d",
-    node.RecordReplayId(),
-    (int) !!old_style,
-    (int) RecalcSizeContainerQueryDependent(),
-    (int) (old_style && old_style->DependsOnSizeContainerQueries()),
-    (int) RecalcStyleContainerQueryDependent(),
-    (int) (old_style && old_style->DependsOnStyleContainerQueries())
-  );
   return !old_style ||
          (RecalcSizeContainerQueryDependent() &&
           old_style->DependsOnSizeContainerQueries()) ||

--- a/third_party/blink/renderer/core/dom/container_node.cc
+++ b/third_party/blink/renderer/core/dom/container_node.cc
@@ -802,11 +802,6 @@ void ContainerNode::RemoveBetween(Node* previous_child,
                                   Node* next_child,
                                   Node& old_child) {
   EventDispatchForbiddenScope assert_no_event_dispatch;
-  recordreplay::Assert("[RUN-1219-1694] ContainerNode::RemoveBetween %d %d %d %d",
-    this->RecordReplayId(),
-    previous_child ? previous_child->RecordReplayId() : -1,
-    next_child ? next_child->RecordReplayId() : -1,
-    old_child.RecordReplayId());
 
   DCHECK_EQ(old_child.parentNode(), this);
 
@@ -1070,12 +1065,7 @@ void ContainerNode::AttachLayoutTree(AttachContext& context) {
 }
 
 void ContainerNode::DetachLayoutTree(bool performing_reattach) {
-  recordreplay::Assert("[RUN-1219-1694] ContainerNode::DetachLayoutTree #1 %d",
-    this->RecordReplayId());
   for (Node* child = firstChild(); child; child = child->nextSibling()) {
-    recordreplay::Assert("[RUN-1219-1694] ContainerNode::DetachLayoutTree #2 %d child=%d",
-      this->RecordReplayId(),
-      child->RecordReplayId());
     child->DetachLayoutTree(performing_reattach);
   }
   Node::DetachLayoutTree(performing_reattach);

--- a/third_party/blink/renderer/core/dom/element.cc
+++ b/third_party/blink/renderer/core/dom/element.cc
@@ -3819,21 +3819,14 @@ scoped_refptr<ComputedStyle> Element::StyleForLayoutObject(
     element_animations->CssAnimations().ClearPendingUpdate();
 
   bool has_custom_style_callbacks = HasCustomStyleCallbacks();
-  recordreplay::Assert("[RUN-1219-1708] Element::StyleForLayoutObject %d #0 %d",
-    this->RecordReplayId(),
-    (int) has_custom_style_callbacks);
   scoped_refptr<ComputedStyle> style =
       has_custom_style_callbacks
           ? CustomStyleForLayoutObject(style_recalc_context)
           : OriginalStyleForLayoutObject(style_recalc_context);
   if (!style) {
-    recordreplay::Assert("[RUN-1219-1708] Element::StyleForLayoutObject %d #1",
-      this->RecordReplayId());
     DCHECK(IsPseudoElement());
     return nullptr;
   }
-  recordreplay::Assert("[RUN-1219-1708] Element::StyleForLayoutObject %d #2",
-    this->RecordReplayId());
 
   style->UpdateIsStackingContextWithoutContainment(
       this == GetDocument().documentElement(), IsInTopLayer(),
@@ -3993,8 +3986,6 @@ StyleRecalcChange Element::RecalcStyle(
   StyleRecalcChange child_change = change.ForChildren(*this);
   if (change.ShouldRecalcStyleFor(*this)) {
     child_change = RecalcOwnStyle(change, style_recalc_context);
-    recordreplay::Assert("[RUN-1219-1706] Element::RecalcStyle %d AfterRecalcOwnStyle",
-                         RecordReplayId());
     if (GetStyleChangeType() == kSubtreeStyleChange) {
       child_change =
           child_change.EnsureAtLeast(StyleRecalcChange::kRecalcDescendants);
@@ -4085,8 +4076,6 @@ StyleRecalcChange Element::RecalcStyle(
   }
 
   if (child_change.TraversePseudoElements(*this)) {
-    recordreplay::Assert("[RUN-1219-1706] Element::RecalcStyle %d UpdatePseudoElement#1",
-      RecordReplayId());
     UpdatePseudoElement(kPseudoIdBackdrop, child_change, child_recalc_context);
     UpdatePseudoElement(kPseudoIdMarker, child_change, child_recalc_context);
     UpdatePseudoElement(kPseudoIdBefore, child_change, child_recalc_context);
@@ -4109,8 +4098,6 @@ StyleRecalcChange Element::RecalcStyle(
   recordreplay::Assert("[RUN-1436-1437] Element::RecalcStyle E");
 
   if (child_change.TraversePseudoElements(*this)) {
-    recordreplay::Assert("[RUN-1219-1706] Element::RecalcStyle %d UpdatePseudoElement#2",
-      RecordReplayId());
     UpdatePseudoElement(kPseudoIdAfter, child_change, child_recalc_context);
 
     // If we are re-attaching us or any of our descendants, we need to attach
@@ -4327,11 +4314,7 @@ StyleRecalcChange Element::RecalcOwnStyle(
     // This is the normal flow through the function; calculates
     // the element's style more or less from scratch (typically
     // ending up calling StyleResolver::ResolveStyle()).
-    recordreplay::Assert("[RUN-1219-1708] Element::RecalcOwnStyle %d StyleForLayoutObject-pre",
-      this->RecordReplayId());
     new_style = StyleForLayoutObject(new_style_recalc_context);
-    recordreplay::Assert("[RUN-1219-1708] Element::RecalcOwnStyle %d StyleForLayoutObject-post",
-      this->RecordReplayId());
   }
   if (new_style && !ShouldStoreComputedStyle(*new_style))
     new_style = nullptr;
@@ -7118,7 +7101,6 @@ PseudoElement* Element::CreatePseudoElementIfNeeded(
     PseudoId pseudo_id,
     const StyleRecalcContext& style_recalc_context,
     const AtomicString& document_transition_tag) {
-  recordreplay::Assert("[RUN-1219-1694] Element::CreatePseudoElementIfNeeded");
   if (!CanGeneratePseudoElement(pseudo_id))
     return nullptr;
   if (pseudo_id == kPseudoIdFirstLetter) {

--- a/third_party/blink/renderer/core/dom/node.cc
+++ b/third_party/blink/renderer/core/dom/node.cc
@@ -1597,8 +1597,6 @@ void Node::AttachLayoutTree(AttachContext& context) {
 }
 
 void Node::DetachLayoutTree(bool performing_reattach) {
-  recordreplay::Assert("[RUN-1219-1694] Node::DetachLayoutTree %d",
-    this->RecordReplayId());
   DCHECK(GetDocument().Lifecycle().StateAllowsDetach() ||
          GetDocument().GetStyleEngine().InContainerQueryStyleRecalc());
   DCHECK(!performing_reattach ||

--- a/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
+++ b/third_party/blink/renderer/core/html/forms/internal_popup_menu.cc
@@ -158,10 +158,6 @@ scoped_refptr<FontData> PopupMenuCSSFontSelector::GetFontData(
 
 void PopupMenuCSSFontSelector::FontsNeedUpdate(FontSelector* font_selector,
                                                FontInvalidationReason reason) {
-  recordreplay::Assert(
-    "[RUN-1219-1728] PopupMenuCSSFontSelector::FontsNeedUpdate %d",
-    this->RecordReplayId()
-  );
   DispatchInvalidationCallbacks(reason);
 }
 

--- a/third_party/blink/renderer/core/layout/layout_box_hot.cc
+++ b/third_party/blink/renderer/core/layout/layout_box_hot.cc
@@ -102,23 +102,11 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   NOT_DESTROYED();
   *out_cache_status = NGLayoutCacheStatus::kNeedsLayout;
 
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult Start %d %d %d",
-    this->RecordReplayId(),
-    (int) new_space.CacheSlot(),
-    layout_results_.empty()
-  );
-
   const bool use_layout_cache_slot =
       new_space.CacheSlot() == NGCacheSlot::kLayout && !layout_results_.empty();
   const NGLayoutResult* cached_layout_result =
       use_layout_cache_slot ? GetCachedLayoutResult(break_token)
                             : GetCachedMeasureResult();
-
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #1 %d %d %d %d",
-    (int) new_space.CacheSlot(),
-    (int) use_layout_cache_slot,
-    (int) !!cached_layout_result,
-    (int) !!early_break);
 
   if (!cached_layout_result)
     return nullptr;
@@ -148,18 +136,12 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       (break_token && break_token->IsRepeated()))
     return nullptr;
 
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2");
-
   if (SelfNeedsLayoutForStyle() || child_needs_layout_unless_locked ||
       NeedsSimplifiedNormalFlowLayout() ||
       (NeedsPositionedMovementLayout() &&
        !NeedsPositionedMovementLayoutOnly())) {
 
-    recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.1");
-
     if (!ChildrenInline()) {
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.1.1");
 
       // Check if we only need "simplified" layout. We don't abort yet, as we
       // need to check if other things (like floats) will require us to perform
@@ -167,13 +149,9 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (!NeedsSimplifiedLayoutOnly())
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.1.2");
-
       cache_status = NGLayoutCacheStatus::kNeedsSimplifiedLayout;
     } else if (!NeedsSimplifiedLayoutOnly() ||
                NeedsSimplifiedNormalFlowLayout()) {
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.1");
 
       // We don't regenerate any lineboxes during our "simplified" layout pass.
       // If something needs "simplified" layout within a linebox, (e.g. an
@@ -186,23 +164,15 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (!use_layout_cache_slot)
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.2");
-
       if (SelfNeedsLayout())
         return nullptr;
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.3");
 
       if (!physical_fragment.HasItems())
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.4");
-
       // Propagating OOF needs re-layout.
       if (physical_fragment.NeedsOOFPositionedInfoPropagation())
         return nullptr;
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.5");
 
       // Any floats might need to move, causing lines to wrap differently,
       // needing re-layout, either in cached result or in new constraint space.
@@ -210,12 +180,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           new_space.HasFloats())
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.2.6");
-
       cache_status = NGLayoutCacheStatus::kCanReuseLines;
     } else {
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #2.3");
 
       cache_status = NGLayoutCacheStatus::kNeedsSimplifiedLayout;
     }
@@ -231,8 +197,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   if (size_cache_status == NGLayoutCacheStatus::kNeedsLayout)
     return nullptr;
 
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #3");
-
   // If we need simplified layout, but the cached fragment's children are not
   // valid (see comment in `SetCachedLayoutResult`), don't return the fragment,
   // since it will be used to iteration the invalid children when running
@@ -241,8 +205,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       (size_cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout ||
        cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout))
     return nullptr;
-
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #4");
 
   // Update our temporary cache status, if the size cache check indicated we
   // might need simplified layout.
@@ -255,15 +217,11 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
     if (IsLayoutReplaced())
       return nullptr;
 
-    recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #4.1");
-
     // Simplified layout requires children to have a cached layout result. If
     // the current box has no cached layout result, its children might not,
     // either.
     if (!use_layout_cache_slot && !GetCachedLayoutResult(break_token))
       return nullptr;
-
-    recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #4.2");
   }
 
   LayoutUnit bfc_line_offset = new_space.BfcOffset().line_offset;
@@ -309,7 +267,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         (!are_bfc_offsets_equal || !is_exclusion_space_equal ||
          !is_margin_strut_equal || !is_clearance_offset_equal)) {
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #5.1");
       DCHECK(!CreatesNewFormattingContext());
 
       // If we have a different BFC offset, or exclusion space we can't perform
@@ -323,21 +280,15 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           cache_status == NGLayoutCacheStatus::kCanReuseLines)
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #5.2");
-
       DCHECK_EQ(cache_status, NGLayoutCacheStatus::kHit);
 
       if (!MaySkipLayoutWithinBlockFormattingContext(
               *cached_layout_result, new_space, &bfc_block_offset,
               &block_offset_delta, &end_margin_strut))
         return nullptr;
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #5.3");
     }
 
     if (UNLIKELY(new_space.HasBlockFragmentation())) {
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.1");
 
       DCHECK(old_space.HasBlockFragmentation());
 
@@ -346,8 +297,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       // cache for these cases as we may grow past the fragmentation line.
       if (cache_status != NGLayoutCacheStatus::kHit)
         return nullptr;
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.2");
 
       // Miss the cache if we have nested multicol containers inside that also
       // have OOF descendants. OOFs in nested multicol containers are handled in
@@ -359,8 +308,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (UNLIKELY(physical_fragment.HasNestedMulticolsWithOOFs()))
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.3");
-
       // Any fragmented out-of-flow positioned items will be placed once we
       // reach the fragmentation context root rather than the containing block,
       // so we should miss the cache in this case to ensure that such OOF
@@ -368,12 +315,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       if (physical_fragment.HasOutOfFlowFragmentChild())
         return nullptr;
 
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.4");
-
       if (column_spanner_path || cached_layout_result->ColumnSpannerPath())
         return nullptr;
-
-      recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5");
 
       // If the node didn't break into multiple fragments, we might be able to
       // re-use the result. If the fragmentainer block-size has changed, or if
@@ -382,8 +325,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       // be sure that this is the case, we need to miss the cache.
       if (new_space.IsInitialColumnBalancingPass()) {
         if (!old_space.IsInitialColumnBalancingPass()) {
-
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.1");
 
           // If the previous result was generated with a known fragmentainer
           // size (i.e. not in the initial column balancing pass),
@@ -410,16 +351,12 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
                  new_space.FragmentainerOffset() !=
                      old_space.FragmentainerOffset()) {
 
-        recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.2");
-
         // The fragment block-offset will either change, or the fragmentainer
         // block-size has changed. If the node is fragmented, we're going to
         // have to refragment, since the fragmentation line has moved,
         // relatively to the fragment.
         if (is_fragmented)
           return nullptr;
-
-        recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.3");
 
         // Fragmentation inside a nested multicol container depends on the
         // amount of remaining space in the outer fragmentation context, so if
@@ -429,15 +366,11 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         if (physical_fragment.IsFragmentationContextRoot())
           return nullptr;
 
-        recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.4");
-
         // If the fragment was forced to stay in a fragmentainer (even if it
         // overflowed), BlockSizeForFragmentation() cannot be used for cache
         // testing.
         if (cached_layout_result->IsBlockSizeForFragmentationClamped())
           return nullptr;
-
-        recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.5");
 
         // If the fragment was truncated at the fragmentation line, and since we
         // have now moved relatively to the fragmentation line, we cannot re-use
@@ -445,14 +378,11 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
         if (cached_layout_result->IsTruncatedByFragmentationLine())
           return nullptr;
 
-        recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.6");
-
         // TODO(layout-dev): This likely shouldn't be scoped to just OOFs, but
         // scoping it more widely results in several perf regressions[1].
         //
         // [1] https://bugs.chromium.org/p/chromium/issues/detail?id=1362550
         if (node.IsOutOfFlowPositioned()) {
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.6.1");
           // If the fragmentainer size has changed, and there previously was
           // space shortage reported, we should re-run layout to avoid reporting
           // the same space shortage again.
@@ -460,8 +390,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
               cached_layout_result->MinimalSpaceShortage();
           if (space_shortage && *space_shortage > LayoutUnit())
             return nullptr;
-
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.6.2");
         }
 
         // Returns true if there are any floats added by |cached_layout_result|
@@ -481,8 +409,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
 
         if (!bfc_block_offset && cached_layout_result->IsSelfCollapsing()) {
 
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.7.1");
-
           // Self-collapsing blocks may have floats and OOF descendants.
           // Checking if floats cross the fragmentation line is easy enough
           // (check the exclusion space), but we currently have no way of
@@ -493,29 +419,17 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           if (old_space.IsInitialColumnBalancingPass())
             return nullptr;
 
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.7.2");
-
           if (DoFloatsCrossFragmentationLine())
             return nullptr;
-
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.7.3");
-
         } else {
-
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.8.1");
-
           // If floats were added inside an inline formatting context, they
           // might extrude (and not included within the block-size for
           // fragmentation calculation above, unlike block formatting contexts).
           if (physical_fragment.IsInlineFormattingContext() &&
               !is_new_formatting_context) {
 
-            recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.8.1.1");
-
             if (DoFloatsCrossFragmentationLine())
               return nullptr;
-
-            recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.8.1.2");
           }
 
           // Check if we have content which might cross the fragmentation line.
@@ -534,8 +448,6 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
               block_size_for_fragmentation;
           if (block_end_offset > new_space.FragmentainerBlockSize())
             return nullptr;
-
-          recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.8.2");
         }
 
         // Multi-cols behave differently between the initial column balancing
@@ -545,13 +457,8 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
           if (physical_fragment.HasOutOfFlowInFragmentainerSubtree())
             return nullptr;
           if (auto* block = DynamicTo<LayoutBlock>(this)) {
-
-            recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.9.1");
-
             if (block->IsFragmentationContextRoot())
               return nullptr;
-
-            recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #6.5.9.2");
           }
         }
       }
@@ -564,16 +471,12 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
       cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout)
     return nullptr;
 
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #7");
-
   // We've performed all of the cache checks at this point. If we need
   // "simplified" layout then abort now.
   *out_cache_status = cache_status;
   if (cache_status == NGLayoutCacheStatus::kNeedsSimplifiedLayout ||
       cache_status == NGLayoutCacheStatus::kCanReuseLines)
     return cached_layout_result;
-
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #8");
 
   physical_fragment.CheckType();
 
@@ -634,16 +537,12 @@ const NGLayoutResult* LayoutBox::CachedLayoutResult(
   if (are_bfc_offsets_equal && is_exclusion_space_equal &&
       is_margin_strut_equal && !needs_cached_result_update) {
 
-    recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #9.1");
-
     // In order not to rebuild the internal derived-geometry "cache" of float
     // data, we need to move this to the new "output" exclusion space.
     cached_layout_result->ExclusionSpace().MoveAndUpdateDerivedGeometry(
         new_space.ExclusionSpace());
     return cached_layout_result;
   }
-
-  recordreplay::Assert("[RUN-1219-1657] LayoutBox::CachedLayoutResult #10");
 
   const NGLayoutResult* new_result = MakeGarbageCollected<NGLayoutResult>(
       *cached_layout_result, new_space, end_margin_strut, bfc_line_offset,

--- a/third_party/blink/renderer/core/layout/layout_object.cc
+++ b/third_party/blink/renderer/core/layout/layout_object.cc
@@ -3652,9 +3652,6 @@ inline void LayoutObject::ClearLayoutRootIfNeeded() const {
 
 void LayoutObject::WillBeDestroyed() {
   NOT_DESTROYED();
-  recordreplay::Assert("[RUN-1219-1694] LayoutObject::WillBeDestroyed %d",
-    this->RecordReplayId());
-
   // Destroy any leftover anonymous children.
   LayoutObjectChildList* children = VirtualChildren();
   if (children)

--- a/third_party/blink/renderer/core/layout/layout_object.h
+++ b/third_party/blink/renderer/core/layout/layout_object.h
@@ -3004,11 +3004,6 @@ class CORE_EXPORT LayoutObject : public GarbageCollected<LayoutObject>,
 
   void Remove() {
     NOT_DESTROYED();
-    recordreplay::Assert(
-      "[RUN-1219-1694] LayoutObject::Remove %d parent=%d",
-      this->RecordReplayId(),
-      this->Parent() ? this->Parent()->RecordReplayId() : -1
-    );
     if (Parent())
       Parent()->RemoveChild(this);
   }

--- a/third_party/blink/renderer/core/layout/layout_object_child_list.cc
+++ b/third_party/blink/renderer/core/layout/layout_object_child_list.cc
@@ -97,14 +97,6 @@ LayoutObject* LayoutObjectChildList::RemoveChildNode(
   DCHECK_EQ(old_child->Parent(), owner);
   DCHECK_EQ(this, owner->VirtualChildren());
 
-  // https://linear.app/replay/issue/RUN-1219
-  if (!recordreplay::AreEventsDisallowed()) {
-    recordreplay::Assert(
-      "[RUN-1219] LayoutObjectChildList::RemoveChildNode owner=%d child=%d",
-      owner ? owner->RecordReplayId() : -1,
-      old_child ? old_child->RecordReplayId() : -1);
-  }
-
   if (old_child->IsFloatingOrOutOfFlowPositioned())
     To<LayoutBox>(old_child)->RemoveFloatingOrPositionedChildFromBlockLists();
 
@@ -176,15 +168,6 @@ void LayoutObjectChildList::InsertChildNode(LayoutObject* owner,
                                             LayoutObject* new_child,
                                             LayoutObject* before_child,
                                             bool notify_layout_object) {
-  // https://linear.app/replay/issue/RUN-1219
-  if (!recordreplay::AreEventsDisallowed()) {
-    recordreplay::Assert(
-      "[RUN-1219] LayoutObjectChildList::InsertChildNode owner=%d new_child=%d before_child=%d",
-      owner ? owner->RecordReplayId() : -1,
-      new_child ? new_child->RecordReplayId() : -1,
-      before_child ? before_child->RecordReplayId() : -1);
-  }
-
   DCHECK(!new_child->Parent());
   DCHECK_EQ(this, owner->VirtualChildren());
   DCHECK(!owner->IsLayoutBlockFlow() ||

--- a/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/inline/ng_inline_node.cc
@@ -1258,10 +1258,6 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
                              const HeapVector<NGInlineItem>* previous_items,
                              const Font* override_font) const {
 
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText id=%d items=%u",
-    RecordReplayId(), (unsigned) data->items.size());
-
   TRACE_EVENT0("fonts", "NGInlineNode::ShapeText");
   const String& text_content = data->text_content;
   HeapVector<NGInlineItem>* items = &data->items;
@@ -1274,15 +1270,12 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
          data->segments->EndOffset() == text_content.length());
 
   for (unsigned index = 0; index < items->size();) {
-    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #1 index=%u", index);
     NGInlineItem& start_item = (*items)[index];
 
     if (start_item.Type() != NGInlineItem::kText || !start_item.Length()) {
       index++;
       continue;
     }
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #2");
 
     const ComputedStyle& start_style = *start_item.Style();
     const Font& font =
@@ -1313,8 +1306,6 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
       index++;
       continue;
     }
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #3");
 
     // Scan forward until an item is encountered that should trigger a shaping
     // break. This ensures that adjacent text items are shaped together whenever
@@ -1368,8 +1359,6 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
       index++;
       continue;
     }
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #4");
 
     // Results may only be reused if all items in the range remain valid.
     if (previous_text) {
@@ -1397,15 +1386,11 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
         continue;
       }
     }
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #5");
 
     // Shape each item with the full context of the entire node.
     scoped_refptr<ShapeResult> shape_result;
     if (MutableData() && MutableData()->IsShapingDeferred() &&
         font.PrimaryFont()) {
-      // https://linear.app/replay/issue/RUN-1219
-      recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeText #6");
       unsigned length = end_offset - start_item.StartOffset();
       shape_result = ShapeResult::CreateForSpacesWithPerGlyphWidth(
           &font, TextDirection::kLtr, start_item.StartOffset(), length,
@@ -1470,10 +1455,6 @@ void NGInlineNode::ShapeText(NGInlineItemsData* data,
 
 // Create HeapVector<NGInlineItem> with :first-line rules applied if needed.
 void NGInlineNode::ShapeTextForFirstLineIfNeeded(NGInlineNodeData* data) const {
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextForFirstLineIfNeeded id=%d",
-    RecordReplayId());
-
   // First check if the document has any :first-line rules.
   DCHECK(!data->first_line_items_);
   LayoutObject* layout_object = GetLayoutBox();
@@ -1524,10 +1505,6 @@ void NGInlineNode::ShapeTextIncludingFirstLine(
     const String* previous_text,
     const HeapVector<NGInlineItem>* previous_items) const {
 
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextIncludingFirstLine id=%d",
-    RecordReplayId());
-
   DCHECK_NE(new_state, NGInlineNodeData::kShapingNone);
   data->shaping_state_ = new_state;
 #if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
@@ -1538,9 +1515,6 @@ void NGInlineNode::ShapeTextIncludingFirstLine(
 #endif
 
   ShapeText(data, previous_text, previous_items);
-
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ShapeTextIncludingFirstLine #2");
 
   if (new_state == NGInlineNodeData::kShapingDone)
     ShapeTextForFirstLineIfNeeded(data);
@@ -1934,10 +1908,6 @@ MinMaxSizesResult NGInlineNode::ComputeMinMaxSizes(
     WritingMode container_writing_mode,
     const NGConstraintSpace& space,
     const MinMaxSizesFloatInput& float_input) const {
-
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGInlineNode::ComputeMinMaxSizes id=%d",
-    RecordReplayId());
 
   PrepareLayoutIfNeeded();
   ShapeTextOrDefer(space);

--- a/third_party/blink/renderer/core/layout/ng/ng_block_layout_algorithm.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_layout_algorithm.cc
@@ -273,16 +273,10 @@ void NGBlockLayoutAlgorithm::SetBoxType(NGPhysicalFragment::NGBoxType type) {
 
 MinMaxSizesResult NGBlockLayoutAlgorithm::ComputeMinMaxSizes(
     const MinMaxSizesFloatInput& float_input) {
-  recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #0 node=%d left=%d right=%d",
-    Node().RecordReplayId(),
-    float_input.float_left_inline_size.RawValue(),
-    float_input.float_right_inline_size.RawValue());
   if (auto result =
           CalculateMinMaxSizesIgnoringChildren(node_, BorderScrollbarPadding())) {
-    recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #1");
     return *result;
   }
-  recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #2");
 
   MinMaxSizes sizes;
   bool depends_on_block_constraints = false;
@@ -293,8 +287,6 @@ MinMaxSizesResult NGBlockLayoutAlgorithm::ComputeMinMaxSizes(
 
   for (NGLayoutInputNode child = Node().FirstChild(); child;
        child = child.NextSibling()) {
-    recordreplay::Assert("[RUN-1219-1406] NGBlockLayoutAlgorithm::ComputeMinMaxSizes #3 child=%d",
-      child.RecordReplayId());
     // We don't check IsRubyText() here intentionally. RubyText width should
     // affect this width.
     if (child.IsOutOfFlowPositioned() ||

--- a/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_block_node.cc
@@ -113,16 +113,8 @@ inline LayoutMultiColumnFlowThread* GetFlowThread(const LayoutBox& box) {
 template <typename Algorithm, typename Callback>
 NOINLINE void CreateAlgorithmAndRun(const NGLayoutAlgorithmParams& params,
                                     const Callback& callback) {
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] CreateAlgorithmAndRun Start %d node_id=%d",
-                       params.node.GetLayoutBox()->RecordReplayId(),
-                       params.node.RecordReplayId());
-
   Algorithm algorithm(params);
   callback(&algorithm);
-
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] CreateAlgorithmAndRun Done");
 }
 
 template <typename Callback>
@@ -416,11 +408,6 @@ const NGLayoutResult* NGBlockNode::Layout(
     const NGBlockBreakToken* break_token,
     const NGEarlyBreak* early_break,
     const NGColumnSpannerPath* column_spanner_path) const {
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGBlockNode::Layout Start %d cs=%d",
-                       GetLayoutBox()->RecordReplayId(),
-                       constraint_space.CacheSlot());
-
   // Use the old layout code and synthesize a fragment.
   if (!CanUseNewLayout())
     return RunLegacyLayout(constraint_space);
@@ -449,10 +436,6 @@ const NGLayoutResult* NGBlockNode::Layout(
   const NGLayoutResult* layout_result = box_->CachedLayoutResult(
       constraint_space, break_token, early_break, column_spanner_path,
       &fragment_geometry, &cache_status);
-
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #2 %d %d",
-                       !!layout_result, (int)cache_status);
 
   if (cache_status == NGLayoutCacheStatus::kHit) {
     DCHECK(layout_result);
@@ -487,9 +470,6 @@ const NGLayoutResult* NGBlockNode::Layout(
     }
   }
 
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #3");
-
   if (!fragment_geometry) {
     fragment_geometry =
         CalculateInitialFragmentGeometry(constraint_space, *this, break_token);
@@ -512,10 +492,6 @@ const NGLayoutResult* NGBlockNode::Layout(
       layout_result = box_->CachedLayoutResult(
           constraint_space, break_token, early_break, column_spanner_path,
           &fragment_geometry, &cache_status);
-
-      // https://linear.app/replay/issue/RUN-1219
-      recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #8 %d %d",
-                           !!layout_result, (int)cache_status);
     }
   }
 
@@ -542,17 +518,11 @@ const NGLayoutResult* NGBlockNode::Layout(
     const NGLayoutResult* previous_result = layout_result;
 #endif
 
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #10");
-
     // A child may have changed size while performing "simplified" layout (it
     // may have gained or removed scrollbars, changing its size). In these
     // cases "simplified" layout will return a null layout-result, indicating
     // we need to perform a full layout.
     layout_result = RunSimplifiedLayout(params, *layout_result);
-
-    // https://linear.app/replay/issue/RUN-1219
-    recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #11");
 
 #if DCHECK_IS_ON()
     if (layout_result) {
@@ -646,9 +616,6 @@ const NGLayoutResult* NGBlockNode::Layout(
       // message.
       box_->SetNeedsLayout(layout_invalidation_reason::kScrollbarChanged,
                            kMarkOnlyThis);
-
-      // https://linear.app/replay/issue/RUN-1219
-      recordreplay::Assert("[RUN-1219] NGBlockNode::Layout #20");
 
       fragment_geometry = CalculateInitialFragmentGeometry(constraint_space,
                                                            *this, break_token);
@@ -1025,11 +992,6 @@ MinMaxSizesResult NGBlockNode::ComputeMinMaxSizes(
     const MinMaxSizesType type,
     const NGConstraintSpace& constraint_space,
     const MinMaxSizesFloatInput float_input) const {
-
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219] NGBlockNode::ComputeMinMaxSizes id=%d",
-    RecordReplayId());
-
   // TODO(layoutng) Can UpdateMarkerTextIfNeeded call be moved
   // somewhere else? List items need up-to-date markers before layout.
   if (IsListItem())

--- a/third_party/blink/renderer/core/layout/ng/ng_layout_utils.cc
+++ b/third_party/blink/renderer/core/layout/ng/ng_layout_utils.cc
@@ -185,17 +185,11 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
       To<NGPhysicalBoxFragment>(layout_result.PhysicalFragment());
   NGBoxFragment fragment(style.GetWritingDirection(), physical_fragment);
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #0");
-
   if (fragment_geometry.border_box_size.inline_size != fragment.InlineSize())
     return NGLayoutCacheStatus::kNeedsLayout;
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #1");
-
   if (style.MayHavePadding() && fragment_geometry.padding != fragment.Padding())
     return NGLayoutCacheStatus::kNeedsLayout;
-
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #2");
 
   // Tables are special - we can't determine the final block-size ahead of time
   // (or based on the previous intrinsic size).
@@ -205,19 +199,15 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
   //
   // *NOTE* - any logic below this branch shouldn't apply to tables.
   if (node.IsTable()) {
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #3.0");
     if (!new_space.AreBlockSizeConstraintsEqual(old_space) ||
         BlockSizeMayChange(node, new_space, old_space, layout_result))
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #3.1");
     return NGLayoutCacheStatus::kHit;
   }
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #4");
   LayoutUnit block_size = fragment_geometry.border_box_size.block_size;
   bool is_initial_block_size_indefinite = block_size == kIndefiniteSize;
   if (is_initial_block_size_indefinite) {
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #5.0");
     LayoutUnit intrinsic_block_size;
     // Intrinsic block-size is only defined if the node is unfragmented.
     if (!physical_fragment.IsFirstForNode() || physical_fragment.BreakToken())
@@ -281,38 +271,29 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
         new_space, style, fragment_geometry.border + fragment_geometry.padding,
         intrinsic_block_size, fragment_geometry.border_box_size.inline_size);
 
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #5.1");
     if (block_size == kIndefiniteSize)
       return NGLayoutCacheStatus::kNeedsLayout;
-
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #5.2");
   }
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #6");
   bool is_block_size_equal = block_size == fragment.BlockSize();
 
   if (!is_block_size_equal) {
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.0");
     // Only block-flow supports changing the block-size for simplified layout.
     if (!node.IsBlockFlow() || node.IsLayoutNGCustom())
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.1");
 
     // Fieldsets stretch their content to the final block-size, which might
     // affect scrollbars.
     if (node.IsFieldsetContainer())
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.2");
 
     if (layout_result.DisableSimplifiedLayout())
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.3");
 
     // If we are the document or body element in quirks mode, changing our size
     // means that a scrollbar was added/removed. Require full layout.
     if (node.IsQuirkyAndFillsViewport())
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.4");
 
     // If a block (within a formatting-context) changes to/from an empty-block,
     // margins may collapse through this node, requiring full layout. We
@@ -320,10 +301,8 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
     if (!physical_fragment.IsFormattingContextRoot() &&
         !block_size != !fragment.BlockSize())
       return NGLayoutCacheStatus::kNeedsLayout;
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #7.5");
   }
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #8");
   const bool has_descendant_that_depends_on_percentage_block_size =
       layout_result.HasDescendantThatDependsOnPercentageBlockSize();
   const bool is_old_initial_block_size_indefinite =
@@ -337,28 +316,18 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
   // TODO(ikilpatrick): There is an "optimization" for grid which would involve
   // *always* setting the initial block-size for grid as indefinite, then
   // re-running computing the grid if we have any "auto" tracks etc.
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #9 %d %d",
-    (int) is_old_initial_block_size_indefinite,
-    (int) is_initial_block_size_indefinite);
   if (is_old_initial_block_size_indefinite !=
       is_initial_block_size_indefinite) {
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #10.0 %d %d",
-      (int) node.IsGrid(),
-      (int) has_descendant_that_depends_on_percentage_block_size);
     if (node.IsGrid() || has_descendant_that_depends_on_percentage_block_size)
       return NGLayoutCacheStatus::kNeedsLayout;
   }
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #11");
 
   if (has_descendant_that_depends_on_percentage_block_size) {
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #12.0");
     // If our initial block-size is definite, we know that if we change our
     // block-size we'll affect any descendant that depends on the resulting
     // percentage block-size.
     if (!is_block_size_equal && !is_initial_block_size_indefinite)
       return NGLayoutCacheStatus::kNeedsLayout;
-
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #12.1");
 
     DCHECK(is_block_size_equal || is_initial_block_size_indefinite);
 
@@ -373,18 +342,8 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
     // As we only care about the quirks-mode %-block-size behavior we remove
     // this false-positive by checking if we have an initial indefinite
     // block-size.
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #12.2 %d %d",
-      (int) is_initial_block_size_indefinite,
-      (int) physical_fragment.DependsOnPercentageBlockSize());
     if (is_initial_block_size_indefinite &&
         physical_fragment.DependsOnPercentageBlockSize()) {
-      recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #12.3 %d %d %d %d %d",
-        (int) is_old_initial_block_size_indefinite,
-        new_space.PercentageResolutionBlockSize().RawValue(),
-        old_space.PercentageResolutionBlockSize().RawValue(),
-        new_space.ReplacedPercentageResolutionBlockSize().RawValue(),
-        old_space.ReplacedPercentageResolutionBlockSize().RawValue());
-        
       DCHECK(is_old_initial_block_size_indefinite);
       if (new_space.PercentageResolutionBlockSize() !=
           old_space.PercentageResolutionBlockSize())
@@ -394,9 +353,6 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
         return NGLayoutCacheStatus::kNeedsLayout;
     }
   }
-
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #13 %d",
-    (int) new_space.IsTableCell());
 
   // Table-cells with vertical alignment might shift their contents if the
   // block-size changes.
@@ -419,10 +375,6 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
         auto new_alignment_baseline = new_space.TableCellAlignmentBaseline();
         auto old_alignment_baseline = old_space.TableCellAlignmentBaseline();
 
-        recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #14.0 %d %d",
-          (int) !!new_alignment_baseline,
-          (int) !!old_alignment_baseline
-        );
         // Do nothing if neither alignment baseline is set.
         if (!new_alignment_baseline && !old_alignment_baseline)
           break;
@@ -432,10 +384,6 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
         if (!new_alignment_baseline && old_alignment_baseline)
           return NGLayoutCacheStatus::kNeedsLayout;
 
-        recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #14.1 %d",
-          new_alignment_baseline->RawValue()
-        );
-
         // We've been provided a new alignment baseline, just check that it
         // matches the previously generated baseline.
         if (!old_alignment_baseline) {
@@ -444,35 +392,20 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatusWithGeometry(
           break;
         }
 
-        recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #14.1 %d %d",
-          old_alignment_baseline->RawValue(),
-          new_alignment_baseline->RawValue()
-        );
-
         // If the alignment baselines differ at this stage, we need layout.
         if (*new_alignment_baseline != *old_alignment_baseline)
           return NGLayoutCacheStatus::kNeedsLayout;
 
-        recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #14.2");
         break;
       }
       case EVerticalAlign::kMiddle:
       case EVerticalAlign::kBottom:
-        recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #15.0 %d",
-          (int) is_block_size_equal);
-
         // 'middle', and 'bottom' vertical alignment depend on the block-size.
         if (!is_block_size_equal)
           return NGLayoutCacheStatus::kNeedsLayout;
         break;
     }
-
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #16");
   }
-
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatusWithGeometry #17 %d %d",
-    (int) node.IsTable(),
-    (int) is_block_size_equal);
 
   // If we've reached here we know that we can potentially "stretch"/"shrink"
   // ourselves without affecting any of our children.
@@ -520,17 +453,12 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatus(
   const NGConstraintSpace& old_space =
       cached_layout_result.GetConstraintSpaceForCaching();
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #0");
-
   if (!new_space.MaySkipLayout(old_space))
     return NGLayoutCacheStatus::kNeedsLayout;
-
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #1");
 
   if (new_space.AreInlineSizeConstraintsEqual(old_space) &&
       new_space.AreBlockSizeConstraintsEqual(old_space)) {
 
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #2.0");
     // It is possible that our intrinsic size has changed, check for that here.
     // TODO(cbiesinger): Investigate why this check doesn't apply to
     // |MaySkipLegacyLayout|.
@@ -538,26 +466,17 @@ NGLayoutCacheStatus CalculateSizeBasedLayoutCacheStatus(
                                 new_space, fragment_geometry))
       return NGLayoutCacheStatus::kNeedsLayout;
 
-    recordreplay::Assert("[RUN-1219-1663] CalculateSizeBasedLayoutCacheStatus #2.1 old=(%s) new=(%s)",
-      old_space.ToString().Ascii().c_str(),
-      new_space.ToString().Ascii().c_str()
-    );
     // We don't have to check our style if we know the constraint space sizes
     // will remain the same.
     if (new_space.AreSizesEqual(old_space))
       return NGLayoutCacheStatus::kHit;
 
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #2.2");
     // TODO(ikilpatrick): Always miss the cache for tables whose block
     // size-constraints change.
     if (!SizeMayChange(node, new_space, old_space, cached_layout_result))
       return NGLayoutCacheStatus::kHit;
-
-    recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #2.3");
   }
 
-  recordreplay::Assert("[RUN-1219-1657] CalculateSizeBasedLayoutCacheStatus #3 %d",
-    (int) !*fragment_geometry);
   if (!*fragment_geometry) {
     *fragment_geometry =
         CalculateInitialFragmentGeometry(new_space, node, break_token);

--- a/third_party/blink/renderer/core/layout/svg/layout_svg_container.cc
+++ b/third_party/blink/renderer/core/layout/svg/layout_svg_container.cc
@@ -119,11 +119,6 @@ void LayoutSVGContainer::AddChild(LayoutObject* child,
 }
 
 void LayoutSVGContainer::RemoveChild(LayoutObject* child) {
-  recordreplay::Assert(
-    "[RUN-1219-1694] LayoutSVGContainer::RemoveChild %d child=%d",
-    this->RecordReplayId(),
-    child->RecordReplayId()
-  );
   NOT_DESTROYED();
   LayoutSVGModelObject::RemoveChild(child);
 

--- a/third_party/blink/renderer/core/svg/svg_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_element.cc
@@ -84,8 +84,6 @@ SVGElement::~SVGElement() {
 }
 
 void SVGElement::DetachLayoutTree(bool performing_reattach) {
-  recordreplay::Assert("[RUN-1219-1694] SVGElement::DetachLayoutTree %d",
-    this->RecordReplayId());
   Element::DetachLayoutTree(performing_reattach);
   // To avoid a noncollectable Blink GC reference cycle, we must clear the
   // ComputedStyle here. See http://crbug.com/878032#c11

--- a/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
+++ b/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
@@ -480,8 +480,6 @@ String CanvasRenderingContext2D::font() const {
 }
 
 void CanvasRenderingContext2D::setFont(const String& new_font) {
-  recordreplay::Assert("[RUN-1219-1694] CanvasRenderingContext2D::setFont %s",
-    new_font.Utf8().c_str());
   // The style resolution required for fonts is not available in frame-less
   // documents.
   if (!canvas()->GetDocument().GetFrame())

--- a/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d_state.cc
+++ b/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d_state.cc
@@ -172,10 +172,6 @@ CanvasRenderingContext2DState::~CanvasRenderingContext2DState() = default;
 
 void CanvasRenderingContext2DState::FontsNeedUpdate(FontSelector* font_selector,
                                                     FontInvalidationReason) {
-  recordreplay::Assert(
-    "[RUN-1219-1728] CanvasRenderingContext2DState::FontNeedsUpdate %d",
-    this->RecordReplayId()
-  );
   DCHECK_EQ(font_selector, font_.GetFontSelector());
   DCHECK(realized_font_);
 

--- a/third_party/blink/renderer/platform/fonts/font.cc
+++ b/third_party/blink/renderer/platform/fonts/font.cc
@@ -60,10 +60,6 @@ FontFallbackMap& GetFontFallbackMap(FontSelector* font_selector) {
 scoped_refptr<FontFallbackList> GetOrCreateFontFallbackList(
     const FontDescription& font_description,
     FontSelector* font_selector) {
-  recordreplay::Assert("[RUN-1219-1694] GetOrCreateFontFallbackList descr=(%s) sel=%d",
-    font_description.ToString().Utf8().c_str(),
-    (int) !!font_selector
-  );
   return GetFontFallbackMap(font_selector).Get(font_description);
 }
 

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
@@ -95,10 +95,6 @@ bool FontFallbackList::ShouldSkipDrawing() const {
 
 const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontData(
     const FontDescription& font_description) {
-  // https://linear.app/replay/issue/RUN-1219
-  recordreplay::Assert("[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontData %d",
-                       record_replay_id_);
-
   base::ElapsedTimer timer;
   const SimpleFontData* result =
       DeterminePrimarySimpleFontDataCore(font_description);
@@ -110,24 +106,12 @@ const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontDataCore(
     const FontDescription& font_description) {
   bool should_load_custom_font = true;
 
-  recordreplay::Assert(
-    "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #0 %d",
-    record_replay_id_
-  );
   for (unsigned font_index = 0;; ++font_index) {
-    recordreplay::Assert(
-      "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #1 %d fontidx=%u",
-      record_replay_id_, font_index
-    );
     const FontData* font_data = FontDataAt(font_description, font_index);
     if (!font_data) {
       // All fonts are custom fonts and are loading. Return the first FontData.
       font_data = FontDataAt(font_description, 0);
       if (font_data) {
-        recordreplay::Assert(
-          "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #2 %d fontidx=%u gotFontData",
-          record_replay_id_, font_index
-        );
         return font_data->FontDataForCharacter(kSpaceCharacter);
       }
 
@@ -135,22 +119,10 @@ const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontDataCore(
       SimpleFontData* last_resort_fallback =
           font_cache.GetLastResortFallbackFont(font_description).get();
       DCHECK(last_resort_fallback);
-      recordreplay::Assert(
-        "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #3 %d fontidx=%u lastResortFb=%d",
-        record_replay_id_,
-        font_index,
-        !!last_resort_fallback
-      );
       return last_resort_fallback;
     }
 
     const auto* segmented = DynamicTo<SegmentedFontData>(font_data);
-    recordreplay::Assert(
-      "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #4 %d fontidx=%u segmented=%d",
-      record_replay_id_,
-      font_index,
-      !!segmented
-    );
     if (segmented && !segmented->ContainsCharacter(kSpaceCharacter))
       continue;
 
@@ -162,12 +134,6 @@ const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontDataCore(
     // layout the text.  Here skip the temporary font for the loading custom
     // font which may not act as the correct fallback font.
     if (!font_data_for_space->IsLoadingFallback()) {
-      recordreplay::Assert(
-        "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #5 %d fontidx=%u fontDataForSpace=%d",
-        record_replay_id_,
-        font_index,
-        !!font_data_for_space
-      );
       return font_data_for_space;
     }
 
@@ -176,12 +142,6 @@ const SimpleFontData* FontFallbackList::DeterminePrimarySimpleFontDataCore(
         const SimpleFontData* range_font_data =
             segmented->FaceAt(i)->FontData();
         if (!range_font_data->IsLoadingFallback()) {
-          recordreplay::Assert(
-            "[RUN-1219-1650] FontFallbackList::DeterminePrimarySimpleFontDataCore #6 %d fontidx=%u rangeFontData=%d",
-            record_replay_id_,
-            font_index,
-            !!range_font_data
-          );
           return range_font_data;
         }
       }

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.h
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.h
@@ -89,13 +89,9 @@ class PLATFORM_EXPORT FontFallbackList : public RefCounted<FontFallbackList> {
 
   const SimpleFontData* PrimarySimpleFontData(
       const FontDescription& font_description) {
-    recordreplay::Assert("[RUN-1219-1406] FontFallbackList::PrimarySimpleFontData %d %d",
-      record_replay_id_, (int) !!cached_primary_simple_font_data_);
     if (!cached_primary_simple_font_data_) {
       cached_primary_simple_font_data_ =
           DeterminePrimarySimpleFontData(font_description);
-      recordreplay::Assert("[RUN-1219-1597] FontFallbackList::PrimarySimpleFontData #2 %d %d",
-        record_replay_id_, (int) !!cached_primary_simple_font_data_);
       DCHECK(cached_primary_simple_font_data_);
     }
     return cached_primary_simple_font_data_;

--- a/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
@@ -21,27 +21,18 @@ FontFallbackMap::~FontFallbackMap() {
 
 scoped_refptr<FontFallbackList> FontFallbackMap::Get(
     const FontDescription& font_description) {
-  recordreplay::Assert("[RUN-1219-1708] FontFallbackMap::Get %d #0",
-    record_replay_id_);
   AutoLockForParallelTextShaping guard(lock_);
   auto iter = fallback_list_for_description_.find(font_description);
   if (iter != fallback_list_for_description_.end()) {
     DCHECK(iter->value->IsValid());
     return iter->value;
   }
-  recordreplay::Assert("[RUN-1219-1708] FontFallbackMap::Get %d #1",
-    record_replay_id_);
   auto add_result = fallback_list_for_description_.insert(
       font_description, FontFallbackList::Create(*this));
-  recordreplay::Assert("[RUN-1219-1708] FontFallbackMap::Get %d #2",
-    record_replay_id_);
   return add_result.stored_value->value;
 }
 
 void FontFallbackMap::Remove(const FontDescription& font_description) {
-  recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::Remove #0 %d %u",
-    record_replay_id_, StringHash::GetHash(font_description.ToString()));
-    
   AutoLockForParallelTextShaping guard(lock_);
   auto iter = fallback_list_for_description_.find(font_description);
   DCHECK_NE(iter, fallback_list_for_description_.end());
@@ -51,14 +42,6 @@ void FontFallbackMap::Remove(const FontDescription& font_description) {
 }
 
 void FontFallbackMap::InvalidateAll() {
-  // Only assert if events aren't disallowed.
-  // This is called from the font-fallback-map destructor, which may
-  // execute during GC.
-  if (!recordreplay::AreEventsDisallowed()) {
-    recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::InvalidateAll %d",
-      record_replay_id_);
-  }
-
   lock_.AssertAcquired();
   for (auto& entry : fallback_list_for_description_)
     entry.value->MarkInvalid();
@@ -67,15 +50,10 @@ void FontFallbackMap::InvalidateAll() {
 
 template <typename Predicate>
 void FontFallbackMap::InvalidateInternal(Predicate predicate) {
-  recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::InvalidateInternal %d #0",
-    record_replay_id_);
   lock_.AssertAcquired();
   Vector<FontDescription> invalidated;
   for (auto& entry : fallback_list_for_description_) {
     if (predicate(*entry.value)) {
-      recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::InvalidateInternal #1 %d %s",
-        record_replay_id_,
-        entry.key.ToString().Utf8().data());
       invalidated.push_back(entry.key);
       entry.value->MarkInvalid();
     }
@@ -85,10 +63,6 @@ void FontFallbackMap::InvalidateInternal(Predicate predicate) {
 
 void FontFallbackMap::FontsNeedUpdate(FontSelector*,
                                       FontInvalidationReason reason) {
-  recordreplay::Assert(
-    "[RUN-1219-1728] FontFallbackMap::FontNeedsUpdate %d",
-    this->RecordReplayId()
-  );
   AutoLockForParallelTextShaping guard(lock_);
   switch (reason) {
     case FontInvalidationReason::kFontFaceLoaded:
@@ -107,8 +81,6 @@ void FontFallbackMap::FontsNeedUpdate(FontSelector*,
 }
 
 void FontFallbackMap::FontCacheInvalidated() {
-  recordreplay::Assert("[RUN-1219-1718] FontFallbackMap::FontCacheInvalidated %d",
-    record_replay_id_);
   AutoLockForParallelTextShaping guard(lock_);
   InvalidateAll();
 }

--- a/third_party/blink/renderer/platform/fonts/font_selector.cc
+++ b/third_party/blink/renderer/platform/fonts/font_selector.cc
@@ -104,10 +104,6 @@ void FontSelector::Trace(Visitor* visitor) const {
 }
 
 FontFallbackMap& FontSelector::GetFontFallbackMap() {
-  recordreplay::Assert(
-    "[RUN-1219-1708] FontSelector::GetFontFallbackMap #0 %d",
-    (int) !font_fallback_map_
-  );
   if (!font_fallback_map_) {
     font_fallback_map_ = MakeGarbageCollected<FontFallbackMap>(this);
     RegisterForInvalidationCallbacks(font_fallback_map_);


### PR DESCRIPTION
We fixed a bunch of root causes with RUN-1219, but also added a ton of asserts for it.  There are new nonfatals showing up in that same area of code, but should be tracked with a new issue and new assertions.

The RUN-1219 assertions are no longer useful.