### PR TITLE
Don't nondeterministically reset waiters in webrtc thread.

### DIFF
--- a/third_party/blink/renderer/modules/peerconnection/webrtc_media_stream_track_adapter.cc
+++ b/third_party/blink/renderer/modules/peerconnection/webrtc_media_stream_track_adapter.cc
@@ -112,7 +112,13 @@ void WebRtcMediaStreamTrackAdapter::Dispose() {
   DCHECK(is_initialized_);
   if (is_disposed_)
     return;
-  remote_track_can_complete_initialization_.Reset();
+  // https://linear.app/replay/issue/RUN-1829
+  // Only reset the WaitableEvent if we're not recording/replaying,
+  // or if we're recording/replaying and events are allowed.
+  if (!recordreplay::IsRecordingOrReplaying("disallow-events") ||
+      !recordreplay::AreEventsDisallowed()) {
+    remote_track_can_complete_initialization_.Reset();
+  }
   is_disposed_ = true;
   if (component_->GetSourceType() == MediaStreamSource::kTypeAudio) {
     if (local_track_audio_sink_)


### PR DESCRIPTION
For RUN-1925 (https://linear.app/replay/issue/RUN-1925/dont-reset-webrtcmediastreamtrackadapterremote-track-can-complete)

Bucket issue RUN-1829.