### PR TITLE
RUN-2017: Assert V8Platform::CurrentClockTimeMillis

### DIFF
--- a/gin/v8_platform.cc
+++ b/gin/v8_platform.cc
@@ -477,8 +477,11 @@ double V8Platform::MonotonicallyIncreasingTime() {
       static_cast<double>(base::Time::kMicrosecondsPerSecond);
 }
 
+extern "C" void V8RecordReplayAssert(const char* format, ...);
+
 double V8Platform::CurrentClockTimeMillis() {
   double now_seconds = base::Time::Now().ToJsTime() / 1000;
+  V8RecordReplayAssert("[RUN-1348-2017] V8Platform::CurrentClockTimeMillis %d", g_time_clamper.IsCreated());
   return g_time_clamper.Get().ClampTimeResolution(now_seconds) * 1000;
 }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1348#comment-8689c20f
* Tests passed (except for 1 dynamic test that failed due to timeout) ✔