### PR TITLE
RUN-1348: Pre-allocate g_time_clamper in the V8Platform ctor

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'dfa88759ef54d737c6711ea62ee50e9efc9a95af',
+  'v8_revision': '1805214468964ccb13a08d2f3d754e4cb178d3d9',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '68c1151f95a36aea12c2d17e8526dbd9890e59e6',
+  'v8_revision': 'dfa88759ef54d737c6711ea62ee50e9efc9a95af',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/gin/v8_platform.cc
+++ b/gin/v8_platform.cc
@@ -360,8 +360,9 @@ class V8Platform::TracingControllerImpl : public v8::TracingController {
 V8Platform* V8Platform::Get() { return g_v8_platform.Pointer(); }
 
 V8Platform::V8Platform() : tracing_controller_(new TracingControllerImpl) {
-  // [RUN-1348] Allocate the time clamper non-divergently.
-  g_time_clamper.Get();
+  if (recordreplay::IsRecordingOrReplaying("eager-initialization"))
+    // [RUN-1348] Eagerly allocate g_time_clamper.
+    g_time_clamper.Get();
 }
 
 V8Platform::~V8Platform() = default;

--- a/gin/v8_platform.cc
+++ b/gin/v8_platform.cc
@@ -359,7 +359,10 @@ class V8Platform::TracingControllerImpl : public v8::TracingController {
 // static
 V8Platform* V8Platform::Get() { return g_v8_platform.Pointer(); }
 
-V8Platform::V8Platform() : tracing_controller_(new TracingControllerImpl) {}
+V8Platform::V8Platform() : tracing_controller_(new TracingControllerImpl) {
+  // [RUN-1348] Allocate the time clamper non-divergently.
+  g_time_clamper.Get();
+}
 
 V8Platform::~V8Platform() = default;
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/149
* https://linear.app/replay/issue/RUN-1348#comment-70e96a90
* Tested: Only one unrelated dynamic test failure ✔