### PR TITLE
remove `AutoDisallowEvents disallow("TaskQueue::~TaskQueue")`

### DIFF
--- a/base/task/sequence_manager/task_queue.cc
+++ b/base/task/sequence_manager/task_queue.cc
@@ -137,12 +137,9 @@ TaskQueue::TaskQueue(std::unique_ptr<internal::TaskQueueImpl> impl,
 }
 
 TaskQueue::~TaskQueue() {
-  recordreplay::UnregisterPointer(this);
-
-  // Because the refcount is threadsafe, destruction can happen at non-deterministic points.
-  recordreplay::AutoDisallowEvents disallow("TaskQueue::~TaskQueue");
-
   ShutdownTaskQueueGracefully();
+
+  recordreplay::UnregisterPointer(this);
 }
 
 void TaskQueue::ShutdownTaskQueueGracefully() {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2217#comment-438582e6
* Testing:
  * Livetests are passing ✔
  * Since we currently only see this issue crop up in QA Wolf, we can probably publish this and investigate potential problems with this approach without affecting our users.