### PR TITLE
Avoid non-deterministic initialization of PowerMonitor

### DIFF
--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -80,6 +80,8 @@ extern "C" void V8InitializeNotRecordingOrReplaying();
 namespace recordreplay { extern void InitBindings(); }
 #endif
 
+#include "base/power_monitor/power_monitor.h"
+
 #if BUILDFLAG(IS_WIN)
 DLLEXPORT int __cdecl ChromeMain(HINSTANCE instance,
                                  sandbox::SandboxInterfaceInfo* sandbox_info,
@@ -126,6 +128,11 @@ int ChromeMain(int argc, const char** argv) {
 #else // !BUILDFLAG(IS_WIN)
 #error Unknown platform
 #endif // !BUILDFLAG(IS_WIN)
+
+  if (recordreplay::IsRecordingOrReplaying("eager-initialization", "ChromeMain")) {
+    // Force initialization that can otherwise happen at non-deterministic points.
+    PowerMonitor::GetInstance();
+  }
 
 #if BUILDFLAG(IS_WIN)
 #if BUILDFLAG(USE_ALLOCATOR_SHIM) && BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-2155