### PR TITLE
[RUN-2739] Fix incorrect ExecutionContexts

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,24 +220,29 @@ void LocalWindowProxy::Initialize() {
   if (origin &&
       !origin->Host().empty()) {
 
-    // Initialize Replay basics.
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event.
+      // Note: We are assuming that each tab can only have one root frame for now.
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      OnNewRootFrame(GetIsolate(), GetFrame());
+    }
+
+    // Initialize Replay globals.
     OnNewWindow1(GetIsolate(), GetFrame());
 
     if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
         !gRecordReplayStateInitialized) {
+      // Assume that we did outer-most frame initialization already.
+      // Else we will likely run into other undecipherable crashes.
+      CHECK(GetFrame()->IsOutermostMainFrame());
+
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
-    }
-
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
     // Initialize Replay things that depend on previous Replay initialization 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -237,7 +237,7 @@ void LocalWindowProxy::Initialize() {
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
-      // Note: We are assuming that each tab can only have one root frame for now.
+      // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
       // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
       V8RecordReplaySetDefaultContext(GetIsolate(), context);
       OnNewRootFrame(GetIsolate(), GetFrame());

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -161,8 +161,6 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
 // Record/replay state is initialized along with the first LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
 
-extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
-
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
   recordreplay::Assert("LocalWindowProxy::Initialize Start");
@@ -231,15 +229,12 @@ void LocalWindowProxy::Initialize() {
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
-      // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
-      // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
       OnNewRootFrame(GetIsolate(), GetFrame());
     }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,29 +220,27 @@ void LocalWindowProxy::Initialize() {
   if (origin &&
       !origin->Host().empty()) {
 
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      // Note: We are assuming that each tab can only have one root frame for now.
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
-      OnNewRootFrame(GetIsolate(), GetFrame());
-    }
-
     // Initialize Replay globals.
     OnNewWindow1(GetIsolate(), GetFrame());
 
     if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
         !gRecordReplayStateInitialized) {
-      // Assume that we did outer-most frame initialization already.
-      // Else we will likely run into other undecipherable crashes.
-      CHECK(GetFrame()->IsOutermostMainFrame());
-
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
+    }
+
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event.
+      // Note: We are assuming that each tab can only have one root frame for now.
+      // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
     // Initialize Replay things that depend on previous Replay initialization 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -74,7 +74,6 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
 } // namespace v8
 
 namespace blink {
-
 // using RemoteObjectIdTypeRaw = v8_inspector::String16;
 // The actual type for RemoteObjectId
 using RemoteObjectIdTypeRaw = std::u16string;
@@ -82,20 +81,36 @@ using RemoteObjectIdTypeRaw = std::u16string;
 // The more convenient type that we use
 using RemoteObjectIdType = WTF::String;
 
+extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
+extern "C" void V8RecordReplayFinishRecording();
+
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
 
 
-LocalFrame* gInitialLocalFrame = nullptr;
+LocalFrame* gCurrentRootFrame = nullptr;
 
 static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalFrame* frame;
   if (!CurrentDOMWindow(isolate)) {
-    frame = gInitialLocalFrame;
+    // This should not happen if we call RecordReplaySetDefaultContext correctly.
+    std::string stack;
+    recordreplay::GetCurrentJSStack(&stack);
+    recordreplay::Warning("[RUN-2739] GetLocalFrameRoot A missing CurrentDOMWindow %d %s",
+                          isolate->GetCurrentContext().IsEmpty(),
+                          stack.c_str());
+    frame = gCurrentRootFrame;
   } else { 
     frame = CurrentDOMWindow(isolate)->GetFrame();
-    if (!frame) {
-      frame = gInitialLocalFrame;
+    if (!frame || frame->IsDetached() || frame->IsProvisional()) {
+      // This should not happen if we call RecordReplaySetDefaultContext correctly.
+      std::string stack;
+      recordreplay::GetCurrentJSStack(&stack);
+      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s",
+                            frame ? frame->RecordReplayId() : 0,
+                            isolate->GetCurrentContext().IsEmpty(),
+                            stack.c_str());
+      frame = gCurrentRootFrame;
     }
   }
   return &frame->LocalFrameRoot();
@@ -3901,8 +3916,6 @@ static void CheckPersistentId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-extern "C" void V8RecordReplayFinishRecording();
-
 
 
 // When JS assertions are enabled, this callback is used to get any pointer ID
@@ -5201,11 +5214,23 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
 }
 
+static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame) {
+  V8RecordReplaySetDefaultContext(isolate, isolate->GetCurrentContext());
+  gCurrentRootFrame = localFrame;
+  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
+  recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
+                      localFrame ? localFrame->RecordReplayId() : 0,
+                      localFrame ? localFrame->IsCrossOriginToParentOrOuterDocument() : 0,
+                      parentFrame ? parentFrame->RecordReplayId() : 0);
+}
+
 void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
+  // Register context and callbacks.
+  RecordReplaySetDefaultContext(isolate, localFrame);
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
-  gInitialLocalFrame = localFrame;
+  gCurrentRootFrame = localFrame;
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
@@ -5237,6 +5262,10 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   recordreplay::AutoMarkReplayCode amrc;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  
+  // 0. Register context, s.t. when handling a command and are not on a JS stack, we can always use the root frame's context.
+  // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
+  RecordReplaySetDefaultContext(isolate, localFrame);
 
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -106,9 +106,10 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
       // This should not happen if we call RecordReplaySetDefaultContext correctly.
       std::string stack;
       recordreplay::GetCurrentJSStack(&stack);
-      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s",
+      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s %s",
                             frame ? frame->RecordReplayId() : 0,
                             isolate->GetCurrentContext().IsEmpty(),
+                            frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "",
                             stack.c_str());
       frame = gCurrentRootFrame;
     }
@@ -5221,9 +5222,10 @@ static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* loca
   gCurrentRootFrame = localFrame;
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
+  recordreplay::CommandDiagnostic("[RUN-2739] RecordReplaySetDefaultContext %d %d %s %d", 
                       localFrame ? localFrame->RecordReplayId() : 0,
                       localFrame ? localFrame->IsCrossOriginToParentOrOuterDocument() : 0,
+                      localFrame ? localFrame->GetDocument()->Url().GetString().Utf8().c_str() : "",
                       parentFrame ? parentFrame->RecordReplayId() : 0);
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5216,7 +5216,10 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
 
 static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetDefaultContext(isolate, isolate->GetCurrentContext());
+
+  // TODO: gCurrentRootFrame should not be necessary anymore. Verify and get rid of it.
   gCurrentRootFrame = localFrame;
+
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
   recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
                       localFrame ? localFrame->RecordReplayId() : 0,
@@ -5230,7 +5233,6 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
-  gCurrentRootFrame = localFrame;
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2739/crash-in-localframeisprovisional-during-eval#comment-09d83cef