### PR TITLE
RUN-2022: Fix JS exception regression

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1ca67bc07629112aa68a713ef8e88f4207afac31',
+  'v8_revision': '68c1151f95a36aea12c2d17e8526dbd9890e59e6',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '68c1151f95a36aea12c2d17e8526dbd9890e59e6',
+  'v8_revision': 'de95f2859e048d9eb519c2e6f46ae3a9efe2cc51',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'de95f2859e048d9eb519c2e6f46ae3a9efe2cc51',
+  'v8_revision': '68c1151f95a36aea12c2d17e8526dbd9890e59e6',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -537,13 +537,7 @@ function Pause_evaluateInFrame({ frameId, expression }) {
     return buildRrpObjectResult({ result: argsCdp });
   }
 
-  let rv = null;
-  try {
-    rv = doEvaluation();
-  }
-  catch (err) {
-    log(`[RuntimeError] evaluateInFrame err: ${err?.stack || err}`);
-  }
+  const rv = doEvaluation();
   return buildRrpObjectResult(rv);
 
   function doEvaluation() {
@@ -564,16 +558,10 @@ function Pause_evaluateInFrame({ frameId, expression }) {
 }
 
 function Pause_evaluateInGlobal({ expression }) {
-  let rv = null;
-  try {
-    rv = sendMessage("Runtime.evaluate", {
-      expression,
-      objectGroup: REPLAY_CDT_PAUSE_OBJECT_GROUP
-    });
-  }
-  catch (err) {
-    log(`[RuntimeError] evaluateInGlobal err: ${err?.stack || err}`);
-  }
+  const rv = sendMessage("Runtime.evaluate", {
+    expression,
+    objectGroup: REPLAY_CDT_PAUSE_OBJECT_GROUP
+  });
   return buildRrpObjectResult(rv);
 }
 


### PR DESCRIPTION
* https://github.com/replayio/chromium-v8/pull/147
* https://linear.app/replay/issue/RUN-2022/js-exceptions-are-not-reported-anymore-when-we-crash-in
* Sneaky Changes:
  * Removing try/catch around `evaluate` commands. I added those to prevent some command crashes I did not want to deal with at the time because they were crashing hard. Adding it back in now that we have proper command crash triage.