### PR TITLE
Remove assertions for RUN-2195

### DIFF
--- a/third_party/blink/renderer/core/frame/settings.cc
+++ b/third_party/blink/renderer/core/frame/settings.cc
@@ -114,7 +114,6 @@ void Settings::SetDelegate(SettingsDelegate* delegate) {
 }
 
 void Settings::Invalidate(SettingsDelegate::ChangeType change_type) {
-  recordreplay::Assert("[RUN-2195-2193] Settings::Invalidate %d %d", !!delegate_, (int)change_type);
   if (delegate_)
     delegate_->SettingsChanged(change_type);
 }

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -305,10 +305,6 @@ v8::Local<v8::Context> MainThreadDebugger::ensureDefaultContextInGroup(
 
 void MainThreadDebugger::beginEnsureAllContextsInGroup(int context_group_id) {
   LocalFrame* frame = WeakIdentifierMap<LocalFrame>::Lookup(context_group_id);
-  recordreplay::Assert(
-      "[RUN-2195-2193] MainThreadDebugger::beginEnsureAllContextsInGroup %d %d %d",
-      context_group_id, !!frame,
-      frame && frame->GetSettings()->GetForceMainWorldInitialization());
   if (frame) {
     frame->GetSettings()->SetForceMainWorldInitialization(true);
   }

--- a/third_party/blink/renderer/core/page/page.cc
+++ b/third_party/blink/renderer/core/page/page.cc
@@ -751,20 +751,14 @@ void Page::SettingsChanged(ChangeType change_type) {
     case ChangeType::kDOMWorlds: {
       if (!GetSettings().GetForceMainWorldInitialization())
         break;
-      recordreplay::Assert("[RUN-2195-2193] Page::SettingsChanged kDOMWorlds A %d", RecordReplayId());
       for (Frame* frame = MainFrame(); frame;
            frame = frame->Tree().TraverseNext()) {
-        recordreplay::Assert(
-            "[RUN-2195-2193] Page::SettingsChanged kDOMWorlds B %d", frame->RecordReplayId());
         if (auto* window = DynamicTo<LocalDOMWindow>(frame->DomWindow())) {
-          recordreplay::Assert("[RUN-2195-2193] Page::SettingsChanged kDOMWorlds C %d",
-                               window->RecordReplayId());
           // Forcibly instantiate WindowProxy.
           window->GetScriptController().WindowProxy(
               DOMWrapperWorld::MainWorld());
         }
       }
-      recordreplay::Assert("[RUN-2195-2193] Page::SettingsChanged kDOMWorlds D %d", RecordReplayId());
       break;
     }
     case ChangeType::kMediaControls:


### PR DESCRIPTION
Some of these assertions are showing up in a lot of windows crash reports because they are being called with events disallowed.