### PR TITLE
make windows build ninja more verbose

### DIFF
--- a/build.js
+++ b/build.js
@@ -147,7 +147,13 @@ if (!process.env["BUILDKITE"]) {
 
 console.log(`Building...`);
 const autoninja = currentPlatform() == "windows" ? "autoninja.bat" : "autoninja";
-spawnChecked(autoninja, ["-C", outdir, "chrome"], { stdio: "inherit" });
+// make the windows build verbose so we can see what's going on
+const platformAutoNinjaArgs = currentPlatform() == "windows" ? ["-v"] : [];
+spawnChecked(
+  autoninja,
+  [...platformAutoNinjaArgs, "-C", outdir, "chrome"],
+  { stdio: "inherit" }
+);
 
 console.log(`Build finished.`);
 

--- a/buildWindows.mjs
+++ b/buildWindows.mjs
@@ -10,5 +10,5 @@ try {
   spawnChecked("git", [
     "checkout",
     "media/audio/win/audio_low_latency_input_win.cc",
-  ]);
+  ], { stdio: "inherit" });
 }


### PR DESCRIPTION
add `-v` to the windows build, which should give us a lot more context on these failures.