### PR TITLE
Add support for manually invoking metabase test dispatch script

### DIFF
--- a/replay_build_scripts/metabase.sh
+++ b/replay_build_scripts/metabase.sh
@@ -1,7 +1,39 @@
-buildkite-agent artifact download build_id/linux/x86_64/build_id ./
-BUILD_ID=$(cat build_id/linux/x86_64/build_id)
+if [ -n "${BUILDKITE}" ]; then
+    buildkite-agent artifact download build_id/linux/x86_64/build_id ./
+    BUILD_ID=$(cat build_id/linux/x86_64/build_id)
 
-echo 'Running metabase tests on GitHub with inputs: {"ref":"master","inputs":{"chromium-build-id":"'${BUILD_ID}'"}}'
+    if [ -z "${BUILD_ID}" ]; then
+        echo "Unable to retrieve build id from buildkite agent"
+        exit 1
+    fi
+else
+    BUILD_ID=$1
+    if [ -z "${BUILD_ID}" ]; then
+        echo "build ID required as first argument";
+        exit 1
+    fi
+fi
+
+if [ -z "${GITHUB_AUTH_SECRET}" ]; then
+    echo "GITHUB_AUTH_SECRET is not set in environment"
+    exit 1
+fi
+
+FOLDERS=""
+if [ -n "$2" ]; then
+    IFS=',' read -ra array <<< "$2"
+
+    # Create a JSON representation of the array
+    FOLDERS=",\"folders\":\"["
+    for element in "${array[@]}"; do
+        FOLDERS+="\\\"$element\\\","
+    done
+    # Remove the trailing comma and add closing square bracket
+    FOLDERS="${FOLDERS%,}]\""
+fi;
+
+INPUTS='{"ref":"master","inputs":{"chromium-build-id":"'${BUILD_ID}'"'${FOLDERS}'}}'
+echo 'Running metabase tests on GitHub with inputs: '${INPUTS}
 
 curl -L -s \
     -X POST \
@@ -9,11 +41,17 @@ curl -L -s \
     -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/replayio-public/metabase/actions/workflows/e2e-tests.yml/dispatches \
-    -d '{"ref":"master","inputs":{"chromium-build-id":"'${BUILD_ID}'"}}'
+    -d ${INPUTS}
 sleep 5
-curl -L -s \
+GH_URL=$(curl -L -s \
     -X GET \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/replayio-public/metabase/actions/runs\?event\=workflow_dispatch | jq -r '"Metabase Test Run: " + (.workflow_runs[0].html_url // "Not Found")' | buildkite-agent annotate --context tests
+    https://api.github.com/repos/replayio-public/metabase/actions/runs\?event\=workflow_dispatch | jq -r '"Metabase Test Run: " + (.workflow_runs[0].html_url // "Not Found")')
+
+if [ -n "${BUILDKITE}" ]; then
+    buildkite-agent annotate --context tests $GH_URL
+else
+    echo $GH_URL
+fi


### PR DESCRIPTION
Extending the metabase script to support calling manually:

```
GITHUB_AUTH_SECRET=<from password manager> ./replay_build_scripts/metabase.sh <build id> [comma-separated list of test folders to run]
```