### PR TITLE
Reset paint surface on new root frame

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -520,4 +520,16 @@ void MaybeTerminate(void (*callback)(void*), void* data) {
   V8RecordReplayMaybeTerminate(callback, data);
 }
 
+// Callback to reset the paint surface.
+static ResetPaintSurfaceCallback gResetPaintSurfaceCallback = nullptr;
+void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface) {
+  gResetPaintSurfaceCallback = reset_paint_surface;
+}
+
+void DoResetPaintSurface() {
+  if (gResetPaintSurfaceCallback) {
+    gResetPaintSurfaceCallback();
+  }
+}
+
 } // namespace recordreplay

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -348,6 +348,10 @@ public:
   }
 };
 
+typedef void (*ResetPaintSurfaceCallback)();
+void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface);
+void DoResetPaintSurface();
+
 } // namespace recordreplay
 
 #endif // BASE_RECORD_REPLAY_H_

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -42,6 +42,18 @@ void NotifyRasterBuffer(const viz::SharedBitmapId& shared_bitmap_id,
 static viz::SoftwareOutputSurface* gOutputSurface;
 static viz::SoftwareRenderer* gRenderer;
 
+// For now we only support drawing a single surface, which is the first one
+// which the process tried to draw.  This variable can be reset when the
+// target surface is expected to change, such as after a navigation, so that
+// the new surface is not ignored.
+// The `SetResetPaintSurfaceCallback` call below is used to install a callback
+// that chrome invokes when the target surface is expected to change.
+// See https://linear.app/replay/issue/RUN-2400
+static viz::LocalSurfaceId* gSurfaceId;
+static void ResetSurfaceId() {
+  gSurfaceId = nullptr;
+}
+
 static void InitializeRenderer() {
   std::unique_ptr<viz::SoftwareOutputDevice> output_device =
       std::make_unique<viz::SoftwareOutputDevice>();
@@ -52,6 +64,8 @@ static void InitializeRenderer() {
                                         gOutputSurface,
                                         nullptr,
                                         nullptr);
+
+  recordreplay::SetResetPaintSurfaceCallback(ResetSurfaceId);
 }
 
 static std::string SurfaceIdString(const viz::LocalSurfaceId& local_surface_id) {
@@ -61,10 +75,6 @@ static std::string SurfaceIdString(const viz::LocalSurfaceId& local_surface_id) 
                             local_surface_id.child_sequence_number(),
                             local_surface_id.embed_token().ToString().c_str());
 }
-
-// For now we only support drawing a single surface, which is the first one
-// which the process tried to draw.
-static viz::LocalSurfaceId* gSurfaceId;
 
 // Current compositor frame.
 static const viz::CompositorFrame* gCurrentFrame;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4925,7 +4925,11 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
         nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
   }
 
-  // 2. Initialize React and Redux Devtools stubs.
+  // 2. Reset paint surface so that paints to the new root's surface are not ignored.
+  // See: https://linear.app/replay/issue/RUN-2400
+  recordreplay::DoResetPaintSurface();
+
+  // 3. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs


### PR DESCRIPTION
For #RUN-2400 (https://linear.app/replay/issue/RUN-2400/[chromium-linux]-replay-paint-updates-freeze-after-page-navigation-on)