### PR TITLE
Make PeerConnectionLocalIdMap ordered

### DIFF
--- a/third_party/blink/renderer/modules/peerconnection/peer_connection_tracker.h
+++ b/third_party/blink/renderer/modules/peerconnection/peer_connection_tracker.h
@@ -290,7 +290,11 @@ class MODULES_EXPORT PeerConnectionTracker
   void AddLegacyStats(int lid, base::Value::List value);
 
   // This map stores the local ID assigned to each RTCPeerConnectionHandler.
-  typedef WTF::HashMap<RTCPeerConnectionHandler*, int> PeerConnectionLocalIdMap;
+  typedef WTF::HashMap<
+        RTCPeerConnectionHandler*,
+        int, 
+        WTF::MemberHashRecordReplayId<RTCPeerConnectionHandler>
+    > PeerConnectionLocalIdMap;
   PeerConnectionLocalIdMap peer_connection_local_id_map_;
   mojom::blink::DeviceThermalState current_thermal_state_ =
       mojom::blink::DeviceThermalState::kUnknown;

--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
@@ -1004,6 +1004,8 @@ RTCPeerConnectionHandler::RTCPeerConnectionHandler(
       task_runner_(std::move(task_runner)) {
   CHECK(client_);
 
+  INIT_RECORD_REPLAY_ID(RTCPeerConnectionHandler);
+
   GetPeerConnectionHandlers()->insert(this);
 }
 

--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.h
+++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.h
@@ -164,6 +164,8 @@ class MODULES_EXPORT RTCPeerConnectionHandler {
 
   virtual ~RTCPeerConnectionHandler();
 
+  HAS_RECORD_REPLAY_ID();
+
   // Initialize method only used for unit test.
   bool InitializeForTest(
       const webrtc::PeerConnectionInterface::RTCConfiguration&

--- a/third_party/blink/renderer/modules/peerconnection/thermal_resource.cc
+++ b/third_party/blink/renderer/modules/peerconnection/thermal_resource.cc
@@ -33,12 +33,7 @@ scoped_refptr<ThermalResource> ThermalResource::Create(
 
 ThermalResource::ThermalResource(
     scoped_refptr<base::SequencedTaskRunner> task_runner)
-    : task_runner_(std::move(task_runner)) {
-  recordreplay::Assert(
-    "[RUN-2911-2912] ThermalResource %d", 
-    task_runner ? recordreplay::PointerId(task_runner.get()) : -1
-  );
-}
+    : task_runner_(std::move(task_runner)) {}
 
 void ThermalResource::OnThermalMeasurement(
     mojom::blink::DeviceThermalState measurement) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2911/mismatch-in-thermalresourcereportmeasurementwhileholdinglock#comment-ff6b3ae9
* Tests: ✅
  * `bbc.co.uk` and `https://biglobe.ne.jp` timed out, as is so very common.