### PR TITLE
Fix Crash: Don't access moved values

### DIFF
--- a/third_party/blink/renderer/modules/indexeddb/web_idb_transaction.cc
+++ b/third_party/blink/renderer/modules/indexeddb/web_idb_transaction.cc
@@ -84,9 +84,8 @@ void WebIDBTransaction::Put(int64_t object_store_id,
                                   WTF::Unretained(this), std::move(callbacks)));
 
   recordreplay::Assert(
-      "[RUN-1806-2265] WebIDBTransaction::Put %lld %lld %zu %zu %zu",
-      transaction_id_, object_store_id, value->DataSize(),
-      primary_key->SizeEstimate(), index_keys_size);
+      "[RUN-1806-2265] WebIDBTransaction::Put %lld %lld %zu",
+      transaction_id_, object_store_id, arg_size);
 }
 
 void WebIDBTransaction::PutCallback(


### PR DESCRIPTION
* This fixes this botched PR: https://github.com/replayio/chromium/pull/807
* → Don't access moved values.