### PR TITLE
Remove asserts for RUN-2154

### DIFF
--- a/mojo/public/cpp/system/wait.cc
+++ b/mojo/public/cpp/system/wait.cc
@@ -71,8 +71,6 @@ MojoResult Wait(Handle handle,
                 MojoHandleSignals signals,
                 MojoTriggerCondition condition,
                 MojoHandleSignalsState* signals_state) {
-  recordreplay::Assert("[RUN-2154] mojo::Wait");
-
   ScopedTrapHandle trap;
   MojoResult rv = CreateTrap(&TriggerContext::OnNotification, &trap);
   DCHECK_EQ(MOJO_RESULT_OK, rv);
@@ -86,8 +84,6 @@ MojoResult Wait(Handle handle,
   rv = MojoAddTrigger(trap.get().value(), handle.value(), signals, condition,
                       context->context_value(), nullptr);
   if (rv == MOJO_RESULT_INVALID_ARGUMENT) {
-    recordreplay::Assert("[RUN-2154] mojo::Wait #1");
-
     // Balanced above.
     context->Release();
     return rv;
@@ -99,20 +95,14 @@ MojoResult Wait(Handle handle,
   rv = MojoArmTrap(trap.get().value(), nullptr, &num_blocking_events,
                    &blocking_event);
   if (rv == MOJO_RESULT_FAILED_PRECONDITION) {
-    recordreplay::Assert("[RUN-2154] mojo::Wait #2");
-
     DCHECK_EQ(1u, num_blocking_events);
     if (signals_state)
       *signals_state = blocking_event.signals_state;
     return blocking_event.result;
   }
 
-  recordreplay::Assert("[RUN-2154] mojo::Wait #3");
-
   // Wait for the first notification only.
   context->event().Wait();
-
-  recordreplay::Assert("[RUN-2154] mojo::Wait #4");
 
   MojoResult ready_result = context->wait_result();
   DCHECK_NE(MOJO_RESULT_UNKNOWN, ready_result);


### PR DESCRIPTION
For https://linear.app/replay/issue/RUN-2154, we don't need these anymore.