### PR TITLE
[RUN-3171] set the target_cpu on the x64 build as well

### DIFF
--- a/replay_build_scripts/mac_x86_64_args.gn
+++ b/replay_build_scripts/mac_x86_64_args.gn
@@ -6,3 +6,4 @@ use_allocator = "none"
 use_allocator_shim = false
 use_system_xcode = false
 mac_sdk_official_version = "13.0"
+target_cpu="x64"


### PR DESCRIPTION
whether we decide to partition builds onto the same host architecture can be decided separately from this, imo.  At the very least if we assign an x64 build to an arm builder, we should get an x64 executable out.