### PR TITLE
Add missing non-optional protocol results to `DOM.getBoxModel`

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1868,6 +1868,9 @@ function DOM_getBoxModel({ node: nodeRrpId }) {
   if (!isBlinkInstanceOf(nodeObj, Element)) {
     // Handle invalid input (this is how we do this in Gecko)
     model.content = [];
+    model.padding = [];
+    model.border = [];
+    model.margin = [];
   } else {
     const nodeId = getBlinkNodeIdByRrpId(nodeRrpId);
     /**


### PR DESCRIPTION
* Addendum to https://linear.app/replay/issue/RUN-2525#comment-e5d2fd22
* As explained by @ryanjduffy here: https://github.com/replayio/chromium/pull/876#discussion_r1306454514