### PR TITLE
Stateful record button.

### DIFF
--- a/chrome/app/vector_icons/BUILD.gn
+++ b/chrome/app/vector_icons/BUILD.gn
@@ -106,6 +106,7 @@ aggregate_vector_icons("chrome_vector_icons") {
     "reader_mode.icon",
     "reader_mode_disabled.icon",
     "record_replay.icon",
+    "record_replay_stop.icon",
     "reload_touch.icon",
     "remove.icon",
     "remove_box.icon",

--- a/chrome/app/vector_icons/record_replay_stop.icon
+++ b/chrome/app/vector_icons/record_replay_stop.icon
@@ -1,0 +1,11 @@
+// Copyright 2023 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+CANVAS_DIMENSIONS, 16,
+PATH_COLOR_ARGB, 0xFF, 0xDD, 0x22, 0x22,
+MOVE_TO, 3, 3,
+LINE_TO, 13, 3,
+LINE_TO, 13, 13,
+LINE_TO, 3, 13,
+CLOSE

--- a/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.cc
+++ b/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.cc
@@ -7,11 +7,34 @@
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/browser.h"
 #include "ui/views/controls/button/button_controller.h"
+#include "content/public/browser/web_contents_observer.h"
+
+struct RecordReplayToolbarButtonWebContentsObserver
+  : public content::WebContentsObserver
+{
+  RecordReplayToolbarButtonWebContentsObserver(
+    content::WebContents* web_contents,
+    RecordReplayToolbarButton* button)
+    : content::WebContentsObserver(web_contents),
+      button_(button)
+  {}
+
+  void WebContentsDestroyed() override {
+    // Tell toolbar button that recording tab has closed.
+    // This will detach the observer from the button.
+    button_->RecordingTabDestroyed();
+  }
+
+  RecordReplayToolbarButton* button_;
+};
 
 RecordReplayToolbarButton::RecordReplayToolbarButton(Browser* browser)
     : ToolbarButton(base::BindRepeating(&RecordReplayToolbarButton::ButtonPressed,
                                         base::Unretained(this))),
-      browser_(browser) {
+      browser_(browser),
+      web_contents_(nullptr),
+      post_recording_web_contents_(nullptr),
+      web_contents_observer_(nullptr) {
   SetVectorIcons(kRecordReplayIcon, kRecordReplayIcon);
   button_controller()->set_notify_action(
       views::ButtonController::NotifyAction::kOnPress);
@@ -20,6 +43,19 @@ RecordReplayToolbarButton::RecordReplayToolbarButton(Browser* browser)
 RecordReplayToolbarButton::~RecordReplayToolbarButton() = default;
 
 void RecordReplayToolbarButton::ButtonPressed() {
+  // Check to see if we're currently recording a tab.
+  if (web_contents_) {
+    // We are recording a tab, stop recording.
+    StopRecording();
+  } else {
+    // We are not recording a tab, start recording.
+    StartRecording();
+  }
+  RefreshIconState();
+}
+
+void RecordReplayToolbarButton::StartRecording() {
+  // Get the current active tab.  This provides the URL we'll be recording.
   TabStripModel* tab_strip_model = browser_->tab_strip_model();
   content::WebContents* old_web_contents = tab_strip_model->GetActiveWebContents();
   if (!old_web_contents) {
@@ -27,26 +63,91 @@ void RecordReplayToolbarButton::ButtonPressed() {
   }
   content::BrowserContext* browser_context = old_web_contents->GetBrowserContext();
 
-  int index = tab_strip_model->GetIndexOfWebContents(old_web_contents);
   GURL url = old_web_contents->GetVisibleURL();
 
-  // Create a new web-contents to load.
+  // Create a new recording web-contents.
+  CHECK(!web_contents_);
+  CHECK(!web_contents_observer_.get());
   content::WebContents::CreateParams new_params(browser_context);
   new_params.record_replay_for_recording = true;
   std::unique_ptr<content::WebContents> new_web_contents(
     content::WebContents::Create(new_params));
-  content::WebContents* new_web_contents_ptr = new_web_contents.get();
+  web_contents_ = new_web_contents.get();
+
+  // Create and add observer.
+  // This will notify the button when the recording tab is closed.
+  // See: `RecordingTabDestroyed()` below.
+  web_contents_observer_ =
+    std::make_unique<RecordReplayToolbarButtonWebContentsObserver>(
+      web_contents_, this);
 
   tab_strip_model->AppendWebContents(std::move(new_web_contents), true);
 
-  // Re-get the index of the old web contents just in case it changed due to the
-  // insert (it shouldn't have).)
-  index = tab_strip_model->GetIndexOfWebContents(old_web_contents);
+  // Get the index of the old non-recording web-contents, to close it.
+  int index = tab_strip_model->GetIndexOfWebContents(old_web_contents);
 
-  // [RecordReplay] NOTE: This close-type doesn't remember history.  Do we want to?
+  // Close old tab and replace with new tab.
   tab_strip_model->CloseWebContentsAt(index, TabCloseTypes::CLOSE_NONE);
 
-  new_web_contents_ptr->GetController().LoadURL(url, content::Referrer(),
-                                                ui::PAGE_TRANSITION_TYPED,
-                                                std::string());
+  web_contents_->GetController().LoadURL(url, content::Referrer(),
+                                         ui::PAGE_TRANSITION_TYPED,
+                                         std::string());
+}
+
+void RecordReplayToolbarButton::StopRecording() {
+  // There should be a recording web-contents.
+  if (!web_contents_) {
+    // TODO: Print a warning here.  `StopRecording` called when
+    // no active recording present.
+    return;
+  }
+
+  EnsurePostRecordingWebContents();
+
+  TabStripModel* tab_strip_model = browser_->tab_strip_model();
+  int index = tab_strip_model->GetIndexOfWebContents(web_contents_);
+  if (index == TabStripModel::kNoTab) {
+    // TODO: Print a warning.  The web contents we have a reference to
+    // is not listed in any tab.
+    web_contents_ = nullptr;
+    web_contents_observer_.release();
+    return;
+  }
+
+  index = tab_strip_model->GetIndexOfWebContents(web_contents_);
+  tab_strip_model->CloseWebContentsAt(index, TabCloseTypes::CLOSE_NONE);
+}
+
+void RecordReplayToolbarButton::RecordingTabDestroyed() {
+  if (web_contents_) {
+    EnsurePostRecordingWebContents();
+    web_contents_ = nullptr;
+    web_contents_observer_.release();
+  }
+  RefreshIconState();
+}
+
+void RecordReplayToolbarButton::RefreshIconState() {
+  if (web_contents_) {
+    SetVectorIcons(kRecordReplayStopIcon, kRecordReplayStopIcon);
+  } else {
+    SetVectorIcons(kRecordReplayIcon, kRecordReplayIcon);
+  }
+}
+
+void RecordReplayToolbarButton::EnsurePostRecordingWebContents() {
+  if (!post_recording_web_contents_) {
+    content::WebContents::CreateParams new_params(web_contents_->GetBrowserContext());
+    std::unique_ptr<content::WebContents> post_recording_web_contents(
+      content::WebContents::Create(new_params));
+    post_recording_web_contents_ = post_recording_web_contents.get();
+    TabStripModel* tab_strip_model = browser_->tab_strip_model();
+    tab_strip_model->AppendWebContents(std::move(post_recording_web_contents), true);
+  }
+
+  // TODO: Make this URL point to `app.replay.io` URL for the recording.
+  GURL url = GURL("https://app.replay.io");
+  post_recording_web_contents_->GetController().LoadURL(url, content::Referrer(),
+                                              ui::PAGE_TRANSITION_TYPED,
+                                              std::string());
 }

--- a/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.h
+++ b/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.h
@@ -6,10 +6,14 @@
 #define CHROME_BROWSER_UI_VIEWS_TOOLBAR_RECORD_REPLAY_TOOLBAR_BUTTON_H_
 
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
+#include "content/public/browser/web_contents.h"
 
 class Browser;
 
-class RecordReplayToolbarButton : public ToolbarButton {
+struct RecordReplayToolbarButtonWebContentsObserver;
+
+class RecordReplayToolbarButton: public ToolbarButton {
+ friend struct RecordReplayToolbarButtonWebContentsObserver;
  public:
   explicit RecordReplayToolbarButton(Browser* browser);
   RecordReplayToolbarButton(const RecordReplayToolbarButton&) = delete;
@@ -18,8 +22,18 @@ class RecordReplayToolbarButton : public ToolbarButton {
 
  private:
   void ButtonPressed();
+  void StartRecording();
+  void StopRecording();
+  void RecordingTabDestroyed();
+
+  void RefreshIconState();
+  void EnsurePostRecordingWebContents();
 
   const raw_ptr<Browser> browser_;
+  content::WebContents* web_contents_;
+  content::WebContents* post_recording_web_contents_;
+  std::unique_ptr<RecordReplayToolbarButtonWebContentsObserver>
+    web_contents_observer_;
 };
 
 #endif  // CHROME_BROWSER_UI_VIEWS_TOOLBAR_RECORD_REPLAY_TOOLBAR_BUTTON_H_

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -1096,6 +1096,13 @@ std::unique_ptr<WebContentsImpl> WebContentsImpl::CreateWithOpener(
     opener = opener_rfh->frame_tree_node();
   std::unique_ptr<WebContentsImpl> new_contents(
       new WebContentsImpl(params.browser_context));
+
+  // Forward flag indicating that this web-contents is being created
+  // for a replay.io recording.
+  if (params.record_replay_for_recording) {
+    new_contents->record_replay_for_recording_ = true;
+  }
+
   new_contents->SetOpenerForNewContents(opener, params.opener_suppressed);
 
   // If the opener is sandboxed, a new popup must inherit the opener's sandbox

--- a/content/browser/web_contents/web_contents_impl.h
+++ b/content/browser/web_contents/web_contents_impl.h
@@ -2368,6 +2368,8 @@ class CONTENT_EXPORT WebContentsImpl : public WebContents,
 
   bool prerender2_disabled_ = false;
 
+  bool record_replay_for_recording_ = false;
+
   base::WeakPtrFactory<WebContentsImpl> loading_weak_factory_{this};
   base::WeakPtrFactory<WebContentsImpl> weak_factory_{this};
 };


### PR DESCRIPTION
Record button changes icon as needed to keep track of recording state:
  * When no recordings are active, show record button.
  * When a recording is active, switch button to "stop record" icon
  * When stop-record button is clicked, kill the recording tab and open a new one
  * When a recording tab is closed, change state of button from "stop record" to "record"
  * Open a new tab and navigate it to a desired URL