### PR TITLE
Kannan/run 2546 pinterest component picker is offset 2

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1786,6 +1786,7 @@ function DOM_getAllBoundingClientRects() {
   const elements = entries
     .map((elem, i) => {
       const id = registerPlainObject(elem.raw) || i;
+      // TODO: handle scaleX/Y/Z
       const scale = elem.context?.transform?.scale || 1;
 
       // Use the bounding client rect as a fallback.
@@ -2543,7 +2544,7 @@ StackingContext.prototype = {
     }
 
     // If the element does not have transform.scale, skip it and its children.
-    // TODO: add support for scaleX/Y/Z
+    // TODO: handle scaleX/Y/Z
     if (!this.transform || !("scale" in this.transform) || this.transform.scale === 1) {
       return;
     }
@@ -2630,6 +2631,7 @@ StackingContext.prototype = {
     top = top || 0;
     opacity = opacity || 1;
     transform = transform || {};
+    // TODO: handle scaleX/Y/Z
     if (this.transform.scale !== undefined) {
       transform.scale = (transform.scale || 1) * this.transform.scale;
     }
@@ -2753,18 +2755,24 @@ function shiftRect(rect, offset, scale) {
  * ```
  * ##########################################################################*/
 function parseCssTransform(transform) {
-  // Parse a string of the form "scale(1.2)"
-  if (!transform || !transform.startsWith("scale(")) {
-    if (transform.length > 0) {
-      // TODO: if we have command error reporting, we might want to attach
-      // this warning there.
-      log(`[RuntimeWarning] parseCssTransform: unsupported transform: ${transform}`);
+  let cssScale;
+  if (transform) {
+    try {
+      const css = CSSStyleValue.parse(
+        "transform",
+        transform,
+      );
+
+      cssScale = Array.from(css).find(entry => entry instanceof CSSScale);
+    } catch (err) {
+      // could not parse CSS transform
     }
-    return;
   }
 
-  const scale = +transform.substring(6, transform.length - 1);
-  return { scale };
+  // TODO: handle scaleX/Y/Z
+  return { 
+    scale: cssScale?.x?.value || 1
+  };
 }
 
 /** ###########################################################################

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1787,7 +1787,7 @@ function DOM_getAllBoundingClientRects() {
     .map((elem, i) => {
       const id = registerPlainObject(elem.raw) || i;
       // TODO: handle scaleX/Y/Z
-      const scale = elem.context?.transform?.scale || 1;
+      const scale = elem.context.transform.scale;
 
       // Use the bounding client rect as a fallback.
       let { left, top, right, bottom } =
@@ -2449,7 +2449,7 @@ function StackingContext(window, options) {
 
   // Transform scale - accumulation of all transform scaling factors
   // applied to this or parent stacking contexts.
-  this.transform = transform;
+  this.transform = transform || { scale: 1 };
 
   // The arrays below are filled in tree order (preorder depth first traversal).
 
@@ -2536,22 +2536,18 @@ StackingContext.prototype = {
       const opacity = elem.style.getPropertyValue("opacity");
       const opacityVal = opacity.length > 0 ? +opacity : 1;
       contextAttrs.opacity = opacityVal;
-
-      // Elements with a nonempty transform get their own stacking context.
-      const transformStr = elem.style.getPropertyValue("transform");
-      const transform = parseCssTransform(transformStr);
-      contextAttrs.transform = transform;
     }
 
-    // If the element does not have transform.scale, skip it and its children.
-    // TODO: handle scaleX/Y/Z
-    if (!this.transform || !("scale" in this.transform) || this.transform.scale === 1) {
-      return;
-    }
+    // Elements with a nonempty transform get their own stacking context.
+    const transformStr = elem.style?.getPropertyValue("transform");
+    const transform = parseCssTransform(transformStr);
+    contextAttrs.transform = transform;
 
     // Create a new stacking context for any iframes.
     if (elem.raw.tagName == "IFRAME" && elem.raw.contentWindow?.document) {
       const { left, top } = elem.raw.getBoundingClientRect();
+      // TODO: handle scaleX/Y/Z
+      // TODO: computation of derived dependencies of `contextAttrs` should be moved to addContext.
       contextAttrs.left = left * this.transform.scale;
       contextAttrs.top = top * this.transform.scale;
       this.addContext(elem, undefined, contextAttrs);
@@ -2630,11 +2626,11 @@ StackingContext.prototype = {
     left = left || 0;
     top = top || 0;
     opacity = opacity || 1;
-    transform = transform || {};
+    transform = transform || { scale: 1 };
+
     // TODO: handle scaleX/Y/Z
-    if (this.transform.scale !== undefined) {
-      transform.scale = (transform.scale || 1) * this.transform.scale;
-    }
+    transform.scale = (transform.scale === undefined ? 1 : transform.scale) * 
+      (this.transform?.scale === undefined ? 1 : this.transform.scale);
 
     if (elem.context) {
       assert(!left && !top);
@@ -2772,7 +2768,7 @@ function parseCssTransform(transform) {
 
   // TODO: handle scaleX/Y/Z
   return { 
-    scale: cssScale?.x?.value || 1
+    scale: cssScale?.x?.value !== undefined ? cssScale?.x?.value : 1
   };
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2569,7 +2569,7 @@ StackingContext.prototype = {
     }
 
     if ((contextAttrs.opacity !== undefined && contextAttrs.opacity < 1) ||
-        (contextAttrs.transform !== undefined)
+        (contextAttrs.transform !== DefaultTransform)
     ) {
       // Elements with opacity < 1, or non-empty transforms, get their own
       // stacking context.
@@ -2637,9 +2637,11 @@ StackingContext.prototype = {
     transform = transform || DefaultTransform;
 
     // TODO: handle scaleX/Y/Z
-    transform = {
-      scale: getContextTransformScale(transform) * getContextTransformScale(this.transform)
-    };
+    if (transform !== DefaultTransform || this.transform !== DefaultTransform) {
+      transform = {
+        scale: getContextTransformScale(transform) * getContextTransformScale(this.transform)
+      };
+    }
 
     if (elem.context) {
       assert(!left && !top);
@@ -2776,7 +2778,7 @@ function parseCssTransform(transform) {
   }
 
   // TODO: handle scaleX/Y/Z
-  return { 
+  return {
     scale: cssScale?.x?.value !== undefined ? cssScale?.x?.value : DefaultTransform.scale
   };
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2758,6 +2758,7 @@ function parseCssTransform(transform) {
   let cssScale;
   if (transform) {
     try {
+      // see https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleValue/parse_static
       const css = CSSStyleValue.parse(
         "transform",
         transform,

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1768,6 +1768,14 @@ function DOM_getDocument() {
  * {@link DOM_getAllBoundingClientRects}
  * ##########################################################################*/
 
+const DefaultTransform = { scale: 1 };
+
+function getContextTransformScale(transform) {
+  transform ||= DefaultTransform;
+  return transform.scale === undefined ? 1 : transform.scale;
+}
+
+
 function getLastBoundingClientRect(nodeRrpId) {
   return gLastBoundingClientRectsByNodeRrpId.get(nodeRrpId);
 }
@@ -1787,7 +1795,7 @@ function DOM_getAllBoundingClientRects() {
     .map((elem, i) => {
       const id = registerPlainObject(elem.raw) || i;
       // TODO: handle scaleX/Y/Z
-      const scale = elem.context.transform.scale;
+      const scale = getContextTransformScale(elem?.context?.transform);
 
       // Use the bounding client rect as a fallback.
       let { left, top, right, bottom } =
@@ -2449,7 +2457,7 @@ function StackingContext(window, options) {
 
   // Transform scale - accumulation of all transform scaling factors
   // applied to this or parent stacking contexts.
-  this.transform = transform || { scale: 1 };
+  this.transform = transform || DefaultTransform;
 
   // The arrays below are filled in tree order (preorder depth first traversal).
 
@@ -2548,8 +2556,8 @@ StackingContext.prototype = {
       const { left, top } = elem.raw.getBoundingClientRect();
       // TODO: handle scaleX/Y/Z
       // TODO: computation of derived dependencies of `contextAttrs` should be moved to addContext.
-      contextAttrs.left = left * this.transform.scale;
-      contextAttrs.top = top * this.transform.scale;
+      contextAttrs.left = left * getContextTransformScale(this.transform);
+      contextAttrs.top = top * getContextTransformScale(this.transform);
       this.addContext(elem, undefined, contextAttrs);
       elem.context.addChildren(elem.raw.contentWindow.document);
     }
@@ -2626,11 +2634,10 @@ StackingContext.prototype = {
     left = left || 0;
     top = top || 0;
     opacity = opacity || 1;
-    transform = transform || { scale: 1 };
+    transform = transform || DefaultTransform;
 
     // TODO: handle scaleX/Y/Z
-    transform.scale = (transform.scale === undefined ? 1 : transform.scale) * 
-      (this.transform?.scale === undefined ? 1 : this.transform.scale);
+    transform.scale = getContextTransformScale(transform) * getContextTransformScale(this.transform);
 
     if (elem.context) {
       assert(!left && !top);
@@ -2768,7 +2775,7 @@ function parseCssTransform(transform) {
 
   // TODO: handle scaleX/Y/Z
   return { 
-    scale: cssScale?.x?.value !== undefined ? cssScale?.x?.value : 1
+    scale: cssScale?.x?.value !== undefined ? cssScale?.x?.value : DefaultTransform.scale
   };
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2637,7 +2637,9 @@ StackingContext.prototype = {
     transform = transform || DefaultTransform;
 
     // TODO: handle scaleX/Y/Z
-    transform.scale = getContextTransformScale(transform) * getContextTransformScale(this.transform);
+    transform = {
+      scale: getContextTransformScale(transform) * getContextTransformScale(this.transform)
+    };
 
     if (elem.context) {
       assert(!left && !top);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2542,16 +2542,17 @@ StackingContext.prototype = {
       contextAttrs.transform = transform;
     }
 
-    // If scale=0, skip the element and its children.
-    if (this.transform?.scale === 0) {
+    // If the element does not have transform.scale, skip it and its children.
+    // TODO: add support for scaleX/Y/Z
+    if (!this.transform || !("scale" in this.transform) || this.transform.scale === 1) {
       return;
     }
 
     // Create a new stacking context for any iframes.
     if (elem.raw.tagName == "IFRAME" && elem.raw.contentWindow?.document) {
       const { left, top } = elem.raw.getBoundingClientRect();
-      contextAttrs.left = left * (this.transform.scale || 1);
-      contextAttrs.top = top * (this.transform.scale || 1);
+      contextAttrs.left = left * this.transform.scale;
+      contextAttrs.top = top * this.transform.scale;
       this.addContext(elem, undefined, contextAttrs);
       elem.context.addChildren(elem.raw.contentWindow.document);
     }


### PR DESCRIPTION
* This is a follow-up fix for https://github.com/replayio/chromium/pull/880.
  * That PR caused command crashes (see [here](https://discord.com/channels/779097926135054346/956618540063010856/threads/1146016098798538853)) because `transform.scale` was accessed when `transform` did not exist.
  * Also, it deals better with the case of `scale = 0`, which effectively hides an element.
  * Made some changes to `parseCssTransform`.
    * I tested `parseCssTransform` in isolation -
![image](https://github.com/replayio/chromium/assets/282899/ac3557fe-21dc-4edf-bef4-050c44dba6f7)
* Update:
  * Tests are not running. Filed separate issue [here](https://linear.app/replay/issue/RUN-2554/trigger-runtime-tests-waiting-indefinitely).