### PR TITLE
RUN-2103: Don't assume that `contentWindow.document` exists

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2470,7 +2470,7 @@ StackingContext.prototype = {
     }
 
     // Create a new stacking context for any iframes.
-    if (elem.raw.tagName == "IFRAME") {
+    if (elem.raw.tagName == "IFRAME" && elem.raw.contentWindow?.document) {
       const { left, top } = elem.raw.getBoundingClientRect();
       this.addContext(elem, undefined, left, top);
       elem.context.addChildren(elem.raw.contentWindow.document);


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2103#comment-fc7119f3