### PR TITLE
trigger metabase test run instead of including it as a step here

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -152,6 +152,7 @@ steps:
     trigger: "testing-runtime-metabase"
     depends_on:
       - "build-chromium-linux-x86_64"
+    if: build.branch == "master"
 
   - label: ":hammer: Trigger Runtime FE Tests"
     trigger: "runtime-fe-end-to-end-tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -147,24 +147,11 @@ steps:
       - "build-chromium-linux-x86_64"
       - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
-  - label: "Metabase Test Suite"
-    key: "metabase-test-suite"
-    depends_on: "build-chromium-linux-x86_64"
-    if: build.branch == "master"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1: ~
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
-    command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
+
+  - label: ":hammer: Trigger Metabase Tests"
+    trigger: "testing-runtime-metabase"
+    depends_on:
+      - "build-chromium-linux-x86_64"
 
   - label: ":hammer: Trigger Runtime FE Tests"
     trigger: "runtime-fe-end-to-end-tests"


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-3072/make-metabase-e2e-tests-blocking

Trigger a workflow in the metabase repo that triggers the GH action with the proper inputs, then awaits completion of that workflow in a flyvm so we don't tie up any buildkite agents. phew.

depends on https://github.com/replayio-public/metabase/pull/108