### PR TITLE
Assert `ThreadControllerWithMessagePumpImpl::DoIdleWork`

### DIFF
--- a/base/allocator/partition_allocator/partition_alloc_base/time/time_win.cc
+++ b/base/allocator/partition_allocator/partition_alloc_base/time/time_win.cc
@@ -145,6 +145,10 @@ UINT GetIntervalMs() {
 // new request). If there is no change then do nothing.
 void UpdateTimerIntervalLocked() {
   UINT new_interval = GetIntervalMs();
+
+  recordreplay::Assert("[RUN-1916-2636] UpdateTimerIntervalLocked A %u %u",
+                       new_interval, g_last_interval_requested_ms);
+
   if (new_interval == g_last_interval_requested_ms)
     return;
   if (g_last_interval_requested_ms) {

--- a/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc
+++ b/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc
@@ -536,7 +536,11 @@ bool ThreadControllerWithMessagePumpImpl::DoIdleWork() {
   hang_watch_scope_.emplace();
 
 #if BUILDFLAG(IS_WIN)
+  recordreplay::Assert(
+      "[RUN-1916-2636] ThreadControllerWithMessagePumpImpl::Run A");
   if (!power_monitor_.IsProcessInPowerSuspendState()) {
+    recordreplay::Assert(
+        "[RUN-1916-2636] ThreadControllerWithMessagePumpImpl::Run B");
     // Avoid calling Time::ActivateHighResolutionTimer() between
     // suspend/resume as the system hangs if we do (crbug.com/1074028).
     // OnResume() will generate a task on this thread per the
@@ -546,6 +550,11 @@ bool ThreadControllerWithMessagePumpImpl::DoIdleWork() {
 
     const bool need_high_res_mode =
         main_thread_only().task_source->HasPendingHighResolutionTasks();
+
+    recordreplay::Assert(
+        "[RUN-1916-2636] ThreadControllerWithMessagePumpImpl::Run C %d %d",
+        main_thread_only().in_high_res_mode, need_high_res_mode);
+
     if (main_thread_only().in_high_res_mode != need_high_res_mode) {
       // On Windows we activate the high resolution timer so that the wait
       // _if_ triggered by the timer happens with good resolution. If we don't

--- a/base/time/time_win.cc
+++ b/base/time/time_win.cc
@@ -147,6 +147,10 @@ UINT GetIntervalMs() {
 // new request). If there is no change then do nothing.
 void UpdateTimerIntervalLocked() {
   UINT new_interval = GetIntervalMs();
+
+  recordreplay::Assert("[RUN-1916-2636] UpdateTimerIntervalLocked A %u %u",
+                       new_interval, g_last_interval_requested_ms);
+
   if (new_interval == g_last_interval_requested_ms)
     return;
   if (g_last_interval_requested_ms) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1916/windows-call-stack-mismatch-movereadydelayedtaskstoworkqueues#comment-6797a2e4