### PR TITLE
RUN-2365: Leak SVGImage::agent_group_scheduler_

### DIFF
--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -215,6 +215,11 @@ SVGImage::~SVGImage() {
   if (frame_client_)
     frame_client_->ClearImage();
 
+  // Leak the agent_group_scheduler_ when removed during GC.
+  // See https://linear.app/replay/issue/RUN-2056#comment-f827701f.
+  if (recordreplay::AreEventsDisallowed("~SVGImage"))
+    agent_group_scheduler_.release();
+
   if (page_) {
     // It is safe to allow UA events within this scope, because event
     // dispatching inside the SVG image's document doesn't trigger JavaScript

--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
@@ -137,12 +137,11 @@ void AgentGroupSchedulerImpl::RemoveAgent(Agent* agent) {
 }
 
 void AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint() {
-  recordreplay::Assert(
-      "[RUN-2056-2298] AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint "
-      "Start %d %d",
-      RecordReplayId(), (int)agents_->size());
-
   for (Agent* agent : *agents_) {
+    recordreplay::Assert(
+        "[RUN-2056-2365] AgentGroupSchedulerImpl::PerformMicrotaskCheckpoint "
+        "%d %d %d",
+        RecordReplayId(), (int)agents_->size(), agent->RecordReplayId());
     agent->PerformMicrotaskCheckpoint();
   }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2056#comment-f827701f