### PR TITLE
Revert "[RUN-2947] Order `ClientDiscardableSharedMemoryManager::allocated_memory_"

### DIFF
--- a/components/discardable_memory/client/client_discardable_shared_memory_manager.h
+++ b/components/discardable_memory/client/client_discardable_shared_memory_manager.h
@@ -197,7 +197,7 @@ class DISCARDABLE_MEMORY_EXPORT ClientDiscardableSharedMemoryManager
       manager_mojo_;
 
   // Holds all locked and unlocked instances which have not yet been purged.
-  std::set<DiscardableMemoryImpl*, recordreplay::CompareByPointerId> allocated_memory_ GUARDED_BY(lock_);
+  std::set<DiscardableMemoryImpl*> allocated_memory_ GUARDED_BY(lock_);
   size_t bytes_allocated_limit_for_testing_ = 0;
 
   // Used in metrics to distinguish in-use consumers from background ones. We


### PR DESCRIPTION
Reverts replayio/chromium#1005
* This caused recording crashes.