### PR TITLE
Separate postimmediatetask logic into orderered/unordered paths.

### DIFF
--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -323,20 +323,25 @@ void TaskQueueImpl::UnregisterTaskQueue() {
   }
 
   TaskDeque immediate_incoming_queue;
-  TaskDeque record_replay_unordered_immediate_incoming_queue;
+  TaskDeque record_replay_unordered_immediate_incoming_queue_old;
 
   base::flat_map<raw_ptr<OnTaskPostedCallbackHandleImpl>, OnTaskPostedHandler>
-      on_task_posted_handlers;
+      on_task_posted_handlers_old;
 
   {
+    // Make sure we take the ordered lock first--if it's not our turn to do so, we won't deadlock
+    // any unordered threads from taking the unordered lock.
     base::internal::CheckedAutoLock lock(any_thread_lock_);
+    base::internal::CheckedAutoLock lock2(unordered_immediate_queue_lock_);
+    base::internal::CheckedAutoLock lock3(unordered_handler_lock_);
+
     any_thread_.unregistered = true;
     immediate_incoming_queue.swap(any_thread_.immediate_incoming_queue);
-    record_replay_unordered_immediate_incoming_queue.swap(any_thread_.record_replay_unordered_immediate_incoming_queue);
+    record_replay_unordered_immediate_incoming_queue_old.swap(record_replay_unordered_immediate_incoming_queue);
 
-    for (auto& handler : any_thread_.on_task_posted_handlers)
+    for (auto& handler : on_task_posted_handlers)
       handler.first->UnregisterTaskQueue();
-    any_thread_.on_task_posted_handlers.swap(on_task_posted_handlers);
+    on_task_posted_handlers.swap(on_task_posted_handlers_old);
   }
 
   if (main_thread_only().wake_up_queue) {
@@ -432,35 +437,28 @@ TimeDelta TaskQueueImpl::GetTaskDelayAdjustment(CurrentThread current_thread) {
 #endif  // DCHECK_IS_ON()
 }
 
-void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
+#pragma clang optimize off
+
+void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
                                           CurrentThread current_thread) {
   // Use CHECK instead of DCHECK to crash earlier. See http://crbug.com/711167
   // for details.
   CHECK(task.callback);
+  CHECK(!recordreplay::AreEventsDisallowed("unordered-tasks") &&
+        !recordreplay::AreEventsPassedThrough("unordered-tasks"));
 
   bool should_schedule_work = false;
   {
-    bool events_disallowed =
-      recordreplay::AreEventsDisallowed("unordered-tasks") ||
-      recordreplay::AreEventsPassedThrough("unordered-tasks");
-    if (events_disallowed)
-      recordreplay::BeginPassThroughEvents();
-
     // TODO(alexclarke): Maybe add a main thread only immediate_incoming_queue
     // See https://crbug.com/901800
     base::internal::CheckedAutoLock lock(any_thread_lock_);
 
-    if (events_disallowed)
-      recordreplay::EndPassThroughEvents();
-
     bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
     TimeTicks queue_time;
 
-    if (!events_disallowed) {
-      recordreplay::Assert(
-          "[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d",
-          add_queue_time_to_tasks || delayed_fence_allowed_);
-    }
+    recordreplay::Assert(
+        "[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d",
+        add_queue_time_to_tasks || delayed_fence_allowed_);
     
     if (add_queue_time_to_tasks || delayed_fence_allowed_)
       queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
@@ -471,26 +469,25 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
     // within a queue.
     EnqueueOrder sequence_number = sequence_manager_->GetNextSequenceNumber();
 
-    bool was_immediate_incoming_queue_empty =
-        !events_disallowed && any_thread_.immediate_incoming_queue.empty();
+    bool was_immediate_incoming_queue_empty = any_thread_.immediate_incoming_queue.empty();
 
-    auto& queue = events_disallowed
-      ? any_thread_.record_replay_unordered_immediate_incoming_queue
-      : any_thread_.immediate_incoming_queue;
-    queue.push_back(
+    any_thread_.immediate_incoming_queue.push_back(
         Task(std::move(task), sequence_number, sequence_number, queue_time));
 
 #if DCHECK_IS_ON()
-    queue.back().cross_thread_ =
+    any_thread_.immediate_incoming_queue.back().cross_thread_ =
         (current_thread == TaskQueueImpl::CurrentThread::kNotMainThread);
 #endif
 
-    sequence_manager_->WillQueueTask(&queue.back());
-    MaybeReportIpcTaskQueuedFromAnyThreadLocked(queue.back());
+    sequence_manager_->WillQueueTask(&any_thread_.immediate_incoming_queue.back());
+    MaybeReportIpcTaskQueuedFromAnyThreadLocked(any_thread_.immediate_incoming_queue.back());
 
-    for (auto& handler : any_thread_.on_task_posted_handlers) {
-      DCHECK(!handler.second.is_null());
-      handler.second.Run(queue.back());
+    {
+      base::internal::CheckedAutoLock hander_lock(unordered_handler_lock_);
+      for (auto& handler : on_task_posted_handlers) {
+        DCHECK(!handler.second.is_null());
+        handler.second.Run(any_thread_.immediate_incoming_queue.back());
+      }
     }
 
     // If this queue was completely empty, then the SequenceManager needs to be
@@ -518,9 +515,61 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
   // when it computes what continuation (if any) is needed.
   if (should_schedule_work)
     sequence_manager_->ScheduleWork();
+}
 
+void TaskQueueImpl::PostImmediateTaskImplUnordered(PostedTask task,
+                                          CurrentThread current_thread) {
+  // Use CHECK instead of DCHECK to crash earlier. See http://crbug.com/711167
+  // for details.
+  CHECK(task.callback);
+  CHECK(recordreplay::AreEventsDisallowed("unordered-tasks") ||
+        recordreplay::AreEventsPassedThrough("unordered-tasks"));
+
+  recordreplay::AutoPassThroughEvents passthrough;
+
+  {
+    // TODO(alexclarke): Maybe add a main thread only immediate_incoming_queue
+    // See https://crbug.com/901800
+    base::internal::CheckedAutoLock lock(unordered_immediate_queue_lock_);
+
+    bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
+    TimeTicks queue_time;
+    
+    if (add_queue_time_to_tasks || delayed_fence_allowed_)
+      queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
+
+    record_replay_unordered_immediate_incoming_queue.push_back(
+        Task(std::move(task), EnqueueOrder(), EnqueueOrder(), queue_time));
+
+#if DCHECK_IS_ON()
+    record_replay_unordered_immediate_incoming_queue.back().cross_thread_ =
+        (current_thread == TaskQueueImpl::CurrentThread::kNotMainThread);
+#endif
+
+    sequence_manager_->WillQueueTask(&record_replay_unordered_immediate_incoming_queue.back());
+
+    {
+      base::internal::CheckedAutoLock handler_lock(unordered_handler_lock_);
+      for (auto& handler : on_task_posted_handlers) {
+        DCHECK(!handler.second.is_null());
+        handler.second.Run(record_replay_unordered_immediate_incoming_queue.back());
+      }
+    }
+  }
+}
+
+void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
+                                          CurrentThread current_thread) {
+  if (recordreplay::AreEventsDisallowed("unordered-tasks") ||
+      recordreplay::AreEventsPassedThrough("unordered-tasks"))
+  {
+    PostImmediateTaskImplUnordered(std::move(task), current_thread);
+  } else {
+    PostImmediateTaskImplOrdered(std::move(task), current_thread);
+  }
   TraceQueueSize();
 }
+#pragma clang optimize on
 
 void TaskQueueImpl::PostDelayedTaskImpl(PostedTask posted_task,
                                         CurrentThread current_thread) {
@@ -650,8 +699,9 @@ void TaskQueueImpl::TakeImmediateIncomingQueueTasks(TaskDeque* queue, TaskDeque*
   queue->MaybeShrinkQueue();
 
   base::internal::CheckedAutoLock lock(any_thread_lock_);
+  base::internal::CheckedAutoLock lock2(unordered_immediate_queue_lock_);
   queue->swap(any_thread_.immediate_incoming_queue);
-  record_replay_unordered_queue->swap(any_thread_.record_replay_unordered_immediate_incoming_queue);
+  record_replay_unordered_queue->swap(record_replay_unordered_immediate_incoming_queue);
 
   // Activate delayed fence if necessary. This is ideologically similar to
   // ActivateDelayedFenceIfNeeded, but due to immediate tasks being posted
@@ -1439,8 +1489,11 @@ TaskQueueImpl::AddOnTaskPostedHandler(OnTaskPostedHandler handler) {
   std::unique_ptr<OnTaskPostedCallbackHandleImpl> handle =
       std::make_unique<OnTaskPostedCallbackHandleImpl>(this,
                                                        associated_thread_);
+  // Ensure we grab the ordered lock first.
   base::internal::CheckedAutoLock lock(any_thread_lock_);
-  any_thread_.on_task_posted_handlers.insert(
+  base::internal::CheckedAutoLock lock2(unordered_handler_lock_);
+
+  on_task_posted_handlers.insert(
       {handle.get(), std::move(handler)});
   return handle;
 }
@@ -1448,8 +1501,10 @@ TaskQueueImpl::AddOnTaskPostedHandler(OnTaskPostedHandler handler) {
 void TaskQueueImpl::RemoveOnTaskPostedHandler(
     TaskQueueImpl::OnTaskPostedCallbackHandleImpl*
         on_task_posted_callback_handle) {
+  // Ensure we grab the ordered lock first.
   base::internal::CheckedAutoLock lock(any_thread_lock_);
-  any_thread_.on_task_posted_handlers.erase(on_task_posted_callback_handle);
+  base::internal::CheckedAutoLock lock2(unordered_handler_lock_);
+  on_task_posted_handlers.erase(on_task_posted_callback_handle);
 }
 
 void TaskQueueImpl::SetTaskExecutionTraceLogger(

--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -332,8 +332,7 @@ void TaskQueueImpl::UnregisterTaskQueue() {
     // Make sure we take the ordered lock first--if it's not our turn to do so, we won't deadlock
     // any unordered threads from taking the unordered locks.
     base::internal::CheckedAutoLock o_lock(any_thread_lock_);
-    base::internal::CheckedAutoLock u_lock1(unordered_immediate_queue_lock_);
-    base::internal::CheckedAutoLock u_lock2(unordered_handler_lock_);
+    base::internal::CheckedAutoLock u_lock1(unordered_lock_);
 
     any_thread_.unregistered = true;
     immediate_incoming_queue.swap(any_thread_.immediate_incoming_queue);
@@ -481,7 +480,10 @@ void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
     MaybeReportIpcTaskQueuedFromAnyThreadLocked(any_thread_.immediate_incoming_queue.back());
 
     {
-      base::internal::CheckedAutoLock hander_lock(unordered_handler_lock_);
+      // This lock must NOT ever enclose an access to an ordered lock (belonging to this queue); 
+      // doing so will cause deadlocks against other threads that are running without order that 
+      // try to do a PostImmediateTask.
+      base::internal::CheckedAutoLock hander_lock(unordered_lock_);
       for (auto& handler : on_task_posted_handlers) {
         DCHECK(!handler.second.is_null());
         handler.second.Run(any_thread_.immediate_incoming_queue.back());
@@ -517,42 +519,31 @@ void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
 
 void TaskQueueImpl::PostImmediateTaskImplUnordered(PostedTask task,
                                           CurrentThread current_thread) {
-  // Use CHECK instead of DCHECK to crash earlier. See http://crbug.com/711167
-  // for details.
   CHECK(task.callback);
   CHECK(recordreplay::AreEventsDisallowed("unordered-tasks") ||
         recordreplay::AreEventsPassedThrough("unordered-tasks"));
 
-  recordreplay::AutoPassThroughEvents passthrough;
+  base::internal::CheckedAutoLock lock(unordered_lock_);
 
-  {
-    // TODO(alexclarke): Maybe add a main thread only immediate_incoming_queue
-    // See https://crbug.com/901800
-    base::internal::CheckedAutoLock lock(unordered_immediate_queue_lock_);
+  bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
+  TimeTicks queue_time;
+  
+  if (add_queue_time_to_tasks || delayed_fence_allowed_)
+    queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
 
-    bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
-    TimeTicks queue_time;
-    
-    if (add_queue_time_to_tasks || delayed_fence_allowed_)
-      queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
-
-    record_replay_unordered_immediate_incoming_queue.push_back(
-        Task(std::move(task), EnqueueOrder(), EnqueueOrder(), queue_time));
+  record_replay_unordered_immediate_incoming_queue.push_back(
+      Task(std::move(task), EnqueueOrder(), EnqueueOrder(), queue_time));
 
 #if DCHECK_IS_ON()
-    record_replay_unordered_immediate_incoming_queue.back().cross_thread_ =
-        (current_thread == TaskQueueImpl::CurrentThread::kNotMainThread);
+  record_replay_unordered_immediate_incoming_queue.back().cross_thread_ =
+      (current_thread == TaskQueueImpl::CurrentThread::kNotMainThread);
 #endif
 
-    sequence_manager_->WillQueueTask(&record_replay_unordered_immediate_incoming_queue.back());
+  sequence_manager_->WillQueueTask(&record_replay_unordered_immediate_incoming_queue.back());
 
-    {
-      base::internal::CheckedAutoLock handler_lock(unordered_handler_lock_);
-      for (auto& handler : on_task_posted_handlers) {
-        DCHECK(!handler.second.is_null());
-        handler.second.Run(record_replay_unordered_immediate_incoming_queue.back());
-      }
-    }
+  for (auto& handler : on_task_posted_handlers) {
+    DCHECK(!handler.second.is_null());
+    handler.second.Run(record_replay_unordered_immediate_incoming_queue.back());
   }
 }
 
@@ -696,7 +687,7 @@ void TaskQueueImpl::TakeImmediateIncomingQueueTasks(TaskDeque* queue, TaskDeque*
   queue->MaybeShrinkQueue();
 
   base::internal::CheckedAutoLock o_lock(any_thread_lock_);
-  base::internal::CheckedAutoLock u_lock(unordered_immediate_queue_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_lock_);
   queue->swap(any_thread_.immediate_incoming_queue);
   record_replay_unordered_queue->swap(record_replay_unordered_immediate_incoming_queue);
 
@@ -1488,7 +1479,7 @@ TaskQueueImpl::AddOnTaskPostedHandler(OnTaskPostedHandler handler) {
                                                        associated_thread_);
   // Ensure we grab the ordered lock first.
   base::internal::CheckedAutoLock o_lock(any_thread_lock_);
-  base::internal::CheckedAutoLock u_lock(unordered_handler_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_lock_);
 
   on_task_posted_handlers.insert(
       {handle.get(), std::move(handler)});
@@ -1500,7 +1491,7 @@ void TaskQueueImpl::RemoveOnTaskPostedHandler(
         on_task_posted_callback_handle) {
   // Ensure we grab the ordered lock first.
   base::internal::CheckedAutoLock o_lock(any_thread_lock_);
-  base::internal::CheckedAutoLock u_lock(unordered_handler_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_lock_);
   on_task_posted_handlers.erase(on_task_posted_callback_handle);
 }
 

--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -330,10 +330,10 @@ void TaskQueueImpl::UnregisterTaskQueue() {
 
   {
     // Make sure we take the ordered lock first--if it's not our turn to do so, we won't deadlock
-    // any unordered threads from taking the unordered lock.
-    base::internal::CheckedAutoLock lock(any_thread_lock_);
-    base::internal::CheckedAutoLock lock2(unordered_immediate_queue_lock_);
-    base::internal::CheckedAutoLock lock3(unordered_handler_lock_);
+    // any unordered threads from taking the unordered locks.
+    base::internal::CheckedAutoLock o_lock(any_thread_lock_);
+    base::internal::CheckedAutoLock u_lock1(unordered_immediate_queue_lock_);
+    base::internal::CheckedAutoLock u_lock2(unordered_handler_lock_);
 
     any_thread_.unregistered = true;
     immediate_incoming_queue.swap(any_thread_.immediate_incoming_queue);
@@ -436,8 +436,6 @@ TimeDelta TaskQueueImpl::GetTaskDelayAdjustment(CurrentThread current_thread) {
   return TimeDelta();
 #endif  // DCHECK_IS_ON()
 }
-
-#pragma clang optimize off
 
 void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
                                           CurrentThread current_thread) {
@@ -569,7 +567,6 @@ void TaskQueueImpl::PostImmediateTaskImpl(PostedTask task,
   }
   TraceQueueSize();
 }
-#pragma clang optimize on
 
 void TaskQueueImpl::PostDelayedTaskImpl(PostedTask posted_task,
                                         CurrentThread current_thread) {
@@ -698,8 +695,8 @@ void TaskQueueImpl::TakeImmediateIncomingQueueTasks(TaskDeque* queue, TaskDeque*
   // wasting memory, before we make it the `immediate_incoming_queue`.
   queue->MaybeShrinkQueue();
 
-  base::internal::CheckedAutoLock lock(any_thread_lock_);
-  base::internal::CheckedAutoLock lock2(unordered_immediate_queue_lock_);
+  base::internal::CheckedAutoLock o_lock(any_thread_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_immediate_queue_lock_);
   queue->swap(any_thread_.immediate_incoming_queue);
   record_replay_unordered_queue->swap(record_replay_unordered_immediate_incoming_queue);
 
@@ -1490,8 +1487,8 @@ TaskQueueImpl::AddOnTaskPostedHandler(OnTaskPostedHandler handler) {
       std::make_unique<OnTaskPostedCallbackHandleImpl>(this,
                                                        associated_thread_);
   // Ensure we grab the ordered lock first.
-  base::internal::CheckedAutoLock lock(any_thread_lock_);
-  base::internal::CheckedAutoLock lock2(unordered_handler_lock_);
+  base::internal::CheckedAutoLock o_lock(any_thread_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_handler_lock_);
 
   on_task_posted_handlers.insert(
       {handle.get(), std::move(handler)});
@@ -1502,8 +1499,8 @@ void TaskQueueImpl::RemoveOnTaskPostedHandler(
     TaskQueueImpl::OnTaskPostedCallbackHandleImpl*
         on_task_posted_callback_handle) {
   // Ensure we grab the ordered lock first.
-  base::internal::CheckedAutoLock lock(any_thread_lock_);
-  base::internal::CheckedAutoLock lock2(unordered_handler_lock_);
+  base::internal::CheckedAutoLock o_lock(any_thread_lock_);
+  base::internal::CheckedAutoLock u_lock(unordered_handler_lock_);
   on_task_posted_handlers.erase(on_task_posted_callback_handle);
 }
 

--- a/base/task/sequence_manager/task_queue_impl.h
+++ b/base/task/sequence_manager/task_queue_impl.h
@@ -491,6 +491,8 @@ class BASE_EXPORT TaskQueueImpl {
   void RemoveCancelableTask(HeapHandle heap_handle);
 
   void PostImmediateTaskImpl(PostedTask task, CurrentThread current_thread);
+  void PostImmediateTaskImplOrdered(PostedTask task, CurrentThread current_thread);
+  void PostImmediateTaskImplUnordered(PostedTask task, CurrentThread current_thread);
   void PostDelayedTaskImpl(PostedTask task, CurrentThread current_thread);
 
   // Push the task onto the |delayed_incoming_queue|. Lock-free main thread
@@ -568,7 +570,11 @@ class BASE_EXPORT TaskQueueImpl {
   const scoped_refptr<GuardedTaskPoster> task_poster_;
 
   mutable base::internal::CheckedLock any_thread_lock_;
+  mutable base::internal::CheckedLock unordered_immediate_queue_lock_;
+  mutable base::internal::CheckedLock unordered_handler_lock_;
 
+  TaskDeque record_replay_unordered_immediate_incoming_queue GUARDED_BY(unordered_immediate_queue_lock_);
+  base::flat_map<raw_ptr<OnTaskPostedCallbackHandleImpl>, OnTaskPostedHandler> on_task_posted_handlers GUARDED_BY(unordered_handler_lock_);
   struct AnyThread {
     // Mirrored from MainThreadOnly. These are only used for tracing.
     struct TracingOnly {
@@ -584,7 +590,6 @@ class BASE_EXPORT TaskQueueImpl {
     ~AnyThread();
 
     TaskDeque immediate_incoming_queue;
-    TaskDeque record_replay_unordered_immediate_incoming_queue;
 
     // True if main_thread_only().immediate_work_queue is empty.
     bool immediate_work_queue_empty = true;
@@ -592,9 +597,6 @@ class BASE_EXPORT TaskQueueImpl {
     bool post_immediate_task_should_schedule_work = true;
 
     bool unregistered = false;
-
-    base::flat_map<raw_ptr<OnTaskPostedCallbackHandleImpl>, OnTaskPostedHandler>
-        on_task_posted_handlers;
 
 #if DCHECK_IS_ON()
     // A cache of |immediate_work_queue->work_queue_set_index()| which is used

--- a/base/task/sequence_manager/task_queue_impl.h
+++ b/base/task/sequence_manager/task_queue_impl.h
@@ -570,11 +570,14 @@ class BASE_EXPORT TaskQueueImpl {
   const scoped_refptr<GuardedTaskPoster> task_poster_;
 
   mutable base::internal::CheckedLock any_thread_lock_;
-  mutable base::internal::CheckedLock unordered_immediate_queue_lock_;
-  mutable base::internal::CheckedLock unordered_handler_lock_;
 
-  TaskDeque record_replay_unordered_immediate_incoming_queue GUARDED_BY(unordered_immediate_queue_lock_);
-  base::flat_map<raw_ptr<OnTaskPostedCallbackHandleImpl>, OnTaskPostedHandler> on_task_posted_handlers GUARDED_BY(unordered_handler_lock_);
+
+  // This lock protects access to the handler callbacks, and is used in both ordered and unordered
+  // contexts.  In particular, this lock must only be used around the handler
+  mutable base::internal::CheckedLock unordered_lock_;
+
+  TaskDeque record_replay_unordered_immediate_incoming_queue GUARDED_BY(unordered_lock_);
+  base::flat_map<raw_ptr<OnTaskPostedCallbackHandleImpl>, OnTaskPostedHandler> on_task_posted_handlers GUARDED_BY(unordered_lock_);
   struct AnyThread {
     // Mirrored from MainThreadOnly. These are only used for tracing.
     struct TracingOnly {


### PR DESCRIPTION
An interaction between the ordered and unordered paths within PostImmedateTaskImpl is leading to a deadlock, whereby one thread is trying to access an ordered lock (any_thread_) in an unordered way (so, trying to take it immediately,) while another thread holds that ordered lock, and is waiting to take another ordered lock that is meant to be taken next by the first thread.

To resolve this, I've made two fields that used to be guarded by the any_thread_ lock, be guarded by two new unordered locks, and split the PostImmediateTaskImpl function into orderered and unordered functions.

In the ordered function, we first take the ordered lock that guards the any_thread_, ensuring that this function will now be ordered.  Within this function, we eventually call the task handlers; because there is now an unordered variant of this function which can also invoke the task handlers, the task handler callback invocation is now guarded by the first new unordered lock.

In the unordered function, we first grab the second new unordered lock, ensuring that access to the queues and surrounding data are protected, and then access the handler by taking the first new unordered lock.

In the various other places where these fields are accessed, we now grab the appropriate unordered locks.  If an ordered lock is also acquired, we grab it first, ensuring that unordered accesses will not be stopped by another thread awaiting the ordered lock.