### PR TITLE
[RUN-2739] Track root frame and set correct ExecutionContext + better diagnostics

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '83d9e3bdfd98a9aabcd3f801ecf3c46e9f7428e8',
+  'v8_revision': '42f2d981a3a2ab1ab3162a34c823ccf7fbcd8bd8',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd69328f1dd769695d727e01011c57509b77da842',
+  'v8_revision': '83d9e3bdfd98a9aabcd3f801ecf3c46e9f7428e8',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '42f2d981a3a2ab1ab3162a34c823ccf7fbcd8bd8',
+  'v8_revision': '56592ccee3e9f578dfe6c72d5aeed6f9f3c20dc1',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -72,6 +72,9 @@ namespace recordreplay {
   Macro(V8RecordReplayTrace,                                            \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
+  Macro(V8RecordReplayCrash,                                            \
+        (const char* format, va_list args),                             \
+        (format, args))                                                 \
   Macro(V8RecordReplayBytes,                                            \
         (const char* why, void* buf, size_t size),                      \
         (why, buf, size))                                               \
@@ -527,6 +530,15 @@ int NewIdAnyThread(const char* name) {
     return 0;
   }
   return (int)RecordReplayValue("NewId", (uintptr_t)gNextAnyThreadId++);
+}
+
+void recordreplay::Crash(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    V8RecordReplayCrash(format, args);
+    va_end(args);
+  }
 }
 
 bool IsInReplayCode(const char* why) {

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -532,7 +532,7 @@ int NewIdAnyThread(const char* name) {
   return (int)RecordReplayValue("NewId", (uintptr_t)gNextAnyThreadId++);
 }
 
-void recordreplay::Crash(const char* format, ...) {
+void Crash(const char* format, ...) {
   if (IsRecordingOrReplaying()) {
     va_list args;
     va_start(args, format);

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -114,8 +114,12 @@ void OnNavigationEvent(const char* kind, const char* url);
 int NewIdMainThread(const char* name);
 int NewIdAnyThread(const char* name);
 
+// Crash instantly with given reason.
+void Crash(const char* format, ...);
+
 // Return whether record/replay specific scripts are executing.
 bool IsInReplayCode(const char* why = nullptr);
+
 
 // Mark a region where record/replay specific scripts are executing.
 struct AutoMarkReplayCode {

--- a/build.js
+++ b/build.js
@@ -138,7 +138,7 @@ console.log(`Build finished.`);
 
 function spawnChecked(cmd, args, options) {
   const prettyCmd = [cmd].concat(args).join(" ");
-  console.error(prettyCmd);
+  console.error("$" + prettyCmd);
 
   const rv = spawnSync(cmd, args, options);
 

--- a/build.js
+++ b/build.js
@@ -140,8 +140,8 @@ function spawnChecked(cmd, args, options) {
 
   if (rv.status != 0 || rv.error) {
     console.error("Process failed:", rv.error || "");
-    console.log(rv.stdout.toString() || "");
-    console.error(rv.stderr.toString() || "");
+    console.log(rv.stdout && rv.stdout.toString() || "");
+    console.error(rv.stderr && rv.stderr.toString() || "");
     throw new Error(`Spawned process failed with exit code ${rv.status}`);
   }
 

--- a/build.js
+++ b/build.js
@@ -116,12 +116,16 @@ const useGoma = !process.env.NO_GOMA;
 const goma_ctl = currentPlatform() == "windows" ? "goma_ctl.bat" : "goma_ctl";
 if (useGoma) {
   // ensure goma is started for cloud builds with engflow
-  spawnChecked(goma_ctl, ["ensure_start"]);
+  spawnChecked(goma_ctl, ["ensure_start"], {
+    stdio: "inherit",
+  });
 }
 
 // ensure that build configuration is written with correct paths
 const gn = currentPlatform() == "windows" ? "gn.bat" : "gn";
-spawnChecked(gn, ["gen", outdir]);
+spawnChecked(gn, ["gen", outdir], {
+  stdio: "inherit",
+});
 
 console.log(`Building...`);
 const autoninja =
@@ -139,7 +143,7 @@ function spawnChecked(cmd, args, options) {
   const rv = spawnSync(cmd, args, options);
 
   if (rv.status != 0 || rv.error) {
-    console.error("Process failed:", rv.error || "");
+    console.error(`Process failed: err=${rv.error || ""}, signal=${rv.signal || ""}`);
     console.log(rv.stdout && rv.stdout.toString() || "");
     console.error(rv.stderr && rv.stderr.toString() || "");
     throw new Error(`Spawned process failed with exit code ${rv.status}`);

--- a/cc/trees/layer_tree_host.cc
+++ b/cc/trees/layer_tree_host.cc
@@ -449,14 +449,14 @@ void LayerTreeHost::WaitForProtectedSequenceCompletion() const {
 }
 
 void LayerTreeHost::WaitForCommitCompletion(bool for_protected_sequence) const {
-  DCHECK(IsMainThread());    
-
-  recordreplay::CommandDiagnosticTrace(
-    "[RUN-2110-2761] LayerTreeHost::WaitForCommitCompletion %d",
-    !!commit_completion_event_);
+  DCHECK(IsMainThread());
 
   if (commit_completion_event_) {
     TRACE_EVENT0("cc", "LayerTreeHost::WaitForCommitCompletion");
+
+    recordreplay::CommandDiagnostic(
+      "[RUN-2110-2761] LayerTreeHost::WaitForCommitCompletion 1");
+
     base::ElapsedTimer timer;
     commit_completion_event_->Wait();
     commit_completion_event_ = nullptr;

--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -68,7 +68,7 @@ class ScopedCommitCompletionEvent {
   ScopedCommitCompletionEvent(const ScopedCommitCompletionEvent&) = delete;
   ~ScopedCommitCompletionEvent() {
 
-    recordreplay::CommandDiagnosticTrace(
+    recordreplay::CommandDiagnostic(
       "[RUN-2110-2761] ~ScopedCommitCompletionEvent");
 
     event_.ExtractAsDangling()->Signal();
@@ -812,7 +812,7 @@ void ProxyImpl::ScheduledActionCommit() {
     data_for_commit_->commit_timestamps->finish = finish_time;
   data_for_commit_->commit_completion_event->SetFinishTime(finish_time);
 
-  recordreplay::CommandDiagnosticTrace(
+  recordreplay::CommandDiagnostic(
     "[RUN-2110-2761] ProxyImpl::ScheduledActionCommit %d",
     commit_state->commit_waits_for_activation);
 

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -221,7 +221,7 @@ void OnCommitPaint() {
 }
 
 void OnReadyToCommit() {
-  recordreplay::CommandDiagnosticTrace("[RUN-2110-2761] OnReadyToCommit");
+  recordreplay::CommandDiagnostic("[RUN-2110-2761] OnReadyToCommit");
   gLastCommitBookmark = gCurrentPaintBookmark;
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,24 +220,29 @@ void LocalWindowProxy::Initialize() {
   if (origin &&
       !origin->Host().empty()) {
 
-    // Initialize Replay basics.
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event.
+      // Note: We are assuming that each tab can only have one root frame for now.
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      OnNewRootFrame(GetIsolate(), GetFrame());
+    }
+
+    // Initialize Replay globals.
     OnNewWindow1(GetIsolate(), GetFrame());
 
     if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
         !gRecordReplayStateInitialized) {
+      // Assume that we did outer-most frame initialization already.
+      // Else we will likely run into other undecipherable crashes.
+      CHECK(GetFrame()->IsOutermostMainFrame());
+
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
-    }
-
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
     // Initialize Replay things that depend on previous Replay initialization 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -237,7 +237,7 @@ void LocalWindowProxy::Initialize() {
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
-      // Note: We are assuming that each tab can only have one root frame for now.
+      // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
       // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
       V8RecordReplaySetDefaultContext(GetIsolate(), context);
       OnNewRootFrame(GetIsolate(), GetFrame());

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -161,8 +161,6 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
 // Record/replay state is initialized along with the first LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
 
-extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
-
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
   recordreplay::Assert("LocalWindowProxy::Initialize Start");
@@ -231,15 +229,12 @@ void LocalWindowProxy::Initialize() {
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
-      // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
-      // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
       OnNewRootFrame(GetIsolate(), GetFrame());
     }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -220,29 +220,27 @@ void LocalWindowProxy::Initialize() {
   if (origin &&
       !origin->Host().empty()) {
 
-    if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      // Note: We are assuming that each tab can only have one root frame for now.
-      V8RecordReplaySetDefaultContext(GetIsolate(), context);
-      OnNewRootFrame(GetIsolate(), GetFrame());
-    }
-
     // Initialize Replay globals.
     OnNewWindow1(GetIsolate(), GetFrame());
 
     if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
         !gRecordReplayStateInitialized) {
-      // Assume that we did outer-most frame initialization already.
-      // Else we will likely run into other undecipherable crashes.
-      CHECK(GetFrame()->IsOutermostMainFrame());
-
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
       SetupRecordReplayCommands(GetIsolate(), GetFrame());
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
+    }
+
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event.
+      // Note: We are assuming that each tab can only have one root frame for now.
+      // Note2: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
+      OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
     // Initialize Replay things that depend on previous Replay initialization 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -215,32 +215,32 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (origin &&
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
+      origin &&
       !origin->Host().empty()) {
 
     // Initialize Replay globals.
     OnNewWindow1(GetIsolate(), GetFrame());
 
-    if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
-        !gRecordReplayStateInitialized) {
+    if (!gRecordReplayStateInitialized) {
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
-      SetupRecordReplayCommands(GetIsolate(), GetFrame());
+      SetupRecordReplayCommands(GetIsolate(), GetFrame(), context);
       recordreplay::NewCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
       // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
-      OnNewRootFrame(GetIsolate(), GetFrame());
+      OnNewRootFrame(GetIsolate(), GetFrame(), context);
     }
 
     // Initialize Replay things that depend on previous Replay initialization 
     // steps.
-    OnNewWindow2(GetIsolate(), GetFrame());
+    OnNewWindow2(GetIsolate(), GetFrame(), context);
   }
 
   {
@@ -636,7 +636,7 @@ LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
 }
 
 bool RecordReplayStateEnsureInitialized() {
-  if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
       !gRecordReplayStateInitialized &&
       gLatestLocalWindowProxy) {
     gLatestLocalWindowProxy->InitializeIfNeeded();

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5323,14 +5323,13 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::
 
 void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> newContext) {
   recordreplay::AutoMarkReplayCode amrc;
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  RunScript(isolate, context, gOnNewWindowScript,
+  RunScript(isolate, newContext, gOnNewWindowScript,
             "record-replay-devtools-OnNewWindow");
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
   recordreplay::CommandDiagnostic(
     "[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
-    newContext == context,
+    newContext == isolate->GetCurrentContext(),
     localFrame->DomWindow()->RecordReplayId(),
     localFrame->RecordReplayId(),
     localFrame->IsCrossOriginToParentOrOuterDocument(),

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -74,7 +74,6 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
 } // namespace v8
 
 namespace blink {
-
 // using RemoteObjectIdTypeRaw = v8_inspector::String16;
 // The actual type for RemoteObjectId
 using RemoteObjectIdTypeRaw = std::u16string;
@@ -82,20 +81,36 @@ using RemoteObjectIdTypeRaw = std::u16string;
 // The more convenient type that we use
 using RemoteObjectIdType = WTF::String;
 
+extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
+extern "C" void V8RecordReplayFinishRecording();
+
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
 
 
-LocalFrame* gInitialLocalFrame = nullptr;
+LocalFrame* gCurrentRootFrame = nullptr;
 
 static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalFrame* frame;
   if (!CurrentDOMWindow(isolate)) {
-    frame = gInitialLocalFrame;
+    // This should not happen if we call RecordReplaySetDefaultContext correctly.
+    std::string stack;
+    recordreplay::GetCurrentJSStack(&stack);
+    recordreplay::Warning("[RUN-2739] GetLocalFrameRoot A missing CurrentDOMWindow %d %s",
+                          isolate->GetCurrentContext().IsEmpty(),
+                          stack.c_str());
+    frame = gCurrentRootFrame;
   } else { 
     frame = CurrentDOMWindow(isolate)->GetFrame();
-    if (!frame) {
-      frame = gInitialLocalFrame;
+    if (!frame || frame->IsDetached() || frame->IsProvisional()) {
+      // This should not happen if we call RecordReplaySetDefaultContext correctly.
+      std::string stack;
+      recordreplay::GetCurrentJSStack(&stack);
+      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s",
+                            frame ? frame->RecordReplayId() : 0,
+                            isolate->GetCurrentContext().IsEmpty(),
+                            stack.c_str());
+      frame = gCurrentRootFrame;
     }
   }
   return &frame->LocalFrameRoot();
@@ -3901,8 +3916,6 @@ static void CheckPersistentId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-extern "C" void V8RecordReplayFinishRecording();
-
 
 
 // When JS assertions are enabled, this callback is used to get any pointer ID
@@ -5201,11 +5214,23 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
 }
 
+static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame) {
+  V8RecordReplaySetDefaultContext(isolate, isolate->GetCurrentContext());
+  gCurrentRootFrame = localFrame;
+  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
+  recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
+                      localFrame ? localFrame->RecordReplayId() : 0,
+                      localFrame ? localFrame->IsCrossOriginToParentOrOuterDocument() : 0,
+                      parentFrame ? parentFrame->RecordReplayId() : 0);
+}
+
 void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
+  // Register context and callbacks.
+  RecordReplaySetDefaultContext(isolate, localFrame);
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
-  gInitialLocalFrame = localFrame;
+  gCurrentRootFrame = localFrame;
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
@@ -5237,6 +5262,10 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   recordreplay::AutoMarkReplayCode amrc;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  
+  // 0. Register context, s.t. when handling a command and are not on a JS stack, we can always use the root frame's context.
+  // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
+  RecordReplaySetDefaultContext(isolate, localFrame);
 
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -106,9 +106,10 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
       // This should not happen if we call RecordReplaySetDefaultContext correctly.
       std::string stack;
       recordreplay::GetCurrentJSStack(&stack);
-      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s",
+      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s %s",
                             frame ? frame->RecordReplayId() : 0,
                             isolate->GetCurrentContext().IsEmpty(),
+                            frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "",
                             stack.c_str());
       frame = gCurrentRootFrame;
     }
@@ -5221,9 +5222,10 @@ static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* loca
   gCurrentRootFrame = localFrame;
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
+  recordreplay::CommandDiagnostic("[RUN-2739] RecordReplaySetDefaultContext %d %d %s %d", 
                       localFrame ? localFrame->RecordReplayId() : 0,
                       localFrame ? localFrame->IsCrossOriginToParentOrOuterDocument() : 0,
+                      localFrame ? localFrame->GetDocument()->Url().GetString().Utf8().c_str() : "",
                       parentFrame ? parentFrame->RecordReplayId() : 0);
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -127,7 +127,7 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
     }
   }
   frame = frame ? &frame->LocalFrameRoot() : nullptr;
-  if (frame && !frame->IsDetached() && !frame->IsProvisional()) {
+  if (!frame || frame->IsDetached() || frame->IsProvisional()) {
     recordreplay::Crash(
       "[RUN-2739] GetLocalFrameRoot: Invalid frame %d win=%d \"%s\" \"%s\" frame=%d %d %d %d \"%s\" ",
         isolate->GetCurrentContext().IsEmpty(),

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5216,7 +5216,10 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
 
 static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetDefaultContext(isolate, isolate->GetCurrentContext());
+
+  // TODO: gCurrentRootFrame should not be necessary anymore. Verify and get rid of it.
   gCurrentRootFrame = localFrame;
+
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
   recordreplay::Print("[RUN-2739] RecordReplaySetDefaultContext %d %d %d", 
                       localFrame ? localFrame->RecordReplayId() : 0,
@@ -5230,7 +5233,6 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
-  gCurrentRootFrame = localFrame;
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -119,7 +119,7 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
             "",
           frame ? frame->RecordReplayId() : 0,
           frame ? frame->IsDetached() : -1,
-          (frame && frame->IsDetached()) ? frame->IsProvisional() : -1,
+          (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
           frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
           frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : ""
       );
@@ -138,7 +138,7 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
           "",
         frame ? frame->RecordReplayId() : 0,
         frame ? frame->IsDetached() : -1,
-        (frame && frame->IsDetached()) ? frame->IsProvisional() : -1,
+        (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
         frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
         frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "");
   }
@@ -5243,15 +5243,16 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
 }
 
-static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* rootFrame, v8::Local<v8::Context> context) {
+static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   V8RecordReplaySetDefaultContext(isolate, context);
 
   // TODO: gCurrentRootFrame should not be necessary anymore. Verify and get rid of it.
-  gCurrentRootFrame = rootFrame;
+  gCurrentRootFrame = &localFrame->LocalFrameRoot();
 }
 
 void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   // Register context and callbacks.
+  RecordReplaySetDefaultContext(isolate, localFrame, context);
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
@@ -5327,13 +5328,15 @@ void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Co
             "record-replay-devtools-OnNewWindow");
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic("[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
-                      newContext == context,
-                      localFrame->DomWindow()->RecordReplayId(),
-                      localFrame->RecordReplayId(),
-                      localFrame->IsCrossOriginToParentOrOuterDocument(),
-                      localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
-                      parentFrame ? parentFrame->RecordReplayId() : 0);
+  recordreplay::CommandDiagnostic(
+    "[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
+    newContext == context,
+    localFrame->DomWindow()->RecordReplayId(),
+    localFrame->RecordReplayId(),
+    localFrame->IsCrossOriginToParentOrOuterDocument(),
+    localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
+    parentFrame ? parentFrame->RecordReplayId() : 0
+  );
 }
 
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -83,6 +83,7 @@ using RemoteObjectIdType = WTF::String;
 
 extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
 extern "C" void V8RecordReplayFinishRecording();
+extern "C" void V8RecordReplaySetCrashReason(const char* reason);
 
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
@@ -92,7 +93,8 @@ LocalFrame* gCurrentRootFrame = nullptr;
 
 static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalFrame* frame;
-  if (!CurrentDOMWindow(isolate)) {
+  LocalDOMWindow* currentWindow = CurrentDOMWindow(isolate);
+  if (!currentWindow) {
     // This should not happen if we call RecordReplaySetDefaultContext correctly.
     std::string stack;
     recordreplay::GetCurrentJSStack(&stack);
@@ -101,20 +103,46 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
                           stack.c_str());
     frame = gCurrentRootFrame;
   } else { 
-    frame = CurrentDOMWindow(isolate)->GetFrame();
+    frame = currentWindow->GetFrame();
     if (!frame || frame->IsDetached() || frame->IsProvisional()) {
-      // This should not happen if we call RecordReplaySetDefaultContext correctly.
-      std::string stack;
-      recordreplay::GetCurrentJSStack(&stack);
-      recordreplay::Warning("[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d %d %s %s",
-                            frame ? frame->RecordReplayId() : 0,
-                            isolate->GetCurrentContext().IsEmpty(),
-                            frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "",
-                            stack.c_str());
+      // This should not happen if we call RecordReplaySetDefaultContext
+      // correctly.
+      // NOTE: The JS stack here is generally showing our internal command handler 
+      // code.
+      recordreplay::Warning(
+        "[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d win=%d \"%s\" \"%s\" frame=%d %d %d %d \"%s\" ",
+          isolate->GetCurrentContext().IsEmpty(),
+          currentWindow->RecordReplayId(),
+          currentWindow->origin().Utf8().c_str(),
+          currentWindow->document() ? 
+            currentWindow->document()->Url().GetString().Utf8().c_str() : 
+            "",
+          frame ? frame->RecordReplayId() : 0,
+          frame ? frame->IsDetached() : -1,
+          (frame && frame->IsDetached()) ? frame->IsProvisional() : -1,
+          frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
+          frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : ""
+      );
       frame = gCurrentRootFrame;
     }
   }
-  return &frame->LocalFrameRoot();
+  frame = frame ? &frame->LocalFrameRoot() : nullptr;
+  if (frame && !frame->IsDetached() && !frame->IsProvisional()) {
+    recordreplay::Crash(
+      "[RUN-2739] GetLocalFrameRoot: Invalid frame %d win=%d \"%s\" \"%s\" frame=%d %d %d %d \"%s\" ",
+        isolate->GetCurrentContext().IsEmpty(),
+        currentWindow ? currentWindow->RecordReplayId() : 0,
+        currentWindow ? currentWindow->origin().Utf8().c_str() : "",
+        (currentWindow && currentWindow->document()) ? 
+          currentWindow->document()->Url().GetString().Utf8().c_str() : 
+          "",
+        frame ? frame->RecordReplayId() : 0,
+        frame ? frame->IsDetached() : -1,
+        (frame && frame->IsDetached()) ? frame->IsProvisional() : -1,
+        frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
+        frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "");
+  }
+  return frame;
 }
 
 class InspectorData {
@@ -5215,31 +5243,21 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
 }
 
-static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame) {
-  V8RecordReplaySetDefaultContext(isolate, isolate->GetCurrentContext());
+static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* rootFrame, v8::Local<v8::Context> context) {
+  V8RecordReplaySetDefaultContext(isolate, context);
 
   // TODO: gCurrentRootFrame should not be necessary anymore. Verify and get rid of it.
-  gCurrentRootFrame = localFrame;
-
-  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic("[RUN-2739] RecordReplaySetDefaultContext %d %d %s %d", 
-                      localFrame ? localFrame->RecordReplayId() : 0,
-                      localFrame ? localFrame->IsCrossOriginToParentOrOuterDocument() : 0,
-                      localFrame ? localFrame->GetDocument()->Url().GetString().Utf8().c_str() : "",
-                      parentFrame ? parentFrame->RecordReplayId() : 0);
+  gCurrentRootFrame = rootFrame;
 }
 
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
+void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   // Register context and callbacks.
-  RecordReplaySetDefaultContext(isolate, localFrame);
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
-
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   // This URL will prevent the script from being reported to the recorder.
   const char* InternalScriptURL = "record-replay-internal";
@@ -5263,13 +5281,23 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 }
 
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   recordreplay::AutoMarkReplayCode amrc;
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   
-  // 0. Register context, s.t. when handling a command and are not on a JS stack, we can always use the root frame's context.
-  // Note: We are assuming that each tab has its own process, for now (although that might not hold true for tabs of the same domain - not sure!).
-  RecordReplaySetDefaultContext(isolate, localFrame);
+  // 0. Register context, s.t. when handling a command and we are not on a 
+  // JS stack, we can always use the current root frame's context.
+  // Note: We are assuming that each tab has its own process, for now.
+  //   (That might not hold true for tabs of the same domain - not sure)
+  RecordReplaySetDefaultContext(isolate, localFrame, context);
+  
+  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
+  recordreplay::CommandDiagnostic(
+    "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\" parentFrame=%d",
+      localFrame->DomWindow()->RecordReplayId(),
+      localFrame->RecordReplayId(),
+      localFrame->IsCrossOriginToParentOrOuterDocument(),
+      localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
+      parentFrame ? parentFrame->RecordReplayId() : 0);
 
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
@@ -5292,11 +5320,20 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   }
 }
 
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame) {
+void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> newContext) {
   recordreplay::AutoMarkReplayCode amrc;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   RunScript(isolate, context, gOnNewWindowScript,
             "record-replay-devtools-OnNewWindow");
+
+  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
+  recordreplay::CommandDiagnostic("[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
+                      newContext == context,
+                      localFrame->DomWindow()->RecordReplayId(),
+                      localFrame->RecordReplayId(),
+                      localFrame->IsCrossOriginToParentOrOuterDocument(),
+                      localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
+                      parentFrame ? parentFrame->RecordReplayId() : 0);
 }
 
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -18,15 +18,15 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Initialize command state after the first context is created, but before the
 // first checkpoint in the recording is created.
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame);
+void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Initialize everything that needs to be initialized with every root frame.
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame);
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Initialize everything that depends on other initialization steps but
 // for all windows.
 // This is the last replay code that we run for a new Window object.
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame);
+void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
@@ -153,8 +153,6 @@ void WindowProxy::SetGlobalProxy(v8::Local<v8::Object> global_proxy) {
 // If there are JS code holds a closure to the old inner window,
 // it won't be able to reach the outer window via its global object.
 void WindowProxy::InitializeIfNeeded() {
-  recordreplay::Assert("[RUN-2351-2355] WindowProxy::InitializeIfNeeded %d",
-                       (int)lifecycle_);
   if (lifecycle_ == Lifecycle::kContextIsUninitialized ||
       lifecycle_ == Lifecycle::kGlobalObjectIsDetached) {
 


### PR DESCRIPTION
* paired w/
  * https://github.com/replayio/chromium-v8/pull/194
  * https://github.com/replayio/backend/pull/8880
* https://linear.app/replay/issue/RUN-2739/crash-in-localframeisprovisional-during-eval#comment-09d83cef
* Sneaky:
  * Fix spammy (and very slow) `Trace` calls, coming from https://github.com/replayio/chromium/pull/936
* Tests: ✔
  * Also testing against new driver/linker build [here](https://buildkite.com/replay/chromium-build/builds/2019): ?