### PR TITLE
Revert last couple V8 changes.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '6e683f090324fcdad291e4e391351093ef84d3f7',
+  'v8_revision': '40cbfd0fb2322a952b84840829c8adbf44941d21',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
Just a guess, but one likely culprit for the recent uptick in crash rates is the changes to allow various V8 and GC features when recording to reduce overhead.