### PR TITLE
[RUN-2324] Disable events in DOMURL::searchParams

### DIFF
--- a/third_party/blink/renderer/core/url/dom_url.cc
+++ b/third_party/blink/renderer/core/url/dom_url.cc
@@ -95,12 +95,7 @@ String DOMURL::CreatePublicURL(ExecutionContext* execution_context,
 
 URLSearchParams* DOMURL::searchParams() {
   if (!search_params_) {
-    if (recordreplay::IsRecordingOrReplaying() && !recordreplay::AreAssertsDisabled()) {
-      std::string stack;
-      recordreplay::GetCurrentJSStack(&stack);
-      recordreplay::Assert("[RUN-2324-2325] DOMURL::searchParams %s stack=%s",
-                           Url().GetString().Utf8().c_str(), stack.c_str());
-    }
+    recordreplay::AutoDisallowEvents disallowed("DOMURL::searchParams");
     search_params_ = URLSearchParams::Create(Url().Query(), this);
   }
 

--- a/third_party/blink/renderer/core/url/dom_url.cc
+++ b/third_party/blink/renderer/core/url/dom_url.cc
@@ -95,6 +95,9 @@ String DOMURL::CreatePublicURL(ExecutionContext* execution_context,
 
 URLSearchParams* DOMURL::searchParams() {
   if (!search_params_) {
+    // disable events for url creation, since jit optimizations can land us
+    // here from different paths.
+    // https://linear.app/replay/issue/RUN-2324/mismatch-in-domurlsearchparams#comment-9287b64a
     recordreplay::AutoDisallowEvents disallowed("DOMURL::searchParams");
     search_params_ = URLSearchParams::Create(Url().Query(), this);
   }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2324/mismatch-in-domurlsearchparams#comment-9287b64a