### PR TITLE
Expose getPlainObjectByRrpId to evaluateInGlobal scripts.

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2674,6 +2674,17 @@ function shiftRect(rect, offset) {
   };
 }
 
+/** ###########################################################################
+ * Export internal methods via `__RECORD_REPLAY_ARGUMENTS__`.
+ * This is to be used for internal debugging purposes.
+ * ##########################################################################*/
+__RECORD_REPLAY_ARGUMENTS__.internal = {
+  getBlinkNodeIdByRrpId,
+  getCdpObjectByRrpId,
+  getBlinkNodeIdByCdpId,
+  getPlainObjectByRrpId,
+};
+
 } catch (e) {
   log(`Error: Initialization exception ${e}`);
 }


### PR DESCRIPTION
Needed to support debugging node-picker and stacking context logic on production builds and recordings that we didn't make.