### PR TITLE
[RUN-2962] Fix console level

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -463,10 +463,16 @@ function Target_evaluatePrivileged({ expression }) {
   return { result };
 }
 
+const cdpToRrpConsoleLevels = new Map([
+  ["info", "info"],
+  ["warning", "warning"],
+  ["error", "error"],
+  ["timeEnd", "timeEnd"]
+]);
+
 // Contents of the last console API call. Runtime.consoleAPICalled will be
 // emitted before the driver gets the current message contents.
 let gLastConsoleAPICall;
-
 function onConsoleAPICall(params) {
   gLastConsoleAPICall = params;
 }
@@ -505,15 +511,7 @@ function Target_getCurrentMessageContents() {
     argumentValues.push(buildRrpObjectFromCdpObject(arg));
   }
 
-  let level = "info";
-  switch (gLastConsoleAPICall.level) {
-    case "warning":
-      level = "warning";
-      break;
-    case "error":
-      level = "error";
-      break;
-  }
+  const level = cdpToRrpConsoleLevels.get(gLastConsoleAPICall.type) || "info";
 
   let url, sourceId, line, column;
   if (gLastConsoleAPICall.stackTrace) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2962/chromium-incorrectly-categorizes-consoleerror-and-consolewarn-messages