### PR TITLE
RUN-2266 Part 2: fix recorder crashes + more Asserts

### DIFF
--- a/cc/paint/display_item_list.cc
+++ b/cc/paint/display_item_list.cc
@@ -80,7 +80,8 @@ DisplayItemList::DisplayItemList(UsageHint usage_hint)
 
 DisplayItemList::~DisplayItemList() {
   if (!recordreplay::AreEventsDisallowed())
-    recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList %d", paint_op_buffer_.unique());
+    recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList %d",
+                         paint_op_buffer_.unique());
 }
 
 void DisplayItemList::Raster(SkCanvas* canvas,

--- a/cc/paint/paint_op_buffer.cc
+++ b/cc/paint/paint_op_buffer.cc
@@ -2922,7 +2922,8 @@ PaintOpBuffer::PaintOpBuffer(PaintOpBuffer&& other) {
 
 PaintOpBuffer::~PaintOpBuffer() {
   if (!recordreplay::AreEventsDisallowed()) {
-    recordreplay::Assert("[RUN-2104-2228] ~PaintOpBuffer");
+    recordreplay::Assert("[RUN-2104-2228] ~PaintOpBuffer %d",
+                         are_ops_destroyed_);
   }
   Reset();
 }
@@ -2955,9 +2956,11 @@ PaintOpBuffer& PaintOpBuffer::operator=(PaintOpBuffer&& other) {
 void PaintOpBuffer::Reset() {
   if (!are_ops_destroyed_) {
     for (PaintOp& op : Iterator(this)) {
+      recordreplay::Assert("[RUN-2104-2266] PaintOpBuffer::Reset A %d", (int)op.GetType());
       op.DestroyThis();
     }
   }
+  recordreplay::Assert("[RUN-2104-2266] PaintOpBuffer::Reset B");
 
   // Leave data_ allocated, reserved_ unchanged. ShrinkToFit will take care of
   // that if called.

--- a/cc/raster/raster_source.cc
+++ b/cc/raster/raster_source.cc
@@ -38,9 +38,10 @@ RasterSource::RasterSource(const RecordingSource* other)
 
 RasterSource::~RasterSource() {
   if (!recordreplay::AreEventsDisallowed())
-    recordreplay::Assert("[RUN-2104-2266] ~RasterSource %s %d %d", debug_name_.c_str(),
-                         display_list_->HasOneRef(),
-                         display_list_->HasAtLeastOneRef());
+    recordreplay::Assert("[RUN-2104-2266] ~RasterSource %s %d %d %d",
+                         debug_name_.c_str(), !!display_list_,
+                         display_list_ && display_list_->HasOneRef(),
+                         display_list_ && display_list_->HasAtLeastOneRef());
 }
 
 void RasterSource::ClearForOpaqueRaster(

--- a/cc/tiles/picture_layer_tiling_set.cc
+++ b/cc/tiles/picture_layer_tiling_set.cc
@@ -79,9 +79,9 @@ PictureLayerTilingSet::PictureLayerTilingSet(
 
 PictureLayerTilingSet::~PictureLayerTilingSet() {
   if (!recordreplay::AreEventsDisallowed())
-    recordreplay::Assert("[RUN-2104-2266] ~PictureLayerTilingSet %d %d",
-                         recordreplay::PointerId(this),
-                         raster_source_->HasOneRef());
+    recordreplay::Assert("[RUN-2104-2266] ~PictureLayerTilingSet %d %d %d",
+                         recordreplay::PointerId(this), !!raster_source_,
+                         raster_source_ && raster_source_->HasOneRef());
   recordreplay::UnregisterPointer(this);
 }
 

--- a/third_party/blink/renderer/platform/graphics/paint/display_item_list.cc
+++ b/third_party/blink/renderer/platform/graphics/paint/display_item_list.cc
@@ -12,10 +12,14 @@ namespace blink {
 
 DisplayItemList::~DisplayItemList() {
   if (!recordreplay::AreEventsDisallowed())
-    recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList %zu",
+    recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList A %zu",
                          MemoryUsageInBytes());
-  for (auto& item : *this)
+  for (auto& item : *this) {
+    recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList B %s",
+                         item.GetId().ToString().Utf8().c_str());
     item.Destruct();
+  }
+  recordreplay::Assert("[RUN-2104-2266] ~DisplayItemList C");
 }
 
 #if DCHECK_IS_ON()


### PR DESCRIPTION
## Recorder Crashes

[RUN-2266](https://linear.app/replay/issue/RUN-2266/assert-displayitemlist-and-more) caused recorder crashes:

* We accessed possibly nulled out `scoped_refptr` in `~PictureLayerTilingSet` (that's what the crashreports show [here](https://ui.honeycomb.io/replay/datasets/backend/result/9Gd6nM72v28)) and probably also in `~RasterSource`.
* This fixes those crashes.
* Also added more Asserts.
* https://linear.app/replay/issue/RUN-2104#comment-9c05f99b