### PR TITLE
RUN-2394: Add a way to query bytecode of a function

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '958cf5c6a8011e9b107a893085e20d4a3bffe8a3',
+  'v8_revision': '401a00360483b7e827dc6d8b1b58b7fa89d0c805',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '401a00360483b7e827dc6d8b1b58b7fa89d0c805',
+  'v8_revision': '6ae779d9b21ffc8dd055db079fa75925ff2522d4',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -62,8 +62,12 @@ namespace internal {
 
 extern int RecordReplayObjectId(v8::Isolate* isolate, v8::Local<v8::Context> cx,
                                 v8::Local<v8::Value> object, bool allow_create);
-extern void RecordReplayConfirmObjectHasId(v8::Isolate* isolate, v8::Local<v8::Context> cx,
+extern void RecordReplayConfirmObjectHasId(v8::Isolate* isolate,
+                                           v8::Local<v8::Context> cx,
                                            v8::Local<v8::Value> object);
+extern v8::Local<v8::Object> RecordReplayGetBytecode(
+    v8::Isolate* isolate_,
+    v8::Local<v8::Object> paramsObj);
 
 } // namespace internal
 } // namespace v8
@@ -4627,6 +4631,19 @@ static void fromJsCollectEventListeners(const v8::FunctionCallbackInfo<v8::Value
   args.GetReturnValue().Set(result);
 }
 
+static void fromJsGetFunctionBytecode(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsObject() &&
+        "[RuntimeError] must be called with a single plain object");
+
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Object> paramObj = args[0].As<v8::Object>();
+
+  v8::Local<v8::Object> rv = v8::internal::RecordReplayGetBytecode(isolate, paramObj);
+
+  args.GetReturnValue().Set(rv);
+}
+
 /** ###########################################################################
  * misc
  * ##########################################################################*/
@@ -4823,6 +4840,8 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
                       fromJsCollectEventListeners);
   SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
                       fromJsDomPerformSearch);
+  SetFunctionProperty(isolate, args, "getFunctionBytecode",
+                      fromJsGetFunctionBytecode);
 
   // unsorted RR stuff
   SetFunctionProperty(


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/175
* https://linear.app/replay/issue/RUN-2394#comment-001e925e