### PR TITLE
RUN-2068: add trace diagnostics for executioncontext lifetime

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '256b2d287e1e1448e3319c53e5b9ba53ee3fcf1a',
+  'v8_revision': '2e406a05750fb9f3bb84df2d3c4423d6c5b39e70',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9ef57f39ba523f5db21c888f83fc3d34dc4c3a74',
+  'v8_revision': '54a6c38e176225a135351dd042d19c005fa55ec4',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '54a6c38e176225a135351dd042d19c005fa55ec4',
+  'v8_revision': '2acff66200bac5fb474b97bdbefe944038edb1ec',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -52,6 +52,9 @@ namespace recordreplay {
   Macro(V8RecordReplayWarning,                                          \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
+  Macro(V8RecordReplayTrace,                                            \
+        (const char* format, va_list args),                             \
+        (format, args))                                                 \
   Macro(V8RecordReplayBytes,                                            \
         (const char* why, void* buf, size_t size),                      \
         (why, buf, size))                                               \
@@ -229,6 +232,15 @@ void Warning(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   V8RecordReplayWarning(format, ap);
+  va_end(ap);
+#endif
+}
+
+void Trace(const char* format, ...) {
+#ifndef NACL_TC_REV
+  va_list ap;
+  va_start(ap, format);
+  V8RecordReplayTrace(format, ap);
   va_end(ap);
 #endif
 }

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -31,6 +31,7 @@ bool HadMismatch();
 void Print(const char* format, ...);
 void Diagnostic(const char* format, ...);
 void Warning(const char* format, ...);
+void Trace(const char* format, ...);
 void Assert(const char* format, ...);
 void AssertBytes(const char* why, const void* buf, size_t size);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -288,12 +288,14 @@ addEventListener("Runtime.executionContextCreated", ({ context }) => {
   for (const callback of gContextChangeCallbacks) {
     callback(context, "add");
   }
+  logTrace(`[RUN-2042-2068] Runtime.executionContextCreated ${context.id}`);
 });
 addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
   const context = gExecutionContexts.get(executionContextId);
   for (const callback of gContextChangeCallbacks) {
     callback(context, "remove");
   }
+  logTrace(`[RUN-2042-2068] Runtime.executionContextDestroyed ${context.id}`);
   gExecutionContexts.delete(executionContextId);
 });
 addEventListener("Runtime.executionContextsCleared", () => {
@@ -302,6 +304,7 @@ addEventListener("Runtime.executionContextsCleared", () => {
       callback(context, "remove");
     }
   }
+  logTrace(`[RUN-2042-2068] Runtime.executionContextsCleared`);
   gExecutionContexts.clear();
 });
 sendMessage("Runtime.enable");

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -91,7 +91,8 @@ const Verbose = false;
 const VerboseCommands = Verbose;
 
 const {
-  log,
+  log: log_,
+  logTrace: logTrace_,
   setCDPMessageCallback,
   sendCDPMessage,
   setCommandCallback,
@@ -142,6 +143,14 @@ const JSON_parse = JSON.parse;
 
 // Some of these are duplicated in gSourceMapScript, so watch out when making
 // modifications to update both versions...
+
+function log(...args) {
+  log_(args.join(' '));
+}
+
+function logTrace(...args) {
+  logTrace_(args.join(' '));
+}
 
 function assert(v, msg = "") {
   if (!v) {
@@ -3325,6 +3334,13 @@ static void LogCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   recordreplay::Print("%s", *text);
 }
 
+static void LogTraceCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "must be called with a single string");
+  v8::String::Utf8Value text(args.GetIsolate(), args[0]);
+  recordreplay::Trace("%s", *text);
+}
+
 // Function to invoke on CDP responses and events.
 static v8::Eternal<v8::Function>* gCDPMessageCallback;
 
@@ -4767,6 +4783,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
                  ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
 
   SetFunctionProperty(isolate, args, "log", LogCallback);
+  SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
 
   // CDP debugger functionality
   SetFunctionProperty(isolate, args, "setCDPMessageCallback",


### PR DESCRIPTION
* paired w/
  * https://github.com/replayio/backend/pull/7867
  * https://github.com/replayio/chromium-v8/pull/151
* https://linear.app/replay/issue/RUN-2042#comment-facc16ef
* Tested [here](https://github.com/replayio/build-test-dashboard/blob/master/02367ed2-ae56-4fde-b4d4-18c7627c1bc9): 27/30 passed ✔