### PR TITLE
build-1208

### DIFF
--- a/components/record_replay/services/auth_token/BUILD.gn
+++ b/components/record_replay/services/auth_token/BUILD.gn
@@ -14,6 +14,7 @@ source_set("lib") {
 
   deps = [
     "//base",
+    "//content/public/browser:browser",
     "//mojo/public/cpp/bindings",
   ]
 

--- a/third_party/blink/renderer/bindings/core/v8/tmp.md
+++ b/third_party/blink/renderer/bindings/core/v8/tmp.md
@@ -1,0 +1,1 @@
+Useless diff, so we can create a PR.

--- a/ui/base/resource/data_pack.cc
+++ b/ui/base/resource/data_pack.cc
@@ -26,6 +26,8 @@
 #include "third_party/zlib/google/compression_utils.h"
 #include "ui/base/resource/scoped_file_writer.h"
 
+#include "base/record_replay.h"
+
 // For details of the file layout, see
 // http://dev.chromium.org/developers/design-documents/linuxresourcesandlocalizedstrings
 
@@ -217,6 +219,14 @@ std::unique_ptr<DataPack::DataSource> DataPack::LoadFromPathInternal(
   base::File data_file(path, base::File::FLAG_OPEN | base::File::FLAG_READ |
                                  base::File::FLAG_WIN_EXCLUSIVE_WRITE |
                                  base::File::FLAG_WIN_SHARE_DELETE);
+  
+  recordreplay::Assert("[RUN-3051] DataPack::LoadFromPathInternal %lld %s",
+    path.LossyDisplayName().c_str(),
+    data_file.GetLength());
+  recordreplay::Print("DDBG DataPack::LoadFromPathInternal %lld %s",
+    path.LossyDisplayName().c_str(),
+    data_file.GetLength());
+
   if (!data_file.IsValid()) {
     DLOG(ERROR) << "Failed to open datapack with base::File::Error "
                 << data_file.error_details();


### PR DESCRIPTION
* This is functionally equivalent to the `1208` build
* Used for testing for https://linear.app/replay/issue/RUN-3050/unblocking-chromium-release
* Actual RUN with reverted `DRIVER_LINKER_REVISION`:
  * https://buildkite.com/replay/chromium-build/builds/2739