### PR TITLE
Assert time functions (MAC)

### DIFF
--- a/base/time/time_mac.mm
+++ b/base/time/time_mac.mm
@@ -28,6 +28,8 @@
 #include "base/ios/ios_util.h"
 #endif
 
+#include "base/record_replay.h"
+
 namespace {
 
 #if BUILDFLAG(IS_MAC)
@@ -117,6 +119,7 @@ int64_t ComputeCurrentTicks() {
   // mach_absolute_time is it when it comes to ticks on the Mac.  Other calls
   // with less precision (such as TickCount) just call through to
   // mach_absolute_time.
+  recordreplay::Assert("[RUN-2860-2933] ComputeCurrentTicks");
   return MachTimeToMicroseconds(mach_absolute_time());
 #endif  // BUILDFLAG(IS_IOS)
 }
@@ -175,6 +178,7 @@ namespace base {
 
 namespace subtle {
 Time TimeNowIgnoringOverride() {
+  recordreplay::Assert("[RUN-2860-2933] TimeNowIgnoringOverride");
   return Time::FromCFAbsoluteTime(CFAbsoluteTimeGetCurrent());
 }
 

--- a/base/time/time_mac.mm
+++ b/base/time/time_mac.mm
@@ -28,8 +28,6 @@
 #include "base/ios/ios_util.h"
 #endif
 
-#include "base/record_replay.h"
-
 namespace {
 
 #if BUILDFLAG(IS_MAC)
@@ -119,9 +117,6 @@ int64_t ComputeCurrentTicks() {
   // mach_absolute_time is it when it comes to ticks on the Mac.  Other calls
   // with less precision (such as TickCount) just call through to
   // mach_absolute_time.
-#if BUILDFLAG(IS_MAC)
-  recordreplay::Assert("[RUN-2860-2933] ComputeCurrentTicks");
-#endif
   return MachTimeToMicroseconds(mach_absolute_time());
 #endif  // BUILDFLAG(IS_IOS)
 }
@@ -180,9 +175,6 @@ namespace base {
 
 namespace subtle {
 Time TimeNowIgnoringOverride() {
-#if BUILDFLAG(IS_MAC)
-  recordreplay::Assert("[RUN-2860-2933] TimeNowIgnoringOverride");
-#endif
   return Time::FromCFAbsoluteTime(CFAbsoluteTimeGetCurrent());
 }
 

--- a/base/time/time_mac.mm
+++ b/base/time/time_mac.mm
@@ -119,7 +119,9 @@ int64_t ComputeCurrentTicks() {
   // mach_absolute_time is it when it comes to ticks on the Mac.  Other calls
   // with less precision (such as TickCount) just call through to
   // mach_absolute_time.
+#if BUILDFLAG(IS_MAC)
   recordreplay::Assert("[RUN-2860-2933] ComputeCurrentTicks");
+#endif
   return MachTimeToMicroseconds(mach_absolute_time());
 #endif  // BUILDFLAG(IS_IOS)
 }
@@ -178,7 +180,9 @@ namespace base {
 
 namespace subtle {
 Time TimeNowIgnoringOverride() {
+#if BUILDFLAG(IS_MAC)
   recordreplay::Assert("[RUN-2860-2933] TimeNowIgnoringOverride");
+#endif
   return Time::FromCFAbsoluteTime(CFAbsoluteTimeGetCurrent());
 }
 

--- a/third_party/blink/renderer/core/timing/performance.cc
+++ b/third_party/blink/renderer/core/timing/performance.cc
@@ -1080,6 +1080,7 @@ base::TimeDelta Performance::MonotonicTimeToTimeDelta(
 }
 
 DOMHighResTimeStamp Performance::now() const {
+  recordreplay::Assert("[RUN-2860-2933] Performance::now");
   return MonotonicTimeToDOMHighResTimeStamp(tick_clock_->NowTicks());
 }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2860/mismatched-call-expected-cfabsolutetimegetcurrent-got-mach-absolute#comment-d47e7716