### PR TITLE
[RUN-2800] Fix diagnostics in `GetLocalFrameRoot` (possibly operating on "bad" frames)

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -120,8 +120,8 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
           frame ? frame->RecordReplayId() : 0,
           frame ? frame->IsDetached() : -1,
           (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
-          frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
-          frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : ""
+          (frame && !frame->IsDetached()) ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
+          (frame && !frame->IsDetached()) ? frame->GetDocument()->Url().GetString().Utf8().c_str() : ""
       );
       frame = gCurrentRootFrame;
     }
@@ -139,8 +139,8 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
         frame ? frame->RecordReplayId() : 0,
         frame ? frame->IsDetached() : -1,
         (frame && !frame->IsDetached()) ? frame->IsProvisional() : -1,
-        frame ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
-        frame ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "");
+        (frame && !frame->IsDetached()) ? frame->IsCrossOriginToParentOrOuterDocument() : -1,
+        (frame && !frame->IsDetached()) ? frame->GetDocument()->Url().GetString().Utf8().c_str() : "");
   }
   return frame;
 }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2800/segfault-in-iscrossorigintoparentorouterdocument#comment-57843fb2