### PR TITLE
Wait for paint to finish during repaintGraphics.

### DIFF
--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -1034,8 +1034,6 @@ void ProxyImpl::RecordReplayRepaint() {
                                                          viz::BeginFrameArgs::DefaultInterval(),
                                                          viz::BeginFrameArgs::NORMAL);
   scheduler_->OnBeginFrameDerivedImpl(args);
-
-  recordreplay::OnRepaintFinished();
 }
 
 }  // namespace cc

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -244,11 +244,16 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   gCurrentPixmap = &pixmap;
 
   if (HasDivergedFromRecording()) {
-    // If we've diverged from the recording then we're probably repainting,
-    // and in any case don't need to notify the recorder that the paint finished.
-    if (gRepaintEvent)
+    // If we've diverged from the recording, check if we're running on
+    // behalf of a repaintGraphics command.  If so, encode the bitmap
+    // contents and notify the main thread.
+    if (gRepaintEvent) {
       gRepaintResult = EncodeBitmapContents(gRepaintMimeType, gRepaintJPEGQuality);
+      gRepaintEvent.load()->Signal();
+    }
   } else {
+    // If not diverged from the recording, notify the driver/linker that
+    // a paint has finished.
     size_t bookmark = gLastCommitBookmark;
     if (bookmark) {
       V8RecordReplayPaintFinished(bookmark);
@@ -256,11 +261,6 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   }
 
   gCurrentPixmap = nullptr;
-}
-
-void OnRepaintFinished() {
-  CHECK(HasDivergedFromRecording());
-  gRepaintEvent.load()->Signal();
 }
 
 static cc::ProxyMain* gCurrentCompositorProxy;

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -42,12 +42,9 @@ void SubmitCompositorFrame(const viz::LocalSurfaceId& local_surface_id,
 // Called to populate a bitmap with information for the given resource in the current frame.
 bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_id);
 
-// Called on the compositor thread when painting to the software output device has finished.
+// Called on the compositor thread when painting to the software output device has finished,
+// or when repainting has finished.
 void OnPaintFinished(const SkPixmap& pixmap);
-
-// Called on the compositor thread when repainting has finished, which may or may not
-// have actually performed a paint.
-void OnRepaintFinished();
 
 // Set the proxy which will be used for triggering repaints from the main thread.
 void SetCompositorProxy(cc::ProxyMain* proxy);

--- a/components/viz/service/display/record_replay_render_nop.cc
+++ b/components/viz/service/display/record_replay_render_nop.cc
@@ -25,8 +25,6 @@ bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_
 
 void OnPaintFinished(const SkPixmap& pixmap) {}
 
-void OnRepaintFinished() {}
-
 void SetCompositorProxy(cc::ProxyMain* proxy) {}
 
 void CompositorProxyDestroyed(cc::ProxyMain* proxy) {}


### PR DESCRIPTION
For RUN-2643 (https://linear.app/replay/issue/RUN-2643)

Main thread gets woken up too early because the logic for waking it up is in the wrong callback method.  We want it in `OnPaintFinished`, not `OnRepaintFinished`.

We currently call `OnRepaintFinished` when immediately after we call `OnBeginFrameDerivedImpl` on the scheduler, but by this point only layout has been done, and the draw may or may not have completed (or even started).

This change fixes things to remove `OnRepaintFinished`, and instead use `OnPaintFinished` to trigger the event that the `PaintWhenDiverged` is waiting on _after_ we receive and encode the pixmap data for the paint.