### PR TITLE
[RUN-2519] use the same macos v8 context snapshot filename

### DIFF
--- a/gin/v8_initializer.cc
+++ b/gin/v8_initializer.cc
@@ -120,18 +120,7 @@ const char* GetSnapshotFileName(const V8SnapshotFileType file_type) {
   return nullptr;
 }
 
-extern "C" bool V8RecordReplayIsARM();
-
 void GetV8FilePath(const char* file_name, base::FilePath* path_out) {
-  // The snapshot file is arch specific, record/replay its contents when we recorded
-  // on ARM because we will replay on x64.
-  if (V8RecordReplayIsARM()) {
-    size_t len = recordreplay::RecordReplayValue("GetV8FilePath Length", strlen(file_name));
-    if (recordreplay::IsReplaying()) {
-      file_name = new char[len + 1];
-    }
-    recordreplay::RecordReplayBytes("GetV8FilePath Contents", (char*)file_name, len + 1);
-  }
 #if BUILDFLAG(IS_ANDROID)
   // This is the path within the .apk.
   *path_out =

--- a/tools/v8_context_snapshot/v8_context_snapshot.gni
+++ b/tools/v8_context_snapshot/v8_context_snapshot.gni
@@ -28,11 +28,15 @@ declare_args() {
   # We use a different filename for arm64 macOS builds so that the arm64 and
   # x64 snapshots can live side-by-side in a universal macOS app.
   if (is_mac) {
-    if (v8_target_cpu == "x64") {
-      v8_context_snapshot_filename = "v8_context_snapshot.x86_64.bin"
-    } else if (v8_target_cpu == "arm64") {
-      v8_context_snapshot_filename = "v8_context_snapshot.arm64.bin"
-    }
+    v8_context_snapshot_filename = "v8_context_snapshot.bin"
+    # we aren't build a universal app currently, and the filenames being
+    # different causes headaches at replay-time.
+    #
+    #if (v8_target_cpu == "x64") {
+    #  v8_context_snapshot_filename = "v8_context_snapshot.x86_64.bin"
+    #} else if (v8_target_cpu == "arm64") {
+    #  v8_context_snapshot_filename = "v8_context_snapshot.arm64.bin"
+    #}
   } else if (target_os == "android") {
     if (v8_current_cpu == "arm" || v8_current_cpu == "x86" ||
         v8_current_cpu == "mipsel") {


### PR DESCRIPTION
We aren't making universal apps, so use the same filename for both architectures.  This makes things much less complicated when locating the file while replaying.