### PR TITLE
Cache begin/end pass through event symbols when dlsyming them.

### DIFF
--- a/base/lazy_instance_helpers.cc
+++ b/base/lazy_instance_helpers.cc
@@ -8,42 +8,8 @@
 
 #include "base/at_exit.h"
 #include "base/threading/platform_thread.h"
+#include "base/record_replay_inline.h"
 
-#if !BUILDFLAG(IS_WIN)
-#include <dlfcn.h>
-#else
-#include <windows.h>
-#endif
-
-static void* LookupRecordReplaySymbol(const char* name) {
-#if !BUILDFLAG(IS_WIN)
-  void* fnptr = dlsym(RTLD_DEFAULT, name);
-#else
-  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
-  void* fnptr = module ? (void*)GetProcAddress(module, name) : nullptr;
-#endif
-  return fnptr ? fnptr : reinterpret_cast<void*>(1);
-}
-
-static void RecordReplayBeginPassThroughEvents() {
-  static void* fnptr;
-  if (!fnptr) {
-    fnptr = LookupRecordReplaySymbol("RecordReplayBeginPassThroughEvents");
-  }
-  if (fnptr != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(fnptr)();
-  }
-}
-
-static void RecordReplayEndPassThroughEvents() {
-  static void* fnptr;
-  if (!fnptr) {
-    fnptr = LookupRecordReplaySymbol("RecordReplayEndPassThroughEvents");
-  }
-  if (fnptr != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(fnptr)();
-  }
-}
 
 namespace base {
 namespace internal {
@@ -70,7 +36,7 @@ bool NeedsLazyInstance(std::atomic<uintptr_t>& state) {
   if (state.load(std::memory_order_acquire) == kLazyInstanceStateCreating) {
     // Don't interact with the recording while we get the current time or sleep
     // in non-deterministic ways.
-    RecordReplayBeginPassThroughEvents();
+    RecordReplayAutoPassThroughEvents pt;
 
     const base::TimeTicks start = base::TimeTicks::Now();
     do {
@@ -85,8 +51,6 @@ bool NeedsLazyInstance(std::atomic<uintptr_t>& state) {
         PlatformThread::Sleep(Milliseconds(1));
     } while (state.load(std::memory_order_acquire) ==
              kLazyInstanceStateCreating);
-
-    RecordReplayEndPassThroughEvents();
   }
   // Someone else created the instance.
   return false;

--- a/base/record_replay_inline.h
+++ b/base/record_replay_inline.h
@@ -1,0 +1,38 @@
+#if !BUILDFLAG(IS_WIN)
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif
+
+static void* LookupRecordReplaySymbol(const char* name) {
+#if !BUILDFLAG(IS_WIN)
+  void* fnptr = dlsym(RTLD_DEFAULT, name);
+#else
+  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
+  void* fnptr = module ? (void*)GetProcAddress(module, name) : nullptr;
+#endif
+  return fnptr ? fnptr : reinterpret_cast<void*>(1);
+}
+
+struct RecordReplayAutoPassThroughEvents {
+  void *fnBegin;
+  void *fnEnd;
+  bool didBegin;
+
+  RecordReplayAutoPassThroughEvents() {
+    // Cache our functions, since begin passthrough events will not allow us to
+    // invoke our own op_dlsym function which can actually find our symbols.
+    fnBegin = LookupRecordReplaySymbol("RecordReplayBeginPassThroughEvents");
+    fnEnd = LookupRecordReplaySymbol("RecordReplayEndPassThroughEvents");
+
+    if (fnBegin != reinterpret_cast<void*>(1)) {
+      reinterpret_cast<void(*)()>(fnBegin)();
+    }
+  }
+
+  ~RecordReplayAutoPassThroughEvents() {
+    if (fnEnd != reinterpret_cast<void*>(1)) {
+      reinterpret_cast<void(*)()>(fnEnd)();
+    }
+  }
+};

--- a/base/record_replay_inline.h
+++ b/base/record_replay_inline.h
@@ -1,3 +1,6 @@
+// For use in situations when the recordreplay:: namespace isn't available
+// due to build dependency ordering.
+
 #if !BUILDFLAG(IS_WIN)
 #include <dlfcn.h>
 #else

--- a/base/win/scoped_handle_verifier.cc
+++ b/base/win/scoped_handle_verifier.cc
@@ -19,46 +19,7 @@
 #include "base/win/base_win_buildflags.h"
 #include "base/win/current_module.h"
 #include "base/win/scoped_handle.h"
-
-static void* LookupRecordReplaySymbol(const char* name) {
-  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
-  void* fnptr = module ? (void*)GetProcAddress(module, name) : nullptr;
-  return fnptr ? fnptr : reinterpret_cast<void*>(1);
-}
-
-static void RecordReplayBeginPassThroughEvents() {
-  static void* fnptr;
-  if (!fnptr) {
-    fnptr = LookupRecordReplaySymbol("RecordReplayBeginPassThroughEvents");
-  }
-  if (fnptr != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(fnptr)();
-  }
-}
-
-static void RecordReplayEndPassThroughEvents() {
-  static void* fnptr;
-  if (!fnptr) {
-    fnptr = LookupRecordReplaySymbol("RecordReplayEndPassThroughEvents");
-  }
-  if (fnptr != reinterpret_cast<void*>(1)) {
-    reinterpret_cast<void(*)()>(fnptr)();
-  }
-}
-
-namespace {
-
-struct RecordReplayAutoPassThroughEvents {
-  RecordReplayAutoPassThroughEvents() {
-    RecordReplayBeginPassThroughEvents();
-  }
-
-  ~RecordReplayAutoPassThroughEvents() {
-    RecordReplayEndPassThroughEvents();
-  }
-};
-
-} // anonymous namespace
+#include "base/record_replay_inline.h"
 
 extern "C" {
 __declspec(dllexport) void* GetHandleVerifier();


### PR DESCRIPTION
Fixes RUN-999.  Once we're in events disallowed/pass through, we won't be able to call our own dlsym to find them.