### PR TITLE
Hook up MaybeTerminate in sync_handle_registry to interrupt waiting.

### DIFF
--- a/mojo/public/cpp/bindings/lib/sync_handle_registry.cc
+++ b/mojo/public/cpp/bindings/lib/sync_handle_registry.cc
@@ -140,11 +140,21 @@ bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
   MojoResult ready_handle_result;
 
   scoped_refptr<SyncHandleRegistry> preserver(this);
-  while (true) {
-    recordreplay::MaybeTerminate(nullptr, nullptr);
+  
+  // Add a quit event that the recorder can use to signal this thread to
+  // wake up and terminate.
+  base::WaitableEvent quitEvent;
+  wait_set_.AddEvent(&quitEvent);
+  recordreplay::MaybeTerminate([](void* data){
+    ((base::WaitableEvent*)data)->Signal();
+  }, (void*)&quitEvent);
 
+  while (true) {
     for (size_t i = 0; i < count; ++i) {
       if (*should_stop[i]) {
+        wait_set_.RemoveEvent(&quitEvent);
+        // Don't forget to clear the wait handler.
+        recordreplay::MaybeTerminate(nullptr, nullptr);
         return true;
       }
     }
@@ -155,6 +165,12 @@ bool SyncHandleRegistry::Wait(const bool* should_stop[], size_t count) {
     num_ready_handles = 1;
     wait_set_.Wait(&ready_event, &num_ready_handles, &ready_handle,
                    &ready_handle_result);
+
+    // We've just woken up, so maybe we have to terminate.
+    if (quitEvent.IsSignaled()) {
+      recordreplay::MaybeTerminate(nullptr, nullptr);
+    }
+
     if (num_ready_handles) {
       DCHECK_EQ(1u, num_ready_handles);
       const auto iter = handles_.find(ready_handle);


### PR DESCRIPTION
This allows the recorder to properly shut down on the main thread.