### PR TITLE
[RUN-3033] trigger devtools tests from our buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,7 @@ steps:
     command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
 
   - label: "Trigger Devtools E2E Tests"
-    key: "metabase-test-suite"
+    key: "devtools-test-suite"
     soft_fail: true
     depends_on: "build-chromium-linux-x86_64"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -139,6 +139,10 @@ steps:
     key: "devtools-test-suite"
     soft_fail: true
     depends_on: "build-chromium-linux-x86_64"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
     plugins:
       - thedyrt/skip-checkout#v0.1.1: ~
       - seek-oss/aws-sm#v2.3.1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -148,7 +148,7 @@ steps:
       - seek-oss/aws-sm#v2.3.1:
           region: us-east-2
           env:
-            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
+            GITHUB_AUTH_SECRET: "prod/devtools-github-secret"
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
       - replayio/buildevents#adb8a05: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,6 +135,21 @@ steps:
       - replayio/buildevents#adb8a05: ~
     command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
 
+  - label: "Trigger Devtools E2E Tests"
+    key: "metabase-test-suite"
+    soft_fail: true
+    depends_on: "build-chromium-linux-x86_64"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1: ~
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    command: "be_cmd devtools-tests -- /home/ubuntu/chromium/src/replay_build_scripts/devtools-tests.sh"
+
   # wait for all steps above, but also continue if they fail
   - wait: ~
     continue_on_failure: true

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -27,7 +27,7 @@ fi
 
 
 # TODO(toshok) when/if the devtools PR (https://github.com/replayio/devtools/pull/10001) lands, change the ref here to `main`
-INPUTS='{"ref":"toshok/accept-run-id","inputs":{"runId":"'${RUN_ID}'","linuxBuildFile":"'${BUILD_ID}'.tar.xz"}}'
+INPUTS='{"ref":"main","inputs":{"runId":"'${RUN_ID}'","linuxBuildFile":"'${BUILD_ID}'.tar.xz"}}'
 echo "Running devtools tests on GitHub with inputs: ${INPUTS}"
 
 curl -L -s \

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -1,0 +1,44 @@
+if [ -n "${BUILDKITE}" ]; then
+    buildkite-agent artifact download build_id/linux/x86_64/build_id ./
+    BUILD_ID=$(cat build_id/linux/x86_64/build_id)
+
+    if [ -z "${BUILD_ID}" ]; then
+        echo "Unable to retrieve build id from buildkite agent"
+        exit 1
+    fi
+else
+    BUILD_ID=$1
+    if [ -z "${BUILD_ID}" ]; then
+        echo "build ID required as first argument";
+        exit 1
+    fi
+fi
+
+if [ -z "${GITHUB_AUTH_SECRET}" ]; then
+    echo "GITHUB_AUTH_SECRET is not set in environment"
+    exit 1
+fi
+
+INPUTS='{"ref":"master","inputs":{"linuxBuildFile":"'${BUILD_ID}'.tar.xz"}}'
+echo 'Running devtools tests on GitHub with inputs: '${INPUTS}
+
+curl -L -s \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/replayio/devtools/actions/workflows/test.yml/dispatches \
+    -d ${INPUTS}
+sleep 5
+
+GH_URL=$(curl -L -s \
+    -X GET \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/replayio/devtools/actions/runs\?event\=workflow_dispatch | jq -r '"Metabase Test Run: " + (.workflow_runs[0].html_url // "Not Found")')
+
+echo "\n${GH_URL}"
+if [ -n "${BUILDKITE}" ]; then
+    buildkite-agent annotate --context tests "${GH_URL}"
+fi

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -72,7 +72,7 @@ while [[ $iter -le $ITER_COUNT ]]; do
       url_annotation_done="yes"
       echo "Github workflow run url: ${RUN_URL}"
       if [ -n "${BUILDKITE}" ]; then
-        buildkite-agent annotate --context tests "${GH_URL}"
+        buildkite-agent annotate --context tests "${RUN_URL}"
       fi
     fi
 

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [ -n "${BUILDKITE}" ]; then
+set -eu
+
+if [ -n "${BUILDKITE-}" ]; then
     buildkite-agent artifact download build_id/linux/x86_64/build_id ./
     BUILD_ID=$(cat build_id/linux/x86_64/build_id)
 

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -10,7 +10,7 @@ if [ -n "${BUILDKITE-}" ]; then
         echo "Unable to retrieve build id from buildkite agent"
         exit 1
     fi
-    RUN_ID="$BUILDKITE_PIPELINE_SLUG/$BUILDKITE_BUILD_NUM"
+    RUN_ID="$BUILDKITE_PIPELINE_SLUG/$BUILDKITE_BUILD_NUMBER"
 else
     BUILD_ID=$1
     if [ -z "${BUILD_ID}" ]; then

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ -n "${BUILDKITE}" ]; then
     buildkite-agent artifact download build_id/linux/x86_64/build_id ./
     BUILD_ID=$(cat build_id/linux/x86_64/build_id)
@@ -6,12 +8,14 @@ if [ -n "${BUILDKITE}" ]; then
         echo "Unable to retrieve build id from buildkite agent"
         exit 1
     fi
+    RUN_ID="$BUILDKITE_PIPELINE_SLUG/$BUILDKITE_BUILD_NUM"
 else
     BUILD_ID=$1
     if [ -z "${BUILD_ID}" ]; then
         echo "build ID required as first argument";
         exit 1
     fi
+    RUN_ID=test-$(uuidgen)
 fi
 
 if [ -z "${GITHUB_AUTH_SECRET}" ]; then
@@ -19,8 +23,10 @@ if [ -z "${GITHUB_AUTH_SECRET}" ]; then
     exit 1
 fi
 
-INPUTS='{"ref":"master","inputs":{"linuxBuildFile":"'${BUILD_ID}'.tar.xz"}}'
-echo 'Running devtools tests on GitHub with inputs: '${INPUTS}
+
+# TODO(toshok) when/if the devtools PR (https://github.com/replayio/devtools/pull/10001) lands, change the ref here to `main`
+INPUTS='{"ref":"toshok/accept-run-id","inputs":{"runId":"'${RUN_ID}'","linuxBuildFile":"'${BUILD_ID}'.tar.xz"}}'
+echo "Running devtools tests on GitHub with inputs: ${INPUTS}"
 
 curl -L -s \
     -X POST \
@@ -29,16 +35,57 @@ curl -L -s \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/replayio/devtools/actions/workflows/test.yml/dispatches \
     -d ${INPUTS}
-sleep 5
 
-GH_URL=$(curl -L -s \
+# and now we wait for a maximum of ITER_COUNT, sleeping SLEEP_SEC_PER_ITER per iteration, polling
+# the GH api to get the build status.
+
+# these values should give us ~20 minutes of wait time, which should be wayyy more than enough.
+SLEEP_SEC_PER_ITER=60
+ITER_COUNT=20
+
+EXPECTED_RUN_NAME="Run test suites - run id ${RUN_ID}"
+echo "Expected workflow run name: ${EXPECTED_RUN_NAME}"
+
+iter=0
+url_annotation_done=""
+
+while [[ $iter -le $ITER_COUNT ]]; do
+  iter=$(( iter + 1 ))
+  echo "Iteration ${iter}, sleeping for ${SLEEP_SEC_PER_ITER} seconds..."
+  sleep $SLEEP_SEC_PER_ITER
+
+  RUN_JSON=$(curl -L -s \
     -X GET \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/replayio/devtools/actions/runs\?event\=workflow_dispatch | jq -r '"Metabase Test Run: " + (.workflow_runs[0].html_url // "Not Found")')
+    https://api.github.com/repos/replayio/devtools/actions/runs\?event\=workflow_dispatch | jq -r ".workflow_runs[] | select(.name==\"${EXPECTED_RUN_NAME}\")")
 
-echo "\n${GH_URL}"
-if [ -n "${BUILDKITE}" ]; then
-    buildkite-agent annotate --context tests "${GH_URL}"
-fi
+  if [[ -n "$RUN_JSON" ]]; then
+    RUN_STATUS=$(echo "${RUN_JSON}" | jq -r .status)
+    RUN_CONCLUSION=$(echo "${RUN_JSON}" | jq -r .conclusion)
+    RUN_URL=$(echo "${RUN_JSON}" | jq -r .html_url)
+
+    if [[ -z "${url_annotation_done}" ]]; then
+      url_annotation_done="yes"
+      echo "Github workflow run url: ${RUN_URL}"
+      if [ -n "${BUILDKITE}" ]; then
+        buildkite-agent annotate --context tests "${GH_URL}"
+      fi
+    fi
+
+    if [[ $RUN_STATUS == "completed" ]]; then
+      echo "Github workflow completed with conclusion: ${RUN_CONCLUSION}"
+      if [[ $RUN_CONCLUSION == "success" ]]; then
+        # reflect the success status back to build kite
+        exit 0
+      else
+        exit -1
+      fi
+    else
+      echo "Run status was ${RUN_STATUS}, continuing to poll..."
+    fi
+  else
+    echo "Run '${EXPECTED_RUN_NAME}' not present in workflow run list"
+  fi
+done

--- a/replay_build_scripts/devtools-tests.sh
+++ b/replay_build_scripts/devtools-tests.sh
@@ -91,3 +91,7 @@ while [[ $iter -le $ITER_COUNT ]]; do
     echo "Run '${EXPECTED_RUN_NAME}' not present in workflow run list"
   fi
 done
+
+echo "GH workflow run didn't complete in time.  failing this step."
+echo "If builds need to take longer, increase the iteration count or sleep time per iteration"
+exit -1


### PR DESCRIPTION
The devtools side of this is https://github.com/replayio/devtools/pull/10001

example of the triggered step here: https://buildkite.com/replay/chromium-build/builds/2644#018c60ce-29cb-44c5-a877-ce0f75031d20

and the corresponding honeycomb trace https://ui.honeycomb.io/replay/datasets/buildevents/result/Ge4XiFPjBgJ/trace/f4p9Y6dZGDB?fields[]=s_name&fields[]=s_serviceName&fields[]=c_pipeline_slug&fields[]=c_meta.arch&span=018c60cd-eaef-4824-b2e4-e884be35d5010