### PR TITLE
[RUN-1976] Fix missing lock ordering

### DIFF
--- a/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
+++ b/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
@@ -22,7 +22,7 @@ namespace mojo {
 class ScopedInterfaceEndpointHandle::State
     : public base::RefCountedThreadSafe<State> {
  public:
-  State() = default;
+  State() : lock_("ScopedInterfaceEndpointHandle::State.lock_") {}
 
   State(InterfaceId id,
         scoped_refptr<AssociatedGroupController> group_controller)


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1976/mismatch-in-scopedinterfaceendpointhandlegroup-controller#comment-badb4eb3