### PR TITLE
RUN-2309: Remove `AutoDisallowEvents` from `MemoryCache::Prune`

### DIFF
--- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
@@ -371,10 +371,6 @@ void MemoryCache::Prune() {
 
   recordreplay::Assert("[RUN-1975-2287] MemoryCache::Prune");
 
-  // Cache state can vary when replaying, make sure we don't interact
-  // with the recording while pruning.
-  recordreplay::AutoDisallowEvents disallow("MemoryCache::Prune");
-
   if (in_prune_resources_)
     return;
   if (size_ <= capacity_)  // Fast path.


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1975#comment-b0006330
* [Tests](https://buildkite.com/replay/testing-runtime-e2e/builds/1068#01892a7c-8cd8-4ce7-8bb5-9f6cbf23e874): ✔ (only Unsplash timeout)