### PR TITLE
Adjust XHR::send string to match recording length.

### DIFF
--- a/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
+++ b/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc
@@ -26,6 +26,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/record_replay.h"
+
 #include "base/auto_reset.h"
 #include "base/feature_list.h"
 #include "base/metrics/histogram_macros.h"
@@ -833,16 +835,54 @@ void XMLHttpRequest::send(Document* document, ExceptionState& exception_state) {
 }
 
 void XMLHttpRequest::send(const String& body, ExceptionState& exception_state) {
-  DVLOG(1) << this << " send() String " << body;
+  // RUN-1350: Use the recording stream to adjust the string value here to
+  // meet expectations.  Sometimes divergences in elsewhere will cause
+  // the sent data to be slightly different.  This will lead to spurious
+  // mmap-related asserts down the line.  To avoid this, massage the
+  // string value here (to a limit) to match the recorded value.
+  std::optional<String> adj_body;
+  if (recordreplay::IsRecordingOrReplaying("values")) {
+    size_t length = body.length();
+    size_t recorded_length =
+      recordreplay::RecordReplayValue("XMLHttpRequest::send", body.length());
+    if (length != recorded_length) {
+      bool mismatch_too_large =
+        (length < recorded_length * 0.95 || length > recorded_length * 1.05) &&
+        (length < recorded_length - 2 || length > recorded_length + 2);
+      recordreplay::Warning(
+        "XMLHttpRequest::Send length mismatch recorded(%zu) != replayed(%zu) toolarge=%s",
+        recorded_length, length,
+        mismatch_too_large ? "yes" : "no"
+      );
+      // If the difference in strings is too big (off by more than 5 percent
+      // or so, then don't adjust the string).
+      if (mismatch_too_large) {
+        recordreplay::Warning(
+          "XMLHttpRequest::Send length mismatch too large, not adjusting"
+        );
+      } else if (length < recorded_length) {
+        size_t padding = recorded_length - length;
+        std::unique_ptr<char[]> buffer(new char[padding + 1]);
+        memset(buffer.get(), ' ', padding);
+        buffer[padding] = '\0';
+        adj_body = body + String(buffer.get());
+      } else {
+        adj_body = body.Substring(0, (unsigned int) recorded_length);
+      }
+    }
+  }
+  const String& use_body = adj_body.value_or(body);
+
+  DVLOG(1) << this << " send() String " << use_body;
 
   if (!InitSend(exception_state))
     return;
 
   scoped_refptr<EncodedFormData> http_body;
 
-  if (!body.IsNull() && AreMethodAndURLValidForSend()) {
+  if (!use_body.IsNull() && AreMethodAndURLValidForSend()) {
     http_body = EncodedFormData::Create(
-        UTF8Encoding().Encode(body, WTF::kNoUnencodables));
+        UTF8Encoding().Encode(use_body, WTF::kNoUnencodables));
     UpdateContentTypeAndCharset("text/plain;charset=UTF-8", "UTF-8");
   }
 


### PR DESCRIPTION
For RUN-1964 (https://linear.app/replay/issue/RUN-1964/force-xhrsend-string-to-match-lengths-by-recordreplaying-value)

Bucket issue RUN-1350