### PR TITLE
Add trigger of fe runtime tests on chromium builds.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,8 +112,8 @@ steps:
       - "queue=runtime"
     artifact_paths:
       - "build_id/windows/x86_64/**"
-  - trigger: "testing-runtime-e2e"
-    label: ":hammer: Trigger Runtime Tests"
+  - label: ":hammer: Trigger Runtime Tests"
+    trigger: "testing-runtime-e2e"
     depends_on:
       - "build-chromium-linux-x86_64"
       - "build-chromium-mac-x86_64"
@@ -136,6 +136,11 @@ steps:
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
       - replayio/buildevents#adb8a05: ~
     command: "be_cmd metabase-tests -- /home/ubuntu/chromium/src/replay_build_scripts/metabase.sh"
+
+  - label: ":hammer: Trigger Runtime FE Tests"
+    trigger: "runtime-fe-end-to-end-tests"
+    depends_on:
+      - "build-chromium-linux-x86_64"
 
   # wait for all steps above, but also continue if they fail
   - wait: ~


### PR DESCRIPTION
Triggers the new FE buildkite action, which re-records all tests with this chromium, and then re-runs the affected FE tests.  We're only running the subset of tests that are supposed to be passing; relevant FE code is located in `packages/e2e-tests/scripts/`, and in particular, `buildkite_run_fe_tests.js`.  See https://github.com/replayio/devtools/commit/94c56095f67fca5ce5f54b8916cd9c2b6a3034d7 for details.