### PR TITLE
Make token guard PostTask in GuardedTaskPoster::PostTask.

### DIFF
--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -112,13 +112,15 @@ bool TaskQueueImpl::GuardedTaskPoster::PostTask(PostedTask task) {
     auto token = record_replay_unordered_operations_controller_.value().TryBeginOperation();
     if (!token)
       return false;
+
+    outer_->PostTask(std::move(task));
   } else {
     auto token = operations_controller_.TryBeginOperation();
     if (!token)
       return false;
-  }
 
-  outer_->PostTask(std::move(task));
+    outer_->PostTask(std::move(task));
+  }
   return true;
 }
 


### PR DESCRIPTION
For #RUN-2602 (https://linear.app/replay/issue/RUN-2602)

We think this is the cause of the recording crash pinterest is seeing.  We modified `GuardedTaskPoster::PostTask()` to add a branch to handle unordered tasks, but in doing so, put the token into an inner block.  This meant that the token destructor, which would have originally run after the call to `outer_->PostTask` would now run before the call.

The token, however, acts as a guard, with a decrement in its destructor to release the guard.  With the following scary comment in its definition code:

```
// The owner of an OperationToken which evaluates to true can safely perform
// an operation while being certain it happens-after
// StartAcceptingOperations() and happens-before
// ShutdownAndWaitForZeroOperations(). Releasing this OperationToken
// relinquishes this right.
//
// This class is thread-safe
```