### PR TITLE
Elements with opacity<1 get own stacking context.

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2530,6 +2530,15 @@ StackingContext.prototype = {
       return;
     }
 
+    // Elements with `opacity < 0` get their own stacking context.
+    const opacity = elem.style.getPropertyValue("opacity");
+    if (opacity) {
+      const opacityVal = +opacity | 0;
+      if (opacityVal < 1) {
+        this.addContext(elem);
+      }
+    }
+
     const parentDisplay = elem.parent?.style?.getPropertyValue("display");
     if (
       position != "static" ||


### PR DESCRIPTION
After discussion with holger on stacking spec.