### PR TITLE
Add wait between layout and redraw during repaintGraphics.

### DIFF
--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -1042,6 +1042,8 @@ void ProxyImpl::RecordReplayRepaint() {
                                                          viz::BeginFrameArgs::DefaultInterval(),
                                                          viz::BeginFrameArgs::NORMAL);
   scheduler_->OnBeginFrameDerivedImpl(args);
+
+  recordreplay::OnRepaintFinished();
 }
 
 }  // namespace cc

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -229,6 +229,9 @@ void OnReadyToCommit() {
 static const char* gRepaintMimeType;
 static int gRepaintJPEGQuality;
 
+// Event to signal when layout has been comitted.
+static std::atomic<base::WaitableEvent*> gRepaintLayoutCommitEvent;
+
 // Event to signal when repainting has finished.
 static std::atomic<base::WaitableEvent*> gRepaintEvent;
 
@@ -245,16 +248,11 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   gCurrentPixmap = &pixmap;
 
   if (HasDivergedFromRecording()) {
-    // If we've diverged from the recording, check if we're running on
-    // behalf of a repaintGraphics command.  If so, encode the bitmap
-    // contents and notify the main thread.
-    if (gRepaintEvent) {
+    // If we've diverged from the recording then we're probably repainting,
+    // and in any case don't need to notify the recorder that the paint finished.
+    if (gRepaintEvent)
       gRepaintResult = EncodeBitmapContents(gRepaintMimeType, gRepaintJPEGQuality);
-      gRepaintEvent.load()->Signal();
-    }
   } else {
-    // If not diverged from the recording, notify the driver/linker that
-    // a paint has finished.
     size_t bookmark = gLastCommitBookmark;
     if (bookmark) {
       V8RecordReplayPaintFinished(bookmark);
@@ -262,6 +260,18 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   }
 
   gCurrentPixmap = nullptr;
+}
+
+void OnRepaintLayoutCommitted() {
+  CHECK(HasDivergedFromRecording());
+  if (gRepaintLayoutCommitEvent) {
+    gRepaintLayoutCommitEvent.load()->Signal();
+  }
+}
+
+void OnRepaintFinished() {
+  CHECK(HasDivergedFromRecording());
+  gRepaintEvent.load()->Signal();
 }
 
 static cc::ProxyMain* gCurrentCompositorProxy;
@@ -296,6 +306,27 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
   begin_main_frame_state->mutator_events = std::make_unique<cc::AnimationEvents>();
   begin_main_frame_state->commit_data = std::make_unique<cc::CompositorCommitData>();
   gCurrentCompositorProxy->BeginMainFrame(std::move(begin_main_frame_state));
+
+  // RUN-2643: https://linear.app/replay/issue/RUN-2643
+  //
+  // FIXME: This is not the final fix for this.  We're waiting here in lieu of
+  // an explicit wake-up event.  If we fire the `RecordReplayRepaint` below too
+  // early, it runs before the layout above has finished committing all the
+  // necessary draw calls to the compositor.
+  //
+  // Places where we have already tried adding an explicit wake-up signal from
+  // but which didn't work:
+  //   * ProxyImpl::BeginMainFrame
+  //   * ProxyImpl::NotifyReadyToCommitOnImpl
+  //   * ProxyImpl::ScheduledActionCommit
+  //   * ProxyImpl::ScheduledActionPostCommit
+  //
+  // When we fix this properly, we need to insert a call to explicitly
+  // wake-up this thread by calling `OnRepaintLayoutCommitted` above.
+  base::WaitableEvent layoutCommittedEvent;
+  gRepaintLayoutCommitEvent = &layoutCommittedEvent;
+  layoutCommittedEvent.TimedWait(base::Milliseconds(100));
+  gRepaintLayoutCommitEvent = nullptr;
 
   // Trigger a new frame on the compositor thread.
   gCurrentCompositorProxy->RecordReplayRepaint();

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -42,9 +42,15 @@ void SubmitCompositorFrame(const viz::LocalSurfaceId& local_surface_id,
 // Called to populate a bitmap with information for the given resource in the current frame.
 bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_id);
 
-// Called on the compositor thread when painting to the software output device has finished,
-// or when repainting has finished.
+// Called on the compositor thread when painting to the software output device has finished.
 void OnPaintFinished(const SkPixmap& pixmap);
+
+// Called on the compositor thread when repainting layout has comitted.
+void OnRepaintLayoutCommitted();
+
+// Called on the compositor thread when repainting has finished, which may or may not
+// have actually performed a paint.
+void OnRepaintFinished();
 
 // Set the proxy which will be used for triggering repaints from the main thread.
 void SetCompositorProxy(cc::ProxyMain* proxy);

--- a/components/viz/service/display/record_replay_render_nop.cc
+++ b/components/viz/service/display/record_replay_render_nop.cc
@@ -25,6 +25,10 @@ bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_
 
 void OnPaintFinished(const SkPixmap& pixmap) {}
 
+void OnRepaintLayoutCommitted() {}
+
+void OnRepaintFinished() {}
+
 void SetCompositorProxy(cc::ProxyMain* proxy) {}
 
 void CompositorProxyDestroyed(cc::ProxyMain* proxy) {}


### PR DESCRIPTION
For RUN-2643 (https://linear.app/replay/issue/RUN-2643)

This is a "better" fix for the original problem of stale paints.

The patch here provides the trappings for later making this timeout into an explicitly woken wait by the main thread, but nothing invokes the wake-up, and we rely on the timeout hitting and the layout finishing by then.