### PR TITLE
Assert ImageDataBuffer::EncodeImageInternal

### DIFF
--- a/third_party/blink/renderer/platform/graphics/image_data_buffer.cc
+++ b/third_party/blink/renderer/platform/graphics/image_data_buffer.cc
@@ -145,6 +145,10 @@ bool ImageDataBuffer::EncodeImageInternal(const ImageEncodingMimeType mime_type,
                                           const SkPixmap& pixmap) const {
   DCHECK(is_valid_);
 
+  recordreplay::Assert(
+    "[RUN-2859-2941] ImageDataBuffer::EncodeImageInternal %d %f %zu",
+    mime_type, quality, encoded_image->size());
+
   if (mime_type == kMimeTypeJpeg) {
     SkJpegEncoder::Options options;
     options.fQuality = ImageEncoder::ComputeJpegQuality(quality);


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2859/ensureconsistentmessagesize-in-blobregistryproxyregister#comment-bf4b456a