### PR TITLE
Don't take ordered atomic in JobTaskSource::GetRemainingConcurrency.

### DIFF
--- a/base/record_replay_ordered_atomic.h
+++ b/base/record_replay_ordered_atomic.h
@@ -31,6 +31,14 @@ class OrderedAtomic {
     return value_.load(memory_order);
   }
 
+  T load_unordered(std::memory_order memory_order = std::memory_order_seq_cst) const {
+    if (recordreplay::AreEventsDisallowed()) {
+      recordreplay::AutoPassThroughEvents pass_through;
+      return value_.load(memory_order);
+    }
+    return value_.load(memory_order);
+  }
+
   void store(T v, std::memory_order memory_order = std::memory_order_seq_cst) {
     AutoOrderedLock ordered(ordered_lock_id_);
     value_.store(v, memory_order);

--- a/base/task/thread_pool/job_task_source.cc
+++ b/base/task/thread_pool/job_task_source.cc
@@ -64,6 +64,10 @@ JobTaskSource::State::Value JobTaskSource::State::Load() const {
   return {value_.load(std::memory_order_relaxed)};
 }
 
+JobTaskSource::State::Value JobTaskSource::State::RecordReplayLoadUnordered() const {
+  return {value_.load_unordered(std::memory_order_relaxed)};
+}
+
 JobTaskSource::JoinFlag::JoinFlag() = default;
 JobTaskSource::JoinFlag::~JoinFlag() = default;
 
@@ -242,7 +246,7 @@ TaskSource::RunStatus JobTaskSource::WillRunTask() {
 size_t JobTaskSource::GetRemainingConcurrency() const {
   // It is safe to read |state_| without a lock since this variable is atomic,
   // and no other state is synchronized with GetRemainingConcurrency().
-  const auto state = TS_UNCHECKED_READ(state_).Load();
+  const auto state = TS_UNCHECKED_READ(state_).RecordReplayLoadUnordered();
   if (state.is_canceled())
     return 0;
   const size_t max_concurrency = GetMaxConcurrency(state.worker_count());

--- a/base/task/thread_pool/job_task_source.h
+++ b/base/task/thread_pool/job_task_source.h
@@ -130,6 +130,12 @@ class BASE_EXPORT JobTaskSource : public TaskSource {
     // Loads and returns the state.
     Value Load() const;
 
+    // [RecordReplay] RUN-2080 (https://linear.app/replay/issue/RUN-2080)
+    // This lock can be acquired in non-deterministic contexts when computing
+    // max concurrency.  This is a variant of `Load` above that doesn't
+    // record its thread acquisition.
+    Value RecordReplayLoadUnordered() const;
+
    private:
     recordreplay::OrderedAtomic<uint32_t> value_{0};
   };


### PR DESCRIPTION
For RUN-2080 (https://linear.app/replay/issue/RUN-2080/ordered-lock-with-events-disallowed-atomic-in-wasmtriggertierup)