### PR TITLE
build: delete git lock file if it exists on Windows at start of build

### DIFF
--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -96,8 +96,20 @@ export function syncRepo(dir, treeish) {
   });
 }
 
+function maybeDeleteGitLockFile(dir) {
+  const lockFile = path.join(dir, ".git", "index.lock");
+  if (fs.existsSync(lockFile)) {
+    fs.unlinkSync(lockFile);
+  }
+}
+
 export function updateRepo() {
   const chromium = process.cwd();
+  // delete git lock file if it exists on Windows
+  if (currentPlatform() == Platform.windows) {
+    maybeDeleteGitLockFile(chromium);
+  }
+  maybeDeleteGitLockFile(chromium);
 
   const branch = process.env["BUILDKITE_BRANCH"];
 


### PR DESCRIPTION
Fixes RUN-2556