### PR TITLE
[RUN-3146] Implemented `extractFunctionParameterNames`

### DIFF
--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1725,12 +1725,91 @@ function getInternalFunctionLocationProp(cdpProperties) {
   return getInternalProp(cdpProperties, '[[FunctionLocation]]');
 }
 
+/**
+ * String utility for function parameter parsing.
+ */
+function hasSubstringAt(haystack, needle, i) {
+  return haystack.substring(1 + i - needle.length, 1 + i) === needle;
+}
+
+/**
+ * [RUN-3146] Extract parameter names from the description.
+ * @param {string} s 
+ * @return {string[]}
+ */
+function extractFunctionParameterNames(s) {
+  /**
+   * Function head declaration patterns:
+   * P1. modifiers function f(PARAMS) Body
+   * P2. modifiers f(PARAMS) Body  // ObjectMethod, ClassMethod
+   * P3. modifiers (PARAMS) => ExpressionOrBody
+   * P4. modifiers PARAM => ExpressionOrBody
+   */
+
+  // All patterns fall into two buckets:
+  // PARENS: Get the thing within the first opening pair of parentheses.
+  // SINGLEARROW: Get the single param before =>.
+
+  // Go: Find A or B (whatever comes first), while ignoring comments.
+  /**
+   * The function header without comments.
+   */
+  let header = "";
+  /**
+   * When in a comment, this is set to the counterpart that we are looking for.
+   * @type {string | null}
+   */
+  let expectedCommentEnd = null;
+  let parensStart = -1;
+  for (let i = 0; i < s.length; ++i) {
+    const c = s[i];
+    if (expectedCommentEnd) {
+      // In a comment.
+      if (hasSubstringAt(s, expectedCommentEnd, i)) {
+        // Comment End: Start new segment from here.
+        expectedCommentEnd = null;
+      } 
+    }
+    else {
+      // Not in a comment.
+      if (hasSubstringAt(s, "//", i) || hasSubstringAt(s, "/*", i)) {
+        // Comment Start.
+        if (c === "*") {
+          expectedCommentEnd = "*/";
+        } else {
+          expectedCommentEnd = "\n";
+        }
+        // Remove "/" from header:
+        header = header.slice(0, -1);
+      } else {
+        if (c === "(") {
+          // PARENS: Params start.
+          parensStart = header.length + 1;
+        } else if (c === ")") {
+          // PARENS: Params end.
+          return header.substring(parensStart).split(",").map(p => p.trim());
+        } else if (hasSubstringAt(s, "=>", i)) {
+          // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
+          const param = header.trim().match(/([^\s]+)\s*=$/)?.[1];
+          return param ? [param] : [];
+        }
+        // Add to the header.
+        header += c;
+      }
+    }
+  }
+
+  // This should not happen, but might.
+  log(`[RuntimeError] extractFunctionParameterNames failed for: ${s.slice(0, 80)}...`);
+  return [];
+}
+
 function previewFunction(cdpProperties) {
   const nameProperty = cdpProperties.result.find(prop => prop.name == "name");
   const locationProperty = getInternalFunctionLocationProp(cdpProperties);
 
   if (nameProperty) {
-    // RUN-1991: nameProperty.value might not always exist, for some reason.
+    // RUN-1991: nameProperty.value might not always exist.
     this.extra.functionName = nameProperty?.value?.value || "";
   }
 
@@ -1740,6 +1819,10 @@ function previewFunction(cdpProperties) {
       warning(`[RUN-1991] previewFunction missing location: ${JSON_stringify(nameProperty)}, ${JSON_stringify(locationProperty)}`);
     }
     this.extra.functionLocation = createProtocolLocation(loc);
+  }
+
+  if (this.cdpObj.description) {
+    this.extra.functionParameterNames = extractFunctionParameterNames(this.cdpObj.description);
   }
 }
 

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1818,8 +1818,7 @@ function extractFunctionParameterNames(s) {
             // Initializer end.
             insideInitializer = false;
           } else if (complementaryTokensStart.includes(c)) {
-            // Inside some arbitrary syntax construct.
-            // → Ignore, since that's not part of the parameter name.
+            // Inside destructuring argument or initializer expression.
             const tokenIdx = complementaryTokensStart.indexOf(c);
             ignoreStack.push(complementaryTokensEnd[tokenIdx]);
           } else if (ignoreStack.length) {

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1811,45 +1811,72 @@ function extractFunctionParameterNames(s) {
       }
 
       // Parse everything but comments:
+
       if (parensStart === -1) {
         // Not in params parentheses.
         if (c === "(") {
           // PARENS: Params start.
-          parensStart = cleanHeader.length + 1;
-        } else if (stringsEndWith(cleanHeader, c, "=>")) {
+          cleanHeader += c;
+          parensStart = cleanHeader.length;
+          continue;
+        }
+
+        if (stringsEndWith(cleanHeader, c, "=>")) {
           // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
           const param = cleanHeader.trim().match(/([^\s]+)\s*=$/)?.[1];
           return param ? [param] : [];
         }
-      } else if (c === "=") {
-        // Initializer start.
-        insideInitializer = true;
-      } else if (insideInitializer && c === ",") {
-        // Initializer end.
-        insideInitializer = false;
-      } else if (ignoreStack.length && ignoreStack[ignoreStack.length - 1] === c) {
-        // Inside destructuring argument or initializer expression:
-        // Exit node.
-        ignoreStack.pop();
-        continue; // Ignore this, too.
-      } else if (complementaryTokensStart.includes(c)) {
+
+        // otherwise keep the character
+        cleanHeader += c;
+        continue;
+      }
+
+      // destructuring
+      if (complementaryTokensStart.includes(c)) {
         // Inside destructuring argument or initializer expression:
         // Enter node. Push complementary (to be searched for) onto stack.
         const tokenIdx = complementaryTokensStart.indexOf(c);
         ignoreStack.push(complementaryTokensEnd[tokenIdx]);
-      } else if (c === ")") {
+        continue; // don't include destructuring in the header
+      }
+      if (ignoreStack.length) {
+        // Inside destructuring or initializer expression.
+        if (c === ignoreStack[ignoreStack.length - 1]) {
+          // Exit node.
+          ignoreStack.pop();
+        }
+
+        continue; // don't include the destructuring in the header
+      }
+
+      if (c === ")") {
         // PARENS: Params end.
         return cleanHeader.substring(parensStart).split(",").map(p => p.trim());
       }
 
-      if (!insideInitializer && !ignoreStack.length) {
-        // Keep the character.
-        cleanHeader += c;
+      // initializers
+      if (c === "=") {
+        // Initializer start.
+        insideInitializer = true;
+        continue; // don't include initializers in the header
       }
+      if (insideInitializer) {
+        if (c === ",") {
+          // Initializer end.
+          insideInitializer = false;
+          cleanHeader += c; // include the comma in the header.  it's not part of an initializer, it's the separator between params.
+        }
+
+        continue;
+      }
+
+      // all other characters are kept
+      cleanHeader += c;
     }
 
     // This should not happen, but might.
-    log(`[RuntimeError] extractFunctionParameterNames fell through for: ${s.slice(0, 80)}...`);
+    log(`[RuntimeError] extractFunctionParameterNames fell through for: ${s.slice(0, 80)}... header=${cleanHeader}`);
     return [];
   } catch (err) {
     log(`[RuntimeError] extractFunctionParameterNames failed for: ${s.slice(0, 80)}...\n ${err?.stack || err}`);

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1725,8 +1725,6 @@ function getInternalFunctionLocationProp(cdpProperties) {
   return getInternalProp(cdpProperties, '[[FunctionLocation]]');
 }
 
-const log = console.log.bind(console);
-
 /**
  * String utility for function parameter parsing.
  */
@@ -1817,19 +1815,16 @@ function extractFunctionParameterNames(s) {
           } else if (insideInitializer && c === ",") {
             // Initializer end.
             insideInitializer = false;
+          } else if (ignoreStack.length && ignoreStack[ignoreStack.length - 1] === c) {
+            // Inside destructuring argument or initializer expression:
+            // Exit node.
+            ignoreStack.pop();
+            continue; // Ignore this, too.
           } else if (complementaryTokensStart.includes(c)) {
-            // Inside destructuring argument or initializer expression.
+            // Inside destructuring argument or initializer expression:
+            // Enter node.
             const tokenIdx = complementaryTokensStart.indexOf(c);
             ignoreStack.push(complementaryTokensEnd[tokenIdx]);
-          } else if (ignoreStack.length) {
-            // Inside destructuring argument or initializer expression.
-            if (complementaryTokensEnd.includes(c)) {
-              const end = ignoreStack.pop();
-              if (end !== c) {
-                log(`[RuntimError] extractFunctionParameterNames unexpected token "${c}", expected "${end}" at "${s.substring(0, i+1)}"`);
-                return [];
-              }
-            }
           } else if (c === ")") {
             // PARENS: Params end.
             return header.substring(parensStart).split(",").map(p => p.trim());

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1728,10 +1728,17 @@ function getInternalFunctionLocationProp(cdpProperties) {
 /**
  * String utility for function parameter parsing.
  */
-function hasSubstringAt(haystack, needle, i) {
+function substringEndsAt(haystack, needle, i) {
   return haystack.substring(1 + i - needle.length, 1 + i) === needle;
 }
 
+/**
+ * @return {boolean} (a + b).endsWith(end)
+ */
+function stringsEndWith(a, b, end) {
+  // NOTE: This can be done more performantly.
+  return (a + b).endsWith(end);
+}
 
 const complementaryTokensStart = "({[\"'`";
 const complementaryTokensEnd =   ")}]\"'`";
@@ -1752,22 +1759,22 @@ function extractFunctionParameterNames(s) {
      */
 
     // All patterns fall into two buckets:
-    // PARENS: Get the thing within the first opening pair of parentheses.
-    // SINGLEARROW: Get the single param before =>.
+    // A. PARENS: Get the thing within the first opening pair of parentheses.
+    // B. SINGLEARROW: Get the single param before =>.
 
-    // Base case: Find A or B (whatever comes first), while ignoring comments.
+    // Base case: Find pattern A or B, while ignoring comments.
     // Special case 1: Parameter initializers (e.g. `x = f()`).
     //    Commas can be part of initializers, but they would have to be contained
     //    by complementary tokens, any of: ``""''[](){}. 
     //    → Let's simply ignore everything inside of that.
     // Special case 2: Argument destructuring.
-    //    Don't give it a name (empty string).
-    //    Same concept as case 1.
+    //    -> Don't give the param a name (empty string).
+    //    Same parsing logic as case 1.
 
     /**
-     * The function header without comments.
+     * The function header without (i) comments and without (ii) nested AST nodes.
      */
-    let header = "";
+    let cleanHeader = "";
     /**
      * When in a comment, this is set to the counterpart that we are looking for.
      * @type {string | null}
@@ -1783,58 +1790,61 @@ function extractFunctionParameterNames(s) {
       const c = s[i];
       if (expectedCommentEnd) {
         // In a comment.
-        if (hasSubstringAt(s, expectedCommentEnd, i)) {
+        if (substringEndsAt(s, expectedCommentEnd, i)) {
           // Comment End: Start new segment from here.
           expectedCommentEnd = null;
-        } 
-      }
-      else {
-        // Not in a comment.
-        if (hasSubstringAt(s, "//", i) || hasSubstringAt(s, "/*", i)) {
-          // Comment Start.
-          if (c === "*") {
-            expectedCommentEnd = "*/";
-          } else {
-            expectedCommentEnd = "\n";
-          }
-          // Remove "/" from header:
-          header = header.slice(0, -1);
-        } else {
-          if (parensStart === -1) {
-            if (c === "(") {
-              // PARENS: Params start.
-              parensStart = header.length + 1;
-            } else if (hasSubstringAt(s, "=>", i)) {
-              // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
-              const param = header.trim().match(/([^\s]+)\s*=$/)?.[1];
-              return param ? [param] : [];
-            }
-          } else if (c === "=") {
-            // Initializer start.
-            insideInitializer = true;
-          } else if (insideInitializer && c === ",") {
-            // Initializer end.
-            insideInitializer = false;
-          } else if (ignoreStack.length && ignoreStack[ignoreStack.length - 1] === c) {
-            // Inside destructuring argument or initializer expression:
-            // Exit node.
-            ignoreStack.pop();
-            continue; // Ignore this, too.
-          } else if (complementaryTokensStart.includes(c)) {
-            // Inside destructuring argument or initializer expression:
-            // Enter node.
-            const tokenIdx = complementaryTokensStart.indexOf(c);
-            ignoreStack.push(complementaryTokensEnd[tokenIdx]);
-          } else if (c === ")") {
-            // PARENS: Params end.
-            return header.substring(parensStart).split(",").map(p => p.trim());
-          }
-
-          if (!insideInitializer && !ignoreStack.length) {
-            // Add to the header.
-            header += c;
-          }
         }
+        continue;
+      }
+
+      // Not in a comment.
+      if (cleanHeader.endsWith("/") && (c === "/" || c === "*")) {
+        // Comment Start.
+        if (c === "*") {
+          expectedCommentEnd = "*/";
+        } else {
+          expectedCommentEnd = "\n";
+        }
+        // Remove "/" from header:
+        cleanHeader = cleanHeader.slice(0, -1);
+        continue;
+      }
+
+      // Parse everything but comments:
+      if (parensStart === -1) {
+        // Not in params parentheses.
+        if (c === "(") {
+          // PARENS: Params start.
+          parensStart = cleanHeader.length + 1;
+        } else if (stringsEndWith(cleanHeader, c, "=>")) {
+          // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
+          const param = cleanHeader.trim().match(/([^\s]+)\s*=$/)?.[1];
+          return param ? [param] : [];
+        }
+      } else if (c === "=") {
+        // Initializer start.
+        insideInitializer = true;
+      } else if (insideInitializer && c === ",") {
+        // Initializer end.
+        insideInitializer = false;
+      } else if (ignoreStack.length && ignoreStack[ignoreStack.length - 1] === c) {
+        // Inside destructuring argument or initializer expression:
+        // Exit node.
+        ignoreStack.pop();
+        continue; // Ignore this, too.
+      } else if (complementaryTokensStart.includes(c)) {
+        // Inside destructuring argument or initializer expression:
+        // Enter node. Push complementary (to be searched for) onto stack.
+        const tokenIdx = complementaryTokensStart.indexOf(c);
+        ignoreStack.push(complementaryTokensEnd[tokenIdx]);
+      } else if (c === ")") {
+        // PARENS: Params end.
+        return cleanHeader.substring(parensStart).split(",").map(p => p.trim());
+      }
+
+      if (!insideInitializer && !ignoreStack.length) {
+        // Keep the character.
+        cleanHeader += c;
       }
     }
 

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -1725,6 +1725,8 @@ function getInternalFunctionLocationProp(cdpProperties) {
   return getInternalProp(cdpProperties, '[[FunctionLocation]]');
 }
 
+const log = console.log.bind(console);
+
 /**
  * String utility for function parameter parsing.
  */
@@ -1732,76 +1734,122 @@ function hasSubstringAt(haystack, needle, i) {
   return haystack.substring(1 + i - needle.length, 1 + i) === needle;
 }
 
+
+const complementaryTokensStart = "({[\"'`";
+const complementaryTokensEnd =   ")}]\"'`";
+
 /**
  * [RUN-3146] Extract parameter names from the description.
  * @param {string} s 
  * @return {string[]}
  */
 function extractFunctionParameterNames(s) {
-  /**
-   * Function head declaration patterns:
-   * P1. modifiers function f(PARAMS) Body
-   * P2. modifiers f(PARAMS) Body  // ObjectMethod, ClassMethod
-   * P3. modifiers (PARAMS) => ExpressionOrBody
-   * P4. modifiers PARAM => ExpressionOrBody
-   */
+  try {
+    /** 
+     * Function head declaration patterns:
+     * P1. modifiers function f(PARAMS) Body
+     * P2. modifiers f(PARAMS) Body  // ObjectMethod, ClassMethod
+     * P3. modifiers (PARAMS) => ExpressionOrBody
+     * P4. modifiers PARAM => ExpressionOrBody
+     */
 
-  // All patterns fall into two buckets:
-  // PARENS: Get the thing within the first opening pair of parentheses.
-  // SINGLEARROW: Get the single param before =>.
+    // All patterns fall into two buckets:
+    // PARENS: Get the thing within the first opening pair of parentheses.
+    // SINGLEARROW: Get the single param before =>.
 
-  // Go: Find A or B (whatever comes first), while ignoring comments.
-  /**
-   * The function header without comments.
-   */
-  let header = "";
-  /**
-   * When in a comment, this is set to the counterpart that we are looking for.
-   * @type {string | null}
-   */
-  let expectedCommentEnd = null;
-  let parensStart = -1;
-  for (let i = 0; i < s.length; ++i) {
-    const c = s[i];
-    if (expectedCommentEnd) {
-      // In a comment.
-      if (hasSubstringAt(s, expectedCommentEnd, i)) {
-        // Comment End: Start new segment from here.
-        expectedCommentEnd = null;
-      } 
-    }
-    else {
-      // Not in a comment.
-      if (hasSubstringAt(s, "//", i) || hasSubstringAt(s, "/*", i)) {
-        // Comment Start.
-        if (c === "*") {
-          expectedCommentEnd = "*/";
+    // Base case: Find A or B (whatever comes first), while ignoring comments.
+    // Special case 1: Parameter initializers (e.g. `x = f()`).
+    //    Commas can be part of initializers, but they would have to be contained
+    //    by complementary tokens, any of: ``""''[](){}. 
+    //    → Let's simply ignore everything inside of that.
+    // Special case 2: Argument destructuring.
+    //    Don't give it a name (empty string).
+    //    Same concept as case 1.
+
+    /**
+     * The function header without comments.
+     */
+    let header = "";
+    /**
+     * When in a comment, this is set to the counterpart that we are looking for.
+     * @type {string | null}
+     */
+    let expectedCommentEnd = null;
+    let parensStart = -1;
+    let insideInitializer = false;
+    /**
+     * @type {string[]}
+     */
+    const ignoreStack = [];
+    for (let i = 0; i < s.length; ++i) {
+      const c = s[i];
+      if (expectedCommentEnd) {
+        // In a comment.
+        if (hasSubstringAt(s, expectedCommentEnd, i)) {
+          // Comment End: Start new segment from here.
+          expectedCommentEnd = null;
+        } 
+      }
+      else {
+        // Not in a comment.
+        if (hasSubstringAt(s, "//", i) || hasSubstringAt(s, "/*", i)) {
+          // Comment Start.
+          if (c === "*") {
+            expectedCommentEnd = "*/";
+          } else {
+            expectedCommentEnd = "\n";
+          }
+          // Remove "/" from header:
+          header = header.slice(0, -1);
         } else {
-          expectedCommentEnd = "\n";
+          if (parensStart === -1) {
+            if (c === "(") {
+              // PARENS: Params start.
+              parensStart = header.length + 1;
+            } else if (hasSubstringAt(s, "=>", i)) {
+              // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
+              const param = header.trim().match(/([^\s]+)\s*=$/)?.[1];
+              return param ? [param] : [];
+            }
+          } else if (c === "=") {
+            // Initializer start.
+            insideInitializer = true;
+          } else if (insideInitializer && c === ",") {
+            // Initializer end.
+            insideInitializer = false;
+          } else if (complementaryTokensStart.includes(c)) {
+            // Inside some arbitrary syntax construct.
+            // → Ignore, since that's not part of the parameter name.
+            const tokenIdx = complementaryTokensStart.indexOf(c);
+            ignoreStack.push(complementaryTokensEnd[tokenIdx]);
+          } else if (ignoreStack.length) {
+            // Inside destructuring argument or initializer expression.
+            if (complementaryTokensEnd.includes(c)) {
+              const end = ignoreStack.pop();
+              if (end !== c) {
+                log(`[RuntimError] extractFunctionParameterNames unexpected token "${c}", expected "${end}" at "${s.substring(0, i+1)}"`);
+                return [];
+              }
+            }
+          } else if (c === ")") {
+            // PARENS: Params end.
+            return header.substring(parensStart).split(",").map(p => p.trim());
+          }
+
+          if (!insideInitializer && !ignoreStack.length) {
+            // Add to the header.
+            header += c;
+          }
         }
-        // Remove "/" from header:
-        header = header.slice(0, -1);
-      } else {
-        if (c === "(") {
-          // PARENS: Params start.
-          parensStart = header.length + 1;
-        } else if (c === ")") {
-          // PARENS: Params end.
-          return header.substring(parensStart).split(",").map(p => p.trim());
-        } else if (hasSubstringAt(s, "=>", i)) {
-          // SINGLEARROW: Found the arrow → The last word in the header (sans "=") is the param.
-          const param = header.trim().match(/([^\s]+)\s*=$/)?.[1];
-          return param ? [param] : [];
-        }
-        // Add to the header.
-        header += c;
       }
     }
-  }
 
-  // This should not happen, but might.
-  log(`[RuntimeError] extractFunctionParameterNames failed for: ${s.slice(0, 80)}...`);
-  return [];
+    // This should not happen, but might.
+    log(`[RuntimeError] extractFunctionParameterNames fell through for: ${s.slice(0, 80)}...`);
+    return [];
+  } catch (err) {
+    log(`[RuntimeError] extractFunctionParameterNames failed for: ${s.slice(0, 80)}...\n ${err?.stack || err}`);
+  }
 }
 
 function previewFunction(cdpProperties) {


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-3146/function-object-preview-is-missing-functionparameternames-in-chromium#comment-fab95193
* Tests are [here](https://github.com/replayio/backend/pull/9661/files#diff-fe039b26aea8da56c20deb9ba81c0d808e31ccf7258f281208c6fdb5f06e9224R38) and pass ✅