### PR TITLE
RUN-1515: fix unordered HeapHashSet iteration

### DIFF
--- a/third_party/blink/renderer/core/inspector/devtools_agent.cc
+++ b/third_party/blink/renderer/core/inspector/devtools_agent.cc
@@ -191,7 +191,9 @@ void DevToolsAgent::Trace(Visitor* visitor) const {
 }
 
 void DevToolsAgent::Dispose() {
-  HeapHashSet<Member<DevToolsSession>> copy(sessions_);
+  HeapHashSet<Member<DevToolsSession>,
+              WTF::MemberHashRecordReplayId<DevToolsSession>>
+      copy(sessions_);
   for (auto& session : copy)
     session->Detach();
   CleanupConnection();
@@ -280,14 +282,8 @@ void DevToolsAgent::InspectElement(const gfx::Point& point) {
 }
 
 void DevToolsAgent::FlushProtocolNotifications() {
-  // https://linear.app/replay/issue/RUN-885
-  recordreplay::Assert("DevToolsAgent::FlushProtocolNotifications");
-
   for (auto& session : sessions_)
     session->FlushProtocolNotifications();
-
-  // https://linear.app/replay/issue/RUN-885
-  recordreplay::Assert("DevToolsAgent::FlushProtocolNotifications Done");
 }
 
 void DevToolsAgent::ReportChildTargetsPostCallbackToIO(

--- a/third_party/blink/renderer/core/inspector/devtools_agent.h
+++ b/third_party/blink/renderer/core/inspector/devtools_agent.h
@@ -145,10 +145,12 @@ class CORE_EXPORT DevToolsAgent : public GarbageCollected<DevToolsAgent>,
       associated_host_remote_{nullptr};
   Member<InspectedFrames> inspected_frames_;
   Member<CoreProbeSink> probe_sink_;
-  HeapHashSet<Member<DevToolsSession>> sessions_;
+  HeapHashSet<Member<DevToolsSession>, WTF::MemberHashRecordReplayId<DevToolsSession>> sessions_;
   scoped_refptr<InspectorTaskRunner> inspector_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
-  HashMap<WorkerThread*, std::unique_ptr<WorkerData>>
+  HashMap<WorkerThread*,
+          std::unique_ptr<WorkerData>,
+          WTF::MemberHashRecordReplayRegisteredPointerId<WorkerThread>>
       unreported_child_worker_threads_;
   IOAgent* io_agent_{nullptr};
   bool report_child_workers_ = false;

--- a/third_party/blink/renderer/core/inspector/devtools_session.cc
+++ b/third_party/blink/renderer/core/inspector/devtools_session.cc
@@ -150,6 +150,8 @@ DevToolsSession::DevToolsSession(
     for (wtf_size_t i = 0; i < agents_.size(); i++)
       agents_[i]->Restore();
   }
+
+  record_replay_id_ = recordreplay::NewIdAnyThread("DevToolsSession");
 }
 
 DevToolsSession::~DevToolsSession() {

--- a/third_party/blink/renderer/core/inspector/devtools_session.h
+++ b/third_party/blink/renderer/core/inspector/devtools_session.h
@@ -94,6 +94,8 @@ class CORE_EXPORT DevToolsSession : public GarbageCollected<DevToolsSession>,
   void PaintTiming(Document* document, const char* name, double timestamp);
   void DomContentLoadedEventFired(LocalFrame*);
 
+  int RecordReplayId() const { return record_replay_id_; }
+
  private:
   class IOSession;
 
@@ -171,6 +173,8 @@ class CORE_EXPORT DevToolsSession : public GarbageCollected<DevToolsSession>,
   InspectorAgentState v8_session_state_;
   InspectorAgentState::Bytes v8_session_state_cbor_;
   const String session_id_;
+
+  int record_replay_id_ = 0;
 };
 
 }  // namespace blink


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1515#comment-ba32619b
* Sneaky fix: Also fix up `unreported_child_worker_threads_`
  * (because it is iterated over in `DevToolsAgent::ReportChildTargetsImpl`)