### PR TITLE
RUN-1906: fix regression for string-based custom previews

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1208,7 +1208,7 @@ ProtocolObjectPreview.prototype = {
             // entry should be string -> Look it up in results
             const cdpEntry = cdpProperties.result.find(prop => prop.name === entry);
             if (cdpEntry) {
-              const rrpEntry = buildRrpObjectFromCdpObject(cdpEntry);
+              const rrpEntry = buildRrpObjectFromCdpObject(cdpEntry.value);
               this.setGetterValue(entry, rrpEntry);
             }
           }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1906/all-errors-show-as-unavailable