### PR TITLE
[RUN-1976] Fix ordering of ScopedInterfaceEndpointHandle::State::lock_

### DIFF
--- a/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
+++ b/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
@@ -22,12 +22,11 @@ namespace mojo {
 class ScopedInterfaceEndpointHandle::State
     : public base::RefCountedThreadSafe<State> {
  public:
-  State() : lock_("ScopedInterfaceEndpointHandle::State.lock_") {}
+  State() = default;
 
   State(InterfaceId id,
         scoped_refptr<AssociatedGroupController> group_controller)
-      : lock_("ScopedInterfaceEndpointHandle::State.lock_"),
-        id_(id), group_controller_(group_controller) {}
+      : id_(id), group_controller_(group_controller) {}
 
   State(const State&) = delete;
   State& operator=(const State&) = delete;
@@ -36,7 +35,7 @@ class ScopedInterfaceEndpointHandle::State
     DCHECK(!lock_);
     DCHECK(!pending_association_);
 
-    lock_.emplace();
+    lock_.emplace("ScopedInterfaceEndpointHandle::State.lock_");
     pending_association_ = true;
     peer_state_ = std::move(peer);
   }


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1976/mismatch-in-scopedinterfaceendpointhandlegroup-controller#comment-23b5ac00