### PR TITLE
Skip fallback font when diverged from the recording

### DIFF
--- a/third_party/blink/renderer/platform/fonts/mac/font_cache_mac.mm
+++ b/third_party/blink/renderer/platform/fonts/mac/font_cache_mac.mm
@@ -129,7 +129,8 @@ scoped_refptr<SimpleFontData> FontCache::PlatformFallbackFontForCharacter(
       return emoji_font;
   }
 
-  if (recordreplay::AreEventsDisallowed("PlatformFallbackFontForCharacter")) {
+  if (recordreplay::AreEventsDisallowed("PlatformFallbackFontForCharacter") ||
+      recordreplay::HasDivergedFromRecording()) {
     // [RUN-2765] Circumvent a rabbit hole of MAC-related font calls.
     return nullptr;
   }


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-2895/segfault-in-fontplatformdatactfont