### PR TITLE
plumb auth token transport from our webui to all app.replay.io RenderFrames.

### DIFF
--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -2239,6 +2239,7 @@ static_library("browser") {
     "//components/query_tiles",
     "//components/reading_list/core",
     "//components/reading_list/features:flags",
+    "//components/record_replay/services/auth_token:lib",
     "//components/reduce_accept_language/browser:browser",
     "//components/renderer_context_menu",
     "//components/reporting/client:report_queue",

--- a/chrome/browser/chrome_browser_interface_binders.cc
+++ b/chrome/browser/chrome_browser_interface_binders.cc
@@ -71,6 +71,8 @@
 #include "components/performance_manager/public/performance_manager.h"
 #include "components/prefs/pref_service.h"
 #include "components/reading_list/features/reading_list_switches.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
 #include "components/safe_browsing/buildflags.h"
 #include "components/security_state/content/content_utils.h"
 #include "components/security_state/core/security_state.h"
@@ -371,6 +373,22 @@ namespace chrome {
 namespace internal {
 
 using content::RegisterWebUIControllerInterfaceBinder;
+
+void BindAuthTokenStore(
+    content::RenderFrameHost* frame_host,
+    mojo::PendingReceiver<auth_token::mojom::AuthTokenStore> receiver) {
+
+  // we only bind the receiver if the frame's origin is app.replay.io
+  if (frame_host->GetLastCommittedOrigin().host() != "app.replay.io") {
+    return;
+  }
+
+  content::BrowserContext* browser_context =
+      frame_host->GetProcess()->GetBrowserContext();
+
+  auth_token::AuthTokenServiceFactory::GetForBrowserContext(browser_context)
+      ->BindAuthTokenStore(std::move(receiver));
+}
 
 #if BUILDFLAG(ENABLE_UNHANDLED_TAP)
 void BindUnhandledTapWebContentsObserver(
@@ -677,6 +695,10 @@ void BindScreen2xMainContentExtractor(
 void PopulateChromeFrameBinders(
     mojo::BinderMapWithContext<content::RenderFrameHost*>* map,
     content::RenderFrameHost* render_frame_host) {
+
+  map->Add<auth_token::mojom::AuthTokenStore>(
+      base::BindRepeating(&BindAuthTokenStore));
+
   map->Add<image_annotation::mojom::Annotator>(
       base::BindRepeating(&BindImageAnnotator));
 

--- a/chrome/browser/chrome_browser_interface_binders.cc
+++ b/chrome/browser/chrome_browser_interface_binders.cc
@@ -374,9 +374,9 @@ namespace internal {
 
 using content::RegisterWebUIControllerInterfaceBinder;
 
-void BindAuthTokenStore(
+void BindRecordReplayAuthTokenStore(
     content::RenderFrameHost* frame_host,
-    mojo::PendingReceiver<auth_token::mojom::AuthTokenStore> receiver) {
+    mojo::PendingReceiver<auth_token::mojom::RecordReplayAuthTokenStore> receiver) {
 
   // we only bind the receiver if the frame's origin is app.replay.io
   if (frame_host->GetLastCommittedOrigin().host() != "app.replay.io") {
@@ -386,7 +386,7 @@ void BindAuthTokenStore(
   content::BrowserContext* browser_context =
       frame_host->GetProcess()->GetBrowserContext();
 
-  auth_token::AuthTokenServiceFactory::GetForBrowserContext(browser_context)
+  auth_token::RecordReplayAuthTokenServiceFactory::GetForBrowserContext(browser_context)
       ->BindAuthTokenStore(std::move(receiver));
 }
 
@@ -696,8 +696,8 @@ void PopulateChromeFrameBinders(
     mojo::BinderMapWithContext<content::RenderFrameHost*>* map,
     content::RenderFrameHost* render_frame_host) {
 
-  map->Add<auth_token::mojom::AuthTokenStore>(
-      base::BindRepeating(&BindAuthTokenStore));
+  map->Add<auth_token::mojom::RecordReplayAuthTokenStore>(
+      base::BindRepeating(&BindRecordReplayAuthTokenStore));
 
   map->Add<image_annotation::mojom::Annotator>(
       base::BindRepeating(&BindImageAnnotator));

--- a/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
+++ b/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "chrome/browser/ui/webui/record_replay/record_replay_manager_handler.h"
-
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
 #include <string>
 
 #include "base/bind.h"
@@ -26,4 +26,7 @@ void RecordReplayManagerHandler::SetManager(
 
 void RecordReplayManagerHandler::ApiKeyReceived(const std::string& api_key) {
   printf("RecordReplay [RUN-2866] ManagerHandler(%p)::ApiKeyReceived(%s)\n", this, api_key.c_str());
+  // Ideally this would use a mojo interface, but since both this code and the AuthTokenStore
+  // are in the browser process, we can just call it directly.
+  auth_token::AuthTokenServiceFactory::GetForBrowserContext(profile_)->SetToken(api_key);
 }

--- a/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
+++ b/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
@@ -26,7 +26,7 @@ void RecordReplayManagerHandler::SetManager(
 
 void RecordReplayManagerHandler::ApiKeyReceived(const std::string& api_key) {
   printf("RecordReplay [RUN-2866] ManagerHandler(%p)::ApiKeyReceived(%s)\n", this, api_key.c_str());
-  // Ideally this would use a mojo interface, but since both this code and the AuthTokenStore
+  // Ideally this would use a mojo interface, but since both this code and the RecordReplayAuthTokenStore
   // are in the browser process, we can just call it directly.
-  auth_token::AuthTokenServiceFactory::GetForBrowserContext(profile_)->SetToken(api_key);
+  auth_token::RecordReplayAuthTokenServiceFactory::GetForBrowserContext(profile_)->SetToken(api_key);
 }

--- a/components/record_replay/services/auth_token/BUILD.gn
+++ b/components/record_replay/services/auth_token/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2022 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+assert(!is_android && !is_ios)
+
+source_set("lib") {
+  sources = [
+    "public/cpp/auth_token_service.cc",
+    "public/cpp/auth_token_service.h",
+    "public/cpp/auth_token_service_factory.cc",
+    "public/cpp/auth_token_service_factory.h",
+  ]
+
+  deps = [
+    "//base",
+    "//mojo/public/cpp/bindings",
+  ]
+
+  public_deps = [
+    "//components/record_replay/services/auth_token/public/mojom",
+  ]
+}

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
@@ -28,7 +28,7 @@ void RecordReplayAuthTokenService::AddObserver(mojo::PendingRemote<mojom::Record
 
 void RecordReplayAuthTokenService::NotifyObservers() {
   for (auto& observer : observers_) {
-    observer->OnTokenChanged(token_);
+    observer->OnRecordReplayAuthTokenChanged(token_);
   }
 }
 

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
@@ -1,0 +1,35 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service.h"
+#include "content/public/browser/service_process_host.h"
+
+namespace auth_token {
+
+AuthTokenService::AuthTokenService() = default;
+AuthTokenService::~AuthTokenService() = default;
+
+void AuthTokenService::BindAuthTokenStore(
+    mojo::PendingReceiver<mojom::AuthTokenStore> store) {
+
+  auth_token_stores_.Add(this, std::move(store));
+}
+
+void AuthTokenService::SetToken(const std::string& token) {
+  token_ = token;
+  NotifyObservers();
+}
+
+void AuthTokenService::AddObserver(mojo::PendingRemote<mojom::AuthTokenStoreObserver> observer) {
+  observers_.Add(std::move(observer));
+  NotifyObservers();
+}
+
+void AuthTokenService::NotifyObservers() {
+  for (auto& observer : observers_) {
+    observer->OnTokenChanged(token_);
+  }
+}
+
+}  // namespace auth_token

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
@@ -7,26 +7,26 @@
 
 namespace auth_token {
 
-AuthTokenService::AuthTokenService() = default;
-AuthTokenService::~AuthTokenService() = default;
+RecordReplayAuthTokenService::RecordReplayAuthTokenService() = default;
+RecordReplayAuthTokenService::~RecordReplayAuthTokenService() = default;
 
-void AuthTokenService::BindAuthTokenStore(
-    mojo::PendingReceiver<mojom::AuthTokenStore> store) {
+void RecordReplayAuthTokenService::BindAuthTokenStore(
+    mojo::PendingReceiver<mojom::RecordReplayAuthTokenStore> store) {
 
   auth_token_stores_.Add(this, std::move(store));
 }
 
-void AuthTokenService::SetToken(const std::string& token) {
+void RecordReplayAuthTokenService::SetToken(const std::string& token) {
   token_ = token;
   NotifyObservers();
 }
 
-void AuthTokenService::AddObserver(mojo::PendingRemote<mojom::AuthTokenStoreObserver> observer) {
+void RecordReplayAuthTokenService::AddObserver(mojo::PendingRemote<mojom::RecordReplayAuthTokenStoreObserver> observer) {
   observers_.Add(std::move(observer));
   NotifyObservers();
 }
 
-void AuthTokenService::NotifyObservers() {
+void RecordReplayAuthTokenService::NotifyObservers() {
   for (auto& observer : observers_) {
     observer->OnTokenChanged(token_);
   }

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef COMPONENTS_XXXX_H_
-#define COMPONENTS_XXXX_H_
+#ifndef COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_
+#define COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_
 
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
@@ -41,4 +41,4 @@ private:
 
 }  // namespace auth_token
 
-#endif  // COMPONENTS_XXXX_H_
+#endif  // COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
@@ -15,28 +15,28 @@
 
 namespace auth_token {
 
-class AuthTokenService : public KeyedService, public mojom::AuthTokenStore {
+class RecordReplayAuthTokenService : public KeyedService, public mojom::RecordReplayAuthTokenStore {
  public:
-  AuthTokenService();
-  AuthTokenService(const AuthTokenService&) = delete;
-  AuthTokenService& operator=(const AuthTokenService&) = delete;
-  ~AuthTokenService() override;
+  RecordReplayAuthTokenService();
+  RecordReplayAuthTokenService(const RecordReplayAuthTokenService&) = delete;
+  RecordReplayAuthTokenService& operator=(const RecordReplayAuthTokenService&) = delete;
+  ~RecordReplayAuthTokenService() override;
 
   void BindAuthTokenStore(
-      mojo::PendingReceiver<mojom::AuthTokenStore> store);
+      mojo::PendingReceiver<mojom::RecordReplayAuthTokenStore> store);
 
-  // mojom::AuthTokenStore:
+  // mojom::RecordReplayAuthTokenStore:
   void SetToken(const std::string& token) override;
-  void AddObserver(mojo::PendingRemote<mojom::AuthTokenStoreObserver> observer) override;
+  void AddObserver(mojo::PendingRemote<mojom::RecordReplayAuthTokenStoreObserver> observer) override;
 
 private:
-  mojo::ReceiverSet<mojom::AuthTokenStore> auth_token_stores_;
+  mojo::ReceiverSet<mojom::RecordReplayAuthTokenStore> auth_token_stores_;
 
   std::string token_;
 
   void NotifyObservers();
 
-  mojo::RemoteSet<mojom::AuthTokenStoreObserver> observers_;
+  mojo::RemoteSet<mojom::RecordReplayAuthTokenStoreObserver> observers_;
 };
 
 }  // namespace auth_token

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
@@ -1,0 +1,44 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_XXXX_H_
+#define COMPONENTS_XXXX_H_
+
+#include "components/keyed_service/core/keyed_service.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+
+namespace auth_token {
+
+class AuthTokenService : public KeyedService, public mojom::AuthTokenStore {
+ public:
+  AuthTokenService();
+  AuthTokenService(const AuthTokenService&) = delete;
+  AuthTokenService& operator=(const AuthTokenService&) = delete;
+  ~AuthTokenService() override;
+
+  void BindAuthTokenStore(
+      mojo::PendingReceiver<mojom::AuthTokenStore> store);
+
+  // mojom::AuthTokenStore:
+  void SetToken(const std::string& token) override;
+  void AddObserver(mojo::PendingRemote<mojom::AuthTokenStoreObserver> observer) override;
+
+private:
+  mojo::ReceiverSet<mojom::AuthTokenStore> auth_token_stores_;
+
+  std::string token_;
+
+  void NotifyObservers();
+
+  mojo::RemoteSet<mojom::AuthTokenStoreObserver> observers_;
+};
+
+}  // namespace auth_token
+
+#endif  // COMPONENTS_XXXX_H_

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
@@ -10,33 +10,33 @@
 namespace auth_token {
 
 // static
-auth_token::AuthTokenService*
-AuthTokenServiceFactory::GetForBrowserContext(
+auth_token::RecordReplayAuthTokenService*
+RecordReplayAuthTokenServiceFactory::GetForBrowserContext(
     content::BrowserContext* context) {
-  return static_cast<auth_token::AuthTokenService*>(
+  return static_cast<auth_token::RecordReplayAuthTokenService*>(
       GetInstance()->GetServiceForBrowserContext(context, /*create=*/true));
 }
 
 // static
-AuthTokenServiceFactory* AuthTokenServiceFactory::GetInstance() {
-  static base::NoDestructor<AuthTokenServiceFactory> instance;
+RecordReplayAuthTokenServiceFactory* RecordReplayAuthTokenServiceFactory::GetInstance() {
+  static base::NoDestructor<RecordReplayAuthTokenServiceFactory> instance;
   return instance.get();
 }
 
-AuthTokenServiceFactory::AuthTokenServiceFactory()
+RecordReplayAuthTokenServiceFactory::RecordReplayAuthTokenServiceFactory()
     : BrowserContextKeyedServiceFactory(
-          "AuthTokenService",
+          "RecordReplayAuthTokenService",
           BrowserContextDependencyManager::GetInstance()) {}
 
-AuthTokenServiceFactory::~AuthTokenServiceFactory() = default;
+RecordReplayAuthTokenServiceFactory::~RecordReplayAuthTokenServiceFactory() = default;
 
-KeyedService* AuthTokenServiceFactory::BuildServiceInstanceFor(
+KeyedService* RecordReplayAuthTokenServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* /*context*/) const {
-  return new auth_token::AuthTokenService();
+  return new auth_token::RecordReplayAuthTokenService();
 }
 
 // Incognito profiles should use their own instance.
-content::BrowserContext* AuthTokenServiceFactory::GetBrowserContextToUse(
+content::BrowserContext* RecordReplayAuthTokenServiceFactory::GetBrowserContextToUse(
     content::BrowserContext* context) const {
   return context;
 }

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
@@ -41,4 +41,4 @@ content::BrowserContext* AuthTokenServiceFactory::GetBrowserContextToUse(
   return context;
 }
 
-}  // namespace screen_ai
+}  // namespace auth_token

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
@@ -1,0 +1,44 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
+
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "content/public/browser/browser_context.h"
+
+namespace auth_token {
+
+// static
+auth_token::AuthTokenService*
+AuthTokenServiceFactory::GetForBrowserContext(
+    content::BrowserContext* context) {
+  return static_cast<auth_token::AuthTokenService*>(
+      GetInstance()->GetServiceForBrowserContext(context, /*create=*/true));
+}
+
+// static
+AuthTokenServiceFactory* AuthTokenServiceFactory::GetInstance() {
+  static base::NoDestructor<AuthTokenServiceFactory> instance;
+  return instance.get();
+}
+
+AuthTokenServiceFactory::AuthTokenServiceFactory()
+    : BrowserContextKeyedServiceFactory(
+          "AuthTokenService",
+          BrowserContextDependencyManager::GetInstance()) {}
+
+AuthTokenServiceFactory::~AuthTokenServiceFactory() = default;
+
+KeyedService* AuthTokenServiceFactory::BuildServiceInstanceFor(
+    content::BrowserContext* /*context*/) const {
+  return new auth_token::AuthTokenService();
+}
+
+// Incognito profiles should use their own instance.
+content::BrowserContext* AuthTokenServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  return context;
+}
+
+}  // namespace screen_ai

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
@@ -15,21 +15,21 @@ class BrowserContext;
 
 namespace auth_token {
 
-class AuthTokenService;
+class RecordReplayAuthTokenService;
 
-// Factory to get or create an instance of AuthTokenService for a
+// Factory to get or create an instance of RecordReplayAuthTokenService for a
 // BrowserContext.
-class AuthTokenServiceFactory : public BrowserContextKeyedServiceFactory {
+class RecordReplayAuthTokenServiceFactory : public BrowserContextKeyedServiceFactory {
  public:
-  static AuthTokenService* GetForBrowserContext(
+  static RecordReplayAuthTokenService* GetForBrowserContext(
       content::BrowserContext* context);
 
  private:
-  friend class base::NoDestructor<AuthTokenServiceFactory>;
-  static AuthTokenServiceFactory* GetInstance();
+  friend class base::NoDestructor<RecordReplayAuthTokenServiceFactory>;
+  static RecordReplayAuthTokenServiceFactory* GetInstance();
 
-  AuthTokenServiceFactory();
-  ~AuthTokenServiceFactory() override;
+  RecordReplayAuthTokenServiceFactory();
+  ~RecordReplayAuthTokenServiceFactory() override;
 
   // BrowserContextKeyedServiceFactory:
   KeyedService* BuildServiceInstanceFor(

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef COMPONENTS_XXX_H_
-#define COMPONENTS_XXX_H_
+#ifndef COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_
+#define COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_
 
 #include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
@@ -38,6 +38,6 @@ class AuthTokenServiceFactory : public BrowserContextKeyedServiceFactory {
       content::BrowserContext* context) const override;
 };
 
-}  // namespace screen_ai
+}  // namespace auth_token
 
-#endif  // COMPONENTS_XXX_H_
+#endif  // COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
@@ -1,0 +1,43 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_XXX_H_
+#define COMPONENTS_XXX_H_
+
+#include "base/no_destructor.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace auth_token {
+
+class AuthTokenService;
+
+// Factory to get or create an instance of AuthTokenService for a
+// BrowserContext.
+class AuthTokenServiceFactory : public BrowserContextKeyedServiceFactory {
+ public:
+  static AuthTokenService* GetForBrowserContext(
+      content::BrowserContext* context);
+
+ private:
+  friend class base::NoDestructor<AuthTokenServiceFactory>;
+  static AuthTokenServiceFactory* GetInstance();
+
+  AuthTokenServiceFactory();
+  ~AuthTokenServiceFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+};
+
+}  // namespace screen_ai
+
+#endif  // COMPONENTS_XXX_H_

--- a/components/record_replay/services/auth_token/public/mojom/BUILD.gn
+++ b/components/record_replay/services/auth_token/public/mojom/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright 2022 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+mojom("mojom") {
+  sources = [ "auth_token.mojom" ]
+
+#  public_deps = [ "//sandbox/policy/mojom" ]
+
+  # The blink variant of the Auth Token Service mojom are depended on by the
+  # blink platform target. All blink variant mojoms use WTF types, which are
+  # part of the blink platform component. In order to avoid a dependency cycle,
+  # these targets must be part of that component.
+  export_class_attribute_blink = "BLINK_PLATFORM_EXPORT"
+  export_define_blink = "BLINK_PLATFORM_IMPLEMENTATION=1"
+  export_header_blink = "third_party/blink/public/platform/web_common.h"
+
+  visibility_blink = [
+    "//third_party/blink/renderer/platform:blink_platform_public_deps",
+    "//third_party/blink/renderer/platform/media:*",
+    "//third_party/blink/public/mojom:mojom_platform_blink",
+  ]
+}

--- a/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
+++ b/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
@@ -9,5 +9,5 @@ interface RecordReplayAuthTokenStore {
 };
 
 interface RecordReplayAuthTokenStoreObserver {
-  OnTokenChanged(string token);
+  OnRecordReplayAuthTokenChanged(string token);
 };

--- a/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
+++ b/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
@@ -1,0 +1,13 @@
+module auth_token.mojom;
+
+// Interface to passing updated token around
+interface AuthTokenStore {
+  SetToken(string token);
+
+  AddObserver(pending_remote<AuthTokenStoreObserver> observer);
+  // how do we remove?
+};
+
+interface AuthTokenStoreObserver {
+  OnTokenChanged(string token);
+};

--- a/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
+++ b/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
@@ -1,13 +1,13 @@
 module auth_token.mojom;
 
 // Interface to passing updated token around
-interface AuthTokenStore {
+interface RecordReplayAuthTokenStore {
   SetToken(string token);
 
-  AddObserver(pending_remote<AuthTokenStoreObserver> observer);
+  AddObserver(pending_remote<RecordReplayAuthTokenStoreObserver> observer);
   // how do we remove?
 };
 
-interface AuthTokenStoreObserver {
+interface RecordReplayAuthTokenStoreObserver {
   OnTokenChanged(string token);
 };

--- a/third_party/blink/public/mojom/BUILD.gn
+++ b/third_party/blink/public/mojom/BUILD.gn
@@ -249,6 +249,7 @@ mojom("mojom_platform") {
     ":web_feature_mojo_bindings",
     "//cc/mojom",
     "//components/payments/mojom",
+    "//components/record_replay/services/auth_token/public/mojom",
     "//components/schema_org/common:mojom",
     "//components/services/filesystem/public/mojom",
     "//mojo/public/mojom/base",

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -235,7 +235,6 @@ void LocalWindowProxy::Initialize() {
       recordreplay::NewCheckpoint();
     }
 
-
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
       // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -79,6 +79,7 @@ namespace blink {
 
 void LocalWindowProxy::Trace(Visitor* visitor) const {
   visitor->Trace(script_state_);
+  visitor->Trace(record_replay_listener_);
   WindowProxy::Trace(visitor);
 }
 
@@ -234,6 +235,7 @@ void LocalWindowProxy::Initialize() {
       recordreplay::NewCheckpoint();
     }
 
+
     if (GetFrame()->IsOutermostMainFrame()) {
       // Root-level navigation event.
       // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
@@ -243,6 +245,7 @@ void LocalWindowProxy::Initialize() {
     // Initialize Replay things that depend on previous Replay initialization 
     // steps.
     OnNewWindow2(GetIsolate(), GetFrame(), context);
+
   }
 
   {
@@ -256,10 +259,25 @@ void LocalWindowProxy::Initialize() {
 
   InstallConditionalFeatures();
 
+  // Add an event listener for the dispatched custom event the devtools uses to register
+  // its listener.  Do this outside the recording.
+  SetupRecordReplayEventListener();
+
   if (World().IsMainWorld()) {
     GetFrame()->Loader().DispatchDidClearWindowObjectInMainWorld();
   }
 }
+
+void LocalWindowProxy::SetupRecordReplayEventListener() {
+  LocalFrame* localFrame = GetFrame();
+
+  record_replay_listener_ = RecordReplayEventListener::Create(GetIsolate(), localFrame);
+
+  bool added = localFrame->DomWindow()->addEventListener("WebChannelMessageToChrome", record_replay_listener_.Get());
+
+  DCHECK(added);
+}
+
 
 void LocalWindowProxy::CreateContext() {
   TRACE_EVENT2("v8", "LocalWindowProxy::CreateContext", "IsMainFrame",

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
@@ -114,7 +114,7 @@ class LocalWindowProxy final : public WindowProxy {
     return To<LocalFrame>(WindowProxy::GetFrame());
   }
 
-  mojo::Remote<auth_token::mojom::AuthTokenStore> auth_token_store_;
+  mojo::Remote<auth_token::mojom::RecordReplayAuthTokenStore> auth_token_store_;
   
   Member<RecordReplayEventListener> record_replay_listener_;
   Member<ScriptState> script_state_;

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
@@ -39,12 +39,14 @@
 #include "third_party/blink/renderer/platform/wtf/casting.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "v8/include/v8.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
 
 namespace blink {
 
 class HTMLDocument;
 class ScriptState;
 class SecurityOrigin;
+class RecordReplayEventListener;
 
 // Subclass of WindowProxy that only handles LocalFrame.
 class LocalWindowProxy final : public WindowProxy {
@@ -71,6 +73,8 @@ class LocalWindowProxy final : public WindowProxy {
       v8::Context::AbortScriptExecutionCallback callback);
 
  private:
+  void SetupRecordReplayEventListener();
+
   // LocalWindowProxy overrides:
   bool IsLocal() const override { return true; }
   void Initialize() override;
@@ -110,6 +114,9 @@ class LocalWindowProxy final : public WindowProxy {
     return To<LocalFrame>(WindowProxy::GetFrame());
   }
 
+  mojo::Remote<auth_token::mojom::AuthTokenStore> auth_token_store_;
+  
+  Member<RecordReplayEventListener> record_replay_listener_;
   Member<ScriptState> script_state_;
   bool context_was_created_from_snapshot_ = false;
 };

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5495,7 +5495,7 @@ void RecordReplayEventListener::Invoke(ExecutionContext* context, Event* event) 
   //   message: { type: "connect" },
   // }
 
-  local_frame_->RegisterAuthTokenObserver();
+  local_frame_->RegisterRecordReplayAuthTokenObserver();
 }
 
 void RecordReplayEventListener::Trace(Visitor* visitor) const {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5448,6 +5448,7 @@ void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Co
   );
 }
 
+
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
 
 static ErrorEvent* gCurrentErrorEvent;
@@ -5484,6 +5485,22 @@ static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
                   v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
 
   args.GetReturnValue().Set(rv);
+}
+
+void RecordReplayEventListener::Invoke(ExecutionContext* context, Event* event) {
+  // TODO only register the observer if the event matches this structure:
+  // type = WebChannelMessageToChrome"
+  // detail (stringified): {
+  //   id: "record-replay-token",
+  //   message: { type: "connect" },
+  // }
+
+  local_frame_->RegisterAuthTokenObserver();
+}
+
+void RecordReplayEventListener::Trace(Visitor* visitor) const {
+  visitor->Trace(local_frame_);
+  EventListener::Trace(visitor);
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -39,7 +39,7 @@ void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
 class RecordReplayEventListener : public NativeEventListener {
  public:
   RecordReplayEventListener(v8::Isolate* isolate, LocalFrame* localFrame)
-      : isolate_(isolate), local_frame_(localFrame) {}
+      : local_frame_(localFrame) {}
 
   void Invoke(ExecutionContext*, Event*) override;
 
@@ -51,7 +51,6 @@ class RecordReplayEventListener : public NativeEventListener {
   }
 
  private:
-  v8::Isolate* isolate_;
   Member<LocalFrame> local_frame_;
 };
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_INTERFACE_H_
 #define THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_INTERFACE_H_
 
+#include "third_party/blink/renderer/core/dom/events/native_event_listener.h"
 #include "third_party/blink/renderer/core/events/error_event.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "base/values.h"
@@ -34,6 +35,25 @@ void RecordReplayOnErrorEvent(ErrorEvent* error_event);
 // Notify record/replay about new inspectors that have been created.
 void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
                                      v8::Isolate* isolate);
+
+class RecordReplayEventListener : public NativeEventListener {
+ public:
+  RecordReplayEventListener(v8::Isolate* isolate, LocalFrame* localFrame)
+      : isolate_(isolate), local_frame_(localFrame) {}
+
+  void Invoke(ExecutionContext*, Event*) override;
+
+  void Trace(Visitor*) const override;
+
+  static RecordReplayEventListener* Create(v8::Isolate* isolate,
+                                      LocalFrame* localFrame) {
+    return MakeGarbageCollected<RecordReplayEventListener>(isolate, localFrame);
+  }
+
+ private:
+  v8::Isolate* isolate_;
+  Member<LocalFrame> local_frame_;
+};
 
 } // namespace blink
 

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -3318,8 +3318,8 @@ bool LocalFrame::HasBlockingReasonsHelper(
   return false;
 }
 
-void LocalFrame::RegisterAuthTokenObserver() {
-  mojo_handler_->RegisterAuthTokenObserver();
+void LocalFrame::RegisterRecordReplayAuthTokenObserver() {
+  mojo_handler_->RegisterRecordReplayAuthTokenObserver();
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -3318,4 +3318,8 @@ bool LocalFrame::HasBlockingReasonsHelper(
   return false;
 }
 
+void LocalFrame::RegisterAuthTokenObserver() {
+  mojo_handler_->RegisterAuthTokenObserver();
+}
+
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/local_frame.h
+++ b/third_party/blink/renderer/core/frame/local_frame.h
@@ -805,6 +805,8 @@ class CORE_EXPORT LocalFrame final
 
   absl::optional<SkColor> GetFrameOverlayColorForTesting() const;
 
+  void RegisterAuthTokenObserver();
+  
  private:
   friend class FrameNavigationDisabler;
   // LocalFrameMojoHandler is a part of LocalFrame.

--- a/third_party/blink/renderer/core/frame/local_frame.h
+++ b/third_party/blink/renderer/core/frame/local_frame.h
@@ -805,7 +805,7 @@ class CORE_EXPORT LocalFrame final
 
   absl::optional<SkColor> GetFrameOverlayColorForTesting() const;
 
-  void RegisterAuthTokenObserver();
+  void RegisterRecordReplayAuthTokenObserver();
   
  private:
   friend class FrameNavigationDisabler;

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -507,7 +507,7 @@ LocalFrameMojoHandler::GetDevicePosture() {
   return current_device_posture_;
 }
 
-void LocalFrameMojoHandler::RegisterAuthTokenObserver() {
+void LocalFrameMojoHandler::RegisterRecordReplayAuthTokenObserver() {
   if (auth_token_store_.is_bound()) {
     return;
   }
@@ -568,7 +568,7 @@ void LocalFrameMojoHandler::BindToHighPriorityReceiver(
 
 void LocalFrameMojoHandler::BindAuthTokenStoreObserver(
       mojo::PendingReceiver<
-          auth_token::mojom::blink::AuthTokenStoreObserver> receiver) {
+          auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver) {
  if (frame_->IsDetached())
     return;
 

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -509,7 +509,6 @@ LocalFrameMojoHandler::GetDevicePosture() {
 
 void LocalFrameMojoHandler::RegisterAuthTokenObserver() {
   if (auth_token_store_.is_bound()) {
-    fprintf(stderr, "LocalFrameMojoHandler::RegisterAuthTokenObserver early out\n");
     return;
   }
 
@@ -517,7 +516,6 @@ void LocalFrameMojoHandler::RegisterAuthTokenObserver() {
   frame_->GetBrowserInterfaceBroker().GetInterface(
       auth_token_store_.BindNewPipeAndPassReceiver(task_runner));
 
-  fprintf(stderr, "Calling auth_token_store_->AddObserver\n");
   auth_token_store_->AddObserver(
       auth_token_store_observer_receiver_.BindNewPipeAndPassRemote(task_runner));
 }

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -569,10 +569,7 @@ void LocalFrameMojoHandler::BindToHighPriorityReceiver(
 void LocalFrameMojoHandler::BindAuthTokenStoreObserver(
       mojo::PendingReceiver<
           auth_token::mojom::blink::AuthTokenStoreObserver> receiver) {
-
-  fprintf(stderr, "BindAuthTokenStoreObserver\n");
-  // I think we don't need this?
-  if (frame_->IsDetached())
+ if (frame_->IsDetached())
     return;
 
   auth_token_store_observer_receiver_.Bind(

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -419,7 +419,7 @@ LocalFrameMojoHandler::LocalFrameMojoHandler(blink::LocalFrame& frame)
       &LocalFrameMojoHandler::BindFullscreenVideoElementReceiver,
       WrapWeakPersistent(this)));
   registry->AddInterface(WTF::BindRepeating(
-      &LocalFrameMojoHandler::BindAuthTokenStoreObserver,
+      &LocalFrameMojoHandler::BindRecordReplayAuthTokenStoreObserver,
       WrapWeakPersistent(this)));
 }
 
@@ -566,7 +566,7 @@ void LocalFrameMojoHandler::BindToHighPriorityReceiver(
       std::make_unique<ActiveURLMessageFilter>(frame_));
 }
 
-void LocalFrameMojoHandler::BindAuthTokenStoreObserver(
+void LocalFrameMojoHandler::BindRecordReplayAuthTokenStoreObserver(
       mojo::PendingReceiver<
           auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver) {
  if (frame_->IsDetached())
@@ -1475,7 +1475,7 @@ void LocalFrameMojoHandler::RequestFullscreenVideoElement() {
   }
 }
 
-void LocalFrameMojoHandler::OnTokenChanged(const WTF::String& token) {
+void LocalFrameMojoHandler::OnRecordReplayAuthTokenChanged(const WTF::String& token) {
   v8::Isolate* isolate = ToIsolate(frame_);
   v8::HandleScope handle_scope(isolate);
 

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -29,8 +29,10 @@
 #include "third_party/blink/renderer/bindings/core/v8/script_controller.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_evaluation_result.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_function.h"
+#include "third_party/blink/renderer/bindings/core/v8/v8_custom_event_init.h"
 #include "third_party/blink/renderer/core/dom/element_traversal.h"
 #include "third_party/blink/renderer/core/dom/ignore_opens_during_unload_count_incrementer.h"
+#include "third_party/blink/renderer/core/dom/events/custom_event.h"
 #include "third_party/blink/renderer/core/editing/editing_utilities.h"
 #include "third_party/blink/renderer/core/editing/frame_selection.h"
 #include "third_party/blink/renderer/core/editing/surrounding_text.h"
@@ -416,6 +418,9 @@ LocalFrameMojoHandler::LocalFrameMojoHandler(blink::LocalFrame& frame)
   registry->AddAssociatedInterface(WTF::BindRepeating(
       &LocalFrameMojoHandler::BindFullscreenVideoElementReceiver,
       WrapWeakPersistent(this)));
+  registry->AddInterface(WTF::BindRepeating(
+      &LocalFrameMojoHandler::BindAuthTokenStoreObserver,
+      WrapWeakPersistent(this)));
 }
 
 void LocalFrameMojoHandler::Trace(Visitor* visitor) const {
@@ -432,6 +437,8 @@ void LocalFrameMojoHandler::Trace(Visitor* visitor) const {
   visitor->Trace(high_priority_frame_receiver_);
   visitor->Trace(fullscreen_video_receiver_);
   visitor->Trace(device_posture_receiver_);
+  visitor->Trace(auth_token_store_);
+  visitor->Trace(auth_token_store_observer_receiver_);
 }
 
 void LocalFrameMojoHandler::WasAttachedAsLocalMainFrame() {
@@ -500,6 +507,21 @@ LocalFrameMojoHandler::GetDevicePosture() {
   return current_device_posture_;
 }
 
+void LocalFrameMojoHandler::RegisterAuthTokenObserver() {
+  if (auth_token_store_.is_bound()) {
+    fprintf(stderr, "LocalFrameMojoHandler::RegisterAuthTokenObserver early out\n");
+    return;
+  }
+
+  auto task_runner = frame_->GetTaskRunner(TaskType::kInternalDefault);
+  frame_->GetBrowserInterfaceBroker().GetInterface(
+      auth_token_store_.BindNewPipeAndPassReceiver(task_runner));
+
+  fprintf(stderr, "Calling auth_token_store_->AddObserver\n");
+  auth_token_store_->AddObserver(
+      auth_token_store_observer_receiver_.BindNewPipeAndPassRemote(task_runner));
+}
+
 Page* LocalFrameMojoHandler::GetPage() const {
   return frame_->GetPage();
 }
@@ -544,6 +566,19 @@ void LocalFrameMojoHandler::BindToHighPriorityReceiver(
       frame_->GetTaskRunner(TaskType::kInternalHighPriorityLocalFrame));
   high_priority_frame_receiver_.SetFilter(
       std::make_unique<ActiveURLMessageFilter>(frame_));
+}
+
+void LocalFrameMojoHandler::BindAuthTokenStoreObserver(
+      mojo::PendingReceiver<
+          auth_token::mojom::blink::AuthTokenStoreObserver> receiver) {
+
+  fprintf(stderr, "BindAuthTokenStoreObserver\n");
+  // I think we don't need this?
+  if (frame_->IsDetached())
+    return;
+
+  auth_token_store_observer_receiver_.Bind(
+      std::move(receiver), frame_->GetTaskRunner(TaskType::kInternalDefault));
 }
 
 void LocalFrameMojoHandler::BindFullscreenVideoElementReceiver(
@@ -1443,6 +1478,53 @@ void LocalFrameMojoHandler::RequestFullscreenVideoElement() {
       return;
     }
   }
+}
+
+void LocalFrameMojoHandler::OnTokenChanged(const WTF::String& token) {
+  v8::Isolate* isolate = ToIsolate(frame_);
+  v8::HandleScope handle_scope(isolate);
+
+  ScriptState* script_state = ToScriptStateForMainWorld(frame_);
+  v8::Local<v8::Context> context = script_state->GetContext();
+  v8::Context::Scope context_scope(context);
+
+  // build up a JS object corresponding to the structure the devtools
+  // expects to receive:
+  //
+  // detail = {
+  //   message: {
+  //     token: "...",
+  //     error?: "...",
+  //   }
+  // }
+  //
+  // we don't currently receive an error from the auth token service, so we don't fill it in.
+  // if there was an error, presumably we wouldn't be called here.
+
+  v8::Local<v8::Object> message = v8::Object::New(isolate);
+  message->Set(context, V8String(isolate, "token"),
+               V8String(isolate, token))
+      .Check();
+
+  v8::Local<v8::Object> detail = v8::Object::New(isolate);
+  detail->Set(context, V8String(isolate, "message"), message)
+      .Check();
+
+
+  ExceptionState exception_state(isolate, ExceptionState::kExecutionContext,
+                                 "LocalFrameMojoHandler", "OnTokenChanged");
+
+  CustomEventInit* ev_init = CustomEventInit::Create(isolate, v8::Null(isolate), exception_state);
+  // bail if the creator of the event threw an exception
+  if (exception_state.HadException()) {
+    return;
+  }
+
+  ev_init->setDetail(ScriptValue::From(script_state, detail));
+
+  frame_->DomWindow()->DispatchEvent(
+    *CustomEvent::Create(script_state, "WebChannelMessageToContent", ev_init)
+  );
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -9,6 +9,7 @@
 #include "build/build_config.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "services/device/public/mojom/device_posture_provider.mojom-blink.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom-blink.h"
 #include "third_party/blink/public/mojom/frame/back_forward_cache_controller.mojom-blink.h"
 #include "third_party/blink/public/mojom/frame/frame.mojom-blink.h"
 #include "third_party/blink/public/mojom/media/fullscreen_video_element.mojom-blink.h"
@@ -47,7 +48,8 @@ class LocalFrameMojoHandler
       public mojom::blink::LocalMainFrame,
       public mojom::blink::HighPriorityLocalFrame,
       public mojom::blink::FullscreenVideoElementHandler,
-      public device::mojom::blink::DevicePostureProviderClient {
+      public device::mojom::blink::DevicePostureProviderClient,
+      public auth_token::mojom::blink::AuthTokenStoreObserver {
  public:
   explicit LocalFrameMojoHandler(blink::LocalFrame& frame);
   void Trace(Visitor* visitor) const;
@@ -73,6 +75,7 @@ class LocalFrameMojoHandler
 
   device::mojom::blink::DevicePostureType GetDevicePosture();
 
+  void RegisterAuthTokenObserver();
  private:
   Page* GetPage() const;
   LocalDOMWindow* DomWindow() const;
@@ -87,6 +90,9 @@ class LocalFrameMojoHandler
   void BindFullscreenVideoElementReceiver(
       mojo::PendingAssociatedReceiver<
           mojom::blink::FullscreenVideoElementHandler> receiver);
+  void BindAuthTokenStoreObserver(
+      mojo::PendingReceiver<
+          auth_token::mojom::blink::AuthTokenStoreObserver> receiver);
 
   // blink::mojom::LocalFrame overrides:
   void GetTextSurroundingSelection(
@@ -243,6 +249,9 @@ class LocalFrameMojoHandler
   // DevicePostureServiceClient implementation:
   void OnPostureChanged(device::mojom::blink::DevicePostureType posture) final;
 
+  // AuthTokenStoreObserver implementation:
+  void OnTokenChanged(const WTF::String& token) final;
+
   Member<blink::LocalFrame> frame_;
 
   HeapMojoAssociatedRemote<mojom::blink::BackForwardCacheControllerHost>
@@ -261,6 +270,9 @@ class LocalFrameMojoHandler
   HeapMojoAssociatedRemote<mojom::blink::LocalFrameHost>
       local_frame_host_remote_{nullptr};
 
+  HeapMojoRemote<auth_token::mojom::blink::AuthTokenStore>
+      auth_token_store_{nullptr};
+
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
   HeapMojoAssociatedReceiver<mojom::blink::LocalFrame, LocalFrameMojoHandler>
       local_frame_receiver_{this, nullptr};
@@ -275,6 +287,11 @@ class LocalFrameMojoHandler
   HeapMojoAssociatedReceiver<mojom::blink::FullscreenVideoElementHandler,
                              LocalFrameMojoHandler>
       fullscreen_video_receiver_{this, nullptr};
+  // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
+  HeapMojoReceiver<auth_token::mojom::blink::AuthTokenStoreObserver,
+                   LocalFrameMojoHandler>
+      auth_token_store_observer_receiver_{this, nullptr};
+
 
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
   HeapMojoReceiver<device::mojom::blink::DevicePostureProviderClient,

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -90,7 +90,7 @@ class LocalFrameMojoHandler
   void BindFullscreenVideoElementReceiver(
       mojo::PendingAssociatedReceiver<
           mojom::blink::FullscreenVideoElementHandler> receiver);
-  void BindRecordReplayhAuthTokenStoreObserver(
+  void BindRecordReplayAuthTokenStoreObserver(
       mojo::PendingReceiver<
           auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver);
 

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -90,7 +90,7 @@ class LocalFrameMojoHandler
   void BindFullscreenVideoElementReceiver(
       mojo::PendingAssociatedReceiver<
           mojom::blink::FullscreenVideoElementHandler> receiver);
-  void BindAuthTokenStoreObserver(
+  void BindRecordReplayhAuthTokenStoreObserver(
       mojo::PendingReceiver<
           auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver);
 
@@ -249,8 +249,8 @@ class LocalFrameMojoHandler
   // DevicePostureServiceClient implementation:
   void OnPostureChanged(device::mojom::blink::DevicePostureType posture) final;
 
-  // AuthTokenStoreObserver implementation:
-  void OnTokenChanged(const WTF::String& token) final;
+  // RecordReplayAuthTokenStoreObserver implementation:
+  void OnRecordReplayAuthTokenChanged(const WTF::String& token) final;
 
   Member<blink::LocalFrame> frame_;
 

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -49,7 +49,7 @@ class LocalFrameMojoHandler
       public mojom::blink::HighPriorityLocalFrame,
       public mojom::blink::FullscreenVideoElementHandler,
       public device::mojom::blink::DevicePostureProviderClient,
-      public auth_token::mojom::blink::AuthTokenStoreObserver {
+      public auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver {
  public:
   explicit LocalFrameMojoHandler(blink::LocalFrame& frame);
   void Trace(Visitor* visitor) const;
@@ -75,7 +75,7 @@ class LocalFrameMojoHandler
 
   device::mojom::blink::DevicePostureType GetDevicePosture();
 
-  void RegisterAuthTokenObserver();
+  void RegisterRecordReplayAuthTokenObserver();
  private:
   Page* GetPage() const;
   LocalDOMWindow* DomWindow() const;
@@ -92,7 +92,7 @@ class LocalFrameMojoHandler
           mojom::blink::FullscreenVideoElementHandler> receiver);
   void BindAuthTokenStoreObserver(
       mojo::PendingReceiver<
-          auth_token::mojom::blink::AuthTokenStoreObserver> receiver);
+          auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver);
 
   // blink::mojom::LocalFrame overrides:
   void GetTextSurroundingSelection(
@@ -270,7 +270,7 @@ class LocalFrameMojoHandler
   HeapMojoAssociatedRemote<mojom::blink::LocalFrameHost>
       local_frame_host_remote_{nullptr};
 
-  HeapMojoRemote<auth_token::mojom::blink::AuthTokenStore>
+  HeapMojoRemote<auth_token::mojom::blink::RecordReplayAuthTokenStore>
       auth_token_store_{nullptr};
 
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
@@ -288,7 +288,7 @@ class LocalFrameMojoHandler
                              LocalFrameMojoHandler>
       fullscreen_video_receiver_{this, nullptr};
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
-  HeapMojoReceiver<auth_token::mojom::blink::AuthTokenStoreObserver,
+  HeapMojoReceiver<auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver,
                    LocalFrameMojoHandler>
       auth_token_store_observer_receiver_{this, nullptr};
 


### PR DESCRIPTION
The big pieces are

A new mojom interface and supporting code for updating the current token and transmitting the new token to any number of observers: `components/record_replay/services/auth_token/**`.

Registering observers from all render frames (with an added browser-side check to only hook up the receiver if the origin is `app.replay.io`): `third_party/blink/renderer/core/frame/**`.

An event listener that handles all the `window.dispatchEvent` calls that devtools uses.  Currently it just registers an observer for any event dispatched.  That'll need fixing.  `third_party/blink/renderer/bindings/core/v8/local_window_proxy.*` and `third_party/blink/renderer/bindings/core/v8/record_replay_interface.*`.

