### PR TITLE
build: force gclient sync to always update with what is in upstream

### DIFF
--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -117,7 +117,13 @@ function gclient() {
 }
 
 function runGclientSync() {
-  spawnChecked(gclient(), ["sync", "-D"], { stdio: "inherit" });
+  spawnChecked(
+    gclient(),
+    ["sync", "-D", "--upstream", "--no-history", "--shallow"],
+    {
+      stdio: "inherit",
+    }
+  );
 }
 
 function updateRepo(repo, treeish) {


### PR DESCRIPTION
Also while I was here I improved the speed of the `gclient sync` step by about 2x by passing the `--no-history` and `--shallow` flags.

Fixes RUN-3202