### PR TITLE
[RUN-2965] Properly re-initialize `gReplayScript` (and its dependencies) where necessary

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,40 @@
 env:
   FORCE_COLOR: 1
   GIT_TERMINAL_PROMPT: 0
+
 steps:
-  - label: Build chromium - Mac (x86)
-    key: build-chromium-mac-x86_64
+  - label: "Build chromium - Linux"
+    key: "build-chromium-linux-x86_64"
+    timeout_in_minutes: 60
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /home/ubuntu/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    commands:
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buck2 kill"
+      - "be_cmd buck2-build -- buck2 build --console simple //:chromium"
+      - "popd"
+    env:
+      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
+      GOMACTL_USE_PROXY: false
+      RECORD_REPLAY_BACKEND_DIR: /home/ubuntu/chromium/backend
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
+    artifact_paths:
+      - "build_id/linux/x86_64/**"
+  - label: "Build chromium - Mac (x86)"
+    key: "build-chromium-mac-x86_64"
     timeout_in_minutes: 60
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
@@ -13,34 +44,27 @@ steps:
           env:
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: null
+      - replayio/buildevents#adb8a05: ~
     commands:
-      - be_cmd git-fetch-all -- git fetch --all
-      - be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH
-      - >-
-        be_cmd update-all-repos -- node
-        replay_build_scripts/update-all-repos.mjs
-      - pushd ../backend
-      - be_cmd buck2-kill -- buckle kill
-      - >-
-        be_cmd buck2-build -- buckle build --console simple //:chromium
-        --target-platforms=//:macos-x86_64
-      - popd
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build --console simple //:chromium --target-platforms=//:macos-x86_64"
+      - "popd"
     env:
       GOMA_SERVER_HOST: simpsonite.goma.engflow.com
       GOMACTL_USE_PROXY: false
       RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-      DRIVER_REVISION: bfa48f25922d
     agents:
-      - runtimeType=chromiumbuild
-      - os=macos
-      - queue=runtime
+      - "runtimeType=chromiumbuild"
+      - "os=macos"
+      - "queue=runtime"
     artifact_paths:
-      - build_id/macOS/x86_64/**
-    depends_on:
-      - build-driver-linker
-  - label: Build chromium - Mac (arm64)
-    key: build-chromium-mac-arm64
+      - "build_id/macOS/x86_64/**"
+  - label: "Build chromium - Mac (arm64)"
+    key: "build-chromium-mac-arm64"
     timeout_in_minutes: 60
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
@@ -50,43 +74,103 @@ steps:
           env:
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: null
+      - replayio/buildevents#adb8a05: ~
     commands:
-      - be_cmd git-fetch-all -- git fetch --all
-      - be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH
-      - >-
-        be_cmd update-all-repos -- node
-        replay_build_scripts/update-all-repos.mjs
-      - pushd ../backend
-      - be_cmd buck2-kill -- buckle kill
-      - >-
-        be_cmd buck2-build -- buckle build --console simple //:chromium
-        --target-platforms=//:macos-arm64
-      - popd
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build --console simple //:chromium --target-platforms=//:macos-arm64"
+      - "popd"
     env:
       GOMA_SERVER_HOST: simpsonite.goma.engflow.com
       GOMACTL_USE_PROXY: false
       REPLAY_BUILD_ARM: true
       RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-      DRIVER_REVISION: bfa48f25922d
     agents:
-      - runtimeType=chromiumbuild
-      - os=macos
-      - queue=runtime
+      - "runtimeType=chromiumbuild"
+      - "os=macos"
+      - "queue=runtime"
     artifact_paths:
-      - build_id/macOS/arm64/**
+      - "build_id/macOS/arm64/**"
+  - label: "Build chromium - Windows"
+    key: "build-chromium-windows"
+    timeout_in_minutes: 60
+    plugins:
+      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
+    command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
+    env:
+      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
+      GOMACTL_USE_PROXY: false
+      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=windows"
+      - "queue=runtime"
+    artifact_paths:
+      - "build_id/windows/x86_64/**"
+  - trigger: "testing-runtime-e2e"
+    label: ":hammer: Trigger Runtime Tests"
     depends_on:
-      - build-driver-linker
-  - trigger: testing-runtime-e2e
-    label: ':hammer: Trigger Runtime Tests'
-    depends_on:
-      - build-chromium-mac-x86_64
-      - build-chromium-mac-arm64
-      - build-driver-linker
-    build:
-      branch: dominik/run-2965-fe-throws-could-not-find-object-id-1
-  - trigger: build-driver-linker
-    key: build-driver-linker
-    label: Build Driver/Linker
-    build:
-      branch: dominik/run-2965-fe-throws-could-not-find-object-id-1
+      - "build-chromium-linux-x86_64"
+      - "build-chromium-mac-x86_64"
+      - "build-chromium-mac-arm64"
+  - label: "Metabase Test Suite"
+    key: "metabase-test-suite"
+    depends_on: "build-chromium-linux-x86_64"
+    if: build.branch == "master"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1: ~
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
+
+  - label: "Trigger Devtools E2E Tests"
+    key: "devtools-test-suite"
+    soft_fail: true
+    depends_on: "build-chromium-linux-x86_64"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1: ~
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            GITHUB_AUTH_SECRET: "prod/devtools-github-secret"
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    command: "be_cmd devtools-tests -- /home/ubuntu/chromium/src/replay_build_scripts/devtools-tests.sh"
+
+  # wait for all steps above, but also continue if they fail
+  - wait: ~
+    continue_on_failure: true
+
+  - label: "Buildevents Watch"
+    key: "buildevents-watch"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /home/ubuntu/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    command: "be_watch"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,40 +1,9 @@
 env:
   FORCE_COLOR: 1
   GIT_TERMINAL_PROMPT: 0
-
 steps:
-  - label: "Build chromium - Linux"
-    key: "build-chromium-linux-x86_64"
-    timeout_in_minutes: 60
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /home/ubuntu/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buck2 kill"
-      - "be_cmd buck2-build -- buck2 build --console simple //:chromium"
-      - "popd"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
-      RECORD_REPLAY_BACKEND_DIR: /home/ubuntu/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
-    artifact_paths:
-      - "build_id/linux/x86_64/**"
-  - label: "Build chromium - Mac (x86)"
-    key: "build-chromium-mac-x86_64"
+  - label: Build chromium - Mac (x86)
+    key: build-chromium-mac-x86_64
     timeout_in_minutes: 60
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
@@ -44,27 +13,34 @@ steps:
           env:
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
+      - replayio/buildevents#adb8a05: null
     commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build --console simple //:chromium --target-platforms=//:macos-x86_64"
-      - "popd"
+      - be_cmd git-fetch-all -- git fetch --all
+      - be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH
+      - >-
+        be_cmd update-all-repos -- node
+        replay_build_scripts/update-all-repos.mjs
+      - pushd ../backend
+      - be_cmd buck2-kill -- buckle kill
+      - >-
+        be_cmd buck2-build -- buckle build --console simple //:chromium
+        --target-platforms=//:macos-x86_64
+      - popd
     env:
       GOMA_SERVER_HOST: simpsonite.goma.engflow.com
       GOMACTL_USE_PROXY: false
       RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+      DRIVER_REVISION: bfa48f25922d
     agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
+      - runtimeType=chromiumbuild
+      - os=macos
+      - queue=runtime
     artifact_paths:
-      - "build_id/macOS/x86_64/**"
-  - label: "Build chromium - Mac (arm64)"
-    key: "build-chromium-mac-arm64"
+      - build_id/macOS/x86_64/**
+    depends_on:
+      - build-driver-linker
+  - label: Build chromium - Mac (arm64)
+    key: build-chromium-mac-arm64
     timeout_in_minutes: 60
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
@@ -74,103 +50,43 @@ steps:
           env:
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
+      - replayio/buildevents#adb8a05: null
     commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build --console simple //:chromium --target-platforms=//:macos-arm64"
-      - "popd"
+      - be_cmd git-fetch-all -- git fetch --all
+      - be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH
+      - >-
+        be_cmd update-all-repos -- node
+        replay_build_scripts/update-all-repos.mjs
+      - pushd ../backend
+      - be_cmd buck2-kill -- buckle kill
+      - >-
+        be_cmd buck2-build -- buckle build --console simple //:chromium
+        --target-platforms=//:macos-arm64
+      - popd
     env:
       GOMA_SERVER_HOST: simpsonite.goma.engflow.com
       GOMACTL_USE_PROXY: false
       REPLAY_BUILD_ARM: true
       RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+      DRIVER_REVISION: bfa48f25922d
     agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
+      - runtimeType=chromiumbuild
+      - os=macos
+      - queue=runtime
     artifact_paths:
-      - "build_id/macOS/arm64/**"
-  - label: "Build chromium - Windows"
-    key: "build-chromium-windows"
-    timeout_in_minutes: 60
-    plugins:
-      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
-    command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
-    env:
-      GOMA_SERVER_HOST: simpsonite.goma.engflow.com
-      GOMACTL_USE_PROXY: false
-      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=windows"
-      - "queue=runtime"
-    artifact_paths:
-      - "build_id/windows/x86_64/**"
-  - trigger: "testing-runtime-e2e"
-    label: ":hammer: Trigger Runtime Tests"
+      - build_id/macOS/arm64/**
     depends_on:
-      - "build-chromium-linux-x86_64"
-      - "build-chromium-mac-x86_64"
-      - "build-chromium-mac-arm64"
-  - label: "Metabase Test Suite"
-    key: "metabase-test-suite"
-    depends_on: "build-chromium-linux-x86_64"
-    if: build.branch == "master"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1: ~
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
-
-  - label: "Trigger Devtools E2E Tests"
-    key: "devtools-test-suite"
-    soft_fail: true
-    depends_on: "build-chromium-linux-x86_64"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1: ~
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            GITHUB_AUTH_SECRET: "prod/devtools-github-secret"
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    command: "be_cmd devtools-tests -- /home/ubuntu/chromium/src/replay_build_scripts/devtools-tests.sh"
-
-  # wait for all steps above, but also continue if they fail
-  - wait: ~
-    continue_on_failure: true
-
-  - label: "Buildevents Watch"
-    key: "buildevents-watch"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /home/ubuntu/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    command: "be_watch"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
+      - build-driver-linker
+  - trigger: testing-runtime-e2e
+    label: ':hammer: Trigger Runtime Tests'
+    depends_on:
+      - build-chromium-mac-x86_64
+      - build-chromium-mac-arm64
+      - build-driver-linker
+    build:
+      branch: dominik/run-2965-fe-throws-could-not-find-object-id-1
+  - trigger: build-driver-linker
+    key: build-driver-linker
+    label: Build Driver/Linker
+    build:
+      branch: dominik/run-2965-fe-throws-could-not-find-object-id-1

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '186402210248a20f7c8adf83e17a9e47190e00f5',
+  'v8_revision': 'e232edc284c73da811c305100aaf6dda3e2d3262',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e232edc284c73da811c305100aaf6dda3e2d3262',
+  'v8_revision': '77a772f20356e73329f90a9ba9c20e8e871d30d9',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -237,7 +237,8 @@ void LocalWindowProxy::Initialize() {
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event, possibly before first checkpoint.
+      // Root-level navigation event, initially happens before
+      // first checkpoint.
       OnNewRootFrame(GetIsolate(), GetFrame(), context);
     }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -215,6 +215,10 @@ void LocalWindowProxy::Initialize() {
         GetFrame()->DomWindow()->GetAgentClusterID());
     SetSecurityToken(origin.get());
   }
+  
+
+  recordreplay::Print("DDBG LocalWindowProxy::Initialize %s",
+    origin ? origin->Host().Utf8().c_str() : "");
 
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       origin &&
@@ -229,9 +233,9 @@ void LocalWindowProxy::Initialize() {
       // commands when recording/replaying, and to create checkpoints. Create
       // the first checkpoint at which execution can pause.
       gRecordReplayStateInitialized = true;
-      SetupRecordReplayCommands(GetIsolate(), GetFrame(), context);
+      InitializeRecordReplay(GetIsolate(), GetFrame(), context);
       recordreplay::NewCheckpoint();
-      SetupRecordReplayCommandsAfterCheckpoint();
+      InitializeRecordReplayAfterCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -215,10 +215,6 @@ void LocalWindowProxy::Initialize() {
         GetFrame()->DomWindow()->GetAgentClusterID());
     SetSecurityToken(origin.get());
   }
-  
-
-  recordreplay::Print("DDBG LocalWindowProxy::Initialize %s",
-    origin ? origin->Host().Utf8().c_str() : "");
 
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       origin &&

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -161,6 +161,7 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
 
 // Record/replay state is initialized along with the first LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
+static LocalFrame* gRecordReplayFrame = nullptr;
 
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
@@ -226,20 +227,20 @@ void LocalWindowProxy::Initialize() {
     if (doInit) {
       gRecordReplayStateInitialized = true;
 
-      // Make sure that Replay initialization happens in a root frame,
-      // since only root frames are injected with the necessary fix-ins.
-      CHECK(GetFrame()->IsOutermostMainFrame());
-
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints.
       InitializeRecordReplay(GetIsolate(), GetFrame(), context);
     }
 
-    if (GetFrame()->IsOutermostMainFrame()) {
+    if (doInit || GetFrame() == gRecordReplayFrame) {
       // Root-level navigation event, initially happens before
       // first checkpoint.
-      OnNewRootFrame(GetIsolate(), GetFrame(), context);
+      // NOTE: We cannot check for GetFrame()->IsOutermostMainFrame() because
+      // we also need to (re-)init CSP'ed iframes, which run in their own
+      // process when recording.
+      gRecordReplayFrame = GetFrame();
+      OnRootFrameInit(GetIsolate(), GetFrame(), context);
     }
 
     if (doInit) {
@@ -249,9 +250,9 @@ void LocalWindowProxy::Initialize() {
       InitializeRecordReplayAfterCheckpoint();
     }
     
-    if (GetFrame()->IsOutermostMainFrame()) {
+    if (GetFrame() == gRecordReplayFrame) {
       // Root-level navigation event, after first checkpoint.
-      OnNewRootFrameAfterCheckpoint(GetIsolate(), GetFrame(), context);
+      OnRootFrameInitAfterCheckpoint(GetIsolate(), GetFrame(), context);
     }
 
     // Event for all new windows.

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -216,7 +216,8 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (recordreplay::IsRecordingOrReplaying("commands") &&
+  if (world_->IsMainWorld() &&
+      recordreplay::IsRecordingOrReplaying("commands") &&
       origin &&
       !origin->Host().empty()) {
     // Initialize and re-initialize Replay state, command handlers and more.

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -219,31 +219,41 @@ void LocalWindowProxy::Initialize() {
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       origin &&
       !origin->Host().empty()) {
+    // Initialize and re-initialize Replay state, command handlers and more.
 
-    // Initialize Replay globals.
-    OnNewWindow1(GetIsolate(), GetFrame());
+    bool doInit = !gRecordReplayStateInitialized;
+    if (doInit) {
+      gRecordReplayStateInitialized = true;
 
-    if (!gRecordReplayStateInitialized) {
+      // Make sure that Replay initialization happens in a root frame,
+      // since only root frames are injected with the necessary fix-ins.
+      CHECK(GetFrame()->IsOutermostMainFrame());
+
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
-      // commands when recording/replaying, and to create checkpoints. Create
-      // the first checkpoint at which execution can pause.
-      gRecordReplayStateInitialized = true;
+      // commands when recording/replaying, and to create checkpoints.
       InitializeRecordReplay(GetIsolate(), GetFrame(), context);
-      recordreplay::NewCheckpoint();
-      InitializeRecordReplayAfterCheckpoint();
     }
 
     if (GetFrame()->IsOutermostMainFrame()) {
-      // Root-level navigation event.
-      // Note: This must happen after our first checkpoint, or we'll crash with "Progress counter updated before first checkpoint".
+      // Root-level navigation event, possibly before first checkpoint.
       OnNewRootFrame(GetIsolate(), GetFrame(), context);
     }
 
-    // Initialize Replay things that depend on previous Replay initialization 
-    // steps.
-    OnNewWindow2(GetIsolate(), GetFrame(), context);
+    if (doInit) {
+      // Create the first checkpoint at which execution can pause.
+      recordreplay::NewCheckpoint();
+      // Initialize some more.
+      InitializeRecordReplayAfterCheckpoint();
+    }
+    
+    if (GetFrame()->IsOutermostMainFrame()) {
+      // Root-level navigation event, after first checkpoint.
+      OnNewRootFrameAfterCheckpoint(GetIsolate(), GetFrame(), context);
+    }
 
+    // Event for all new windows.
+    OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -4055,7 +4055,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   // time; just log it and inform the client.
   if (!contextGroupId.has_value()) {
     if (gCDPMessageCallback != nullptr) {
-      // Ensure the message has an ID.
+      // Ensure the message has an ID. If not, handle the error in JavaScript.
       v8::String::Utf8Value inmessage(args.GetIsolate(), args[0]);
       std::string nmessage(*inmessage);
       absl::optional<base::Value> jsonMessage = base::JSONReader::Read(nmessage);
@@ -5470,6 +5470,13 @@ static bool TestEnv(const char* env) {
 
 void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  
+  recordreplay::Print(
+    "[RUN-2739] OnNewWindow1 win=%d frame=%d %d \"%s\"",
+      localFrame->DomWindow()->RecordReplayId(),
+      localFrame->RecordReplayId(),
+      localFrame->IsCrossOriginToParentOrOuterDocument(),
+      localFrame->GetDocument()->Url().GetString().Utf8().c_str());
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
@@ -5576,14 +5583,26 @@ static void RecordReplaySetDefaultContext(v8::Isolate* isolate, LocalFrame* loca
   V8RecordReplaySetDefaultContext(isolate, context);
 }
 
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
-  // Register context and callbacks.
-  RecordReplaySetDefaultContext(isolate, localFrame, context);
+void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   V8RecordReplaySetAPIObjectIdCallback(GetBlinkPersistentId);
-
+  RecordReplaySetDefaultContext(isolate, localFrame, context);
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
+}
+
+void InitializeRecordReplayAfterCheckpoint() {
+  // Note: This can immediately invoke the callback for events that happened
+  // before the callback was registered.
+  V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
+}
+
+static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
+  // Register context, s.t. when handling a command and we are not on a 
+  // JS stack, we can always use the current root frame's context.
+  // Note: We are assuming that each tab has its own process, for now.
+  //   (That might not hold true for tabs of the same domain - not sure)
+  RecordReplaySetDefaultContext(isolate, localFrame, context);
 
   // This URL will prevent the script from being reported to the recorder.
   const char* InternalScriptURL = "record-replay-internal";
@@ -5599,36 +5618,28 @@ void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8:
     // https://linear.app/replay/issue/RUN-2195#comment-e0b6c75b
     localFrame->GetSettings()->SetForceMainWorldInitialization(true);
   }
+
   if (IsGReplayScriptEnabled()) {
     recordreplay::AutoMarkReplayCode amrc;
-    recordreplay::AutoDisallowEvents disallow("SetupRecordReplayCommands");
+    recordreplay::AutoDisallowEvents disallow("InitializeRecordReplay");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
   }
 }
 
-void SetupRecordReplayCommandsAfterCheckpoint() {
-  // Note: This can immediately invoke the callback for events that happened
-  // before the callback was registered.
-  V8RecordReplayRegisterBrowserEventCallback(HandleBrowserEvent);
-}
-
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   recordreplay::AutoMarkReplayCode amrc;
-  
-  // 0. Register context, s.t. when handling a command and we are not on a 
-  // JS stack, we can always use the current root frame's context.
-  // Note: We are assuming that each tab has its own process, for now.
-  //   (That might not hold true for tabs of the same domain - not sure)
-  RecordReplaySetDefaultContext(isolate, localFrame, context);
-  
+
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic(
+  recordreplay::Print(
     "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\" parentFrame=%d",
       localFrame->DomWindow()->RecordReplayId(),
       localFrame->RecordReplayId(),
       localFrame->IsCrossOriginToParentOrOuterDocument(),
       localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
       parentFrame ? parentFrame->RecordReplayId() : 0);
+  
+  // 0. Initialize our scripts.
+  InitializeReplayScripts(isolate, localFrame, context);
 
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
@@ -5657,7 +5668,7 @@ void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Co
             "record-replay-devtools-OnNewWindow");
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
-  recordreplay::CommandDiagnostic(
+  recordreplay::Print(
     "[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
     newContext == isolate->GetCurrentContext(),
     localFrame->DomWindow()->RecordReplayId(),

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -101,20 +101,20 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalDOMWindow* currentWindow = CurrentDOMWindow(isolate);
 
   if (!currentWindow) {
-    recordreplay::Print("GetLocalFrameRoot has no window.");
+    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: no window.");
     return nullptr;
   }
 
   LocalFrame *f = currentWindow->GetFrame();
   if (!f || f->IsDetached() || f->IsProvisional()) {
-    recordreplay::Print("GetLocalFrameRoot has no frame.");
+    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: window has no frame.");
     return nullptr;
   }
 
   LocalFrame& root = f->LocalFrameRoot();
 
   if (root.IsDetached() || root.IsProvisional()) {
-    recordreplay::Print("GetLocalFrameRoot has no root frame.");
+    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: root is detached or provisional.");
     return nullptr;
   }
 
@@ -151,6 +151,8 @@ public:
 
   LocalFrame* GetLocalFrameRoot() const { return blink::GetLocalFrameRoot(isolate); }
 };
+
+static LocalFrame* gLocalRootFrame = nullptr;
 
 typedef std::unordered_map<int, InspectorData*> ContextGroupIdInspectorMap;
 
@@ -3883,7 +3885,6 @@ static void LogWarningCallback(const v8::FunctionCallbackInfo<v8::Value>& args) 
 static v8::Eternal<v8::Function>* gCDPMessageCallback;
 
 static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(!gCDPMessageCallback);
   v8::Isolate* isolate = args.GetIsolate();
   CHECK(args[0]->IsFunction());
   v8::Local<v8::Function> callback = args[0].As<v8::Function>();
@@ -5621,23 +5622,24 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
 
   if (IsGReplayScriptEnabled()) {
     recordreplay::AutoMarkReplayCode amrc;
-    recordreplay::AutoDisallowEvents disallow("InitializeRecordReplay");
+    recordreplay::AutoDisallowEvents disallow("InitializeReplayScripts");
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
   }
 }
 
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   recordreplay::AutoMarkReplayCode amrc;
-
-  LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
   recordreplay::Print(
-    "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\" parentFrame=%d",
+    "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\"",
       localFrame->DomWindow()->RecordReplayId(),
       localFrame->RecordReplayId(),
       localFrame->IsCrossOriginToParentOrOuterDocument(),
-      localFrame->GetDocument()->Url().GetString().Utf8().c_str(),
-      parentFrame ? parentFrame->RecordReplayId() : 0);
+      localFrame->GetDocument()->Url().GetString().Utf8().c_str()
+      );
   
+  // NOTE: The root `LocalFrame` will actually not change over time.
+  gLocalRootFrame = localFrame;
+
   // 0. Initialize our scripts.
   InitializeReplayScripts(isolate, localFrame, context);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5469,15 +5469,8 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
-void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame) {
+static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  
-  recordreplay::Print(
-    "[RUN-2739] OnNewWindow1 win=%d frame=%d %d \"%s\"",
-      localFrame->DomWindow()->RecordReplayId(),
-      localFrame->RecordReplayId(),
-      localFrame->IsCrossOriginToParentOrOuterDocument(),
-      localFrame->GetDocument()->Url().GetString().Utf8().c_str());
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
@@ -5604,6 +5597,9 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   // Note: We are assuming that each tab has its own process, for now.
   //   (That might not hold true for tabs of the same domain - not sure)
   RecordReplaySetDefaultContext(isolate, localFrame, context);
+  
+  // Initialize __RECORD_REPLAY__ things.
+  InitializeRecordReplayApiObjects(isolate, localFrame);
 
   // This URL will prevent the script from being reported to the recorder.
   const char* InternalScriptURL = "record-replay-internal";
@@ -5623,6 +5619,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   if (IsGReplayScriptEnabled()) {
     recordreplay::AutoMarkReplayCode amrc;
     recordreplay::AutoDisallowEvents disallow("InitializeReplayScripts");
+    // Run `gReplayScript`.
     RunScript(isolate, context, gReplayScript, InternalScriptURL);
   }
 }
@@ -5640,18 +5637,20 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::
   // NOTE: The root `LocalFrame` will actually not change over time.
   gLocalRootFrame = localFrame;
 
-  // 0. Initialize our scripts.
-  InitializeReplayScripts(isolate, localFrame, context);
+  // 1. Reset paint surface so that paints to the new root's surface are not ignored.
+  // See: https://linear.app/replay/issue/RUN-2400
+  recordreplay::DoResetPaintSurface();
 
+  // 2. Initialize our scripts, command handlers etc.
+  InitializeReplayScripts(isolate, localFrame, context);
+}
+
+void OnNewRootFrameAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
     recordreplay::OnNavigationEvent(
         nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
   }
-
-  // 2. Reset paint surface so that paints to the new root's surface are not ignored.
-  // See: https://linear.app/replay/issue/RUN-2400
-  recordreplay::DoResetPaintSurface();
 
   // 3. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
@@ -5664,14 +5663,14 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::
   }
 }
 
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> newContext) {
+void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> newContext) {
   recordreplay::AutoMarkReplayCode amrc;
   RunScript(isolate, newContext, gOnNewWindowScript,
             "record-replay-devtools-OnNewWindow");
 
   LocalFrame* parentFrame = DynamicTo<LocalFrame>(localFrame->Parent());
   recordreplay::Print(
-    "[RUN-2739] OnNewWindow2 %d win=%d frame=%d %d \"%s\" parent=%d",
+    "[RUN-2739] OnNewWindowAfterCheckpoint %d win=%d frame=%d %d \"%s\" parent=%d",
     newContext == isolate->GetCurrentContext(),
     localFrame->DomWindow()->RecordReplayId(),
     localFrame->RecordReplayId(),

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -5624,10 +5624,10 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   }
 }
 
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
+void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   recordreplay::AutoMarkReplayCode amrc;
   recordreplay::Print(
-    "[RUN-2739] OnNewRootFrame win=%d frame=%d %d \"%s\"",
+    "[RUN-2739] OnRootFrameInit win=%d frame=%d %d \"%s\"",
       localFrame->DomWindow()->RecordReplayId(),
       localFrame->RecordReplayId(),
       localFrame->IsCrossOriginToParentOrOuterDocument(),
@@ -5645,14 +5645,14 @@ void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::
   InitializeReplayScripts(isolate, localFrame, context);
 }
 
-void OnNewRootFrameAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
+void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   // 1. Register navigation event.
   if (localFrame->GetDocument()->Url().ProtocolIsInHTTPFamily()) {
     recordreplay::OnNavigationEvent(
         nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
   }
 
-  // 3. Initialize React and Redux Devtools stubs.
+  // 2. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -263,7 +263,7 @@ function getSourceMapURLs(sourceURL, relativeSourceMapURL) {
   try {
     sourceMapURL = new URL(relativeSourceMapURL, sourceBaseURL).toString();
   } catch (err) {
-    log("Failed to process sourcemap url: " + err.message);
+    log("[RuntimeError] Failed to process sourcemap url: " + err.message);
     return null;
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -101,20 +101,20 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
   LocalDOMWindow* currentWindow = CurrentDOMWindow(isolate);
 
   if (!currentWindow) {
-    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: no window.");
+    recordreplay::Print("[RuntimeError] GetLocalFrameRoot: no window.");
     return nullptr;
   }
 
   LocalFrame *f = currentWindow->GetFrame();
   if (!f || f->IsDetached() || f->IsProvisional()) {
-    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: window has no frame.");
+    recordreplay::Print("[RuntimeError] GetLocalFrameRoot: window has no frame.");
     return nullptr;
   }
 
   LocalFrame& root = f->LocalFrameRoot();
 
   if (root.IsDetached() || root.IsProvisional()) {
-    recordreplay::Warning("[RuntimeError] GetLocalFrameRoot: root is detached or provisional.");
+    recordreplay::Print("[RuntimeError] GetLocalFrameRoot: root is detached or provisional.");
     return nullptr;
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -21,11 +21,11 @@ void InitializeRecordReplayAfterCheckpoint();
 
 // Initialize everything that needs to be initialized with every root frame,
 // before the first Checkpoint.
-void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Initialize everything that needs to be initialized with every root frame,
 // after the first Checkpoint.
-void OnNewRootFrameAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Initialize everything that depends on other initialization steps but
 // for all windows.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -12,11 +12,6 @@
 #include "v8/include/v8.h"
 
 namespace blink {
-
-// Initialize everything that needs to be initialized with every new global window.
-// This is the first replay code that we run for a new Window object.
-void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame);
-
 // Initialize command state after the first context is created, but before the
 // first checkpoint in the recording is created.
 void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
@@ -24,13 +19,18 @@ void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Lo
 // Do any remaining initialization after the first checkpoint is created.
 void InitializeRecordReplayAfterCheckpoint();
 
-// Initialize everything that needs to be initialized with every root frame.
+// Initialize everything that needs to be initialized with every root frame,
+// before the first Checkpoint.
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+
+// Initialize everything that needs to be initialized with every root frame,
+// after the first Checkpoint.
+void OnNewRootFrameAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Initialize everything that depends on other initialization steps but
 // for all windows.
-// This is the last replay code that we run for a new Window object.
-void OnNewWindow2(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+// This is the last Replay code that we run for a new Window object.
+void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -19,10 +19,10 @@ void OnNewWindow1(v8::Isolate* isolate, LocalFrame* localFrame);
 
 // Initialize command state after the first context is created, but before the
 // first checkpoint in the recording is created.
-void SetupRecordReplayCommands(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Do any remaining initialization after the first checkpoint is created.
-void SetupRecordReplayCommandsAfterCheckpoint();
+void InitializeRecordReplayAfterCheckpoint();
 
 // Initialize everything that needs to be initialized with every root frame.
 void OnNewRootFrame(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/206
* https://linear.app/replay/issue/RUN-2965/-record-replay-and-other-replay-only-props-are-not-available-after
* Tests:
  * [Live tests](https://buildkite.com/replay/testing-runtime-e2e/builds/2157): ✅ (and no recorder crashes)
    * [Live tests re-run](https://buildkite.com/replay/testing-runtime-e2e/builds/2158):  ✅ (and no recorder crashes)
  * [FE](https://buildkite.com/replay/runtime-fe-end-to-end-tests/builds/52#018cdb35-b598-4b1c-a40e-5f0be21770c9): ✅
    * [FE re-run](https://buildkite.com/replay/runtime-fe-end-to-end-tests/builds/54#018cdbb7-88ad-4f99-8fae-f8a73bf04422): ✅
  * Spot check: [src](https://github.com/replayio/backend/pull/9239/files#diff-889527a7a6533312177fc7a9c606ed65ea618fa16e04fc108366bb0999b1d015R1) ✅ -
      ```
      $ npm test -- dynamic_websites/run-2965.spec.ts

      > runtime-tests@0.0.1 test
      > npx playwright test --config=playwright.config.ts dynamic_websites/run-2965.spec.ts


      Running 1 test using 1 worker
      [chromium] › dynamic_websites/run-2965.spec.ts:18:5 › [RUN-2965] Use Replay API after Reload
      Starting RUNTIME test-http-server...
      Runtime Test Server running on port 3456.
        1 passed (2.0s)
      ```