### PR TITLE
Revert "[RUN-2739] Track root frame and set correct ExecutionContext + better diagnostics"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '56592ccee3e9f578dfe6c72d5aeed6f9f3c20dc1',
+  'v8_revision': 'd69328f1dd769695d727e01011c57509b77da842',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -72,9 +72,6 @@ namespace recordreplay {
   Macro(V8RecordReplayTrace,                                            \
         (const char* format, va_list args),                             \
         (format, args))                                                 \
-  Macro(V8RecordReplayCrash,                                            \
-        (const char* format, va_list args),                             \
-        (format, args))                                                 \
   Macro(V8RecordReplayBytes,                                            \
         (const char* why, void* buf, size_t size),                      \
         (why, buf, size))                                               \
@@ -530,15 +527,6 @@ int NewIdAnyThread(const char* name) {
     return 0;
   }
   return (int)RecordReplayValue("NewId", (uintptr_t)gNextAnyThreadId++);
-}
-
-void Crash(const char* format, ...) {
-  if (IsRecordingOrReplaying()) {
-    va_list args;
-    va_start(args, format);
-    V8RecordReplayCrash(format, args);
-    va_end(args);
-  }
 }
 
 bool IsInReplayCode(const char* why) {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -114,12 +114,8 @@ void OnNavigationEvent(const char* kind, const char* url);
 int NewIdMainThread(const char* name);
 int NewIdAnyThread(const char* name);
 
-// Crash instantly with given reason.
-void Crash(const char* format, ...);
-
 // Return whether record/replay specific scripts are executing.
 bool IsInReplayCode(const char* why = nullptr);
-
 
 // Mark a region where record/replay specific scripts are executing.
 struct AutoMarkReplayCode {

--- a/build.js
+++ b/build.js
@@ -116,16 +116,12 @@ const useGoma = !process.env.NO_GOMA;
 const goma_ctl = currentPlatform() == "windows" ? "goma_ctl.bat" : "goma_ctl";
 if (useGoma) {
   // ensure goma is started for cloud builds with engflow
-  spawnChecked(goma_ctl, ["ensure_start"], {
-    stdio: "inherit",
-  });
+  spawnChecked(goma_ctl, ["ensure_start"]);
 }
 
 // ensure that build configuration is written with correct paths
 const gn = currentPlatform() == "windows" ? "gn.bat" : "gn";
-spawnChecked(gn, ["gen", outdir], {
-  stdio: "inherit",
-});
+spawnChecked(gn, ["gen", outdir]);
 
 console.log(`Building...`);
 const autoninja =
@@ -138,14 +134,14 @@ console.log(`Build finished.`);
 
 function spawnChecked(cmd, args, options) {
   const prettyCmd = [cmd].concat(args).join(" ");
-  console.error("$" + prettyCmd);
+  console.error(prettyCmd);
 
   const rv = spawnSync(cmd, args, options);
 
   if (rv.status != 0 || rv.error) {
-    console.error(`Process failed: err=${rv.error || ""}, signal=${rv.signal || ""}`);
-    console.log(rv.stdout && rv.stdout.toString() || "");
-    console.error(rv.stderr && rv.stderr.toString() || "");
+    console.error("Process failed:", rv.error || "");
+    console.log(rv.stdout.toString() || "");
+    console.error(rv.stderr.toString() || "");
     throw new Error(`Spawned process failed with exit code ${rv.status}`);
   }
 

--- a/cc/trees/layer_tree_host.cc
+++ b/cc/trees/layer_tree_host.cc
@@ -449,14 +449,14 @@ void LayerTreeHost::WaitForProtectedSequenceCompletion() const {
 }
 
 void LayerTreeHost::WaitForCommitCompletion(bool for_protected_sequence) const {
-  DCHECK(IsMainThread());
+  DCHECK(IsMainThread());    
+
+  recordreplay::CommandDiagnosticTrace(
+    "[RUN-2110-2761] LayerTreeHost::WaitForCommitCompletion %d",
+    !!commit_completion_event_);
 
   if (commit_completion_event_) {
     TRACE_EVENT0("cc", "LayerTreeHost::WaitForCommitCompletion");
-
-    recordreplay::CommandDiagnostic(
-      "[RUN-2110-2761] LayerTreeHost::WaitForCommitCompletion 1");
-
     base::ElapsedTimer timer;
     commit_completion_event_->Wait();
     commit_completion_event_ = nullptr;

--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -68,7 +68,7 @@ class ScopedCommitCompletionEvent {
   ScopedCommitCompletionEvent(const ScopedCommitCompletionEvent&) = delete;
   ~ScopedCommitCompletionEvent() {
 
-    recordreplay::CommandDiagnostic(
+    recordreplay::CommandDiagnosticTrace(
       "[RUN-2110-2761] ~ScopedCommitCompletionEvent");
 
     event_.ExtractAsDangling()->Signal();
@@ -812,7 +812,7 @@ void ProxyImpl::ScheduledActionCommit() {
     data_for_commit_->commit_timestamps->finish = finish_time;
   data_for_commit_->commit_completion_event->SetFinishTime(finish_time);
 
-  recordreplay::CommandDiagnostic(
+  recordreplay::CommandDiagnosticTrace(
     "[RUN-2110-2761] ProxyImpl::ScheduledActionCommit %d",
     commit_state->commit_waits_for_activation);
 

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -221,7 +221,7 @@ void OnCommitPaint() {
 }
 
 void OnReadyToCommit() {
-  recordreplay::CommandDiagnostic("[RUN-2110-2761] OnReadyToCommit");
+  recordreplay::CommandDiagnosticTrace("[RUN-2110-2761] OnReadyToCommit");
   gLastCommitBookmark = gCurrentPaintBookmark;
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -161,6 +161,8 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
 // Record/replay state is initialized along with the first LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
 
+extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
+
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
   recordreplay::Assert("LocalWindowProxy::Initialize Start");
@@ -215,32 +217,32 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (recordreplay::IsRecordingOrReplaying("commands") &&
-      origin &&
+  if (origin &&
       !origin->Host().empty()) {
 
-    // Initialize Replay globals.
+    // Initialize Replay basics.
     OnNewWindow1(GetIsolate(), GetFrame());
 
-    if (!gRecordReplayStateInitialized) {
+    if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
+        !gRecordReplayStateInitialized) {
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
-      SetupRecordReplayCommands(GetIsolate(), GetFrame(), context);
+      SetupRecordReplayCommands(GetIsolate(), GetFrame());
+      V8RecordReplaySetDefaultContext(GetIsolate(), context);
       recordreplay::NewCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
-      // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
-      OnNewRootFrame(GetIsolate(), GetFrame(), context);
+      OnNewRootFrame(GetIsolate(), GetFrame());
     }
 
     // Initialize Replay things that depend on previous Replay initialization 
     // steps.
-    OnNewWindow2(GetIsolate(), GetFrame(), context);
+    OnNewWindow2(GetIsolate(), GetFrame());
   }
 
   {
@@ -636,7 +638,7 @@ LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
 }
 
 bool RecordReplayStateEnsureInitialized() {
-  if (recordreplay::IsRecordingOrReplaying("commands") &&
+  if (recordreplay::IsRecordingOrReplaying("checkpoints") &&
       !gRecordReplayStateInitialized &&
       gLatestLocalWindowProxy) {
     gLatestLocalWindowProxy->InitializeIfNeeded();

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -74,6 +74,7 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
 } // namespace v8
 
 namespace blink {
+
 // using RemoteObjectIdTypeRaw = v8_inspector::String16;
 // The actual type for RemoteObjectId
 using RemoteObjectIdTypeRaw = std::u16string;
@@ -81,68 +82,23 @@ using RemoteObjectIdTypeRaw = std::u16string;
 // The more convenient type that we use
 using RemoteObjectIdType = WTF::String;
 
-extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
-extern "C" void V8RecordReplayFinishRecording();
-extern "C" void V8RecordReplaySetCrashReason(const char* reason);
-
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
 
 
-LocalFrame* gCurrentRootFrame = nullptr;
+LocalFrame* gInitialLocalFrame = nullptr;
 
 static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalFrame* frame;
-  LocalDOMWindow* currentWindow = CurrentDOMWindow(isolate);
-  if (!currentWindow) {
-    // This should not happen if we call RecordReplaySetDefaultContext correctly.
-    std::string stack;
-    recordreplay::GetCurrentJSStack(&stack);
-    recordreplay::Warning("[RUN-2739] GetLocalFrameRoot A missing CurrentDOMWindow %d %s",
-                          isolate->GetCurrentContext().IsEmpty(),
-                          stack.c_str());
-    frame = gCurrentRootFrame;
+  if (!CurrentDOMWindow(isolate)) {
+    frame = gInitialLocalFrame;
   } else { 
-    frame = currentWindow->GetFrame();
-    if (!frame || frame->IsDetached() || frame->IsProvisional()) {
-      // This should not happen if we call RecordReplaySetDefaultContext
-      // correctly.
-      // NOTE: The JS stack here is generally showing our internal command handler 
-      // code.
-      recordreplay::Warning(
-        "[RUN-2739] GetLocalFrameRoot B CurrentDOMWindow has no valid frame %d win=%d \"%s\" \"%s\" frame=%d %d %d %d \"%s\" ",
-          isolate->GetCurrentContext().IsEmpty(),
-          currentWindow->RecordReplayId(),
-          currentWindow->origin().Utf8().c_str(),
-          currentWindow->document() ? 
-            currentWindow->document()->Url().GetString().Utf8().c_str() : 
-            "",
-          frame ? frame->RecordReplayId() : 0,
-          frame ? frame->IsDetached() : -1,
-          (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
-          frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
-          frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : ""
-      );
-      frame = gCurrentRootFrame;
+    frame = CurrentDOMWindow(isolate)->GetFrame();
+    if (!frame) {
+      frame = gInitialLocalFrame;
     }
   }
-  frame = frame ? &frame->LocalFrameRoot() : nullptr;
-  if (!frame || frame->IsDetached() || frame->IsProvisional()) {
-    recordreplay::Crash(
-      "[RUN-2739] GetLocalFrameRoot: Invalid frame %d win=%d \"%s\" \"%s\" frame=%d %d %d %d \"%s\" ",
-        isolate->GetCurrentContext().IsEmpty(),
-        currentWindow ? currentWindow->RecordReplayId() : 0,
-        currentWindow ? currentWindow->origin().Utf8().c_str() : "",
-        (currentWindow && currentWindow->document()) ? 
-          currentWindow->document()->Url().GetString().Utf8().c_str() : 
-          "",
-        frame ? frame->RecordReplayId() : 0,
-        frame ? frame->IsDetached() : -1,
-        (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
-        frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
-        frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "");
-  }
-  return frame;
+  return &frame->LocalFrameRoot();
 }
 
 class InspectorData {
@@ -3945,6 +3901,8 @@ static void CheckPersistentId(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+extern "C" void V8RecordReplayFinishRecording();
+
 
 
 // When JS assertions are enabled, this callback is used to get any pointer ID
@@ -5243,22 +5201,16 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   SetFunctionProperty(isolate, args, "checkPersistentId", CheckPersistentId);
 }
 
-static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
-  V8RecordReplaySetDefaultContext(isolate, context);
-
-  // TODO: gCurrentRootFrame should not be necessary anymore. Verify and get rid of it.
-  gCurrentRootFrame = &localFrame->LocalFrameRoot();
-}
-
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
-  // Register context and callbacks.
-  RecordReplaySetDefaultContext(isolate, localFrame, context);
+void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame) {
   V8RecordReplaySetAPIObjectIdCallback(GetAPIObjectIdCallback);
   V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
 
+  gInitialLocalFrame = localFrame;
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   // This URL will prevent the script from being reported to the recorder.
   const char* InternalScriptURL = "record-replay-internal";
@@ -5282,23 +5234,9 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8:
   }
 }
 
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame) {
   recordreplay::AutoMarkReplayCode amrc;
-  
-  // 0. Register context, s.t. when handling a command and we are not on a 
-  // JS stack, we can always use the current root frame's context.
-  // Note: We are assuming that each tab has its own process, for now.
-  //   (That might not hold true for tabs of the same domain - not sure)
-  RecordReplaySetDefaultContext(isolate, localFrame, context);
-  
-  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic(
-    "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\" parentFrame=%d",
-      localFrame->DomWindow()->RecordReplayId(),
-      localFrame->RecordReplayId(),
-      localFrame->IsCrossOriginToParentOrOuterDocument(),
-      localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
-      parentFrame ? parentFrame->RecordReplayId() : 0);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
@@ -5321,21 +5259,11 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::
   }
 }
 
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> newContext) {
+void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame) {
   recordreplay::AutoMarkReplayCode amrc;
-  RunScript(isolate, newContext, gOnNewWindowScript,
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  RunScript(isolate, context, gOnNewWindowScript,
             "record-replay-devtools-OnNewWindow");
-
-  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic(
-    "[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
-    newContext == isolate->GetCurrentContext(),
-    localFrame->DomWindow()->RecordReplayId(),
-    localFrame->RecordReplayId(),
-    localFrame->IsCrossOriginToParentOrOuterDocument(),
-    localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
-    parentFrame ? parentFrame->RecordReplayId() : 0
-  );
 }
 
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -18,15 +18,15 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Initialize command state after the first context is created, but before the
 // first checkpoint in the recording is created.
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Initialize everything that needs to be initialized with every root frame.
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Initialize everything that depends on other initialization steps but
 // for all windows.
 // This is the last replay code that we run for a new Window object.
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/window_proxy.cc
@@ -153,6 +153,8 @@ void WindowProxy::SetGlobalProxy(v8::Local<v8::Object> global_proxy) {
 // If there are JS code holds a closure to the old inner window,
 // it won't be able to reach the outer window via its global object.
 void WindowProxy::InitializeIfNeeded() {
+  recordreplay::Assert("[RUN-2351-2355] WindowProxy::InitializeIfNeeded %d",
+                       (int)lifecycle_);
   if (lifecycle_ == Lifecycle::kContextIsUninitialized ||
       lifecycle_ == Lifecycle::kGlobalObjectIsDetached) {
 


### PR DESCRIPTION
* This caused Windows CI recordings to just timeout indefinitely.
* → Revert replayio/chromium#938