### PR TITLE
remove redundant repo syncs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -519,6 +519,8 @@ allowed_hosts = [
   'skia.googlesource.com',
   'swiftshader.googlesource.com',
   'webrtc.googlesource.com',
+  # for replayio deps
+  'github.com'
 ]
 
 deps = {

--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -148,53 +148,9 @@ export function updateChromiumRepo() {
   const branch = process.env["BUILDKITE_BRANCH"];
   updateRepo(chromium, `origin/${branch}`);
 
-  const deps = getChromiumDeps();
-
-  syncRepo(path.join(chromium, "v8"), deps.v8);
-
-  syncRepo(path.join(chromium, "third_party", "skia"), deps.skia);
-
-  syncRepo(path.join(chromium, "third_party", "webrtc"), deps.webrtc);
-
-  syncRepo(
-    path.join(chromium, "third_party", "boringssl", "src"),
-    deps.boringssl
-  );
-
   runGclientSync();
 
   runGnGen();
-}
-
-function getChromiumDeps() {
-  const text = fs.readFileSync("DEPS", "utf8");
-  let results = {
-    v8: "",
-    skia: "",
-    webrtc: "",
-    boringssl: "",
-  };
-
-  let match = /'v8_revision': '(.*?)'/.exec(text);
-  assert(match, "Could not find V8 revision");
-  results.v8 = match[1];
-
-  match = /'skia_revision': '(.*?)'/.exec(text);
-  assert(match, "Could not find skia revision");
-  results.skia = match[1];
-
-  match =
-    /'https:\/\/github.com\/replayio\/chromium-webrtc.git' \+ '@' \+ '(.*?)'/.exec(
-      text
-    );
-  assert(match, "Could not find webrtc revision");
-  results.webrtc = match[1];
-
-  match = /'boringssl_revision': '(.*?)'/.exec(text);
-  assert(match, "Could not find boringssl revision");
-  results.boringssl = match[1];
-
-  return results;
 }
 
 export function getBackendDir() {

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -226,6 +226,7 @@
 /r8/lib
 /r8/d8/lib
 /re2/src
+/reclient_configs
 /requests/src
 /robolectric/lib/
 /robolectric/robolectric


### PR DESCRIPTION
we're running `gclient sync` now.  That'll take care of syncing these deps - no need to do it manually anymore.