### PR TITLE
build: use buckle to invoke buck everywhere

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,8 +20,8 @@ steps:
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "pushd ../backend"
-      - "be_cmd buck2-kill -- buck2 kill"
-      - "be_cmd buck2-build -- buck2 build --console simple //:chromium"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build --console simple //:chromium"
       - "popd"
     env:
       GOMA_SERVER_HOST: simpsonite.goma.engflow.com
@@ -132,7 +132,7 @@ steps:
     command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
 
   # wait for all steps above, but also continue if they fail
-  - wait: ~ 
+  - wait: ~
     continue_on_failure: true
 
   - label: "Buildevents Watch"


### PR DESCRIPTION
[buckle](https://github.com/benbrittain/buckle) is a tool that automates the download and installation of `buck2` and its prelude via the `.buckversion` file. I was already using this to run the mac builds and figured I should bring it to Linux as well so that everthing is standard