### PR TITLE
RUN-2625: More font early-outs

### DIFF
--- a/content/child/dwrite_font_proxy/dwrite_font_proxy_win.cc
+++ b/content/child/dwrite_font_proxy/dwrite_font_proxy_win.cc
@@ -22,6 +22,8 @@
 #include "content/public/child/child_thread.h"
 #include "third_party/blink/public/common/thread_safe_browser_interface_broker_proxy.h"
 
+#include "base/record_replay.h"
+
 namespace mswr = Microsoft::WRL;
 
 namespace content {
@@ -500,6 +502,11 @@ bool DWriteFontCollectionProxy::LoadFamily(
     UINT32 family_index,
     IDWriteFontCollection** containing_collection) {
   TRACE_EVENT0("dwrite,fonts", "FontProxy::LoadFamily");
+
+  // RUN-2625: We cannot load fonts without accessing the recording stream.
+  if (recordreplay::IsInReplayCode()) {
+    return false;
+  }
 
   uint32_t index = family_index;
   // CreateCustomFontCollection ends up calling

--- a/content/child/dwrite_font_proxy/dwrite_font_proxy_win.cc
+++ b/content/child/dwrite_font_proxy/dwrite_font_proxy_win.cc
@@ -504,7 +504,9 @@ bool DWriteFontCollectionProxy::LoadFamily(
   TRACE_EVENT0("dwrite,fonts", "FontProxy::LoadFamily");
 
   // RUN-2625: We cannot load fonts without accessing the recording stream.
-  if (recordreplay::IsInReplayCode()) {
+  if (recordreplay::IsInReplayCode() &&
+      recordreplay::FeatureEnabled("replay-code",
+                                   "DWriteFontCollectionProxy::LoadFamily")) {
     return false;
   }
 

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
@@ -258,6 +258,11 @@ const FontData* FontFallbackList::FontDataAt(
   if (family_index_ == kCAllFamiliesScanned)
     return nullptr;
 
+  // RUN-2625: We cannot (yet) make up font data if its not loaded already.
+  if (recordreplay::IsInReplayCode()) {
+    return nullptr;
+  }
+
   // Ask the font cache for the font data.
   // We are obtaining this font for the first time.  We keep track of the
   // families we've looked at before in |family_index_|, so that we never scan

--- a/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
@@ -259,7 +259,9 @@ const FontData* FontFallbackList::FontDataAt(
     return nullptr;
 
   // RUN-2625: We cannot (yet) make up font data if its not loaded already.
-  if (recordreplay::IsInReplayCode()) {
+  if (recordreplay::IsInReplayCode() &&
+      recordreplay::FeatureEnabled("replay-code",
+                                   "FontFallbackList::FontDataAt")) {
     return nullptr;
   }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2625/crash-when-loading-font-data#comment-29eb7d62