### PR TITLE
Expose more gReplayScript code to evaluation methods.

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2697,6 +2697,11 @@ __RECORD_REPLAY_ARGUMENTS__.internal = {
   getCdpObjectByRrpId,
   getBlinkNodeIdByCdpId,
   getPlainObjectByRrpId,
+  registerPlainObject,
+  gLastBoundingClientRectsByNodeRrpId,
+  getNextStackingContextId: () => gNextStackingContextId,
+  setNextStackingContextId: (id) => { gNextStackingContextId = id; },
+  updateNextStackingContextId: (f) => { gNextStackingContextId = f(gNextStackingContextId); },
 };
 
 } catch (e) {


### PR DESCRIPTION
For #RUN-2551 (https://linear.app/replay/issue/RUN-2551)

Having these methods available on `__RECORD_REPLAY_ARGUMENTS__` will allow for evaluating new StackingContext algorithms on existing recordings, by leveraging `evaluateInGlobal` calls.

This will be handy if my independent attempt to fix `transform: scale()` handling in the stacking context algorithm doesn't work - to allow me to try new algorithms on the same recording and verify it directly.