### PR TITLE
RUN-2282: Use V8Node::ToImplWithTypeCheck

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -151,7 +151,7 @@ const {
   fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
   fromJsIsBlinkObject,
-  fromJsGetNodeId,
+  fromJsGetNodeIdByCpdId,
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForElement,
   fromJsCssGetStylesheetByCpdId,
@@ -195,8 +195,9 @@ function warning(...args) {
 
 function assert(v, msg = "") {
   if (!v) {
-    log(`[RuntimeError] Assertion failed ${msg} ${Error().stack}`);
-    throw new Error("Assertion failed!");
+    const m = `Command handler Assertion failed (${msg})`;
+    log(`[RuntimeError] ${m} - ${Error().stack}`);
+    throw new Error(m);
   }
 }
 
@@ -1065,21 +1066,12 @@ function getCdpScopeByRrpId(rrpScopeId) {
   return scope;
 }
 
-
-/**
- * Get blink's `nodeId` by `cdpId`.
- *
- * @param {*} cdpId
- */
-function getBlinkNodeIdByCdpId(cdpId) {
-  const nodeId = fromJsGetNodeId(cdpId);
-  assert(nodeId);
-  return nodeId;
-}
-
 function getBlinkNodeIdByRrpId(nodeRrpId) {
   const cdpObject = getCdpObjectByRrpId(nodeRrpId);
-  return getBlinkNodeIdByCdpId(cdpObject.objectId);
+  const nodeId = fromJsGetNodeIdByCpdId(cdpObject.objectId);
+  // Note: Don't generate assert message if assert did not fail.
+  assert(nodeId, !nodeId && `${nodeRrpId}: ${JSON.stringify(cdpObject)}`);
+  return nodeId;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2924,7 +2916,7 @@ function adjustCoordinateByTransformMatrix(coord, m) {
 __RECORD_REPLAY_ARGUMENTS__.internal = {
   getBlinkNodeIdByRrpId,
   getCdpObjectByRrpId,
-  getBlinkNodeIdByCdpId,
+  fromJsGetNodeIdByCpdId,
   getPlainObjectByRrpId,
   registerPlainObject,
   gLastBoundingClientRectsByNodeRrpId,
@@ -4740,7 +4732,7 @@ static bool checkCDPResponse(const char* label,
   return true;
 }
 
-static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
+static void fromJsGetNodeIdByCpdId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "[RuntimeError] must be called with a single string");
 
@@ -4753,7 +4745,7 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Local<v8::Object> nodeObj;
   if (getObjectByCdpId(isolate, cdpIdV8, nodeObj)) {
-    Node* node = V8Node::ToImpl(nodeObj);
+    Node* node = V8Node::ToImplWithTypeCheck(isolate, nodeObj);
     if (node) {
       // Bind node and get nodeId.
       auto* domAgent = getOrCreateInspectorDOMAgent(isolate);
@@ -4761,10 +4753,10 @@ static void fromJsGetNodeId(const v8::FunctionCallbackInfo<v8::Value>& args) {
       args.GetReturnValue().Set(v8::Number::New(isolate, nodeId));
       return;
     } else {
-      recordreplay::Print("[RuntimeError] fromJsGetNodeId failed for cdpId: \"%s\"", *cdpId);
+      // This should be reported by the caller, where we have more relevant
+      // context info.
     }
-  } else { /* already reported */
-  }
+  } else { /* already reported by getObjectByCdpId */ }
 
   args.GetReturnValue().SetNull();
 }
@@ -4941,11 +4933,11 @@ static void fromJsCollectEventListeners(const v8::FunctionCallbackInfo<v8::Value
   v8::Isolate* isolate = args.GetIsolate();
   auto context = isolate->GetCurrentContext();
   auto nodeObject = args[0].As<v8::Object>();
-  auto* node = V8Node::ToImpl(nodeObject);
+  auto* node = V8Node::ToImplWithTypeCheck(isolate, nodeObject);
 
   v8::Local<v8::Array> result = v8::Array::New(isolate);
   if (!node) {
-    recordreplay::Warning("JS fromJsCollectEventListeners invalid argument is not blink Node");
+    recordreplay::Warning("JS fromJsCollectEventListeners: invalid argument is not blink Node");
   } else {
     auto report_for_all_contexts = true;
     V8EventListenerInfoList eventListenerInfos;
@@ -5169,7 +5161,7 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   //                     jsGetObjectIdForAnyObject);
   // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
   // jsPreviewBlinkObjectForObjectId);
-  SetFunctionProperty(isolate, args, "fromJsGetNodeId", fromJsGetNodeId);
+  SetFunctionProperty(isolate, args, "fromJsGetNodeIdByCpdId", fromJsGetNodeIdByCpdId);
   SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
   SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForElement",
                       fromJsGetMatchedStylesForElement);


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2282/crash-in-fromjsgetnodeid#comment-18d33286
* Tests are basically passing :heavy_check_mark:  
  * There is one weird issue where the fuzzer seems to have generated a reason of unhappiness:
    ```
    1 error was not a part of any test, see above for details
    ```
    * which seems to be coming from this:
    ```
    Error: protocol client Graphics.getPaintContents error -1
    --
      |  
      | at ../../src/protocol/client.ts:156
      |  
      | 154 \|
      | 155 \|     if (!value) {
      | > 156 \|       throw new ProtocolClientError(method, {
      | \|             ^
      | 157 \|         code: -1,
      | 158 \|         message: "Command failed due to socket disconnect",
      | 159 \|       });
      |  
      | at RecordingClient.waitForCommandResult (/buildkite/builds/2865117f647e18-1/replay/testing-runtime-e2e/src/protocol/client.ts:156:13)
      | at RecordingClient.sendCommand (/buildkite/builds/2865117f647e18-1/replay/testing-runtime-e2e/src/processing/recording-client.ts:30:22)
      | at Fuzzer.sendCommand (/buildkite/builds/2865117f647e18-1/replay/testing-runtime-e2e/src/processing/replayRecording.ts:301:16)
      | at Fuzzer.repaintAndLookForBlackRectangle (/buildkite/builds/2865117f647e18-1/replay/testing-runtime-e2e/src/processing/replayRecording.ts:687:28)
    ```

