### PR TITLE
RUN-2303: Make TaskQueueEnabledVoterMap deterministic

### DIFF
--- a/third_party/blink/renderer/platform/scheduler/main_thread/frame_task_queue_controller.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/frame_task_queue_controller.h
@@ -121,7 +121,8 @@ class PLATFORM_EXPORT FrameTaskQueueController {
 
   using TaskQueueEnabledVoterMap = WTF::HashMap<
       scoped_refptr<MainThreadTaskQueue>,
-      std::unique_ptr<base::sequence_manager::TaskQueue::QueueEnabledVoter>>;
+      std::unique_ptr<base::sequence_manager::TaskQueue::QueueEnabledVoter>,
+      WTF::RecordReplayRefPtrPointerIdHash<MainThreadTaskQueue>>;
 
   // QueueEnabledVoters for the task queues we've created.
   TaskQueueEnabledVoterMap task_queue_enabled_voters_;

--- a/third_party/blink/renderer/platform/wtf/hash_functions.h
+++ b/third_party/blink/renderer/platform/wtf/hash_functions.h
@@ -30,6 +30,8 @@
 #include "third_party/blink/renderer/platform/wtf/hash_table_deleted_value_type.h"
 #include "third_party/blink/renderer/platform/wtf/std_lib_extras.h"
 
+#include "base/record_replay.h"
+
 namespace WTF {
 
 template <size_t size>
@@ -149,12 +151,51 @@ struct PtrHash {
 };
 
 template <typename T>
+struct RecordReplayPointerIdHash {
+  static unsigned GetHash(T* key) {
+#if defined(COMPILER_MSVC)
+#pragma warning(push)
+// work around what seems to be a bug in MSVC's conversion warnings
+#pragma warning(disable : 4244)
+#endif
+    if (recordreplay::IsRecordingOrReplaying("pointer-ids")) {
+      int id = recordreplay::PointerId(key);
+      if (id) {
+        return IntHash<int>::GetHash(id);
+      }
+    }
+    return IntHash<uintptr_t>::GetHash(reinterpret_cast<uintptr_t>(key));
+#if defined(COMPILER_MSVC)
+#pragma warning(pop)
+#endif
+  }
+  static bool Equal(T* a, T* b) { return a == b; }
+  static bool Equal(std::nullptr_t, T* b) { return !b; }
+  static bool Equal(T* a, std::nullptr_t) { return !a; }
+  static const bool safe_to_compare_to_empty_or_deleted = true;
+};
+
+template <typename T>
 struct RefPtrHash : PtrHash<T> {
   using PtrHash<T>::GetHash;
   static unsigned GetHash(const scoped_refptr<T>& key) {
     return GetHash(key.get());
   }
   using PtrHash<T>::Equal;
+  static bool Equal(const scoped_refptr<T>& a, const scoped_refptr<T>& b) {
+    return a == b;
+  }
+  static bool Equal(T* a, const scoped_refptr<T>& b) { return a == b; }
+  static bool Equal(const scoped_refptr<T>& a, T* b) { return a == b; }
+};
+
+template <typename T>
+struct RecordReplayRefPtrPointerIdHash : RecordReplayPointerIdHash<T> {
+  using RecordReplayPointerIdHash<T>::GetHash;
+  static unsigned GetHash(const scoped_refptr<T>& key) {
+    return GetHash(key.get());
+  }
+  using RecordReplayPointerIdHash<T>::Equal;
   static bool Equal(const scoped_refptr<T>& a, const scoped_refptr<T>& b) {
     return a == b;
   }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2303/iteration-order-in-frametaskqueuecontroller-taskqueueenabledvotermap