### PR TITLE
use eslint's formatter to print things out

### DIFF
--- a/replay_build_scripts/lint.mjs
+++ b/replay_build_scripts/lint.mjs
@@ -1,104 +1,163 @@
-import * as fs from 'fs';
-import * as eslint from 'eslint';
+import * as fs from "fs";
+import * as eslint from "eslint";
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as path from "path";
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-let lintFile = process.argv[2] ||
-    path.join(__dirname, "../third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc");
+let lintFile =
+  process.argv[2] ||
+  path.join(
+    __dirname,
+    "../third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc",
+  );
 
-let replayText = fs.readFileSync(lintFile, 'utf8');
+let replayText = fs.readFileSync(lintFile, "utf8");
 
-let regex = new RegExp('//js', 'g');
-let endRegex = new RegExp('\\)""""', 'g');
+let regex = new RegExp("//js", "g");
+let endRegex = new RegExp('\\)""""', "g");
 const linter = new eslint.Linter();
 
-function findMatches(text/*: string*/, regex/*: RegExp*/) {
-    let match;
-    const matches/*: number[] */ = [];
-    while ((match = regex.exec(text)) != null) {
-        const res = text.substr(0, match.index).split('\n').length - 1;
-        matches.push(res);
-    }
+const engine = new eslint.ESLint();
+const formatter = await engine.loadFormatter();
 
-    return matches
+function findMatches(text /*: string*/, regex /*: RegExp*/) {
+  let match;
+  const matches /*: number[] */ = [];
+  while ((match = regex.exec(text)) != null) {
+    const res = text.substr(0, match.index).split("\n").length - 1;
+    matches.push(res);
+  }
+
+  return matches;
 }
 
-function getNamedTextBlock(text/*: string*/, start/*: number*/, end/*: number*/) {
-    const lines = text.split('\n');
-    const name = lines[start-1].split(' ')[2];
-    const block_lines = lines.slice(start, end);
-    return { name, text: "\n".repeat(start) + block_lines.join('\n') };
+function getNamedTextBlock(
+  text /*: string*/,
+  start /*: number*/,
+  end /*: number*/,
+) {
+  const lines = text.split("\n");
+  const name = lines[start - 1].split(" ")[2];
+  const block_lines = lines.slice(start, end);
+  return { name, text: "\n".repeat(start) + block_lines.join("\n") };
 }
 
-function lintScript({ name, text }/*: { name: string, text: string }*/) {
-    const messages = linter.verify(text, {
-        parserOptions: {
-            ecmaVersion: 2023,
-            sourceType: "module",
-        },
-        rules: {
-            "no-undef": ["error"],
-            "no-unused-vars": ["warn", {
-              "argsIgnorePattern": "^_",
-              "varsIgnorePattern": "^_",
-              "caughtErrorsIgnorePattern": "^_",
-            }],
-        },
-        env: {
-            "browser": true
-        },
-        globals: {
-            __RECORD_REPLAY_ARGUMENTS__: true,
-            __RECORD_REPLAY__: true,
-            log: true,
+// this function from eslint (lib/eslint/flat-eslint.js)
+function calculateStatsPerFile(messages) {
+  const stat = {
+    errorCount: 0,
+    fatalErrorCount: 0,
+    warningCount: 0,
+    fixableErrorCount: 0,
+    fixableWarningCount: 0,
+  };
 
-            // browser globals
-            CSSStyleValue: true,
-            CSSStyleDeclaration: true,
-            Element: true,
-            Map: true,
-            Node: true,
-            window: true,
-            URL: true,
-            Set: true,
-            location: true,
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
 
-            // CDP
-            InspectorUtils: true
-
-        }
-    });
-
-    if (messages.length > 0) {
-        console.log(`Script ${name}:\n`, messages)
+    if (message.fatal || message.severity === 2) {
+      stat.errorCount++;
+      if (message.fatal) {
+        stat.fatalErrorCount++;
+      }
+      if (message.fix) {
+        stat.fixableErrorCount++;
+      }
+    } else {
+      stat.warningCount++;
+      if (message.fix) {
+        stat.fixableWarningCount++;
+      }
     }
-
-    return {
-        errors: messages.filter(m => m.severity === 2).length,
-        warnings: messages.filter(m => m.severity === 1).length,
-    }
+  }
+  return stat;
 }
 
-const lineNumbers = findMatches(replayText, regex)
-const endLineNumbers = findMatches(replayText, endRegex)
-// console.log('Lines with "//js":', lineNumbers);
-// console.log('Lines with ")"""":', endLineNumbers);
+async function lintScript({ name, text } /*: { name: string, text: string }*/) {
+  const messages = linter.verify(text, {
+    parserOptions: {
+      ecmaVersion: 2023,
+      sourceType: "module",
+    },
 
-const textBlocks = lineNumbers.map((lineNumber, index) => getNamedTextBlock(replayText, lineNumber, endLineNumbers[index]))
+    rules: {
+      "no-undef": ["error"],
+      "no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+
+    env: {
+      browser: true,
+    },
+    globals: {
+      __RECORD_REPLAY_ARGUMENTS__: true,
+      __RECORD_REPLAY__: true,
+      log: true,
+
+      // browser globals
+      CSSStyleValue: true,
+      CSSStyleDeclaration: true,
+      Element: true,
+      Map: true,
+      Node: true,
+      window: true,
+      URL: true,
+      Set: true,
+      location: true,
+
+      // CDP
+      InspectorUtils: true,
+    },
+  });
+
+  let results = [
+    {
+      filePath: `${lintFile} (${name})`,
+      messages,
+      ...calculateStatsPerFile(messages),
+    },
+  ];
+
+  console.log(await formatter.format(results, {}));
+
+  let errorCount = 0;
+  let fatalErrorCount = 0;
+  let warningCount = 0;
+
+  for (const result of results) {
+    errorCount += result.errorCount;
+    fatalErrorCount += result.fatalErrorCount;
+    warningCount += result.warningCount;
+  }
+
+  return { errorCount, fatalErrorCount, warningCount };
+}
+
+const lineNumbers = findMatches(replayText, regex);
+const endLineNumbers = findMatches(replayText, endRegex);
+
+const textBlocks = lineNumbers.map((lineNumber, index) =>
+  getNamedTextBlock(replayText, lineNumber, endLineNumbers[index]),
+);
 
 let errorCount = 0;
 let warningCount = 0;
 for (const block of textBlocks) {
-  const { errors, warnings } = lintScript(block);
-  errorCount += errors;
-  warningCount += warnings;
+  const { errorCount: blockErrorCount, warningCount: blockWarningCount } =
+    await lintScript(block);
+  errorCount += blockErrorCount;
+  warningCount += blockWarningCount;
 }
 
-console.log(`ESLint: ${errorCount} errors, ${warningCount} warnings`)
+console.log(`Total counts: ${errorCount} errors, ${warningCount} warnings`);
 if (errorCount > 0) {
-    process.exit(1)
+  process.exit(1);
 }
-


### PR DESCRIPTION
just because it's a v0, it doesn't have to look bad.

here's what things look like now if you run `node replay_build_scripts/lint.mjs`:

![image](https://github.com/replayio/chromium/assets/24245/6b8c38b8-8e32-436a-a9b0-484bf34ce5a7)

also ran prettier on this file since I was constantly futzing with things that altered formatting.