### PR TITLE
When diverged, don't try to load fallback fonts.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '71b2afd141750e0a3661b9ae668f64fe2ca2b885',
+  'skia_revision': '788e06fe673a634178e822b1fbe2a5efe4cf3786',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': 'bc9b2d3c17b8a9ab282220beb404a0e22166c54c',
+  'skia_revision': '71b2afd141750e0a3661b9ae668f64fe2ca2b885',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
@@ -274,6 +274,14 @@ scoped_refptr<SimpleFontData> FontFallbackIterator::UniqueSystemFontForHintList(
   if (!hint_list.size())
     return nullptr;
 
+  if (recordreplay::IsReplaying() && recordreplay::HasDivergedFromRecording()) {
+    // If we've run out of recording data, then following this chain of logic will lead to
+    // hangs, as we await conditional vars on epoll waiters that don't actually exist, held
+    // by threads that are dead (waiting forever.)  Luckily, it seems we can just early out 
+    // and have Chromium use some defaults for us.
+    return nullptr;
+  }
+
   FontCache& font_cache = FontCache::Get();
   UChar32 hint = hint_list[ChooseHintIndex(hint_list)];
 


### PR DESCRIPTION
Part of the fix for [RUN-3341](https://linear.app/replay/issue/RUN-3341/fix-hang-threadwaitforeverforrecordedcall-epoll-wait).

During a call to getComputedStyle, we end up kicking off a layout of the page, which eventually does something involving font height computation, which for some reason requests a font that is not in the font cache. This leads the font system to invoke a mojo call to get this font, which hangs indefinitely, because the thread on the other end of the call is looping forever, because it tried to epoll_wait without any more recording data.

Basically, I'm hoping we can just ignore/sidestep all this font stuff, and just return some null ptrs (which blink/skia do indeed handle), and have blink/skia use cached defaults. This is the chromium-related work, there's another skia PR for a similar call.