### PR TITLE
[RUN-3046] Add patchReplayApi()

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -436,7 +436,6 @@ function commandCallback(method, params) {
     return {};
   }
 
-  firstReplayApiError = null;
   try {
     VerboseCommands && log(`[Command ${method}] Handling command, params=${JSON_stringify(params)}...`);
     const result = CommandCallbacks[method](params);
@@ -452,11 +451,6 @@ function commandCallback(method, params) {
       message: e?.message || (e + ''),
       stack: e?.stack?.split?.("\n") || e?.stack || [],
     };
-  } finally {
-    // Note: This ignores the actually thrown error, which might not exist or
-    // be entirely different from the error that was thrown from within a
-    // Replay API call.
-    checkCommandHandlingErrors(method);
   }
 }
 const executeCommand = commandCallback;
@@ -694,6 +688,7 @@ function getCurrentEvaluateFrame() {
 }
 
 function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
+  // TODO: I need to take one more pass at this, so we can, under some circumstances, catch all exceptions thrown by eval, rather than just our own API.
   const frameIndex = +frameIndexStr;
   const frame = getFrameByIndex(frameIndex);
   gCurrentEvaluateFrame = frame;
@@ -741,6 +736,13 @@ function Pause_evaluateInGlobal({ expression }) {
 }
 
 function buildEvalResult(cdpResult) {
+  if (usedReplayApi && cdpResult?.exceptionDetails) {
+    const cdpException = cdpResult.exceptionDetails.exception;
+    const exceptionObj = cdpException ?
+      getPlainObjectFromCdpObject(cdpException) : 
+      { message: cdpResult.exceptionDetails.text || "" };
+    warning(`REPLAY_API_EVAL_ERROR Exception: ${JSON_stringify(exceptionObj)}`);
+  }
   return buildRrpObjectResult(cdpResult);
 }
 
@@ -993,6 +995,12 @@ function getPlainObjectByRrpId(rrpId) {
     gPlainObjectByRrpId.set(rrpId, plainObject);
   }
   return plainObject;
+}
+
+function getPlainObjectFromCdpObject(cdpObject) {
+  const cdpId = cdpObject.objectId;
+  assert(cdpId);
+  return fromJsGetObjectByCdpId(cdpId);
 }
 
 /**
@@ -3127,7 +3135,7 @@ Object.assign(__RECORD_REPLAY__, {
  * diagnostics.
  * ##########################################################################*/
 
-let firstReplayApiError = null;
+let usedReplayApi = 0;
 
 function patchReplayApi() {
   patchReplayApiObject(__RECORD_REPLAY__);
@@ -3146,33 +3154,13 @@ function patchReplayApiObject(obj) {
 
 function wrapReplayApiFunction(fn) {
   if (fn === commandCallback) {
-    // The command callback should not be patched to avoid infinite loops.
+    // The command callback itself should not be patched.
     return commandCallback;
   }
   return (...args) => {
-    try {
-      log(`DDBG wrapReplayApiFunction ${fn.name}`);
-      return fn(...args);
-    } catch (err) {
-      // Remember internal errors for possible reporting later.
-      log(`DDBG firstReplayApiError ${err.stack}`);
-      firstReplayApiError ||= err;
-      throw err;
-    }
+    ++usedReplayApi;
+    return fn(...args);
   };
-}
-
-/**
- * Check for potential internal errors and report them.
- */
-function checkCommandHandlingErrors(method) {
-  if (firstReplayApiError) {
-    const msg = firstReplayApiError.stack ||
-      firstReplayApiError.toString?.() ||
-      firstReplayApiError;
-    warning(`INTERNAL_API_ERROR ${method} - ${msg}`);
-    firstReplayApiError = null;
-  }
 }
 
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -737,6 +737,7 @@ function Pause_evaluateInGlobal({ expression }) {
 
 function buildEvalResult(cdpResult) {
   if (usedReplayApi && cdpResult?.exceptionDetails) {
+    // Emit warning if an eval that used the Replay API throws.
     const cdpException = cdpResult.exceptionDetails.exception?.description || cdpResult.exceptionDetails;
     warning(`REPLAY_API_EVAL_ERROR ${JSON_stringify(cdpException)}`);
   }
@@ -3150,10 +3151,6 @@ function patchReplayApiObject(obj) {
 }
 
 function wrapReplayApiFunction(fn) {
-  if (fn === commandCallback) {
-    // The command callback itself should not be patched.
-    return commandCallback;
-  }
   return (...args) => {
     ++usedReplayApi;
     return fn(...args);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -234,8 +234,12 @@ function assert(v, msg = "") {
   }
 }
 
+function isFunction(val) {
+  return typeof val === "function";
+}
+
 function isObject(val) {
-  return !!val && (typeof val === "object" || typeof val === "function")
+  return !!val && (typeof val === "object" || isFunction(val))
 }
 
 function typeofMaybeNull(value) {
@@ -388,7 +392,7 @@ function messageCallback(message) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// main.js
+// Command Handlers
 ///////////////////////////////////////////////////////////////////////////////
 
 // Methods for interacting with the record/replay driver.
@@ -397,31 +401,6 @@ function messageCallback(message) {
 // inject via evaluatePrivilegd can know what contexts are available.
 const gExecutionContexts = new Map();
 const gContextChangeCallbacks = new Set();
-
-initMessages();
-addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
-addEventListener("Runtime.executionContextCreated", ({ context }) => {
-  gExecutionContexts.set(context.id, context);
-  for (const callback of gContextChangeCallbacks) {
-    callback(context, "add");
-  }
-});
-addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
-  const context = gExecutionContexts.get(executionContextId);
-  for (const callback of gContextChangeCallbacks) {
-    callback(context, "remove");
-  }
-  gExecutionContexts.delete(executionContextId);
-});
-addEventListener("Runtime.executionContextsCleared", () => {
-  for (const context of gExecutionContexts.values()) {
-    for (const callback of gContextChangeCallbacks) {
-      callback(context, "remove");
-    }
-  }
-  gExecutionContexts.clear();
-});
-sendMessage("Runtime.enable");
 
 const CommandCallbacks = {
   "Graphics.getDevicePixelRatio": Graphics_getDevicePixelRatio,
@@ -457,6 +436,7 @@ function commandCallback(method, params) {
     return {};
   }
 
+  firstReplayApiError = null;
   try {
     VerboseCommands && log(`[Command ${method}] Handling command, params=${JSON_stringify(params)}...`);
     const result = CommandCallbacks[method](params);
@@ -472,6 +452,11 @@ function commandCallback(method, params) {
       message: e?.message || (e + ''),
       stack: e?.stack?.split?.("\n") || e?.stack || [],
     };
+  } finally {
+    // Note: This ignores the actually thrown error, which might not exist or
+    // be entirely different from the error that was thrown from within a
+    // Replay API call.
+    checkCommandHandlingErrors(method);
   }
 }
 const executeCommand = commandCallback;
@@ -708,14 +693,14 @@ function getCurrentEvaluateFrame() {
   return gCurrentEvaluateFrame;
 }
 
-function Pause_evaluateInFrame({ internal, frameId: frameIndexStr, expression }) {
+function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
   const frameIndex = +frameIndexStr;
   const frame = getFrameByIndex(frameIndex);
   gCurrentEvaluateFrame = frame;
   let rv;
   try {
     rv = doEvaluation();
-    return buildEvalResult(internal, rv);
+    return buildEvalResult(rv);
   } catch (err) {
     return handleEvalError(err);
   } finally {
@@ -739,7 +724,7 @@ function Pause_evaluateInFrame({ internal, frameId: frameIndexStr, expression })
   }
 }
 
-function Pause_evaluateInGlobal({ internal, expression }) {
+function Pause_evaluateInGlobal({ expression }) {
   let rv;
   try {
     rv = sendMessage(
@@ -752,14 +737,10 @@ function Pause_evaluateInGlobal({ internal, expression }) {
   } catch (err) {
     return handleEvalError(err);
   }
-  return buildEvalResult(internal, rv);
+  return buildEvalResult(rv);
 }
 
-/**
- * 
- */
-function buildEvalResult(internal, cdpResult) {
-  // TODO
+function buildEvalResult(cdpResult) {
   return buildRrpObjectResult(cdpResult);
 }
 
@@ -3077,6 +3058,9 @@ function adjustCoordinateByTransformMatrix(coord, m) {
  * Export internal methods via `__RECORD_REPLAY_ARGUMENTS__`.
  * This is to be used for internal debugging purposes.
  * ##########################################################################*/
+
+// TODO: Get rid of `internal`. There is no reason to have this in addition to
+//       __RECORD_REPLAY_ARGUMENTS__ and __RECORD_REPLAY__.
 __RECORD_REPLAY_ARGUMENTS__.internal = {
   getBlinkNodeIdByRrpId,
   getCdpObjectByRrpId,
@@ -3137,6 +3121,90 @@ Object.assign(__RECORD_REPLAY__, {
   getCurrentEvaluateFrame,
   replayEval
 });
+
+/** ###########################################################################
+ * {@link patchReplayApi} decorates our API objects/functions with extra
+ * diagnostics.
+ * ##########################################################################*/
+
+let firstReplayApiError = null;
+
+function patchReplayApi() {
+  patchReplayApiObject(__RECORD_REPLAY__);
+  patchReplayApiObject(__RECORD_REPLAY_ARGUMENTS__);
+  patchReplayApiObject(__RECORD_REPLAY_ARGUMENTS__.internal);
+}
+
+function patchReplayApiObject(obj) {
+  for (const key in obj) {
+    const value = obj[key];
+    if (isFunction(value)) {
+      obj[key] = wrapReplayApiFunction(value);
+    }
+  }
+}
+
+function wrapReplayApiFunction(fn) {
+  if (fn === commandCallback) {
+    // The command callback should not be patched to avoid infinite loops.
+    return commandCallback;
+  }
+  return (...args) => {
+    try {
+      log(`DDBG wrapReplayApiFunction ${fn.name}`);
+      return fn(...args);
+    } catch (err) {
+      // Remember internal errors for possible reporting later.
+      log(`DDBG firstReplayApiError ${err.stack}`);
+      firstReplayApiError ||= err;
+      throw err;
+    }
+  };
+}
+
+/**
+ * Check for potential internal errors and report them.
+ */
+function checkCommandHandlingErrors(method) {
+  if (firstReplayApiError) {
+    const msg = firstReplayApiError.stack ||
+      firstReplayApiError.toString?.() ||
+      firstReplayApiError;
+    warning(`INTERNAL_API_ERROR ${method} - ${msg}`);
+    firstReplayApiError = null;
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// main.js
+///////////////////////////////////////////////////////////////////////////////
+
+patchReplayApi();
+initMessages();
+addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
+addEventListener("Runtime.executionContextCreated", ({ context }) => {
+  gExecutionContexts.set(context.id, context);
+  for (const callback of gContextChangeCallbacks) {
+    callback(context, "add");
+  }
+});
+addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
+  const context = gExecutionContexts.get(executionContextId);
+  for (const callback of gContextChangeCallbacks) {
+    callback(context, "remove");
+  }
+  gExecutionContexts.delete(executionContextId);
+});
+addEventListener("Runtime.executionContextsCleared", () => {
+  for (const context of gExecutionContexts.values()) {
+    for (const callback of gContextChangeCallbacks) {
+      callback(context, "remove");
+    }
+  }
+  gExecutionContexts.clear();
+});
+sendMessage("Runtime.enable");
 
 } catch (e) {
   log(`Error: Initialization exception ${e}`);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -737,11 +737,8 @@ function Pause_evaluateInGlobal({ expression }) {
 
 function buildEvalResult(cdpResult) {
   if (usedReplayApi && cdpResult?.exceptionDetails) {
-    const cdpException = cdpResult.exceptionDetails.exception;
-    const exceptionObj = cdpException ?
-      getPlainObjectFromCdpObject(cdpException) : 
-      { message: cdpResult.exceptionDetails.text || "" };
-    warning(`REPLAY_API_EVAL_ERROR Exception: ${JSON_stringify(exceptionObj)}`);
+    const cdpException = cdpResult.exceptionDetails.exception?.description || cdpResult.exceptionDetails;
+    warning(`REPLAY_API_EVAL_ERROR ${JSON_stringify(cdpException)}`);
   }
   return buildRrpObjectResult(cdpResult);
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -591,7 +591,7 @@ function Target_topFrameLocation() {
     if (e instanceof CDPMessageError) {
       // No available context group; this can happen, so just return nothing.
       if (e.code == CDPERROR_MISSINGCONTEXT) {
-        warning(`JS Target_topFrameLocation has no context.`);
+        warning(`[RUN-2600] JS Target_topFrameLocation has no context.`);
         return {};
       }
     }
@@ -619,7 +619,7 @@ function getStackFrames() {
     if (e instanceof CDPMessageError) {
       // No available context group; this can happen, so just return nothing.
       if (e.code == CDPERROR_MISSINGCONTEXT) {
-        warning(`JS getStackFrames has no context.`);
+        warning(`[RUN-2600] JS getStackFrames has no context.`);
         return [];
       }
     }
@@ -1419,7 +1419,7 @@ ProtocolObjectPreview.prototype = {
       } catch (e) {
         // No available context group; this can happen, so just return nothing.
         if (e.code == CDPERROR_MISSINGCONTEXT) {
-          warning(`JS ProtocolObjectPreview.fill has no context.`);
+          warning(`[RUN-2600] JS ProtocolObjectPreview.fill has no context.`);
           cdpProperties = { result: [] };
         } else {
           throw e;
@@ -4075,7 +4075,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
       // Construct our error result.
       std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
-      error->SetStringKey("message", "No context group available for Isolate.");
+      error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
       error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
 
       base::DictionaryValue result;
@@ -4473,7 +4473,7 @@ getObjectByCdpId(v8::Isolate* isolate,
 
   absl::optional<int> contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
   if (!contextGroupId.has_value()) {
-    recordreplay::Warning("getObjectByCdpId - Failed to find contextGroupId");
+    recordreplay::Warning("[RUN-2600] getObjectByCdpId - Failed to find contextGroupId");
     return false;
   }
 
@@ -4522,7 +4522,7 @@ static void fromJsMakeDebuggeeValue(
   auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
 
   if (!contextGroupId.has_value()) {
-      recordreplay::Warning("fromJsMakeDebuggeeValue - no valid context id");
+      recordreplay::Warning("[RUN-2600] fromJsMakeDebuggeeValue - no valid context id");
       args.GetReturnValue().SetNull();
       return;
   }
@@ -4557,7 +4557,7 @@ static void fromJsGetArgumentsInFrame(
   auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
 
   if (!contextGroupId.has_value()) {
-    recordreplay::Warning("fromJsGetArgumentsInFrame - no valid context id");
+    recordreplay::Warning("[RUN-2600] fromJsGetArgumentsInFrame - no valid context id");
     args.GetReturnValue().SetNull();
     return;
   }
@@ -5162,7 +5162,7 @@ static void fromJsGetMatchedStylesForElement(
 
   auto cssAgent = getOrCreateInspectorCSSAgent(isolate);
   if (!cssAgent.has_value()) {
-    recordreplay::Warning("CDP CSS.getMatchedStylesForNode failed no context id");
+    recordreplay::Warning("[RUN-2600] fromJsGetMatchedStylesForElement failed no context id");
     args.GetReturnValue().SetNull();
     return;
   }
@@ -5229,7 +5229,7 @@ static void fromJsCssGetStylesheetByCpdId(
   auto sheetId = ToCoreString(args[0].As<v8::String>());
   auto cssAgent = getOrCreateInspectorCSSAgent(isolate);
   if (!cssAgent.has_value()) {
-    recordreplay::Warning("fromJsCssGetStylesheetByCpdId failed no context id");
+    recordreplay::Warning("[RUN-2600] fromJsCssGetStylesheetByCpdId failed no context id");
     args.GetReturnValue().SetNull();
     return;
   }
@@ -5253,7 +5253,7 @@ static void fromJsDomPerformSearch(
   auto query = ToCoreString(args[0].As<v8::String>());
   auto domAgent = getOrCreateInspectorDOMAgent(isolate);
   if (!domAgent.has_value()) {
-    recordreplay::Warning("fromJsDomPerformSearch failed no context id");
+    recordreplay::Warning("[RUN-2600] fromJsDomPerformSearch failed no context id");
     return;
   }
 
@@ -5307,7 +5307,7 @@ static void fromJsCollectEventListeners(const v8::FunctionCallbackInfo<v8::Value
 
   v8::Local<v8::Array> result = v8::Array::New(isolate);
   if (!node) {
-    recordreplay::Warning("JS fromJsCollectEventListeners: invalid argument is not blink Node");
+    recordreplay::Warning("[RUN-2282] JS fromJsCollectEventListeners: invalid argument is not blink Node");
   } else {
     auto report_for_all_contexts = true;
     V8EventListenerInfoList eventListenerInfos;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -708,14 +708,14 @@ function getCurrentEvaluateFrame() {
   return gCurrentEvaluateFrame;
 }
 
-function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
+function Pause_evaluateInFrame({ internal, frameId: frameIndexStr, expression }) {
   const frameIndex = +frameIndexStr;
   const frame = getFrameByIndex(frameIndex);
   gCurrentEvaluateFrame = frame;
   let rv;
   try {
     rv = doEvaluation();
-    return buildRrpObjectResult(rv);
+    return buildEvalResult(internal, rv);
   } catch (err) {
     return handleEvalError(err);
   } finally {
@@ -739,7 +739,7 @@ function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
   }
 }
 
-function Pause_evaluateInGlobal({ expression }) {
+function Pause_evaluateInGlobal({ internal, expression }) {
   let rv;
   try {
     rv = sendMessage(
@@ -752,7 +752,15 @@ function Pause_evaluateInGlobal({ expression }) {
   } catch (err) {
     return handleEvalError(err);
   }
-  return buildRrpObjectResult(rv);
+  return buildEvalResult(internal, rv);
+}
+
+/**
+ * 
+ */
+function buildEvalResult(internal, cdpResult) {
+  // TODO
+  return buildRrpObjectResult(cdpResult);
 }
 
 function Pause_getAllFrames() {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -688,7 +688,6 @@ function getCurrentEvaluateFrame() {
 }
 
 function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
-  // TODO: I need to take one more pass at this, so we can, under some circumstances, catch all exceptions thrown by eval, rather than just our own API.
   const frameIndex = +frameIndexStr;
   const frame = getFrameByIndex(frameIndex);
   gCurrentEvaluateFrame = frame;
@@ -2113,7 +2112,6 @@ function DOM_getEventListeners({ node }) {
 
   if (nodeObject.nodeName && nodeObject.nodeName == "HTML") {
     // Add event listeners for the document and window as well.
-    // TODO: figure out ownerGlobal for chromium - https://linear.app/replay/issue/RUN-1041
     listenerInfos.push(
       ...fromJsCollectEventListeners(nodeObject.parentNode)   // document
       // ...fromJsCollectEventListeners(nodeObject.ownerGlobal)  // window
@@ -3916,11 +3914,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
   if (result->IsString()) {
     v8::String::Utf8Value messageValue(isolate, result);
     std::string messageStr(*messageValue);
-
-    // TODO: Replace this with an API call to `RecordReplaySetCrashReasonCallback`
-    // See RUN-1562: https://linear.app/replay/issue/RUN-1562
-    recordreplay::Print("ErrorFatal %s:%d %s", "js", 0, messageStr.c_str());
-    IMMEDIATE_CRASH();
+    recordreplay::Crash("CDPMessageCallback FAILED %s:%d %s", "js", 0, messageStr.c_str());
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -693,6 +693,7 @@ function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
   gCurrentEvaluateFrame = frame;
   let rv;
   try {
+    onBeforeEval();
     rv = doEvaluation();
     return buildEvalResult(rv);
   } catch (err) {
@@ -721,6 +722,7 @@ function Pause_evaluateInFrame({ frameId: frameIndexStr, expression }) {
 function Pause_evaluateInGlobal({ expression }) {
   let rv;
   try {
+    onBeforeEval();
     rv = sendMessage(
       "Runtime.evaluate",
       {
@@ -732,6 +734,10 @@ function Pause_evaluateInGlobal({ expression }) {
     return handleEvalError(err);
   }
   return buildEvalResult(rv);
+}
+
+function onBeforeEval() {
+  onReplayApiReset();
 }
 
 function buildEvalResult(cdpResult) {
@@ -3128,10 +3134,18 @@ Object.assign(__RECORD_REPLAY__, {
 
 /** ###########################################################################
  * {@link patchReplayApi} decorates our API objects/functions with extra
- * diagnostics.
+ * diagnostics, e.g. whether the Replay API was called at all.
  * ##########################################################################*/
 
 let usedReplayApi = 0;
+
+function onReplayApiUsed() {
+  ++usedReplayApi;
+}
+
+function onReplayApiReset() {
+  usedReplayApi = 0;
+}
 
 function patchReplayApi() {
   patchReplayApiObject(__RECORD_REPLAY__);
@@ -3150,7 +3164,7 @@ function patchReplayApiObject(obj) {
 
 function wrapReplayApiFunction(fn) {
   return (...args) => {
-    ++usedReplayApi;
+    onReplayApiUsed();
     return fn(...args);
   };
 }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-3046/produce-warnings-if-evals-using-record-replay-internal-api-fail#comment-b27dbe4f
* Sneaky:
  * Move `gReplayScript` init code from somewhere in the middle to the very end, so its easier to reason about and does not run the risk of unfulfilled dependencies following the init code itself.
  * Add tags to `eval` warnings (`2600`).