### PR TITLE
RUN-2521: Ensure InspectorCSSAgent is (somewhat) initialized

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4410,7 +4410,7 @@ static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) 
 }
 
 /** ###########################################################################
- * blink (DOM, CSS etc.)
+ * blink (DOM, CSS queries etc.)
  * @see https://static.replay.io/protocol/tot/DOM/
  * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
  * ##########################################################################*/
@@ -4438,8 +4438,6 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Isolate* isolate = args.GetIsolate();
 
-  auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
-
   // convert v8::String → v8::String::Utf8Value → v8_inspector::StringView
   v8::String::Utf8Value cdpId(isolate, args[0]);
   const uint8_t* cdpIdPtr = reinterpret_cast<const uint8_t*>(*cdpId);
@@ -4449,8 +4447,8 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
     Node* node = V8Node::ToImpl(nodeObj);
     if (node) {
-      // hackfix: bind node here
-      //   (if the DOMAgent was enabled, it would track nodes automatically)
+      // Bind node and get nodeId.
+      auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
       int nodeId = domAgent->BindDocumentNode(node);
       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
       return;
@@ -4460,7 +4458,6 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   } else { /* already reported */
   }
 
-  // auto response = domAgent->requestNode(cdpId, &nodeId);
   args.GetReturnValue().SetNull();
 }
 
@@ -4518,11 +4515,9 @@ static void fromJsGetMatchedStylesForElement(
   Maybe<int> parentLayoutNodeId;
 
   auto response = cssAgent->getMatchedStylesForNode(
-      nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
-      &inheritedEntries, &inherited_pseudo_id_matches, &keyframesRules,
-      &parentLayoutNodeId);
-
-  // WIP: will fix everything up and clean up when done w/ RUN-981
+    nodeId, &inlineStyle, &attributesStyle, &matchedRules, &pseudoIdMatches,
+    &inheritedEntries, &inherited_pseudo_id_matches, &keyframesRules,
+    &parentLayoutNodeId);
 
   if (!response.IsSuccess()) {
     recordreplay::Warning(
@@ -4530,34 +4525,35 @@ static void fromJsGetMatchedStylesForElement(
         "%d): %s",
         nodeId, response.Code(), response.Message().c_str());
     args.GetReturnValue().SetNull();
-  } else {
-    v8::Local<v8::Object> result = v8::Object::New(isolate);
-    // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
-    if (attributesStyle.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
-      if (!rulesJs.IsEmpty()) {
-        SetDataProperty(isolate, result, "attributesStyle",
-                        rulesJs.ToLocalChecked());
-      }
-    }
-    if (matchedRules.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
-      SetDataProperty(isolate, result, "matchedRules", rulesJs);
-    }
-    if (pseudoIdMatches.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
-      SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
-    }
-    if (inheritedEntries.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
-      SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
-    }
-    if (keyframesRules.isJust()) {
-      auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
-      SetDataProperty(isolate, result, "keyframesRules", rulesJs);
-    }
-    args.GetReturnValue().Set(result);
+    return;
   }
+
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  // NOTE: not sure what `attributesStyle` is and how its different from `inlineStyle`?
+  if (attributesStyle.isJust()) {
+    auto rulesJs = convertCborToJS(isolate, attributesStyle.fromJust());
+    if (!rulesJs.IsEmpty()) {
+      SetDataProperty(isolate, result, "attributesStyle",
+                      rulesJs.ToLocalChecked());
+    }
+  }
+  if (matchedRules.isJust()) {
+    auto rulesJs = convertCborToJS(isolate, matchedRules.fromJust());
+    SetDataProperty(isolate, result, "matchedRules", rulesJs);
+  }
+  if (pseudoIdMatches.isJust()) {
+    auto rulesJs = convertCborToJS(isolate, pseudoIdMatches.fromJust());
+    SetDataProperty(isolate, result, "pseudoIdMatches", rulesJs);
+  }
+  if (inheritedEntries.isJust()) {
+    auto rulesJs = convertCborToJS(isolate, inheritedEntries.fromJust());
+    SetDataProperty(isolate, result, "inheritedEntries", rulesJs);
+  }
+  if (keyframesRules.isJust()) {
+    auto rulesJs = convertCborToJS(isolate, keyframesRules.fromJust());
+    SetDataProperty(isolate, result, "keyframesRules", rulesJs);
+  }
+  args.GetReturnValue().Set(result);
 }
 
 
@@ -4593,6 +4589,9 @@ static void fromJsDomPerformSearch(
   bool includeUserAgentShadowDom = true;
   String searchId;
   int resultCount;
+
+  // NOTE: We modified performSearch to work even though the agent is not
+  // enabled.
   auto response = domAgent->performSearch(query, includeUserAgentShadowDom,
                                           &searchId, &resultCount);
   if (checkCDPResponse("DOM.performSearch", response, args)) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4425,7 +4425,7 @@ static void HandleNetworkDidReceiveDataEvent(const base::DictionaryValue& info) 
 }
 
 /** ###########################################################################
- * blink (DOM, CSS queries etc.)
+ * blink (DOM, CSS etc.) queries
  * @see https://static.replay.io/protocol/tot/DOM/
  * @see https://chromedevtools.github.io/devtools-protocol/tot/DOM/
  * ##########################################################################*/

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -998,7 +998,7 @@ Response InspectorCSSAgent::getMatchedStylesForNode(
     return response;
 
   Element* element = nullptr;
-  auto response = dom_agent_->AssertElement(node_id, element);
+  response = dom_agent_->AssertElement(node_id, element);
   if (!response.IsSuccess())
     return response;
 

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -610,6 +610,11 @@ InspectorCSSAgent::InspectorCSSAgent(
       local_fonts_enabled_(&agent_state_, /*default_value=*/true) {
   DCHECK(dom_agent);
   DCHECK(network_agent);
+
+  if (recordreplay::IsInReplayCode()) {
+    // RUN-2521: Make sure documents (and fonts) are registered.
+    CompleteEnabled();
+  }
 }
 
 InspectorCSSAgent::~InspectorCSSAgent() = default;
@@ -988,11 +993,9 @@ Response InspectorCSSAgent::getMatchedStylesForNode(
     Maybe<protocol::Array<protocol::CSS::CSSKeyframesRule>>*
         css_keyframes_rules,
     Maybe<int>* parentLayoutNodeId) {
-  if (!recordreplay::HasDivergedFromRecording()) {
-    Response response = AssertEnabled();
-    if (!response.IsSuccess())
-      return response;
-  }
+  Response response = AssertEnabled();
+  if (!response.IsSuccess())
+    return response;
 
   Element* element = nullptr;
   auto response = dom_agent_->AssertElement(node_id, element);
@@ -2370,10 +2373,6 @@ InspectorStyleSheet* InspectorCSSAgent::ViaInspectorStyleSheet(
 }
 
 Response InspectorCSSAgent::AssertEnabled() {
-  if (recordreplay::HasDivergedFromRecording()) {
-    // [replay] act as though it is enabled
-    return Response::Success();
-  }
   return enable_completed_ ? Response::Success()
                            : Response::ServerError("CSS agent was not enabled");
 }

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -613,7 +613,13 @@ InspectorCSSAgent::InspectorCSSAgent(
 
   if (recordreplay::IsInReplayCode()) {
     // RUN-2521: Make sure documents (and fonts) are registered.
-    CompleteEnabled();
+    // This is partial copy-and-paste from |CompleteEnabled|
+    dom_agent_->AddDOMListener(this);
+    HeapVector<Member<Document>> documents = dom_agent_->Documents();
+    for (Document* document : documents) {
+      UpdateActiveStyleSheets(document);
+    }
+    enable_completed_ = true;
   }
 }
 
@@ -670,9 +676,7 @@ void InspectorCSSAgent::ResourceContentLoaded(
 }
 
 void InspectorCSSAgent::CompleteEnabled() {
-  if (!recordreplay::IsInReplayCode() || instrumenting_agents_) {
-    instrumenting_agents_->AddInspectorCSSAgent(this);
-  }
+  instrumenting_agents_->AddInspectorCSSAgent(this);
   dom_agent_->AddDOMListener(this);
   HeapVector<Member<Document>> documents = dom_agent_->Documents();
   for (Document* document : documents) {

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -670,7 +670,9 @@ void InspectorCSSAgent::ResourceContentLoaded(
 }
 
 void InspectorCSSAgent::CompleteEnabled() {
-  instrumenting_agents_->AddInspectorCSSAgent(this);
+  if (!recordreplay::IsInReplayCode() || instrumenting_agents_) {
+    instrumenting_agents_->AddInspectorCSSAgent(this);
+  }
   dom_agent_->AddDOMListener(this);
   HeapVector<Member<Document>> documents = dom_agent_->Documents();
   for (Document* document : documents) {

--- a/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_css_agent.cc
@@ -612,7 +612,7 @@ InspectorCSSAgent::InspectorCSSAgent(
   DCHECK(network_agent);
 
   if (recordreplay::IsInReplayCode()) {
-    // RUN-2521: Make sure documents (and fonts) are registered.
+    // RUN-2521: Make sure documents are registered.
     // This is partial copy-and-paste from |CompleteEnabled|
     dom_agent_->AddDOMListener(this);
     HeapVector<Member<Document>> documents = dom_agent_->Documents();

--- a/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_dom_agent.cc
@@ -841,7 +841,7 @@ int InspectorDOMAgent::PushNodePathToFrontend(Node* node_to_push,
   if (!document_)
     return 0;
 
-  if (!enabled_.Get() && recordreplay::HasDivergedFromRecording()) {
+  if (!enabled_.Get() && recordreplay::IsInReplayCode()) {
     // [replay] hackfix: track node if `DevToolsSession` is not active
     //    TODO: This might not handle dangling nodes properly - https://linear.app/replay/issue/RUN-1005/
     return BindDocumentNode(node_to_push);
@@ -1158,9 +1158,8 @@ Response InspectorDOMAgent::performSearch(
     Maybe<bool> optional_include_user_agent_shadow_dom,
     String* search_id,
     int* result_count) {
-  
-  if (!recordreplay::HasDivergedFromRecording()) {
-    // [replay] act as though it is enabled
+  if (!recordreplay::IsInReplayCode()) {
+    // [replay] act as though it is enabled when in Replay code.
     if (!enabled_.Get()) {
       return Response::ServerError("DOM agent is not enabled");
     }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2521#comment-626f0d6c
* Tested + fuzzed [here](https://buildkite.com/replay/testing-runtime-e2e/builds/1353#018a46e2-8aa8-4f42-862a-09ee0eb5a1ce): Hundreds and hundreds of `Command failed` but:
  * Almost all of them are `DOM.getBoxModel` which has been fixed in https://github.com/replayio/chromium/pull/884.
  * No `CSS.getAppliedRules` failures.✔