### PR TITLE
RUN-2733 Introduce and call PageScheduler::BreakLinkages in Page::WillBeDestroyed

### DIFF
--- a/third_party/blink/renderer/core/page/page.cc
+++ b/third_party/blink/renderer/core/page/page.cc
@@ -1027,7 +1027,12 @@ void Page::WillBeDestroyed() {
     // we leak the scheduler, so the finalizer does not touch the recording
     // stream.
     // https://linear.app/replay/issue/RUN-1347#comment-bc4e3f9d
-    page_scheduler_.release();
+    PageScheduler* s = page_scheduler_.release();
+
+    // We're about to destroy this page, which acts as the page scheduler's
+    // delegate.  Make sure we break that linkage before we go away.
+    // https://linear.app/replay/issue/RUN-2733
+    s->BreakLinkages();
   }
 
   page_scheduler_ = nullptr;

--- a/third_party/blink/renderer/platform/scheduler/common/dummy_schedulers.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/dummy_schedulers.cc
@@ -166,6 +166,7 @@ class DummyPageScheduler : public PageScheduler {
     return CreateDummyFrameScheduler();
   }
 
+  void BreakLinkages() override {}
   void OnTitleOrFaviconUpdated() override {}
   void SetPageVisible(bool) override {}
   void SetPageFrozen(bool) override {}

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
@@ -193,6 +193,7 @@ PageSchedulerImpl::PageSchedulerImpl(
       &PageSchedulerImpl::OnAudioSilent, base::Unretained(this)));
   do_freeze_page_callback_.Reset(base::BindRepeating(
       &PageSchedulerImpl::DoFreezePage, base::Unretained(this)));
+
 }
 
 PageSchedulerImpl::~PageSchedulerImpl() {
@@ -204,6 +205,11 @@ PageSchedulerImpl::~PageSchedulerImpl() {
     frame_scheduler->DetachFromPageScheduler();
   }
   main_thread_scheduler_->RemovePageScheduler(this);
+}
+
+void
+PageSchedulerImpl::BreakLinkages() {
+  delegate_ = nullptr;
 }
 
 // static

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
@@ -193,7 +193,6 @@ PageSchedulerImpl::PageSchedulerImpl(
       &PageSchedulerImpl::OnAudioSilent, base::Unretained(this)));
   do_freeze_page_callback_.Reset(base::BindRepeating(
       &PageSchedulerImpl::DoFreezePage, base::Unretained(this)));
-
 }
 
 PageSchedulerImpl::~PageSchedulerImpl() {

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.h
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.h
@@ -59,6 +59,8 @@ class PLATFORM_EXPORT PageSchedulerImpl : public PageScheduler {
   ~PageSchedulerImpl() override;
 
   // PageScheduler implementation:
+  void BreakLinkages() override;
+
   void OnTitleOrFaviconUpdated() override;
   void SetPageVisible(bool page_visible) override;
   void SetPageFrozen(bool) override;

--- a/third_party/blink/renderer/platform/scheduler/public/page_scheduler.h
+++ b/third_party/blink/renderer/platform/scheduler/public/page_scheduler.h
@@ -42,6 +42,8 @@ class PLATFORM_EXPORT PageScheduler {
 
   virtual ~PageScheduler() = default;
 
+  virtual void BreakLinkages() = 0;
+
   // Signals that communications with the user took place via either a title
   // updates or a change to the favicon.
   virtual void OnTitleOrFaviconUpdated() = 0;


### PR DESCRIPTION
When a `Page` is going to go away (in `Page::WillBeDestroyed`), we release the `PageScheduler` without destroying it.  The `PageScheduler`'s `delegate_` _is_ the `Page` that will be going away, and it will later make calls to it.

Keep the behavior of leaking the PageScheduler intact, but break the linkage (using `PageScheduler::BreakLinkages`) to the `delegate_`. 