### PR TITLE
Use the new symbol extractor for windows/PDBs.

### DIFF
--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -5,15 +5,14 @@ import * as path from "path";
 import { toNumber, getBackendDir } from "./common.mjs";
 
 export async function readSymbols(file, pdbFile) {
-  const symbols = {};
+  let symbols = {};
   if (process.platform == "win32") {
     if (!pdbFile) {
       throw new Error("Need PDB file to read symbols on windows");
     }
-    const textStart = await getTextSectionAddress(pdbFile);
 
-    const pdbPath = path.join(getBackendDir(), "lib", "llvm-pdbutil.exe");
-    const process = spawn(pdbPath, ["dump", "-symbols", pdbFile]);
+    const pdbPath = path.join(getBackendDir(), "lib", "symextract.exe");
+    const process = spawn(pdbPath, ["read_symbols", pdbFile]);
     process.on("error", (error) => {
       console.error(`spawn error: ${error}`);
     });
@@ -22,22 +21,14 @@ export async function readSymbols(file, pdbFile) {
       input: process.stdout,
       crlfDelay: Infinity,
     });
-    let currentFunction;
+    let allLines = [];
     for await (const line of lines) {
-      if (currentFunction) {
-        const match = /addr = 0001:(\d+),/.exec(line);
-        if (match) {
-          const addr = textStart + +match[1];
-          symbols[addr] = currentFunction;
-        }
-        currentFunction = undefined;
-      } else if (line.includes("S_GPROC32") || line.includes("S_LPROC32")) {
-        const backtick = line.indexOf("`");
-        if (backtick != -1) {
-          currentFunction = line.substring(backtick + 1, line.length - 1);
-        }
-      }
+      allLines.push(line);
     }
+
+    // TODO: this just converts a string to an object, and then
+    // immediately converts it back (in the caller.)  Fix this.
+    symbols = JSON.parse(allLines.join(''));
   } else {
     const nmProcess = spawn("/usr/bin/nm", [file], { maxBuffer: 1e100 });
 


### PR DESCRIPTION
For windows builds, on the build box, we've adjusted down the amount of symbolic information dumped into the PDBs.  Before the changes, a no-op windows build took about 30 minutes; 10 minutes on "compiling" (linking, really), 12 minutes on generating the symbol json files, and a few more minutes doing the compressing/uploading.  The PDB generated for chrome.dll at this level was over 3GB; putting all the line-level debug info into the compiling step bloated it massively.  Similarly, the llvm-pdb.exe step (where we emit ALL the symbols to stdio and grep them) had to contend with over 7GB of text written to stdio.  With the recent changes, no-op builds are about 5 minutes, and the chrome.dll.pdb file is only a few hundred MB.  Hooray!

However.  This _breaks_ the llvm-pdb output parsing step (llvm-pdb spams errors about missing "module streams", which I don't fully understand.  I tried my hand at playing with output options, but nothing worked.)  Instead, I wrote `symextract`, which is a rust program using some 3rd party libraries to parse symbolic information in elf/macho/pdb files.  I wrote and verified that it produces the correct output we expect (one good thing about having lots of windows crashes right now is lots of stack traces to examine), and it only takes a few seconds to parse the pdb, on par with our other tools.  

This PR is the pr that changes the windows chromium build over to using this new binary (which is checked into backend/lib.) 