### PR TITLE
Fix recorder crash: Add WeakIdentifierMap::HasIdentifier

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '7ac1cd65af50e64c3f953b8f3d8ac90bf942a50f',
+  'v8_revision': '175aec400ee3d1c131c05e6767ecc5346c2363e0',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -62,6 +62,9 @@ namespace recordreplay {
   Macro(V8RecordReplayCommandDiagnosticVA,                              \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
+  Macro(V8RecordReplayCommandDiagnosticTraceVA,                         \
+        (const char* format, va_list args),                             \
+        (format, args))                                                 \
   Macro(V8RecordReplayWarning,                                          \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
@@ -256,6 +259,15 @@ void CommandDiagnostic(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   V8RecordReplayCommandDiagnosticVA(format, ap);
+  va_end(ap);
+#endif
+}
+
+void CommandDiagnosticTrace(const char* format, ...) {
+#ifndef NACL_TC_REV
+  va_list ap;
+  va_start(ap, format);
+  V8RecordReplayCommandDiagnosticTraceVA(format, ap);
   va_end(ap);
 #endif
 }

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -32,6 +32,7 @@ bool HadMismatch();
 void Print(const char* format, ...);
 void Diagnostic(const char* format, ...);
 void CommandDiagnostic(const char* format, ...);
+void CommandDiagnosticTrace(const char* format, ...);
 void Warning(const char* format, ...);
 void Trace(const char* format, ...);
 void Assert(const char* format, ...);

--- a/third_party/blink/renderer/core/dom/weak_identifier_map.h
+++ b/third_party/blink/renderer/core/dom/weak_identifier_map.h
@@ -43,6 +43,10 @@ class WeakIdentifierMap final
     return result;
   }
 
+  static IdentifierType HasIdentifier(T* object) {
+    return Instance().object_to_identifier_.Contains(object);
+  }
+
   static IdentifierType ExistingIdentifier(T* object) {
     return Instance().object_to_identifier_.at(object);
   }

--- a/third_party/blink/renderer/core/dom/weak_identifier_map.h
+++ b/third_party/blink/renderer/core/dom/weak_identifier_map.h
@@ -43,7 +43,7 @@ class WeakIdentifierMap final
     return result;
   }
 
-  static IdentifierType HasIdentifier(T* object) {
+  static bool HasIdentifier(T* object) {
     return Instance().object_to_identifier_.Contains(object);
   }
 

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -386,7 +386,9 @@ LocalFrame::~LocalFrame() {
   if (!IsA<LocalFrame>(Tree().Parent())) {
     recordreplay::CommandDiagnostic(
         "[RUN-2486-2577] ~LocalFrame %d",
-        WeakIdentifierMap<LocalFrame>::ExistingIdentifier(this));
+        WeakIdentifierMap<LocalFrame>::HasIdentifier(this)
+            ? WeakIdentifierMap<LocalFrame>::ExistingIdentifier(this)
+            : -1);
   }
   if (IsAdFrame())
     InstanceCounters::DecrementCounter(InstanceCounters::kAdSubframeCounter);
@@ -620,7 +622,9 @@ bool LocalFrame::DetachImpl(FrameDetachType type) {
   if (!IsA<LocalFrame>(Tree().Parent())) {
     recordreplay::CommandDiagnosticTrace(
         "[RUN-2486-2577] LocalFrame::DetachImpl %d",
-        WeakIdentifierMap<LocalFrame>::ExistingIdentifier(this));
+        WeakIdentifierMap<LocalFrame>::HasIdentifier(this)
+            ? WeakIdentifierMap<LocalFrame>::ExistingIdentifier(this)
+            : -1);
   }
   WeakIdentifierMap<LocalFrame>::NotifyObjectDestroyed(this);
 

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -216,10 +216,8 @@ void MainThreadDebugger::ExceptionThrown(ExecutionContext* context,
 int MainThreadDebugger::ContextGroupId(LocalFrame* frame) {
   LocalFrame& local_frame_root = frame->LocalFrameRoot();
 
-  bool existed =
-      WeakIdentifierMap<LocalFrame>::HasIdentifier(&local_frame_root);
-  int newId = WeakIdentifierMap<LocalFrame>::Identifier(&local_frame_root);
-  if (!existed) {
+  if (!WeakIdentifierMap<LocalFrame>::HasIdentifier(&local_frame_root)) {
+    int newId = WeakIdentifierMap<LocalFrame>::Identifier(&local_frame_root);
     recordreplay::CommandDiagnosticTrace(
         "[RUN-2486-2577] WeakIdentifierMap<LocalFrame>::Put %d", newId);
   }

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -217,7 +217,7 @@ int MainThreadDebugger::ContextGroupId(LocalFrame* frame) {
   LocalFrame& local_frame_root = frame->LocalFrameRoot();
 
   bool existed =
-      WeakIdentifierMap<LocalFrame>::ExistingIdentifier(&local_frame_root);
+      WeakIdentifierMap<LocalFrame>::HasIdentifier(&local_frame_root);
   int newId = WeakIdentifierMap<LocalFrame>::Identifier(&local_frame_root);
   if (!existed) {
     recordreplay::CommandDiagnosticTrace(


### PR DESCRIPTION
* This fixes recorder crashes I introduced in https://github.com/replayio/chromium/pull/898
* The crash was caused by a call to `HashMap::at(key)` where `key` does not exist. This fixes that.