### PR TITLE
fix buildevents on master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,6 +113,7 @@ steps:
       - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
   - label: "Metabase Test Suite"
+    key: "metabase-test-suite"
     depends_on: "build-chromium-linux-x86_64"
     if: build.branch == "master"
     agents:


### PR DESCRIPTION
The metabase tests only run on master, and were missing a `key`