### PR TITLE
split up runtime e2e step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,12 +120,27 @@ steps:
     artifact_paths:
       - "build_id/windows/x86_64/**"
 
-  - trigger: "testing-runtime-e2e"
-    label: ":hammer: Trigger Runtime Tests"
+  - trigger: "testing-runtime-e2e-linux"
+    label: ":hammer: Trigger Linux Runtime Tests"
     depends_on:
       - "build-chromium-linux-x86_64"
-      - "build-chromium-mac-x86_64"
-      - "build-chromium-mac-arm64"
+    build:
+      branch: "toshok/split-up-runtime-e2e"
+
+  # - trigger: "testing-runtime-e2e-mac-x86_64"
+  #   label: ":hammer: Trigger Mac (x86) Runtime Tests"
+  #   depends_on:
+  #     - "build-chromium-mac-x86_64"
+
+  # - trigger: "testing-runtime-e2e-mac-arm64"
+  #   label: ":hammer: Trigger Mac (arm64) Runtime Tests"
+  #   depends_on:
+  #     - "build-chromium-mac-arm64"
+
+  # - trigger: "testing-runtime-e2e-windows"
+  #   label: ":hammer: Trigger Windows Runtime Tests"
+  #   depends_on:
+  #     - "build-chromium-windows"
 
   - label: "Metabase Test Suite"
     key: "metabase-test-suite"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,15 +4,12 @@ queues:
       runtimeType: chromiumbuild
       queue: runtime
   - &linux_agent_queue
-    agents:
       <<: *chromium_queue
       os: linux
   - &windows_agent_queue
-    agents:
       <<: *chromium_queue
       os: windows
   - &mac_agent_queue
-    agents:
       <<: *chromium_queue
       os: macos
 
@@ -85,41 +82,41 @@ steps:
   - label: "Build chromium - Linux"
     key: "build-chromium-linux-x86_64"
     timeout_in_minutes: 60
-    <<: *linux_agent_queue
+    agents: *linux_agent_queue
+    env: *linux_env
     <<: *linux_plugins
     <<: *buck2_build
-    env: *linux_env
     artifact_paths:
       - "build_id/linux/x86_64/**"
 
   - label: "Build chromium - Mac (x86)"
     key: "build-chromium-mac-x86_64"
     timeout_in_minutes: 60
-    <<: *mac_agent_queue
+    agents: *mac_agent_queue
+    env: *mac_env
     <<: *mac_plugins
     <<: *buckle_build
-    env: *mac_env
     artifact_paths:
       - "build_id/macOS/x86_64/**"
 
   - label: "Build chromium - Mac (arm64)"
     key: "build-chromium-mac-arm64"
     timeout_in_minutes: 60
-    <<: *mac_agent_queue
-    <<: *mac_plugins
-    <<: *buckle_build
+    agents: *mac_agent_queue
     env: 
       <<: *mac_env
       REPLAY_BUILD_ARM: true
+    <<: *mac_plugins
+    <<: *buckle_build
     artifact_paths:
       - "build_id/macOS/arm64/**"
 
   - label: "Build chromium - Windows"
     key: "build-chromium-windows"
     timeout_in_minutes: 60
-    <<: *windows_agent_queue
-    <<: *windows_plugins
+    agents: *windows_agent_queue
     env: *windows_env
+    <<: *windows_plugins
     command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
     artifact_paths:
       - "build_id/windows/x86_64/**"
@@ -133,7 +130,7 @@ steps:
 
   - label: "Metabase Test Suite"
     key: "metabase-test-suite"
-    <<: *linux_agent_queue
+    agents: *linux_agent_queue
     <<: *linux_plugins
     depends_on: "build-chromium-linux-x86_64"
     if: build.branch == "master"
@@ -145,6 +142,6 @@ steps:
 
   - label: "Buildevents Watch"
     key: "buildevents-watch"
-    <<: *linux_agent_queue
+    agents: *linux_agent_queue
     <<: *linux_plugins
     command: "be_watch"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,20 +127,26 @@ steps:
     build:
       branch: "toshok/split-up-runtime-e2e"
 
-  # - trigger: "testing-runtime-e2e-mac-x86_64"
-  #   label: ":hammer: Trigger Mac (x86) Runtime Tests"
-  #   depends_on:
-  #     - "build-chromium-mac-x86_64"
+  - trigger: "testing-runtime-e2e-mac-x86-64"
+    label: ":hammer: Trigger Mac (x86) Runtime Tests"
+    depends_on:
+      - "build-chromium-mac-x86_64"
+    build:
+      branch: "toshok/split-up-runtime-e2e"
 
-  # - trigger: "testing-runtime-e2e-mac-arm64"
-  #   label: ":hammer: Trigger Mac (arm64) Runtime Tests"
-  #   depends_on:
-  #     - "build-chromium-mac-arm64"
+  - trigger: "testing-runtime-e2e-mac-arm64"
+    label: ":hammer: Trigger Mac (arm64) Runtime Tests"
+    depends_on:
+      - "build-chromium-mac-arm64"
+    build:
+      branch: "toshok/split-up-runtime-e2e"
 
-  # - trigger: "testing-runtime-e2e-windows"
-  #   label: ":hammer: Trigger Windows Runtime Tests"
-  #   depends_on:
-  #     - "build-chromium-windows"
+  - trigger: "testing-runtime-e2e-windows"
+    label: ":hammer: Trigger Windows Runtime Tests"
+    depends_on:
+      - "build-chromium-windows"
+    build:
+      branch: "toshok/split-up-runtime-e2e"
 
   - label: "Metabase Test Suite"
     key: "metabase-test-suite"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,19 +1,19 @@
 ---
 queues:
-  - &linux_agent_queue
-    agents:
+  - &chromium_queue
       runtimeType: chromiumbuild
       queue: runtime
+  - &linux_agent_queue
+    agents:
+      <<: *chromium_queue
       os: linux
   - &windows_agent_queue
     agents:
-      runtimeType: chromiumbuild
-      queue: runtime
+      <<: *chromium_queue
       os: windows
   - &mac_agent_queue
     agents:
-      runtimeType: chromiumbuild
-      queue: runtime
+      <<: *chromium_queue
       os: macos
 
 plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,3 @@
----
 queues:
   - &chromium_queue
       runtimeType: chromiumbuild

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,63 @@
-env:
-  FORCE_COLOR: 1
-  GIT_TERMINAL_PROMPT: 0
+---
+queues:
+  - &linux_agent_queue
+    agents:
+      runtimeType: chromiumbuild
+      queue: runtime
+      os: linux
+  - &windows_agent_queue
+    agents:
+      runtimeType: chromiumbuild
+      queue: runtime
+      os: windows
+  - &mac_agent_queue
+    agents:
+      runtimeType: chromiumbuild
+      queue: runtime
+      os: macos
 
-steps:
-  - label: "Build chromium - Linux"
-    key: "build-chromium-linux-x86_64"
-    timeout_in_minutes: 60
+plugins:
+  - &aws_sm_plugin
+    seek-oss/aws-sm#v2.3.1:
+      region: us-east-2
+      env:
+        BUILDEVENT_APIKEY: honeycomb-api-key
+        BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+  - &buildevents_plugin
+    replayio/buildevents#adb8a05: ~
+
+  - &linux_plugins
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
           cd: /home/ubuntu/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
+      - *aws_sm_plugin
+      - *buildevents_plugin
+  - &mac_plugins
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /Users/administrator/chromium/src
+      - *aws_sm_plugin
+      - *buildevents_plugin
+  - &windows_plugins
+    plugins:
+      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
+
+environments:
+  - &goma_env
+    GOMA_SERVER_HOST: simpsonite.goma.engflow.com
+    GOMACTL_USE_PROXY: false
+  - &linux_env
+      <<: *goma_env
+      RECORD_REPLAY_BACKEND_DIR: /home/ubuntu/chromium/backend
+  - &mac_env
+      <<: *goma_env
+      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+  - &windows_env
+      <<: *goma_env
+      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
+
+commands:
+  - &buck2_build
     commands:
       - "be_cmd git-fetch-all -- git fetch --all"
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
@@ -23,116 +66,77 @@ steps:
       - "be_cmd buck2-kill -- buck2 kill"
       - "be_cmd buck2-build -- buck2 build --console simple //:chromium"
       - "popd"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
-      RECORD_REPLAY_BACKEND_DIR: /home/ubuntu/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
+  - &buckle_build
+    commands:
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build --console simple //:chromium"
+      - "popd"
+
+
+env:
+  FORCE_COLOR: 1
+  GIT_TERMINAL_PROMPT: 0
+
+steps:
+  - label: "Build chromium - Linux"
+    key: "build-chromium-linux-x86_64"
+    timeout_in_minutes: 60
+    <<: *linux_agent_queue
+    <<: *linux_plugins
+    <<: *buck2_build
+    env: *linux_env
     artifact_paths:
       - "build_id/linux/x86_64/**"
+
   - label: "Build chromium - Mac (x86)"
     key: "build-chromium-mac-x86_64"
     timeout_in_minutes: 60
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /Users/administrator/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build --console simple //:chromium"
-      - "popd"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
-      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
+    <<: *mac_agent_queue
+    <<: *mac_plugins
+    <<: *buckle_build
+    env: *mac_env
     artifact_paths:
       - "build_id/macOS/x86_64/**"
+
   - label: "Build chromium - Mac (arm64)"
     key: "build-chromium-mac-arm64"
     timeout_in_minutes: 60
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /Users/administrator/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build --console simple //:chromium"
-      - "popd"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
+    <<: *mac_agent_queue
+    <<: *mac_plugins
+    <<: *buckle_build
+    env: 
+      <<: *mac_env
       REPLAY_BUILD_ARM: true
-      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
     artifact_paths:
       - "build_id/macOS/arm64/**"
+
   - label: "Build chromium - Windows"
     key: "build-chromium-windows"
     timeout_in_minutes: 60
-    plugins:
-      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
+    <<: *windows_agent_queue
+    <<: *windows_plugins
+    env: *windows_env
     command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
-      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=windows"
-      - "queue=runtime"
     artifact_paths:
       - "build_id/windows/x86_64/**"
+
   - trigger: "testing-runtime-e2e"
     label: ":hammer: Trigger Runtime Tests"
     depends_on:
       - "build-chromium-linux-x86_64"
       - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
+
   - label: "Metabase Test Suite"
     key: "metabase-test-suite"
+    <<: *linux_agent_queue
+    <<: *linux_plugins
     depends_on: "build-chromium-linux-x86_64"
     if: build.branch == "master"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1: ~
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
     command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
 
   # wait for all steps above, but also continue if they fail
@@ -141,17 +145,6 @@ steps:
 
   - label: "Buildevents Watch"
     key: "buildevents-watch"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /home/ubuntu/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
+    <<: *linux_agent_queue
+    <<: *linux_plugins
     command: "be_watch"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"


### PR DESCRIPTION
we could potentially save a lot of time by running tests as they are unblocked by their specific platform build, instead of waiting for all platform builds to run any of them.