### PR TITLE
Assert ThemalResource::task_runner_

### DIFF
--- a/third_party/blink/renderer/modules/peerconnection/thermal_resource.cc
+++ b/third_party/blink/renderer/modules/peerconnection/thermal_resource.cc
@@ -33,7 +33,12 @@ scoped_refptr<ThermalResource> ThermalResource::Create(
 
 ThermalResource::ThermalResource(
     scoped_refptr<base::SequencedTaskRunner> task_runner)
-    : task_runner_(std::move(task_runner)) {}
+    : task_runner_(std::move(task_runner)) {
+  recordreplay::Assert(
+    "[RUN-2911-2912] ThermalResource %d", 
+    task_runner ? recordreplay::PointerId(task_runner.get()) : -1
+  );
+}
 
 void ThermalResource::OnThermalMeasurement(
     mojom::blink::DeviceThermalState measurement) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2911/mismatch-in-thermalresourcereportmeasurementwhileholdinglock#comment-cdc814fd