### PR TITLE
Assert BlobDataHandle::BlobDataHandle

### DIFF
--- a/third_party/blink/renderer/platform/blob/blob_data.cc
+++ b/third_party/blink/renderer/platform/blob/blob_data.cc
@@ -307,6 +307,7 @@ BlobDataHandle::BlobDataHandle(std::unique_ptr<BlobData> data, uint64_t size)
       is_single_unknown_size_file_(data->IsSingleUnknownSizeFile()) {
   auto elements = data->ReleaseElements();
   TRACE_EVENT0("Blob", "Registry::RegisterBlob");
+  mojo::internal::AutoRecordReplayAssertBufferAllocations assertsEnabled("RUN-2859-2904");
   GetThreadSpecificRegistry()->Register(
       blob_remote_.InitWithNewPipeAndPassReceiver(), uuid_,
       type_.IsNull() ? "" : type_, "", std::move(elements));


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2859/ensureconsistentmessagesize-in-blobregistryproxyregister#comment-af0b6edb
* Tests: ✅
  * (We see a few `timeouts` on every platform for some reason, but it should be fine 🤷‍♀️.)