### PR TITLE
Continue watching iframes for src changes

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -3302,7 +3302,6 @@ const char* gDevtoolsIframeSetupScript = R""""(
               try {
                 const newLocation = iframe.contentWindow.location.href
                 if (newLocation !== oldLocation) {
-                  iframeSrcObserver.disconnect()
                   addDevtoolsToIframe(iframe)
                   return
                 }


### PR DESCRIPTION
This PR:

- Tweaks the "watch for added iframes" logic to continue watching `iframe.src` for changes indefinitely and always copy in the React/Redux DevTools pointers, instead of only watching for the _first_ time it changes and then disconnecting

I _think_ this should handle cases where iframes are navigated over time.