### PR TITLE
Take lock nondeterministically when disposing WebRtcMediaStreamTrackA…

### DIFF
--- a/base/synchronization/waitable_event.h
+++ b/base/synchronization/waitable_event.h
@@ -80,6 +80,9 @@ class BASE_EXPORT WaitableEvent {
   // Put the event in the un-signaled state.
   void Reset();
 
+  // [RecordReplay] Allow resetting this waiter non-deterministically.
+  void ResetDuringRecordReplayDisallowEvents();
+
   // Put the event in the signaled state.  Causing any thread blocked on Wait
   // to be woken up.
   void Signal();

--- a/base/synchronization/waitable_event_posix.cc
+++ b/base/synchronization/waitable_event_posix.cc
@@ -63,6 +63,10 @@ void WaitableEvent::Reset() {
   base::AutoLock locked(kernel_->lock_);
   kernel_->signaled_ = false;
 }
+void WaitableEvent::ResetDuringRecordReplayDisallowEvents() {
+  recordreplay::AutoLockMaybeEventsDisallowed locked(kernel_->lock_);
+  kernel_->signaled_ = false;
+}
 
 void WaitableEvent::Signal() {
   base::AutoLock locked(kernel_->lock_);


### PR DESCRIPTION
…dapter

For RUN-1865 (https://linear.app/replay/issue/RUN-1865/take-lock-nondeterministically-when-disposing)

Bucket issue RUN-1829