### PR TITLE
Add missing dep in auth_token service

### DIFF
--- a/components/record_replay/services/auth_token/BUILD.gn
+++ b/components/record_replay/services/auth_token/BUILD.gn
@@ -14,8 +14,8 @@ source_set("lib") {
 
   deps = [
     "//base",
-    "//mojo/public/cpp/bindings",
     "//content/public/browser:browser",
+    "//mojo/public/cpp/bindings",
   ]
 
   public_deps = [

--- a/components/record_replay/services/auth_token/BUILD.gn
+++ b/components/record_replay/services/auth_token/BUILD.gn
@@ -15,6 +15,7 @@ source_set("lib") {
   deps = [
     "//base",
     "//mojo/public/cpp/bindings",
+    "//content/public/browser:browser",
   ]
 
   public_deps = [


### PR DESCRIPTION
stateful builds both local and in CI masked this issue.  We depend on `BrowserContext.h`, which pulls in other mojom generated files, so we really need this dep.