### PR TITLE
Fix metabase test run url

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
       - "build-chromium-mac-arm64"
   - label: "Metabase Test Suite"
     depends_on: "build-chromium-linux-x86_64"
-    # if: build.branch == "master"
+    if: build.branch == "master"
     agents:
       - "runtimeType=chromiumbuild"
       - "os=linux"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
       - "build-chromium-mac-arm64"
   - label: "Metabase Test Suite"
     depends_on: "build-chromium-linux-x86_64"
-    if: build.branch == "master"
+    # if: build.branch == "master"
     agents:
       - "runtimeType=chromiumbuild"
       - "os=linux"

--- a/replay_build_scripts/metabase.sh
+++ b/replay_build_scripts/metabase.sh
@@ -1,5 +1,3 @@
-set -x
-
 if [ -n "${BUILDKITE}" ]; then
     buildkite-agent artifact download build_id/linux/x86_64/build_id ./
     BUILD_ID=$(cat build_id/linux/x86_64/build_id)
@@ -54,5 +52,5 @@ GH_URL=$(curl -L -s \
 
 echo "\n${GH_URL}"
 if [ -n "${BUILDKITE}" ]; then
-    buildkite-agent annotate --context tests $GH_URL
+    buildkite-agent annotate --context tests "${GH_URL}"
 fi

--- a/replay_build_scripts/metabase.sh
+++ b/replay_build_scripts/metabase.sh
@@ -1,3 +1,5 @@
+set -x
+
 if [ -n "${BUILDKITE}" ]; then
     buildkite-agent artifact download build_id/linux/x86_64/build_id ./
     BUILD_ID=$(cat build_id/linux/x86_64/build_id)
@@ -50,8 +52,7 @@ GH_URL=$(curl -L -s \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/replayio-public/metabase/actions/runs\?event\=workflow_dispatch | jq -r '"Metabase Test Run: " + (.workflow_runs[0].html_url // "Not Found")')
 
+echo "\n${GH_URL}"
 if [ -n "${BUILDKITE}" ]; then
     buildkite-agent annotate --context tests $GH_URL
-else
-    echo $GH_URL
 fi


### PR DESCRIPTION
The buildkite annotation was only "Metabase" because I was capturing the url in a variable but the contents had spaces so only the first word was populated into the annotation.

... quotes ...