### PR TITLE
Fix platform check

### DIFF
--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -57,7 +57,7 @@ function platformTasks(platform) {
   tasks.push(testStaticTask);
 
   // Playwright tests are currently only supported on linux.
-  if (process.platform == "linux") {
+  if (platform == "linux") {
     const testPlaywrightTask = newTask(
       `Chromium Playwright Tests ${platform}`,
       {


### PR DESCRIPTION
Fix a bug in the action which was causing us to run playwright tests on mac and windows, which will always fail.