### PR TITLE
Fix building against Windows 10 SDK

### DIFF
--- a/media/audio/win/audio_low_latency_input_win.cc
+++ b/media/audio/win/audio_low_latency_input_win.cc
@@ -193,7 +193,7 @@ const char* EffectTypeToString(
       return "DynamicRangeCompression";
     case ABI::Windows::Media::Effects::AudioEffectType_FarFieldBeamForming:
       return "FarFieldBeamForming";
-#if _MSC_VER >= 1930 // Visual Studio 2022
+#if (WDK_NTDDI_VERSION >= NTDDI_WIN10)  // Windows 10 SDK or greater
     case ABI::Windows::Media::Effects::AudioEffectType_DeepNoiseSuppression:
       return "DeepNoise";
 #endif

--- a/media/audio/win/audio_low_latency_input_win.cc
+++ b/media/audio/win/audio_low_latency_input_win.cc
@@ -193,7 +193,7 @@ const char* EffectTypeToString(
       return "DynamicRangeCompression";
     case ABI::Windows::Media::Effects::AudioEffectType_FarFieldBeamForming:
       return "FarFieldBeamForming";
-#if (WDK_NTDDI_VERSION >= NTDDI_WIN10)  // Windows 10 SDK or greater
+#if (WDK_NTDDI_VERSION >= NTDDI_WIN11)  // Windows 11 SDK or greater
     case ABI::Windows::Media::Effects::AudioEffectType_DeepNoiseSuppression:
       return "DeepNoise";
 #endif

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -63,11 +63,10 @@ export async function readSymbols(file, pdbFile) {
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
 function getTextSectionAddress(pdbFile) {
-  const lines = spawnChecked(`${__dirname}\\..\\..\\lib\\llvm-pdbutil.exe`, [
-    "dump",
-    "-section-headers",
-    pdbFile,
-  ])
+  const lines = spawnChecked(
+    `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
+    ["dump", "-section-headers", pdbFile]
+  )
     .stdout.toString()
     .split("\n");
 

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -65,10 +65,11 @@ export async function readSymbols(file, pdbFile) {
 // Symbol addresses are relative to the start of this section.
 function getTextSectionAddress(pdbFile) {
   const oneGigabyte = 1024 * 1024 * 1024;
+  const sixteenGigabytes = 16 * oneGigabyte;
   const lines = spawnSync(
     `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
     ["dump", "-section-headers", pdbFile],
-    { maxBuffer: oneGigabyte }
+    { maxBuffer: sixteenGigabytes }
   )
     .stdout.toString()
     .split("\n");

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "url";
 import path from "path";
 
 import { toNumber, spawnChecked } from "./common.mjs";
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,29 +63,53 @@ export async function readSymbols(file, pdbFile) {
 
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
-function getTextSectionAddress(pdbFile) {
-  const oneGigabyte = 1024 * 1024 * 1024;
-  const sixteenGigabytes = 16 * oneGigabyte;
-  const lines = spawnSync(
-    `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
-    ["dump", "-section-headers", pdbFile],
-    { maxBuffer: sixteenGigabytes }
-  )
-    .stdout.toString()
-    .split("\n");
+async function getTextSectionAddress(pdbFile) {
+  const command = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
+  const args = ["dump", "-section-headers", pdbFile];
+  const subprocess = spawn(command, args, { encoding: "utf8", shell: true });
 
   let inTextSection = false;
-  for (const line of lines) {
-    if (line.includes(".text name")) {
-      inTextSection = true;
-    }
-    const match = /([0-9A-F]+) virtual address/.exec(line);
-    if (match) {
-      if (!inTextSection) {
-        throw new Error("Expected first section to be text section");
+  let textSectionAddress = null;
+
+  const readLineByLine = (stream) => {
+    let remaining = "";
+    stream.on("data", (data) => {
+      remaining += data;
+      let index = remaining.indexOf("\n");
+      while (index > -1) {
+        const line = remaining.substring(0, index);
+        remaining = remaining.substring(index + 1);
+        processLine(line);
+        index = remaining.indexOf("\n");
       }
-      return parseInt(`0x${match[1]}`);
-    }
-  }
-  throw new Error("Could not find start of text section");
+    });
+
+    const processLine = (line) => {
+      if (line.includes(".text name")) {
+        inTextSection = true;
+      }
+      const match = /([0-9A-F]+) virtual address/.exec(line);
+      if (match) {
+        if (!inTextSection) {
+          throw new Error("Expected first section to be text section");
+        }
+        textSectionAddress = parseInt(`0x${match[1]}`);
+      }
+    };
+  };
+
+  readLineByLine(subprocess.stdout);
+
+  return new Promise((resolve, reject) => {
+    subprocess.on("error", reject);
+    subprocess.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Process exited with status code ${code}`));
+      } else if (textSectionAddress === null) {
+        reject(new Error("Could not find start of text section"));
+      } else {
+        resolve(textSectionAddress);
+      }
+    });
+  });
 }

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -63,9 +63,6 @@ export async function readSymbols(file, pdbFile) {
 
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
-const { spawn } = require("child_process");
-const readline = require("readline");
-
 async function getTextSectionAddress(pdbFile) {
   const command = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
   const args = ["dump", "-section-headers", pdbFile];

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -15,11 +15,10 @@ export async function readSymbols(file, pdbFile) {
     }
     const textStart = getTextSectionAddress(pdbFile);
 
-    const process = spawn(`${__dirname}\\..\\..\\lib\\llvm-pdbutil.exe`, [
-      "dump",
-      "-symbols",
-      pdbFile,
-    ]);
+    const process = spawn(
+      `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
+      ["dump", "-symbols", pdbFile]
+    );
     // We use readline here instead of streamToLineIterator so that we can
     // keep the dependencies of this file to a minimum since this is also
     // used to build the linker and rebuilding the linker every time anything

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -15,10 +15,9 @@ export async function readSymbols(file, pdbFile) {
     }
     const textStart = getTextSectionAddress(pdbFile);
 
-    const process = spawn(
-      `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
-      ["dump", "-symbols", pdbFile]
-    );
+    const pdbPath = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
+    console.log(`Reading symbols from ${pdbFile} with ${pdbPath}`);
+    const process = spawn(pdbPath, ["dump", "-symbols", pdbFile]);
     // We use readline here instead of streamToLineIterator so that we can
     // keep the dependencies of this file to a minimum since this is also
     // used to build the linker and rebuilding the linker every time anything

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -1,12 +1,9 @@
 import readline from "readline";
 import { fileURLToPath } from "url";
 import path from "path";
-import * as child_process from "child_process";
-import * as util from "util";
 
 import { toNumber, spawnChecked } from "./common.mjs";
-
-const spawn = util.promisify(child_process.spawn);
+import { spawnSync } from "child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -64,49 +61,29 @@ export async function readSymbols(file, pdbFile) {
   return symbols;
 }
 
-async function getTextSectionAddress(pdbFile) {
-  const command = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
-  const args = ["dump", "-section-headers", pdbFile];
-  const subprocess = spawn(command, args, { encoding: "utf8", shell: true });
+// Get the start virtual address of the text section from a PDB file.
+// Symbol addresses are relative to the start of this section.
+function getTextSectionAddress(pdbFile) {
+  const lines = spawnSync(
+    `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
+    ["dump", "-section-headers", pdbFile],
+    { maxBuffer: 1e100 }
+  )
+    .stdout.toString()
+    .split("\n");
 
-  try {
-    const result = await new Promise((resolve, reject) => {
-      let stdout = "";
-      subprocess.stdout.on("data", (data) => {
-        stdout += data;
-      });
-
-      subprocess.on("error", reject);
-
-      subprocess.on("close", (code) => {
-        if (code !== 0) {
-          reject(new Error(`Process exited with status code ${code}`));
-        } else if (!stdout) {
-          reject(
-            new Error("Empty output, could not find start of text section")
-          );
-        } else {
-          resolve(stdout);
-        }
-      });
-    });
-
-    const lines = result.split("\n");
-    let inTextSection = false;
-    for (const line of lines) {
-      if (line.includes(".text name")) {
-        inTextSection = true;
-      }
-      const match = /([0-9A-F]+) virtual address/.exec(line);
-      if (match) {
-        if (!inTextSection) {
-          throw new Error("Expected first section to be text section");
-        }
-        return parseInt(`0x${match[1]}`);
-      }
+  let inTextSection = false;
+  for (const line of lines) {
+    if (line.includes(".text name")) {
+      inTextSection = true;
     }
-    throw new Error("Could not find start of text section");
-  } catch (err) {
-    console.error(`Error: ${err.message}`);
+    const match = /([0-9A-F]+) virtual address/.exec(line);
+    if (match) {
+      if (!inTextSection) {
+        throw new Error("Expected first section to be text section");
+      }
+      return parseInt(`0x${match[1]}`);
+    }
   }
+  throw new Error("Could not find start of text section");
 }

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -2,6 +2,7 @@ import readline from "readline";
 import { fileURLToPath } from "url";
 import path from "path";
 import * as child_process from "child_process";
+import * as util from "util";
 
 import { toNumber, spawnChecked } from "./common.mjs";
 

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -17,7 +17,7 @@ export async function readSymbols(file, pdbFile) {
 
     const pdbPath = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
     console.log(`Reading symbols from ${pdbFile} with ${pdbPath}`);
-    const process = spawn(pdbPath, ["dump", "-symbols", pdbFile]);
+    const process = spawnChecked(pdbPath, ["dump", "-symbols", pdbFile]);
     // We use readline here instead of streamToLineIterator so that we can
     // keep the dependencies of this file to a minimum since this is also
     // used to build the linker and rebuilding the linker every time anything

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -3,6 +3,7 @@ import { fileURLToPath } from "url";
 import path from "path";
 
 import { toNumber, spawnChecked } from "./common.mjs";
+import { spawnSync } from "child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,13 +64,25 @@ export async function readSymbols(file, pdbFile) {
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
 function getTextSectionAddress(pdbFile) {
-  const lines = spawnChecked(
+  const spawnResult = spawnSync(
     `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
     ["dump", "-section-headers", pdbFile]
-  )
-    .stdout.toString()
-    .split("\n");
+  );
 
+  if (spawnResult.error) {
+    throw new Error(`SpawnSync error: ${spawnResult.error.message}`);
+  }
+
+  if (spawnResult.status !== 0) {
+    throw new Error(`Process exited with status code ${spawnResult.status}`);
+  }
+
+  const stdout = spawnResult.stdout.toString();
+  if (!stdout) {
+    throw new Error("Empty output, could not find start of text section");
+  }
+
+  const lines = stdout.split("\n");
   let inTextSection = false;
   for (const line of lines) {
     if (line.includes(".text name")) {

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -1,9 +1,11 @@
 import readline from "readline";
 import { fileURLToPath } from "url";
 import path from "path";
+import { spawn } from "child_process";
 
 import { toNumber, spawnChecked } from "./common.mjs";
-import { spawnSync } from "child_process";
+
+const spawn = util.promisify(child_process.spawn);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -61,40 +63,49 @@ export async function readSymbols(file, pdbFile) {
   return symbols;
 }
 
-// Get the start virtual address of the text section from a PDB file.
-// Symbol addresses are relative to the start of this section.
-function getTextSectionAddress(pdbFile) {
-  const spawnResult = spawnSync(
-    `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
-    ["dump", "-section-headers", pdbFile]
-  );
+async function getTextSectionAddress(pdbFile) {
+  const command = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
+  const args = ["dump", "-section-headers", pdbFile];
+  const subprocess = spawn(command, args, { encoding: "utf8", shell: true });
 
-  if (spawnResult.error) {
-    throw new Error(`SpawnSync error: ${spawnResult.error.message}`);
-  }
+  try {
+    const result = await new Promise((resolve, reject) => {
+      let stdout = "";
+      subprocess.stdout.on("data", (data) => {
+        stdout += data;
+      });
 
-  if (spawnResult.status !== 0) {
-    throw new Error(`Process exited with status code ${spawnResult.status}`);
-  }
+      subprocess.on("error", reject);
 
-  const stdout = spawnResult.stdout.toString();
-  if (!stdout) {
-    throw new Error("Empty output, could not find start of text section");
-  }
+      subprocess.on("close", (code) => {
+        if (code !== 0) {
+          reject(new Error(`Process exited with status code ${code}`));
+        } else if (!stdout) {
+          reject(
+            new Error("Empty output, could not find start of text section")
+          );
+        } else {
+          resolve(stdout);
+        }
+      });
+    });
 
-  const lines = stdout.split("\n");
-  let inTextSection = false;
-  for (const line of lines) {
-    if (line.includes(".text name")) {
-      inTextSection = true;
-    }
-    const match = /([0-9A-F]+) virtual address/.exec(line);
-    if (match) {
-      if (!inTextSection) {
-        throw new Error("Expected first section to be text section");
+    const lines = result.split("\n");
+    let inTextSection = false;
+    for (const line of lines) {
+      if (line.includes(".text name")) {
+        inTextSection = true;
       }
-      return parseInt(`0x${match[1]}`);
+      const match = /([0-9A-F]+) virtual address/.exec(line);
+      if (match) {
+        if (!inTextSection) {
+          throw new Error("Expected first section to be text section");
+        }
+        return parseInt(`0x${match[1]}`);
+      }
     }
+    throw new Error("Could not find start of text section");
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
   }
-  throw new Error("Could not find start of text section");
 }

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -1,5 +1,11 @@
 import readline from "readline";
+import { fileURLToPath } from "url";
+import path from "path";
+
 import { toNumber, spawnChecked } from "./common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export async function readSymbols(file, pdbFile) {
   const symbols = {};

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -1,7 +1,7 @@
 import readline from "readline";
 import { fileURLToPath } from "url";
 import path from "path";
-import { spawn } from "child_process";
+import * as child_process from "child_process";
 
 import { toNumber, spawnChecked } from "./common.mjs";
 

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -63,6 +63,9 @@ export async function readSymbols(file, pdbFile) {
 
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
+const { spawn } = require("child_process");
+const readline = require("readline");
+
 async function getTextSectionAddress(pdbFile) {
   const command = `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`;
   const args = ["dump", "-section-headers", pdbFile];
@@ -71,34 +74,25 @@ async function getTextSectionAddress(pdbFile) {
   let inTextSection = false;
   let textSectionAddress = null;
 
-  const readLineByLine = (stream) => {
-    let remaining = "";
-    stream.on("data", (data) => {
-      remaining += data;
-      let index = remaining.indexOf("\n");
-      while (index > -1) {
-        const line = remaining.substring(0, index);
-        remaining = remaining.substring(index + 1);
-        processLine(line);
-        index = remaining.indexOf("\n");
-      }
-    });
+  const rl = readline.createInterface({
+    input: subprocess.stdout,
+    output: process.stdout,
+    terminal: false,
+  });
 
-    const processLine = (line) => {
-      if (line.includes(".text name")) {
-        inTextSection = true;
+  rl.on("line", (line) => {
+    if (line.includes(".text name")) {
+      inTextSection = true;
+    }
+    const match = /([0-9A-F]+) virtual address/.exec(line);
+    if (match) {
+      if (!inTextSection) {
+        throw new Error("Expected first section to be text section");
       }
-      const match = /([0-9A-F]+) virtual address/.exec(line);
-      if (match) {
-        if (!inTextSection) {
-          throw new Error("Expected first section to be text section");
-        }
-        textSectionAddress = parseInt(`0x${match[1]}`);
-      }
-    };
-  };
-
-  readLineByLine(subprocess.stdout);
+      textSectionAddress = parseInt(`0x${match[1]}`);
+      rl.close(); // We've found what we needed, so we can stop reading the output
+    }
+  });
 
   return new Promise((resolve, reject) => {
     subprocess.on("error", reject);

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -64,10 +64,11 @@ export async function readSymbols(file, pdbFile) {
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
 function getTextSectionAddress(pdbFile) {
+  const oneGigabyte = 1024 * 1024 * 1024;
   const lines = spawnSync(
     `${__dirname}\\..\\..\\..\\backend\\lib\\llvm-pdbutil.exe`,
     ["dump", "-section-headers", pdbFile],
-    { maxBuffer: 1e100 }
+    { maxBuffer: oneGigabyte }
   )
     .stdout.toString()
     .split("\n");


### PR DESCRIPTION
I _think_ we care about the version of the Windows 10 SDK we are building against, not the version of the compiler that we're using?

Related to RUN-2091