### PR TITLE
add -D to the gclient sync command line

### DIFF
--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -117,7 +117,7 @@ function gclient() {
 }
 
 function runGclientSync() {
-  spawnChecked(gclient(), ["sync"], { stdio: "inherit" });
+  spawnChecked(gclient(), ["sync", "-D"], { stdio: "inherit" });
 }
 
 function updateRepo(repo, treeish) {


### PR DESCRIPTION
Peeling off from work on RUN-3079 in #1083.

The system behaves a lot better generally (fewer gclient warnings in the build, better `.gclient_entries` output) if we delete unused deps.