### PR TITLE
[RUN-2519] use absolute paths for framework resources

### DIFF
--- a/base/mac/foundation_util.mm
+++ b/base/mac/foundation_util.mm
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/mac_logging.h"
@@ -102,7 +103,7 @@ FilePath PathForFrameworkBundleResource(CFStringRef resourceName) {
   NSBundle* bundle = base::mac::FrameworkBundle();
   NSString* resourcePath = [bundle pathForResource:(NSString*)resourceName
                                             ofType:nil];
-  return NSStringToFilePath(resourcePath);
+  return base::MakeAbsoluteFilePath(NSStringToFilePath(resourcePath));
 }
 
 OSType CreatorCodeForCFBundleRef(CFBundleRef bundle) {


### PR DESCRIPTION
Our check for "is this file inside the install directory?" is using an absolute path for both the install dir and the framework resource, but `realpath` has been called on the executable path, from which we compute the install dir.  This changes `/tmp` to `/private/tmp` on macos, so the paths no longer match up.