### PR TITLE
Revert diagnostics

### DIFF
--- a/ui/base/resource/data_pack.cc
+++ b/ui/base/resource/data_pack.cc
@@ -26,8 +26,6 @@
 #include "third_party/zlib/google/compression_utils.h"
 #include "ui/base/resource/scoped_file_writer.h"
 
-#include "base/record_replay.h"
-
 // For details of the file layout, see
 // http://dev.chromium.org/developers/design-documents/linuxresourcesandlocalizedstrings
 
@@ -302,8 +300,6 @@ bool DataPack::SanityCheckFileAndRegisterResources(size_t margin_to_skip,
   // entry after the last item which gives us the length of the last item.
   for (size_t i = 0; i < resource_count_ + 1; ++i) {
     if (resource_table_[i].file_offset > data_length) {
-      recordreplay::Diagnostic("[RUN-2142] Data pack file corruption %zu %zu %zu %zu",
-                               i,resource_table_[i].file_offset, margin_to_skip, data_length);
       LOG(ERROR) << "Data pack file corruption: "
                  << "Entry #" << i << " past end.";
       LogDataPackError(ENTRY_NOT_FOUND);

--- a/ui/base/resource/resource_bundle.cc
+++ b/ui/base/resource/resource_bundle.cc
@@ -68,8 +68,6 @@
 #undef LoadBitmap
 #endif
 
-#include "base/record_replay.h"
-
 namespace ui {
 
 namespace {
@@ -974,9 +972,6 @@ void ResourceBundle::AddDataPackFromPathInternal(
     const base::FilePath& path,
     ResourceScaleFactor scale_factor,
     bool optional) {
-  recordreplay::Diagnostic("[RUN-2142] Data pack file corruption %s",
-                           path.AsUTF8Unsafe().c_str());
-
   // Do not pass an empty |path| value to this method. If the absolute path is
   // unknown pass just the pack file name.
   DCHECK(!path.empty());


### PR DESCRIPTION
These diagnostics were added for a build system problem as part of the GC tasks work. They seem to be breaking the macOS build though and aren't essential so let's just remove them.