### PR TITLE
revert the gclient trickery

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -519,8 +519,6 @@ allowed_hosts = [
   'skia.googlesource.com',
   'swiftshader.googlesource.com',
   'webrtc.googlesource.com',
-  # for replayio deps
-  'github.com'
 ]
 
 deps = {

--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -148,9 +148,53 @@ export function updateChromiumRepo() {
   const branch = process.env["BUILDKITE_BRANCH"];
   updateRepo(chromium, `origin/${branch}`);
 
+  const deps = getChromiumDeps();
+
+  syncRepo(path.join(chromium, "v8"), deps.v8);
+
+  syncRepo(path.join(chromium, "third_party", "skia"), deps.skia);
+
+  syncRepo(path.join(chromium, "third_party", "webrtc"), deps.webrtc);
+
+  syncRepo(
+    path.join(chromium, "third_party", "boringssl", "src"),
+    deps.boringssl
+  );
+
   runGclientSync();
 
   runGnGen();
+}
+
+function getChromiumDeps() {
+  const text = fs.readFileSync("DEPS", "utf8");
+  let results = {
+    v8: "",
+    skia: "",
+    webrtc: "",
+    boringssl: "",
+  };
+
+  let match = /'v8_revision': '(.*?)'/.exec(text);
+  assert(match, "Could not find V8 revision");
+  results.v8 = match[1];
+
+  match = /'skia_revision': '(.*?)'/.exec(text);
+  assert(match, "Could not find skia revision");
+  results.skia = match[1];
+
+  match =
+    /'https:\/\/github.com\/replayio\/chromium-webrtc.git' \+ '@' \+ '(.*?)'/.exec(
+      text
+    );
+  assert(match, "Could not find webrtc revision");
+  results.webrtc = match[1];
+
+  match = /'boringssl_revision': '(.*?)'/.exec(text);
+  assert(match, "Could not find boringssl revision");
+  results.boringssl = match[1];
+
+  return results;
 }
 
 export function getBackendDir() {

--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -117,13 +117,7 @@ function gclient() {
 }
 
 function runGclientSync() {
-  spawnChecked(
-    gclient(),
-    ["sync", "-D", "--upstream", "--no-history", "--shallow"],
-    {
-      stdio: "inherit",
-    }
-  );
+  spawnChecked(gclient(), ["sync", "-D"], { stdio: "inherit" });
 }
 
 function updateRepo(repo, treeish) {

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -226,7 +226,6 @@
 /r8/lib
 /r8/d8/lib
 /re2/src
-/reclient_configs
 /requests/src
 /robolectric/lib/
 /robolectric/robolectric


### PR DESCRIPTION
This reverts both #1095 and @jazzdan's subsequence fix for it (#1104).

The problem boils down to: `gclient sync -D` will only move forward.  if the sha exists on the currently checked out branch, gclient will _not_, at least in this mode, back HEAD up to an older sha.

#1104 added args that should have fixed things (and they did when tested manually locally), but it looks like maybe they didn't?