### PR TITLE
RUN-2620: Make ResourceDataDLL::GetStringPiece no-op when diverged

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0bc66aa25366936114e478933c56f7df32cb7d29',
+  'v8_revision': 'd69328f1dd769695d727e01011c57509b77da842',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'f2b31c25605c3b630ed0c34f0dbaa3f63b3b3c29',
+  'v8_revision': 'e7bed289301496f2e337b08038299d3a8991dd1e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '2b4bc826283fb28e65237553f85c4f36353e8037',
+  'v8_revision': 'f2b31c25605c3b630ed0c34f0dbaa3f63b3b3c29',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1a4e04bec5db150e17e1e5f7dcf3084475a15ed7',
+  'v8_revision': '6d9842bfa66bf8254025824d7a515bf656b21a27',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -40,7 +40,8 @@ namespace recordreplay {
   Macro(V8RecordReplayHasDisabledFeatures, (), (), bool, false)         \
   Macro(V8RecordReplayAreAssertsDisabled, (), (), bool, false)          \
   Macro(V8IsMainThread, (), (), bool, false)                            \
-  Macro(V8RecordReplayIsInReplayCode, (), (), bool, false)              \
+  Macro(V8RecordReplayIsInReplayCode,                                   \
+        (const char* why), (why), bool, false)                          \
   Macro(V8RecordReplayHadMismatch, (), (), bool, false)
 
 #define ForEachV8APIVoid(Macro)                                         \
@@ -528,8 +529,8 @@ int NewIdAnyThread(const char* name) {
   return (int)RecordReplayValue("NewId", (uintptr_t)gNextAnyThreadId++);
 }
 
-bool IsInReplayCode() {
-  return V8RecordReplayIsInReplayCode();
+bool IsInReplayCode(const char* why) {
+  return V8RecordReplayIsInReplayCode(why);
 }
 
 AutoMarkReplayCode::AutoMarkReplayCode() {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -115,7 +115,7 @@ int NewIdMainThread(const char* name);
 int NewIdAnyThread(const char* name);
 
 // Return whether record/replay specific scripts are executing.
-bool IsInReplayCode();
+bool IsInReplayCode(const char* why = nullptr);
 
 // Mark a region where record/replay specific scripts are executing.
 struct AutoMarkReplayCode {

--- a/ui/base/resource/resource_data_dll_win.cc
+++ b/ui/base/resource/resource_data_dll_win.cc
@@ -10,6 +10,8 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/win/resource_util.h"
 
+#include "base/record_replay.h"
+
 namespace ui {
 
 ResourceDataDLL::ResourceDataDLL(HINSTANCE module) : module_(module) {
@@ -33,6 +35,11 @@ bool ResourceDataDLL::GetStringPiece(uint16_t resource_id,
   DCHECK(data);
   void* data_ptr;
   size_t data_size;
+
+  // RUN-2620
+  if (recordreplay::IsInReplayCode())
+    return false;
+
   if (base::win::GetDataResourceFromModule(module_,
                                            resource_id,
                                            &data_ptr,

--- a/ui/base/resource/resource_data_dll_win.cc
+++ b/ui/base/resource/resource_data_dll_win.cc
@@ -37,7 +37,7 @@ bool ResourceDataDLL::GetStringPiece(uint16_t resource_id,
   size_t data_size;
 
   // RUN-2620
-  if (recordreplay::IsInReplayCode())
+  if (recordreplay::IsInReplayCode("ResourceDataDLL::GetStringPiece"))
     return false;
 
   if (base::win::GetDataResourceFromModule(module_,


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/192
* https://linear.app/replay/issue/RUN-2620/unknown-call-findresourcew#comment-2d624bf8