### PR TITLE
Assert in Core::WriteMessage

### DIFF
--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -551,14 +551,19 @@ MojoResult Core::WriteMessage(MojoHandle message_pipe_handle,
                               MojoMessageHandle message_handle,
                               const MojoWriteMessageOptions* options) {
   RequestContext request_context;
+  recordreplay::Assert("[RUN-1647-2207] Core::WriteMessage A handle=%d", (int) !!message_handle);
   if (!message_handle)
     return MOJO_RESULT_INVALID_ARGUMENT;
   auto message_event = base::WrapUnique(
       reinterpret_cast<ports::UserMessageEvent*>(message_handle));
   auto* message = message_event->GetMessage<UserMessageImpl>();
+  recordreplay::Assert("[RUN-1647-2207] Core::WriteMessage B msg=%d txable=%d",
+    (int) !!message, (int) (message && message->IsTransmittable()));
   if (!message || !message->IsTransmittable())
     return MOJO_RESULT_INVALID_ARGUMENT;
   auto dispatcher = GetDispatcher(message_pipe_handle);
+  recordreplay::Assert("[RUN-1647-2207] Core::WriteMessage C dispatcher=%d",
+    (int) !!dispatcher);
   if (!dispatcher)
     return MOJO_RESULT_INVALID_ARGUMENT;
   return dispatcher->WriteMessage(std::move(message_event));


### PR DESCRIPTION
For RUN-2207 (https://linear.app/replay/issue/RUN-2207/add-asserts-to-corewritemessage)

Bucket issue RUN-1647