### PR TITLE
[RUN-3079] record/verify resources.pak file sizes across macos architectures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -141,6 +141,31 @@ steps:
       - "queue=runtime"
     artifact_paths:
       - "build_id/windows/x86_64/**"
+
+  - label: ":sleuth_or_spy: Verify cross-arch `.pak` sizes"
+    key: "verify-cross-arch-pak-sizes"
+    commands:
+      - "rm -f pak-sizes-arm pak-sizes"
+      - "be_cmd download-macos-arm64 -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
+      - "be_cmd download-macos-x86_64 -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
+      - "be_cmd macos-diff -- diff build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
+    depends_on:
+      - "build-chromium-mac-x86_64"
+      - "build-chromium-mac-arm64"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /home/ubuntu/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
+
   - label: ":hammer: Trigger Runtime Tests"
     trigger: "testing-runtime-e2e"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -142,13 +142,15 @@ steps:
     artifact_paths:
       - "build_id/windows/x86_64/**"
 
-  - label: ":sleuth_or_spy: Verify cross-arch `.pak` sizes"
+  - label: ":sleuth_or_spy: Verify cross-arch `.pak` sizes and dep hashes"
     key: "verify-cross-arch-pak-sizes"
     commands:
-      - "rm -f pak-sizes-arm pak-sizes"
-      - "be_cmd download-macos-arm64 -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
-      - "be_cmd download-macos-x86_64 -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
-      - "be_cmd macos-diff -- diff build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
+      - "be_cmd download-macos-arm64-gclient_entries -- buildkite-agent artifact download build_id/macOS/arm64/entries ."
+      - "be_cmd download-macos-x86_64-gclient_entries -- buildkite-agent artifact download build_id/macOS/x86_64/entries ."
+      - "be_cmd macos-diff-gclient-entries -- diff -u build_id/macOS/arm64/entries build_id/macOS/x86_64/entries"
+      - "be_cmd download-macos-arm64-pak-sizes -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
+      - "be_cmd download-macos-x86_64-pak-sizes -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
+      - "be_cmd macos-diff-pak-sizes -- diff -u build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes || true"
     depends_on:
       - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,7 +87,6 @@ steps:
     agents:
       - "runtimeType=chromiumbuild"
       - "os=macos"
-      - "arch=x86_64"
       - "queue=runtime"
     artifact_paths:
       - "build_id/macOS/x86_64/**"
@@ -120,7 +119,6 @@ steps:
     agents:
       - "runtimeType=chromiumbuild"
       - "os=macos"
-      - "arch=x86_64"
       - "queue=runtime"
     artifact_paths:
       - "build_id/macOS/arm64/**"

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -107,6 +107,10 @@ action("about_credits") {
     "--target-os=$target_os",
     "--depfile",
     rebase_path(depfile, root_build_dir),
+    "--gn-out-dir",
+    ".",
+    "--gn-target",
+    "//chrome", # TODO(toshok) can't imagine we want this, but I'm not sure how else to do it?
     "credits",
     rebase_path(about_credits_file, root_build_dir),
   ]

--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -117,7 +117,7 @@ function gclient() {
 }
 
 function runGclientSync() {
-  spawnChecked(gclient(), ["sync"], { stdio: "inherit" });
+  spawnChecked(gclient(), ["sync", "-D"], { stdio: "inherit" });
 }
 
 function updateRepo(repo, treeish) {

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -246,6 +246,7 @@ async function main(options) {
   // Perform all buildkite-specific stuff
   if (process.env["BUILDKITE"]) {
     const pakSizesFile = recordPAKSizes(options);
+    const entriesFile = recordGClientEntries(options);
 
     buildkiteStuff(
       downloadUris,
@@ -253,10 +254,12 @@ async function main(options) {
       buildId,
       buildArm ? "arm64" : "x86_64",
       symbolsArchiveFile,
-      pakSizesFile
+      pakSizesFile,
+      entriesFile
     );
 
     fs.unlinkSync(pakSizesFile);
+    fs.unlinkSync(entriesFile);
   }
   fs.unlinkSync(symbolsArchiveFile);
 }
@@ -267,7 +270,8 @@ function buildkiteStuff(
   buildId,
   arch,
   symbolsArchiveFile,
-  pakSizesFile
+  pakSizesFile,
+  entriesFile
 ) {
   const markdownDownloadList = downloadUris
     .map((uri) =>
@@ -309,10 +313,8 @@ function buildkiteStuff(
     symbolsArchiveFile,
     path.join(BUILDKITE_ARTIFACT_DIRECTORY, symbolsArchiveFile)
   );
-  fs.cpSync(
-    pakSizesFile,
-    path.join(BUILDKITE_ARTIFACT_DIRECTORY, "pak-sizes")
-  );
+  fs.cpSync(pakSizesFile, path.join(BUILDKITE_ARTIFACT_DIRECTORY, "pak-sizes"));
+  fs.cpSync(entriesFile, path.join(BUILDKITE_ARTIFACT_DIRECTORY, "entries"));
 
   log(
     `Wrote build_id to ${BUILDKITE_ARTIFACT_DIRECTORY}/${BUILDKITE_BUILD_ID_ARTIFACT}`
@@ -512,7 +514,11 @@ function recordPAKSizes(options) {
   let pakDir;
   switch (currentPlatform()) {
     case Platform.macOS:
-      pakDir = path.join("out", releaseDir, "Chromium Framework.framework/Versions/Current/Resources");
+      pakDir = path.join(
+        "out",
+        releaseDir,
+        "Chromium Framework.framework/Versions/Current/Resources"
+      );
       break;
     case Platform.linux:
       pakDir = path.join("out", releaseDir);
@@ -535,6 +541,34 @@ function recordPAKSizes(options) {
   const pakSizesFile = `pak-sizes${archSuffix}`;
   fs.writeFileSync(pakSizesFile, pakSizes);
   return pakSizesFile;
+}
+
+function recordGClientEntries(options) {
+  // TODO(toshok) this is probably broken on windows.  need to look what the filename is there.
+  let gclient_entries_contents = fs.readFileSync("../.gclient_entries", "utf8");
+
+  let third_party_entries = {};
+  gclient_entries_contents.split("\n").forEach((line) => {
+    if (!line.includes("src/third_party/")) {
+      // we skip all non-third_party lines
+      return;
+    }
+    const match = line.match(/\'src\/third_party\/([^\']+)\': \'([^\']+)\'/);
+    if (!match) {
+      throw new Error(`Unexpected line format: ${line}`);
+    }
+    third_party_entries[match[1]] = match[2];
+  });
+
+  const keys = Object.keys(third_party_entries);
+  keys.sort();
+  const output = keys.map((k) => `${k} ${third_party_entries[k]}`).join("\n");
+
+  const archSuffix = options.useArm ? "-arm" : "";
+  const entriesFile = `entries${archSuffix}`;
+  fs.writeFileSync(entriesFile, output);
+
+  return entriesFile;
 }
 
 async function buildSymbolsArchive(

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -245,13 +245,18 @@ async function main(options) {
 
   // Perform all buildkite-specific stuff
   if (process.env["BUILDKITE"]) {
+    const pakSizesFile = recordPAKSizes(options);
+
     buildkiteStuff(
       downloadUris,
       platform,
       buildId,
       buildArm ? "arm64" : "x86_64",
-      symbolsArchiveFile
+      symbolsArchiveFile,
+      pakSizesFile
     );
+
+    fs.unlinkSync(pakSizesFile);
   }
   fs.unlinkSync(symbolsArchiveFile);
 }
@@ -261,7 +266,8 @@ function buildkiteStuff(
   platform,
   buildId,
   arch,
-  symbolsArchiveFile
+  symbolsArchiveFile,
+  pakSizesFile
 ) {
   const markdownDownloadList = downloadUris
     .map((uri) =>
@@ -302,6 +308,10 @@ function buildkiteStuff(
   fs.cpSync(
     symbolsArchiveFile,
     path.join(BUILDKITE_ARTIFACT_DIRECTORY, symbolsArchiveFile)
+  );
+  fs.cpSync(
+    pakSizesFile,
+    path.join(BUILDKITE_ARTIFACT_DIRECTORY, "pak-sizes")
   );
 
   log(
@@ -491,6 +501,40 @@ function computeBuildId(
       : driverDate;
 
   return `${currentPlatform()}-${runtimeName}-${date}-${runtimeRevision}-${driverRevision}${buildIdExtension}`;
+}
+
+function recordPAKSizes(options) {
+  // Record the size of each pak file we care about.
+  const pakFiles = ["resources.pak"];
+
+  const releaseDir = options.useARM ? "Release-ARM" : "Release";
+  // the containing directory (a subdir of releaseDir) of these files varies by Platform
+  let pakDir;
+  switch (currentPlatform()) {
+    case Platform.macOS:
+      pakDir = path.join("out", releaseDir, "Chromium Framework.framework/Versions/Current/Resources");
+      break;
+    case Platform.linux:
+      pakDir = path.join("out", releaseDir);
+      break;
+    case Platform.windows:
+      throw new Error("No Clue Yet");
+      break;
+    default:
+      throw new Error("NYI");
+  }
+
+  let pakSizes = "";
+  for (const pakFile of pakFiles) {
+    const file = path.join(pakDir, pakFile);
+    const size = fs.statSync(file).size;
+    pakSizes += `${pakFile} ${size}\n`;
+  }
+
+  const archSuffix = options.useArm ? "-arm" : "";
+  const pakSizesFile = `pak-sizes${archSuffix}`;
+  fs.writeFileSync(pakSizesFile, pakSizes);
+  return pakSizesFile;
 }
 
 async function buildSymbolsArchive(


### PR DESCRIPTION
Add a step in `upload_build_artifacts.mjs` for all platforms to record/upload the size of the `resources.pak` file, as well as the list of all third_party deps (and their hashes).

Add a buildkite step to verify the third party deps and the sizes of the `resource.pak` files are the same between macos arm64/x86_64.

also track down and fix the remaining sources of differences between `resources.pak` on x86 vs arm (the `sync -D` and `//tools/license.py` commits).