### PR TITLE
Assert DevToolsSession id

### DIFF
--- a/third_party/blink/renderer/core/inspector/devtools_session.cc
+++ b/third_party/blink/renderer/core/inspector/devtools_session.cc
@@ -353,8 +353,8 @@ void DevToolsSession::flushProtocolNotifications() {
 
 void DevToolsSession::FlushProtocolNotifications() {
   recordreplay::Assert(
-      "[RUN-1515-1924] DevToolsSession::FlushProtocolNotifications A %d %d",
-      (int)agents_.size(), (int)notification_queue_.size());
+      "[RUN-1515-2157] DevToolsSession::FlushProtocolNotifications A %d %s %d %d",
+      record_replay_id_, session_id_.Utf8().c_str(), (int)agents_.size(), (int)notification_queue_.size());
 
   if (IsDetached())
     return;

--- a/third_party/blink/renderer/platform/graphics/bitmap_image.cc
+++ b/third_party/blink/renderer/platform/graphics/bitmap_image.cc
@@ -87,9 +87,6 @@ bool BitmapImage::CurrentFrameHasSingleSecurityOrigin() const {
 }
 
 void BitmapImage::DestroyDecodedData() {
-  recordreplay::Assert(
-      "[RUN-1975-2225] BitmapImage::DestroyDecodedData %d %u",
-      paint_image_id(), reset_animation_sequence_id_);
   cached_frame_ = PaintImage();
   NotifyMemoryChanged();
 }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1515#comment-0bb79deb
* Sneaky: Remove spammy `BitmapImage::DestroyDecodedData` Assert.