### PR TITLE
RUN-2020: Handle global creation events properly

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -217,19 +217,33 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  // After creating the first context that is associated with a non-empty
-  // origin, we are ready to set up the state used to process driver commands
-  // when recording/replaying, and to create checkpoints. Create the first
-  // checkpoint at which execution can pause.
+  recordreplay::Print("[RUN-TODO] LocalWindowProxy::Initialize %d %s",
+                      !!gRecordReplayStateInitialized,
+                      GetFrame()->DomWindow()->Url().GetString().Utf8().c_str());
+
   if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
       origin &&
-      !origin->Host().empty() &&
-      !gRecordReplayStateInitialized) {
-    gRecordReplayStateInitialized = true;
-    SetupRecordReplayCommands(GetIsolate(), GetFrame());
-    V8RecordReplaySetDefaultContext(GetIsolate(), context);
-    recordreplay::NewCheckpoint();
-    RunInitialRecordReplayScripts(GetIsolate());
+      !origin->Host().empty()) {
+    if (!gRecordReplayStateInitialized) {
+      // After creating the first context that is associated with a non-empty
+      // origin, we are ready to set up the state used to process driver
+      // commands when recording/replaying, and to create checkpoints. Create
+      // the first checkpoint at which execution can pause.
+      gRecordReplayStateInitialized = true;
+      SetupRecordReplayCommands(GetIsolate(), GetFrame());
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      recordreplay::NewCheckpoint();
+    }
+
+    if (GetFrame()->IsOutermostMainFrame() || GetFrame()->IsFencedFrameRoot()) {
+      // Whenver a new isolated global root is created, initialize our devtools
+      // scripts within it.
+      // Note that we handle iframes in `gDevtoolsIframeSetupScript`.
+      recordreplay::Print(
+          "[RUN-TODO] InitializeDevToolsScripts %s",
+          GetFrame()->DomWindow()->Url().GetString().Utf8().c_str());
+      InitializeDevToolsScripts(GetIsolate());
+    }
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -236,9 +236,10 @@ void LocalWindowProxy::Initialize() {
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
-      // Whenver a new isolated global root is created, initialize our devtools
-      // scripts within it.
-      // Note that we handle iframes in `gDevtoolsIframeSetupScript`.
+      // Upon root-level navigation, (re-)initialize our devtools
+      // scripts within the new frame.
+      // Note that we handle iframes and in-iframe navigation in
+      // `gDevtoolsIframeSetupScript`.
       recordreplay::Print(
           "[RUN-TODO] InitializeDevToolsScripts %s",
           GetFrame()->DomWindow()->Url().GetString().Utf8().c_str());

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -223,10 +223,6 @@ void LocalWindowProxy::Initialize() {
     // New Window (proxy) init event.
     OnNewWindow(GetIsolate(), GetFrame());
 
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      OnNewRootFrame(GetIsolate(), GetFrame());
-    }
 
     if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
         !gRecordReplayStateInitialized) {
@@ -238,6 +234,11 @@ void LocalWindowProxy::Initialize() {
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
       V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
+    }
+
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event.
+      OnNewRootFrame(GetIsolate(), GetFrame());
     }
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,6 +220,15 @@ void LocalWindowProxy::Initialize() {
   if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
       origin &&
       !origin->Host().empty()) {
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event:
+      // 1. Record the event.
+      // 2. (re-)initialize our devtools scripts within the new frame.
+      // Note that we handle iframes and in-iframe navigation in
+      // `gDevtoolsIframeSetupScript`.
+      OnNewRootFrame(GetIsolate(), GetFrame());
+    }
+
     if (!gRecordReplayStateInitialized) {
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
@@ -229,14 +238,6 @@ void LocalWindowProxy::Initialize() {
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
       V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
-    }
-
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Upon root-level navigation, (re-)initialize our devtools
-      // scripts within the new frame.
-      // Note that we handle iframes and in-iframe navigation in
-      // `gDevtoolsIframeSetupScript`.
-      InitializeDevToolsScripts(GetIsolate());
     }
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -235,7 +235,7 @@ void LocalWindowProxy::Initialize() {
       recordreplay::NewCheckpoint();
     }
 
-    if (GetFrame()->IsOutermostMainFrame() || GetFrame()->IsFencedFrameRoot()) {
+    if (GetFrame()->IsOutermostMainFrame()) {
       // Whenver a new isolated global root is created, initialize our devtools
       // scripts within it.
       // Note that we handle iframes in `gDevtoolsIframeSetupScript`.

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -217,8 +217,7 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
-      origin &&
+  if (origin &&
       !origin->Host().empty()) {
 
     // New Window (proxy) init event.
@@ -229,7 +228,8 @@ void LocalWindowProxy::Initialize() {
       OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
-    if (!gRecordReplayStateInitialized) {
+    if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
+        !gRecordReplayStateInitialized) {
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -217,10 +217,6 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  recordreplay::Print("[RUN-TODO] LocalWindowProxy::Initialize %d %s",
-                      !!gRecordReplayStateInitialized,
-                      GetFrame()->DomWindow()->Url().GetString().Utf8().c_str());
-
   if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
       origin &&
       !origin->Host().empty()) {
@@ -240,9 +236,6 @@ void LocalWindowProxy::Initialize() {
       // scripts within the new frame.
       // Note that we handle iframes and in-iframe navigation in
       // `gDevtoolsIframeSetupScript`.
-      recordreplay::Print(
-          "[RUN-TODO] InitializeDevToolsScripts %s",
-          GetFrame()->DomWindow()->Url().GetString().Utf8().c_str());
       InitializeDevToolsScripts(GetIsolate());
     }
   }

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,12 +220,12 @@ void LocalWindowProxy::Initialize() {
   if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
       origin &&
       !origin->Host().empty()) {
+
+    // New Window (proxy) init event.
+    OnNewWindow(GetIsolate(), GetFrame());
+
     if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event:
-      // 1. Record the event.
-      // 2. (re-)initialize our devtools scripts within the new frame.
-      // Note that we handle iframes and in-iframe navigation in
-      // `gDevtoolsIframeSetupScript`.
+      // Root-level navigation event.
       OnNewRootFrame(GetIsolate(), GetFrame());
     }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4950,7 +4950,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 }
 
-void RunInitialRecordReplayScripts(v8::Isolate* isolate) {
+void InitializeDevToolsScripts(v8::Isolate* isolate) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4848,11 +4848,6 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
 
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  // Add the "__RECORD_REPLAY_ANNOTATION_HOOK__" hook function to
-  // the page window global.
-  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
-                      InvokeOnAnnotation);
-
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__", args);
 
@@ -4950,9 +4945,20 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 }
 
-void InitializeDevToolsScripts(v8::Isolate* isolate) {
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  
+  // 1. Register navigation event.
+  if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
+    recordreplay::OnNavigationEvent(
+        nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
+  }
 
+  // 2. Add the __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
+  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
+                      InvokeOnAnnotation);
+
+  // 3. Initialize React and Redux Devtools scripts.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4948,7 +4948,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
 void OnNewWindow(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  // Add the __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
+  // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4945,6 +4945,14 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 }
 
+void OnNewWindow(v8::Isolate* isolate, LocalFrame* localFrame) {
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+  // Add the __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
+  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
+                      InvokeOnAnnotation);
+}
+
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   
@@ -4954,11 +4962,7 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
         nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
   }
 
-  // 2. Add the __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
-  SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
-                      InvokeOnAnnotation);
-
-  // 3. Initialize React and Redux Devtools stubs.
+  // 2. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4958,7 +4958,7 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  // 3. Initialize React and Redux Devtools scripts.
+  // 3. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -18,7 +18,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Run any special record/replay scripts that need to happen after the first
 // checkpoint is created, so that they can be registered with the recorder.
-void InitializeDevToolsScripts(v8::Isolate* isolate);
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -16,8 +16,10 @@ namespace blink {
 // first checkpoint in the recording is created.
 void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame);
 
-// Run any special record/replay scripts that need to happen after the first
-// checkpoint is created, so that they can be registered with the recorder.
+// Initialize everything that needs to be initialized with every new global window.
+void OnNewWindow(v8::Isolate* isolate, LocalFrame* localFrame);
+
+// Initialize everything that needs to be initialized with every root frame.
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Notify the driver that we're adding an error to the console.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -18,7 +18,7 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Run any special record/replay scripts that need to happen after the first
 // checkpoint is created, so that they can be registered with the recorder.
-void RunInitialRecordReplayScripts(v8::Isolate* isolate);
+void InitializeDevToolsScripts(v8::Isolate* isolate);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/core/loader/document_loader.cc
+++ b/third_party/blink/renderer/core/loader/document_loader.cc
@@ -1886,8 +1886,6 @@ void DocumentLoader::WillCommitNavigation() {
 }
 
 void DocumentLoader::DidCommitNavigation() {
-  recordreplay::Assert("[RUN-1436] DocumentLoader::DidCommitNavigation");
-
   if (commit_reason_ != CommitReason::kRegular)
     return;
 
@@ -1925,8 +1923,6 @@ void DocumentLoader::DidCommitNavigation() {
 
   DEVTOOLS_TIMELINE_TRACE_EVENT("CommitLoad", inspector_commit_load_event::Data,
                                 frame_);
-
-  recordreplay::Assert("[RUN-1436] DocumentLoader::DidCommitNavigation #1");
 
   // Needs to run before dispatching preloads, as it may evict the memory cache.
   probe::DidCommitLoad(frame_, this);
@@ -2432,10 +2428,6 @@ void DocumentLoader::CommitNavigation() {
       mojom::blink::DocumentPolicyFeature::kForceLoadAtTop);
 
   WillCommitNavigation();
-
-  if (Url().ProtocolIsInHTTPFamily()) {
-    recordreplay::OnNavigationEvent(nullptr, Url().GetString().Utf8().c_str());
-  }
 
   is_prerendering_ = frame_->GetPage()->IsPrerendering();
   Document* document = frame_->DomWindow()->InstallNewDocument(


### PR DESCRIPTION
1. Re-initialize things on new windows and also root frame navigation: https://linear.app/replay/issue/RUN-2020#comment-c2aba5a0
2. This is probably also the culprit behind [SCS-1187](https://linear.app/replay/issue/SCS-1187/missing-annotations).
3. Improve navigation events not showing up (will need a follow-up): https://linear.app/replay/issue/RUN-1100/fix-chromium-navigation-events-they-dont-always-show-up

* Tests are good again ✔ (only `rollingstone.com` failing)