### PR TITLE
lint replay_build_scripts/*

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,7 @@ steps:
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "pushd replay_build_scripts"
       - "be_cmd npm-ci -- npm ci"
+      - "be_cmd lint-replay_build_scripts -- npm run lint"
       - "popd"
       - "be_cmd lint-replay-scripts -- node replay_build_scripts/lint.mjs third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc"
     env:

--- a/replay_build_scripts/.eslintrc.json
+++ b/replay_build_scripts/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "quotes": "off",
+    "prefer-const": "off",
+    "comma-dangle": "off",
+    "no-console": "off",
+    "no-undef": ["error"],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
+  }
+}

--- a/replay_build_scripts/lint.mjs
+++ b/replay_build_scripts/lint.mjs
@@ -6,21 +6,15 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-let lintFile =
+const lintFile =
   process.argv[2] ||
   path.join(
     __dirname,
     "../third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc",
   );
 
-let replayText = fs.readFileSync(lintFile, "utf8");
-
-let regex = new RegExp("//js", "g");
-let endRegex = new RegExp('\\)""""', "g");
 const linter = new eslint.Linter();
-
 const engine = new eslint.ESLint();
-const formatter = await engine.loadFormatter();
 
 function findMatches(text /*: string*/, regex /*: RegExp*/) {
   let match;
@@ -126,6 +120,7 @@ async function lintScript({ name, text } /*: { name: string, text: string }*/) {
     },
   ];
 
+  const formatter = await engine.loadFormatter();
   console.log(await formatter.format(results, {}));
 
   let errorCount = 0;
@@ -141,23 +136,32 @@ async function lintScript({ name, text } /*: { name: string, text: string }*/) {
   return { errorCount, fatalErrorCount, warningCount };
 }
 
-const lineNumbers = findMatches(replayText, regex);
-const endLineNumbers = findMatches(replayText, endRegex);
+async function main() {
+  const replayText = fs.readFileSync(lintFile, "utf8");
 
-const textBlocks = lineNumbers.map((lineNumber, index) =>
-  getNamedTextBlock(replayText, lineNumber, endLineNumbers[index]),
-);
+  const regex = new RegExp("//js", "g");
+  const endRegex = new RegExp('\\)""""', "g");
 
-let errorCount = 0;
-let warningCount = 0;
-for (const block of textBlocks) {
-  const { errorCount: blockErrorCount, warningCount: blockWarningCount } =
-    await lintScript(block);
-  errorCount += blockErrorCount;
-  warningCount += blockWarningCount;
+  const lineNumbers = findMatches(replayText, regex);
+  const endLineNumbers = findMatches(replayText, endRegex);
+
+  const textBlocks = lineNumbers.map((lineNumber, index) =>
+    getNamedTextBlock(replayText, lineNumber, endLineNumbers[index]),
+  );
+
+  let errorCount = 0;
+  let warningCount = 0;
+  for (const block of textBlocks) {
+    const { errorCount: blockErrorCount, warningCount: blockWarningCount } =
+      await lintScript(block);
+    errorCount += blockErrorCount;
+    warningCount += blockWarningCount;
+  }
+
+  console.log(`Total counts: ${errorCount} errors, ${warningCount} warnings`);
+  if (errorCount > 0) {
+    process.exit(1);
+  }
 }
 
-console.log(`Total counts: ${errorCount} errors, ${warningCount} warnings`);
-if (errorCount > 0) {
-  process.exit(1);
-}
+main();

--- a/replay_build_scripts/package.json
+++ b/replay_build_scripts/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "upload_build_artifacts.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint --env node *.mjs",
+    "eslint": "eslint --env node"
   },
   "author": "",
   "license": "ISC",

--- a/replay_build_scripts/symbolication.mjs
+++ b/replay_build_scripts/symbolication.mjs
@@ -63,6 +63,7 @@ export async function readSymbols(file, pdbFile) {
 
 // Get the start virtual address of the text section from a PDB file.
 // Symbol addresses are relative to the start of this section.
+// eslint-disable-next-line no-unused-vars
 async function getTextSectionAddress(pdbFile) {
   const pdbPath = path.join(getBackendDir(), "lib", "llvm-pdbutil.exe");
   const pdbProcess = spawn(pdbPath, ["dump", "-section-headers", pdbFile]);


### PR DESCRIPTION
initial lint config is basically geared at minimizing the number of changes to get it in.  Basically the only thing I fixed was the toplevel `await` in `lint.mjs`.  We can make it more/less strict if we want, but having `no-unused`/`no-undef` on will be nice.