### PR TITLE
buck: start chromium linux build via buck

### DIFF
--- a/.github/approveman.yml
+++ b/.github/approveman.yml
@@ -15,3 +15,7 @@ ownership_rules:
       path: "replay_build_scripts/**"
     - name: More Replay build scripts
       path: "replay-scripts/**"
+    - name: BUCK files
+      path: "**/BUCK"
+    - name: Root BUCK file
+      path: "BUCK"

--- a/.github/replay-soc2.yml
+++ b/.github/replay-soc2.yml
@@ -18,4 +18,6 @@ allowlist:
   - DEPS
   - replay_build_scripts/**
   - replay-scripts/**
+  - "**/BUCK"
+  - BUCK
 blocklist:

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,10 @@
+genrule(
+  name = "chromium",
+  srcs = glob(['**/*.*']),
+  remote = False,
+  cmd = 'docker build -t chromium-build-new - < Dockerfile.build && node buildLinux.mjs && cp -r out/Release $OUT',
+  out = 'out/Release/',
+  labels = [
+    'no_srcs_environment',
+  ],
+)


### PR DESCRIPTION
Subsequent PRs will add mac and windows support via `select` and `alias` but for now we'll just stick with Linux.

Part of RUN-2771