### PR TITLE
Backout revision b58cf6eab7b9193543d563bc31ab578f0df73649.

### DIFF
--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
@@ -63,14 +63,6 @@ AgentGroupSchedulerImpl::~AgentGroupSchedulerImpl() {
 
   default_task_queue_->DetachFromMainThreadScheduler();
   compositor_task_queue_->DetachFromMainThreadScheduler();
-
-  // Leak this when removed during GC and if it contains agents.
-  // See https://linear.app/replay/issue/RUN-2056#comment-460ec1ff
-  if (recordreplay::AreEventsDisallowed(
-          "MainThreadSchedulerImpl::RemoveAgentGroupScheduler") &&
-      agents_->size())
-    return;
-
   main_thread_scheduler_.RemoveAgentGroupScheduler(this);
 }
 
@@ -145,16 +137,16 @@ void AgentGroupSchedulerImpl::RemoveAgent(Agent* agent) {
 }
 
 void AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint() {
+  recordreplay::Assert(
+      "[RUN-2056-2298] AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint "
+      "Start %d %d",
+      RecordReplayId(), (int)agents_->size());
+
   for (Agent* agent : *agents_) {
-    // WARN: Don't Assert on AgentGroupSchedulerImpl on its own since they are
-    // allowed to diverge. However, agents are not allowed to diverge.
-    // See https://linear.app/replay/issue/RUN-2056#comment-460ec1ff
-    recordreplay::Assert(
-        "[RUN-2056-2365] AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint "
-        "%d %d %d",
-        RecordReplayId(), (int)agents_->size(), agent->RecordReplayId());
     agent->PerformMicrotaskCheckpoint();
   }
+
+  recordreplay::Assert("[RUN-2056-2211] AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint Done");
 }
 
 }  // namespace scheduler

--- a/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
@@ -1121,14 +1121,10 @@ void MainThreadSchedulerImpl::SetHaveSeenABlockingGestureForTesting(
 void MainThreadSchedulerImpl::PerformMicrotaskCheckpoint() {
   // This will fallback to execute the microtask checkpoint for the
   // default EventLoop for the isolate.
-
-  // Warn: Don't assert on `agent_group_schedulers.size()` since they are
-  // allowed to diverge.
-  // See https://linear.app/replay/issue/RUN-2056#comment-460ec1ff
   recordreplay::Assert(
-      "[RUN-2056-2365] MainThreadSchedulerImpl::PerformMicrotaskCheckpoint A %d %d",
-      recordreplay::PointerId(this), !!isolate());
-
+      "[RUN-2056-2298] MainThreadSchedulerImpl::PerformMicrotaskCheckpoint %d %d %u",
+      recordreplay::PointerId(this), !!isolate(),
+      main_thread_only().agent_group_schedulers.size());
   if (isolate())
     EventLoop::PerformIsolateGlobalMicrotasksCheckpoint(isolate());
   // Perform a microtask checkpoint for each AgentSchedulingGroup. This
@@ -1141,8 +1137,7 @@ void MainThreadSchedulerImpl::PerformMicrotaskCheckpoint() {
     agent_group_scheduler->PerformMicrotaskCheckpoint();
   }
   recordreplay::Assert(
-      "[RUN-2056-2365] MainThreadSchedulerImpl::PerformMicrotaskCheckpoint "
-      "B");
+      "[RUN-2056] MainThreadSchedulerImpl::PerformMicrotaskCheckpoint Done");
 }
 
 // static
@@ -2170,6 +2165,9 @@ void MainThreadSchedulerImpl::RemoveAgentGroupScheduler(
     AgentGroupSchedulerImpl* agent_group_scheduler) {
   DCHECK(main_thread_only().agent_group_schedulers.Contains(
       agent_group_scheduler));
+  recordreplay::Assert(
+      "[RUN-2056-2316] MainThreadSchedulerImpl::RemoveAgentGroupScheduler %d",
+      agent_group_scheduler->RecordReplayId());
   main_thread_only().agent_group_schedulers.erase(agent_group_scheduler);
 }
 


### PR DESCRIPTION
For #RUN-2375 (https://linear.app/replay/issue/RUN-2375/recording-crash-in-agentgroupschedulerimplperformmicrotaskcheckpoint)

Orig PR: https://github.com/replayio/chromium/pull/826
Orig linear: RUN-2056