### PR TITLE
Re-land auth-token communication to app.replay.io tabs

### DIFF
--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -2239,6 +2239,7 @@ static_library("browser") {
     "//components/query_tiles",
     "//components/reading_list/core",
     "//components/reading_list/features:flags",
+    "//components/record_replay/services/auth_token:lib",
     "//components/reduce_accept_language/browser:browser",
     "//components/renderer_context_menu",
     "//components/reporting/client:report_queue",

--- a/chrome/browser/chrome_browser_interface_binders.cc
+++ b/chrome/browser/chrome_browser_interface_binders.cc
@@ -71,6 +71,8 @@
 #include "components/performance_manager/public/performance_manager.h"
 #include "components/prefs/pref_service.h"
 #include "components/reading_list/features/reading_list_switches.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
 #include "components/safe_browsing/buildflags.h"
 #include "components/security_state/content/content_utils.h"
 #include "components/security_state/core/security_state.h"
@@ -371,6 +373,22 @@ namespace chrome {
 namespace internal {
 
 using content::RegisterWebUIControllerInterfaceBinder;
+
+void BindRecordReplayAuthTokenStore(
+    content::RenderFrameHost* frame_host,
+    mojo::PendingReceiver<auth_token::mojom::RecordReplayAuthTokenStore> receiver) {
+
+  // we only bind the receiver if the frame's origin is app.replay.io
+  if (frame_host->GetLastCommittedOrigin().host() != "app.replay.io") {
+    return;
+  }
+
+  content::BrowserContext* browser_context =
+      frame_host->GetProcess()->GetBrowserContext();
+
+  auth_token::RecordReplayAuthTokenServiceFactory::GetForBrowserContext(browser_context)
+      ->BindAuthTokenStore(std::move(receiver));
+}
 
 #if BUILDFLAG(ENABLE_UNHANDLED_TAP)
 void BindUnhandledTapWebContentsObserver(
@@ -677,6 +695,10 @@ void BindScreen2xMainContentExtractor(
 void PopulateChromeFrameBinders(
     mojo::BinderMapWithContext<content::RenderFrameHost*>* map,
     content::RenderFrameHost* render_frame_host) {
+
+  map->Add<auth_token::mojom::RecordReplayAuthTokenStore>(
+      base::BindRepeating(&BindRecordReplayAuthTokenStore));
+
   map->Add<image_annotation::mojom::Annotator>(
       base::BindRepeating(&BindImageAnnotator));
 

--- a/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
+++ b/chrome/browser/ui/webui/record_replay/record_replay_manager_handler.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "chrome/browser/ui/webui/record_replay/record_replay_manager_handler.h"
-
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
 #include <string>
 
 #include "base/bind.h"
@@ -26,4 +26,7 @@ void RecordReplayManagerHandler::SetManager(
 
 void RecordReplayManagerHandler::ApiKeyReceived(const std::string& api_key) {
   printf("RecordReplay [RUN-2866] ManagerHandler(%p)::ApiKeyReceived(%s)\n", this, api_key.c_str());
+  // Ideally this would use a mojo interface, but since both this code and the RecordReplayAuthTokenStore
+  // are in the browser process, we can just call it directly.
+  auth_token::RecordReplayAuthTokenServiceFactory::GetForBrowserContext(profile_)->SetToken(api_key);
 }

--- a/components/record_replay/services/auth_token/BUILD.gn
+++ b/components/record_replay/services/auth_token/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2022 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+assert(!is_android && !is_ios)
+
+source_set("lib") {
+  sources = [
+    "public/cpp/auth_token_service.cc",
+    "public/cpp/auth_token_service.h",
+    "public/cpp/auth_token_service_factory.cc",
+    "public/cpp/auth_token_service_factory.h",
+  ]
+
+  deps = [
+    "//base",
+    "//mojo/public/cpp/bindings",
+  ]
+
+  public_deps = [
+    "//components/record_replay/services/auth_token/public/mojom",
+  ]
+}

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.cc
@@ -1,0 +1,35 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service.h"
+#include "content/public/browser/service_process_host.h"
+
+namespace auth_token {
+
+RecordReplayAuthTokenService::RecordReplayAuthTokenService() = default;
+RecordReplayAuthTokenService::~RecordReplayAuthTokenService() = default;
+
+void RecordReplayAuthTokenService::BindAuthTokenStore(
+    mojo::PendingReceiver<mojom::RecordReplayAuthTokenStore> store) {
+
+  auth_token_stores_.Add(this, std::move(store));
+}
+
+void RecordReplayAuthTokenService::SetToken(const std::string& token) {
+  token_ = token;
+  NotifyObservers();
+}
+
+void RecordReplayAuthTokenService::AddObserver(mojo::PendingRemote<mojom::RecordReplayAuthTokenStoreObserver> observer) {
+  observers_.Add(std::move(observer));
+  NotifyObservers();
+}
+
+void RecordReplayAuthTokenService::NotifyObservers() {
+  for (auto& observer : observers_) {
+    observer->OnRecordReplayAuthTokenChanged(token_);
+  }
+}
+
+}  // namespace auth_token

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service.h
@@ -1,0 +1,44 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_
+#define COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_
+
+#include "components/keyed_service/core/keyed_service.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+
+namespace auth_token {
+
+class RecordReplayAuthTokenService : public KeyedService, public mojom::RecordReplayAuthTokenStore {
+ public:
+  RecordReplayAuthTokenService();
+  RecordReplayAuthTokenService(const RecordReplayAuthTokenService&) = delete;
+  RecordReplayAuthTokenService& operator=(const RecordReplayAuthTokenService&) = delete;
+  ~RecordReplayAuthTokenService() override;
+
+  void BindAuthTokenStore(
+      mojo::PendingReceiver<mojom::RecordReplayAuthTokenStore> store);
+
+  // mojom::RecordReplayAuthTokenStore:
+  void SetToken(const std::string& token) override;
+  void AddObserver(mojo::PendingRemote<mojom::RecordReplayAuthTokenStoreObserver> observer) override;
+
+private:
+  mojo::ReceiverSet<mojom::RecordReplayAuthTokenStore> auth_token_stores_;
+
+  std::string token_;
+
+  void NotifyObservers();
+
+  mojo::RemoteSet<mojom::RecordReplayAuthTokenStoreObserver> observers_;
+};
+
+}  // namespace auth_token
+
+#endif  // COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_H_

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.cc
@@ -1,0 +1,44 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h"
+
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "content/public/browser/browser_context.h"
+
+namespace auth_token {
+
+// static
+auth_token::RecordReplayAuthTokenService*
+RecordReplayAuthTokenServiceFactory::GetForBrowserContext(
+    content::BrowserContext* context) {
+  return static_cast<auth_token::RecordReplayAuthTokenService*>(
+      GetInstance()->GetServiceForBrowserContext(context, /*create=*/true));
+}
+
+// static
+RecordReplayAuthTokenServiceFactory* RecordReplayAuthTokenServiceFactory::GetInstance() {
+  static base::NoDestructor<RecordReplayAuthTokenServiceFactory> instance;
+  return instance.get();
+}
+
+RecordReplayAuthTokenServiceFactory::RecordReplayAuthTokenServiceFactory()
+    : BrowserContextKeyedServiceFactory(
+          "RecordReplayAuthTokenService",
+          BrowserContextDependencyManager::GetInstance()) {}
+
+RecordReplayAuthTokenServiceFactory::~RecordReplayAuthTokenServiceFactory() = default;
+
+KeyedService* RecordReplayAuthTokenServiceFactory::BuildServiceInstanceFor(
+    content::BrowserContext* /*context*/) const {
+  return new auth_token::RecordReplayAuthTokenService();
+}
+
+// Incognito profiles should use their own instance.
+content::BrowserContext* RecordReplayAuthTokenServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  return context;
+}
+
+}  // namespace auth_token

--- a/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
+++ b/components/record_replay/services/auth_token/public/cpp/auth_token_service_factory.h
@@ -1,0 +1,43 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_
+#define COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_
+
+#include "base/no_destructor.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "components/record_replay/services/auth_token/public/cpp/auth_token_service.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace auth_token {
+
+class RecordReplayAuthTokenService;
+
+// Factory to get or create an instance of RecordReplayAuthTokenService for a
+// BrowserContext.
+class RecordReplayAuthTokenServiceFactory : public BrowserContextKeyedServiceFactory {
+ public:
+  static RecordReplayAuthTokenService* GetForBrowserContext(
+      content::BrowserContext* context);
+
+ private:
+  friend class base::NoDestructor<RecordReplayAuthTokenServiceFactory>;
+  static RecordReplayAuthTokenServiceFactory* GetInstance();
+
+  RecordReplayAuthTokenServiceFactory();
+  ~RecordReplayAuthTokenServiceFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+};
+
+}  // namespace auth_token
+
+#endif  // COMPONENTS_RECORD_REPLAY_SERVICES_AUTH_TOKEN_PUBLIC_CPP_AUTH_TOKEN_SERVICE_FACTORY_H_

--- a/components/record_replay/services/auth_token/public/mojom/BUILD.gn
+++ b/components/record_replay/services/auth_token/public/mojom/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright 2022 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+mojom("mojom") {
+  sources = [ "auth_token.mojom" ]
+
+#  public_deps = [ "//sandbox/policy/mojom" ]
+
+  # The blink variant of the Auth Token Service mojom are depended on by the
+  # blink platform target. All blink variant mojoms use WTF types, which are
+  # part of the blink platform component. In order to avoid a dependency cycle,
+  # these targets must be part of that component.
+  export_class_attribute_blink = "BLINK_PLATFORM_EXPORT"
+  export_define_blink = "BLINK_PLATFORM_IMPLEMENTATION=1"
+  export_header_blink = "third_party/blink/public/platform/web_common.h"
+
+  visibility_blink = [
+    "//third_party/blink/renderer/platform:blink_platform_public_deps",
+    "//third_party/blink/renderer/platform/media:*",
+    "//third_party/blink/public/mojom:mojom_platform_blink",
+  ]
+}

--- a/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
+++ b/components/record_replay/services/auth_token/public/mojom/auth_token.mojom
@@ -1,0 +1,13 @@
+module auth_token.mojom;
+
+// Interface to passing updated token around
+interface RecordReplayAuthTokenStore {
+  SetToken(string token);
+
+  AddObserver(pending_remote<RecordReplayAuthTokenStoreObserver> observer);
+  // how do we remove?
+};
+
+interface RecordReplayAuthTokenStoreObserver {
+  OnRecordReplayAuthTokenChanged(string token);
+};

--- a/content/browser/browser_interface_binders.cc
+++ b/content/browser/browser_interface_binders.cc
@@ -13,6 +13,7 @@
 #include "build/branding_buildflags.h"
 #include "build/build_config.h"
 #include "cc/base/switches.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom-blink.h"
 #include "content/browser/aggregation_service/aggregation_service_internals.mojom.h"
 #include "content/browser/aggregation_service/aggregation_service_internals_ui.h"
 #include "content/browser/attribution_reporting/attribution_internals.mojom.h"
@@ -978,6 +979,9 @@ void PopulateBinderMapWithContext(
   // by blink.
   // This avoids renderer kills when no binder is found in the absence of the
   // production embedder (such as in tests).
+  map->Add<auth_token::mojom::blink::RecordReplayAuthTokenStore>(
+      base::BindRepeating(&EmptyBinderForFrame<
+                          auth_token::mojom::blink::RecordReplayAuthTokenStore>));
   map->Add<blink::mojom::NoStatePrefetchProcessor>(base::BindRepeating(
       &EmptyBinderForFrame<blink::mojom::NoStatePrefetchProcessor>));
   map->Add<payments::mojom::PaymentCredential>(base::BindRepeating(

--- a/third_party/blink/public/mojom/BUILD.gn
+++ b/third_party/blink/public/mojom/BUILD.gn
@@ -249,6 +249,7 @@ mojom("mojom_platform") {
     ":web_feature_mojo_bindings",
     "//cc/mojom",
     "//components/payments/mojom",
+    "//components/record_replay/services/auth_token/public/mojom",
     "//components/schema_org/common:mojom",
     "//components/services/filesystem/public/mojom",
     "//mojo/public/mojom/base",

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -79,6 +79,7 @@ namespace blink {
 
 void LocalWindowProxy::Trace(Visitor* visitor) const {
   visitor->Trace(script_state_);
+  visitor->Trace(record_replay_listener_);
   WindowProxy::Trace(visitor);
 }
 
@@ -243,6 +244,7 @@ void LocalWindowProxy::Initialize() {
     // Initialize Replay things that depend on previous Replay initialization 
     // steps.
     OnNewWindow2(GetIsolate(), GetFrame(), context);
+
   }
 
   {
@@ -256,10 +258,25 @@ void LocalWindowProxy::Initialize() {
 
   InstallConditionalFeatures();
 
+  // Add an event listener for the dispatched custom event the devtools uses to register
+  // its listener.  Do this outside the recording.
+  SetupRecordReplayEventListener();
+
   if (World().IsMainWorld()) {
     GetFrame()->Loader().DispatchDidClearWindowObjectInMainWorld();
   }
 }
+
+void LocalWindowProxy::SetupRecordReplayEventListener() {
+  LocalFrame* localFrame = GetFrame();
+
+  record_replay_listener_ = RecordReplayEventListener::Create(GetIsolate(), localFrame);
+
+  bool added = localFrame->DomWindow()->addEventListener("WebChannelMessageToChrome", record_replay_listener_.Get());
+
+  DCHECK(added);
+}
+
 
 void LocalWindowProxy::CreateContext() {
   TRACE_EVENT2("v8", "LocalWindowProxy::CreateContext", "IsMainFrame",

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.h
@@ -39,12 +39,14 @@
 #include "third_party/blink/renderer/platform/wtf/casting.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "v8/include/v8.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom.h"
 
 namespace blink {
 
 class HTMLDocument;
 class ScriptState;
 class SecurityOrigin;
+class RecordReplayEventListener;
 
 // Subclass of WindowProxy that only handles LocalFrame.
 class LocalWindowProxy final : public WindowProxy {
@@ -71,6 +73,8 @@ class LocalWindowProxy final : public WindowProxy {
       v8::Context::AbortScriptExecutionCallback callback);
 
  private:
+  void SetupRecordReplayEventListener();
+
   // LocalWindowProxy overrides:
   bool IsLocal() const override { return true; }
   void Initialize() override;
@@ -110,6 +114,9 @@ class LocalWindowProxy final : public WindowProxy {
     return To<LocalFrame>(WindowProxy::GetFrame());
   }
 
+  mojo::Remote<auth_token::mojom::RecordReplayAuthTokenStore> auth_token_store_;
+  
+  Member<RecordReplayEventListener> record_replay_listener_;
   Member<ScriptState> script_state_;
   bool context_was_created_from_snapshot_ = false;
 };

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5463,6 +5463,7 @@ void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Co
   );
 }
 
+
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
 
 static ErrorEvent* gCurrentErrorEvent;
@@ -5499,6 +5500,22 @@ static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args) {
                   v8::Number::New(isolate, gCurrentErrorEvent->Location()->ScriptId()));
 
   args.GetReturnValue().Set(rv);
+}
+
+void RecordReplayEventListener::Invoke(ExecutionContext* context, Event* event) {
+  // TODO only register the observer if the event matches this structure:
+  // type = WebChannelMessageToChrome"
+  // detail (stringified): {
+  //   id: "record-replay-token",
+  //   message: { type: "connect" },
+  // }
+
+  local_frame_->RegisterRecordReplayAuthTokenObserver();
+}
+
+void RecordReplayEventListener::Trace(Visitor* visitor) const {
+  visitor->Trace(local_frame_);
+  EventListener::Trace(visitor);
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -5,6 +5,7 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_INTERFACE_H_
 #define THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_V8_RECORD_REPLAY_INTERFACE_H_
 
+#include "third_party/blink/renderer/core/dom/events/native_event_listener.h"
 #include "third_party/blink/renderer/core/events/error_event.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "base/values.h"
@@ -34,6 +35,24 @@ void RecordReplayOnErrorEvent(ErrorEvent* error_event);
 // Notify record/replay about new inspectors that have been created.
 void RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
                                      v8::Isolate* isolate);
+
+class RecordReplayEventListener : public NativeEventListener {
+ public:
+  RecordReplayEventListener(v8::Isolate* isolate, LocalFrame* localFrame)
+      : local_frame_(localFrame) {}
+
+  void Invoke(ExecutionContext*, Event*) override;
+
+  void Trace(Visitor*) const override;
+
+  static RecordReplayEventListener* Create(v8::Isolate* isolate,
+                                      LocalFrame* localFrame) {
+    return MakeGarbageCollected<RecordReplayEventListener>(isolate, localFrame);
+  }
+
+ private:
+  Member<LocalFrame> local_frame_;
+};
 
 } // namespace blink
 

--- a/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/third_party/blink/renderer/core/frame/local_frame.cc
@@ -3318,4 +3318,8 @@ bool LocalFrame::HasBlockingReasonsHelper(
   return false;
 }
 
+void LocalFrame::RegisterRecordReplayAuthTokenObserver() {
+  mojo_handler_->RegisterRecordReplayAuthTokenObserver();
+}
+
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/local_frame.h
+++ b/third_party/blink/renderer/core/frame/local_frame.h
@@ -805,6 +805,8 @@ class CORE_EXPORT LocalFrame final
 
   absl::optional<SkColor> GetFrameOverlayColorForTesting() const;
 
+  void RegisterRecordReplayAuthTokenObserver();
+  
  private:
   friend class FrameNavigationDisabler;
   // LocalFrameMojoHandler is a part of LocalFrame.

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
@@ -29,8 +29,10 @@
 #include "third_party/blink/renderer/bindings/core/v8/script_controller.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_evaluation_result.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_function.h"
+#include "third_party/blink/renderer/bindings/core/v8/v8_custom_event_init.h"
 #include "third_party/blink/renderer/core/dom/element_traversal.h"
 #include "third_party/blink/renderer/core/dom/ignore_opens_during_unload_count_incrementer.h"
+#include "third_party/blink/renderer/core/dom/events/custom_event.h"
 #include "third_party/blink/renderer/core/editing/editing_utilities.h"
 #include "third_party/blink/renderer/core/editing/frame_selection.h"
 #include "third_party/blink/renderer/core/editing/surrounding_text.h"
@@ -416,6 +418,9 @@ LocalFrameMojoHandler::LocalFrameMojoHandler(blink::LocalFrame& frame)
   registry->AddAssociatedInterface(WTF::BindRepeating(
       &LocalFrameMojoHandler::BindFullscreenVideoElementReceiver,
       WrapWeakPersistent(this)));
+  registry->AddInterface(WTF::BindRepeating(
+      &LocalFrameMojoHandler::BindRecordReplayAuthTokenStoreObserver,
+      WrapWeakPersistent(this)));
 }
 
 void LocalFrameMojoHandler::Trace(Visitor* visitor) const {
@@ -432,6 +437,8 @@ void LocalFrameMojoHandler::Trace(Visitor* visitor) const {
   visitor->Trace(high_priority_frame_receiver_);
   visitor->Trace(fullscreen_video_receiver_);
   visitor->Trace(device_posture_receiver_);
+  visitor->Trace(auth_token_store_);
+  visitor->Trace(auth_token_store_observer_receiver_);
 }
 
 void LocalFrameMojoHandler::WasAttachedAsLocalMainFrame() {
@@ -500,6 +507,19 @@ LocalFrameMojoHandler::GetDevicePosture() {
   return current_device_posture_;
 }
 
+void LocalFrameMojoHandler::RegisterRecordReplayAuthTokenObserver() {
+  if (auth_token_store_.is_bound()) {
+    return;
+  }
+
+  auto task_runner = frame_->GetTaskRunner(TaskType::kInternalDefault);
+  frame_->GetBrowserInterfaceBroker().GetInterface(
+      auth_token_store_.BindNewPipeAndPassReceiver(task_runner));
+
+  auth_token_store_->AddObserver(
+      auth_token_store_observer_receiver_.BindNewPipeAndPassRemote(task_runner));
+}
+
 Page* LocalFrameMojoHandler::GetPage() const {
   return frame_->GetPage();
 }
@@ -544,6 +564,16 @@ void LocalFrameMojoHandler::BindToHighPriorityReceiver(
       frame_->GetTaskRunner(TaskType::kInternalHighPriorityLocalFrame));
   high_priority_frame_receiver_.SetFilter(
       std::make_unique<ActiveURLMessageFilter>(frame_));
+}
+
+void LocalFrameMojoHandler::BindRecordReplayAuthTokenStoreObserver(
+      mojo::PendingReceiver<
+          auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver) {
+ if (frame_->IsDetached())
+    return;
+
+  auth_token_store_observer_receiver_.Bind(
+      std::move(receiver), frame_->GetTaskRunner(TaskType::kInternalDefault));
 }
 
 void LocalFrameMojoHandler::BindFullscreenVideoElementReceiver(
@@ -1443,6 +1473,53 @@ void LocalFrameMojoHandler::RequestFullscreenVideoElement() {
       return;
     }
   }
+}
+
+void LocalFrameMojoHandler::OnRecordReplayAuthTokenChanged(const WTF::String& token) {
+  v8::Isolate* isolate = ToIsolate(frame_);
+  v8::HandleScope handle_scope(isolate);
+
+  ScriptState* script_state = ToScriptStateForMainWorld(frame_);
+  v8::Local<v8::Context> context = script_state->GetContext();
+  v8::Context::Scope context_scope(context);
+
+  // build up a JS object corresponding to the structure the devtools
+  // expects to receive:
+  //
+  // detail = {
+  //   message: {
+  //     token: "...",
+  //     error?: "...",
+  //   }
+  // }
+  //
+  // we don't currently receive an error from the auth token service, so we don't fill it in.
+  // if there was an error, presumably we wouldn't be called here.
+
+  v8::Local<v8::Object> message = v8::Object::New(isolate);
+  message->Set(context, V8String(isolate, "token"),
+               V8String(isolate, token))
+      .Check();
+
+  v8::Local<v8::Object> detail = v8::Object::New(isolate);
+  detail->Set(context, V8String(isolate, "message"), message)
+      .Check();
+
+
+  ExceptionState exception_state(isolate, ExceptionState::kExecutionContext,
+                                 "LocalFrameMojoHandler", "OnTokenChanged");
+
+  CustomEventInit* ev_init = CustomEventInit::Create(isolate, v8::Null(isolate), exception_state);
+  // bail if the creator of the event threw an exception
+  if (exception_state.HadException()) {
+    return;
+  }
+
+  ev_init->setDetail(ScriptValue::From(script_state, detail));
+
+  frame_->DomWindow()->DispatchEvent(
+    *CustomEvent::Create(script_state, "WebChannelMessageToContent", ev_init)
+  );
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.h
@@ -9,6 +9,7 @@
 #include "build/build_config.h"
 #include "components/power_scheduler/power_mode_voter.h"
 #include "services/device/public/mojom/device_posture_provider.mojom-blink.h"
+#include "components/record_replay/services/auth_token/public/mojom/auth_token.mojom-blink.h"
 #include "third_party/blink/public/mojom/frame/back_forward_cache_controller.mojom-blink.h"
 #include "third_party/blink/public/mojom/frame/frame.mojom-blink.h"
 #include "third_party/blink/public/mojom/media/fullscreen_video_element.mojom-blink.h"
@@ -47,7 +48,8 @@ class LocalFrameMojoHandler
       public mojom::blink::LocalMainFrame,
       public mojom::blink::HighPriorityLocalFrame,
       public mojom::blink::FullscreenVideoElementHandler,
-      public device::mojom::blink::DevicePostureProviderClient {
+      public device::mojom::blink::DevicePostureProviderClient,
+      public auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver {
  public:
   explicit LocalFrameMojoHandler(blink::LocalFrame& frame);
   void Trace(Visitor* visitor) const;
@@ -73,6 +75,7 @@ class LocalFrameMojoHandler
 
   device::mojom::blink::DevicePostureType GetDevicePosture();
 
+  void RegisterRecordReplayAuthTokenObserver();
  private:
   Page* GetPage() const;
   LocalDOMWindow* DomWindow() const;
@@ -87,6 +90,9 @@ class LocalFrameMojoHandler
   void BindFullscreenVideoElementReceiver(
       mojo::PendingAssociatedReceiver<
           mojom::blink::FullscreenVideoElementHandler> receiver);
+  void BindRecordReplayAuthTokenStoreObserver(
+      mojo::PendingReceiver<
+          auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver> receiver);
 
   // blink::mojom::LocalFrame overrides:
   void GetTextSurroundingSelection(
@@ -243,6 +249,9 @@ class LocalFrameMojoHandler
   // DevicePostureServiceClient implementation:
   void OnPostureChanged(device::mojom::blink::DevicePostureType posture) final;
 
+  // RecordReplayAuthTokenStoreObserver implementation:
+  void OnRecordReplayAuthTokenChanged(const WTF::String& token) final;
+
   Member<blink::LocalFrame> frame_;
 
   HeapMojoAssociatedRemote<mojom::blink::BackForwardCacheControllerHost>
@@ -261,6 +270,9 @@ class LocalFrameMojoHandler
   HeapMojoAssociatedRemote<mojom::blink::LocalFrameHost>
       local_frame_host_remote_{nullptr};
 
+  HeapMojoRemote<auth_token::mojom::blink::RecordReplayAuthTokenStore>
+      auth_token_store_{nullptr};
+
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
   HeapMojoAssociatedReceiver<mojom::blink::LocalFrame, LocalFrameMojoHandler>
       local_frame_receiver_{this, nullptr};
@@ -275,6 +287,11 @@ class LocalFrameMojoHandler
   HeapMojoAssociatedReceiver<mojom::blink::FullscreenVideoElementHandler,
                              LocalFrameMojoHandler>
       fullscreen_video_receiver_{this, nullptr};
+  // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
+  HeapMojoReceiver<auth_token::mojom::blink::RecordReplayAuthTokenStoreObserver,
+                   LocalFrameMojoHandler>
+      auth_token_store_observer_receiver_{this, nullptr};
+
 
   // LocalFrameMojoHandler can be reused by multiple ExecutionContext.
   HeapMojoReceiver<device::mojom::blink::DevicePostureProviderClient,


### PR DESCRIPTION
Reverts #1006, which itself reverts #992.

Contains 1 additional commit (3af1d0795d9b1659e05f3292ffdd1e8e52286c9e) over #992, which fixes things when used in a headless context (like in our tests.)