### PR TITLE
tell //tools/licenses.py to only include licenses for things in the build

### DIFF
--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -107,6 +107,10 @@ action("about_credits") {
     "--target-os=$target_os",
     "--depfile",
     rebase_path(depfile, root_build_dir),
+    "--gn-out-dir",
+    ".",
+    "--gn-target",
+    "//chrome", # TODO(toshok) can't imagine we want this, but I'm not sure how else to do it?
     "credits",
     rebase_path(about_credits_file, root_build_dir),
   ]


### PR DESCRIPTION
After #1088, the only apparent difference in `resources.pak` can be attributed to the x86 builder having a `native_client` directory checked out, while the arm builder doesn't.  The nacl license is included in the x86 resources.pak, and not in arm.

NACL is disabled on both builds, so we shouldn't include the license for either.  Modify `licenses.py` to take our current gn args (and unfortunately a hardcoded `//chrome` - I couldn't figure out how to disable that.) and let's see if things are any better.