### PR TITLE
[RUN-2829] exclude `--pdf-renderer` renderer processes from recording

### DIFF
--- a/chrome/app/record_replay_main.cc
+++ b/chrome/app/record_replay_main.cc
@@ -306,11 +306,14 @@ static bool RecordReplayShouldRecord(int* pargc, const char*** pargv) {
   // Figure out what type of process this is.
   const char* type = nullptr;
   for (int i = 0; i < *pargc; i++) {
-    if (!strncmp((*pargv)[i], "--type=", 7)) {
+    if (!type && !strncmp((*pargv)[i], "--type=", 7)) {
       type = (*pargv)[i] + 7;
     }
     if (!strcmp((*pargv)[i], "--record-replay-for-recording")) {
       for_recording_flag = true;
+    }
+    if (!strcmp((*pargv)[i], "--pdf-renderer")) {
+      return false;
     }
   }
 


### PR DESCRIPTION
We crash while recording the pdf renderer process when the print dialog comes up.  Turns out that is a `--type=renderer` process (with an additional `--pdf-renderer` flag.)

Turn off recording for `--pdf-renderer` renderers.

This might be the cause of RUN-2829.