### PR TITLE
[RUN-3081] force macos builds to go to the x86_64 builder

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,7 @@ steps:
     agents:
       - "runtimeType=chromiumbuild"
       - "os=macos"
+      - "arch=x86_64"
       - "queue=runtime"
     artifact_paths:
       - "build_id/macOS/x86_64/**"
@@ -91,6 +92,7 @@ steps:
     agents:
       - "runtimeType=chromiumbuild"
       - "os=macos"
+      - "arch=x86_64"
       - "queue=runtime"
     artifact_paths:
       - "build_id/macOS/arm64/**"


### PR DESCRIPTION
The arm builder, while fast, is having some issues.  Let's switch to using x86_64 only for the time being.