### PR TITLE
part of RUN-2680: CI annotations - Better AA URLs

### DIFF
--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -256,7 +256,10 @@ function buildkiteStuff(downloadUris, platform, buildId, arch) {
     // Linux is usually the first. Let's prefix it with relevant Admin App link.
     const buildPattern = buildId.substring(buildId.indexOf("-"));
     const aaCrashTriageLink = `http://admin.replay.io/crash?buildReleaseOptions=DevOnly&builds=${buildPattern}&platforms=macOS&platforms=linux&platforms=windows`;
-    const aaCrashTriageMessage = `# Admin App Crash Triage\n* ${aaCrashTriageLink}\n`;
+    const aaCommandCrashTriageLink = `${aaCrashTriageLink}&kind=command`;
+    const aaCrashTriageMessage = `# Admin App Crash Triage\n` + 
+      `* [Fatals](${aaCrashTriageLink})\n` +
+      `* [Commands](${aaCommandCrashTriageLink})\n`;
     markdownMessage = aaCrashTriageMessage + markdownMessage;
   }
 


### PR DESCRIPTION
* Add command crash link to annotations
* -> https://linear.app/replay/issue/RUN-2680/fixing-ci-test-run-reports

Preview:
![image](https://github.com/replayio/chromium/assets/282899/a45f632b-01f8-4113-8b9e-81c4f6c4cf18)
