### PR TITLE
[RUN-3292] run fe tests for both linux-x86_64 and macos-arm64

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -211,7 +211,6 @@ steps:
     depends_on:
       - "build-chromium-linux-x86_64"
     build:
-      branch: toshok/mac-e2e
       env:
         OS: "linux"
         ARCH: "x86_64"
@@ -228,7 +227,6 @@ steps:
     depends_on:
       - "build-chromium-mac-arm64"
     build:
-      branch: toshok/mac-e2e
       env:
         OS: "macos"
         ARCH: "arm64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,6 +223,7 @@ steps:
         RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
   - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
+    soft_fail: true
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:
       - "build-chromium-mac-arm64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,12 +206,31 @@ steps:
     depends_on:
       - "build-chromium-linux-x86_64"
 
-  - label: "Trigger FE E2E Tests :hammer:"
+  - label: "Trigger FE E2E Tests (linux-x86_64) :hammer:"
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:
       - "build-chromium-linux-x86_64"
     build:
+      branch: toshok/mac-e2e
       env:
+        OS: "linux"
+        ARCH: "x86_64"
+        RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
+        RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
+        RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"
+        RECORD_REPLAY_METADATA_SOURCE_MERGE_ID: "${BUILDKITE_PULL_REQUEST}"
+        # this is passed as a git URL which the replay plugin expects and parses
+        RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+
+  - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
+    trigger: "runtime-fe-end-to-end-tests"
+    depends_on:
+      - "build-chromium-mac-arm64"
+    build:
+      branch: toshok/mac-e2e
+      env:
+        OS: "macos"
+        ARCH: "arm64"
         RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
         RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
         RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
Most of the work needed to support this is in the devtools repo at https://github.com/replayio/devtools/pull/10392.

The same buildkite pipeline is triggered for each build, but the step is targeted on the devtools side using the `OS`/`ARCH` env vars.

macos-arm64 is current flagged `soft_fail: true` until we decide to make it blocking as well.