### PR TITLE
[RUN-2989] DevicePixelRatio initially wrong on Mac ARM

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -624,6 +624,8 @@ mixed_component("base") {
     "record_replay.cc",
     "record_replay.h",
     "record_replay_ordered_atomic.h",
+    "record_replay_render_interface.h",
+    "record_replay_render_interface.cc",
     "record_replay_atomic_sequence_num.h",
     "run_loop.cc",
     "run_loop.h",

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -611,18 +611,6 @@ void FinishRecording() {
   V8RecordReplayFinishRecording();
 }
 
-// Callback to reset the paint surface.
-static ResetPaintSurfaceCallback gResetPaintSurfaceCallback = nullptr;
-void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface) {
-  gResetPaintSurfaceCallback = reset_paint_surface;
-}
-
-void DoResetPaintSurface() {
-  if (gResetPaintSurfaceCallback) {
-    gResetPaintSurfaceCallback();
-  }
-}
-
 std::vector<std::string> *gPseudoStack = nullptr;
 
 static std::vector<std::string>* GetPseudoStack() {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -390,10 +390,6 @@ public:
   }
 };
 
-typedef void (*ResetPaintSurfaceCallback)();
-void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface);
-void DoResetPaintSurface();
-
 /*
  * A Pseudo-stack mechanism for diagnostics.
  *

--- a/base/record_replay_render_interface.cc
+++ b/base/record_replay_render_interface.cc
@@ -26,11 +26,13 @@ static GetCurrentViewportPixelSizeCallback gGetCurrentViewportPixelSize = nullpt
 void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb) {
   gGetCurrentViewportPixelSize = cb;
 }
-const gfx::Size* GetCurrentViewportPixelSize() {
+
+const gfx::Size gDefaultSize; // {0,0}
+gfx::Size GetCurrentViewportPixelSize() {
   if (gGetCurrentViewportPixelSize) {
     return gGetCurrentViewportPixelSize();
   }
-  return nullptr;
+  return gDefaultSize;
 }
 
 }  // namespace recordreplay

--- a/base/record_replay_render_interface.cc
+++ b/base/record_replay_render_interface.cc
@@ -1,0 +1,26 @@
+// Copyright 2024 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/record_replay.h"
+#include "base/record_replay_render_interface.h"
+
+// We use this file to allow depending on record_replay_render from blink.
+// We cannot access it directly since, during V8 snapshotting, blink is linked
+// but the display service is not.
+
+namespace recordreplay {
+
+// Callback to reset the paint surface.
+static ResetPaintSurfaceCallback gResetPaintSurfaceCallback = nullptr;
+void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface) {
+  gResetPaintSurfaceCallback = reset_paint_surface;
+}
+
+void DoResetPaintSurface() {
+  if (gResetPaintSurfaceCallback) {
+    gResetPaintSurfaceCallback();
+  }
+}
+
+}  // namespace recordreplay

--- a/base/record_replay_render_interface.cc
+++ b/base/record_replay_render_interface.cc
@@ -6,8 +6,8 @@
 #include "base/record_replay_render_interface.h"
 
 // We use this file to allow depending on record_replay_render from blink.
-// We cannot access it directly since, during V8 snapshotting, blink is linked
-// but the display service is not.
+// We cannot access the render code directly since, during V8 snapshotting,
+// blink is linked, but the display service is not.
 
 namespace recordreplay {
 
@@ -22,7 +22,6 @@ void DoResetPaintSurface() {
   }
 }
 
-// Callback to retrieve size data.
 static GetCurrentViewportPixelSizeCallback gGetCurrentViewportPixelSize = nullptr;
 void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb) {
   gGetCurrentViewportPixelSize = cb;

--- a/base/record_replay_render_interface.cc
+++ b/base/record_replay_render_interface.cc
@@ -16,11 +16,22 @@ static ResetPaintSurfaceCallback gResetPaintSurfaceCallback = nullptr;
 void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface) {
   gResetPaintSurfaceCallback = reset_paint_surface;
 }
-
 void DoResetPaintSurface() {
   if (gResetPaintSurfaceCallback) {
     gResetPaintSurfaceCallback();
   }
+}
+
+// Callback to retrieve size data.
+static GetCurrentViewportPixelSizeCallback gGetCurrentViewportPixelSize = nullptr;
+void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb) {
+  gGetCurrentViewportPixelSize = cb;
+}
+const gfx::Size* GetCurrentViewportPixelSize() {
+  if (gGetCurrentViewportPixelSize) {
+    return gGetCurrentViewportPixelSize();
+  }
+  return nullptr;
 }
 
 }  // namespace recordreplay

--- a/base/record_replay_render_interface.h
+++ b/base/record_replay_render_interface.h
@@ -1,0 +1,21 @@
+// Copyright 2024 Record Replay Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+#ifndef BASE_RECORD_REPLAY_RENDER_INTERFACE_H_
+#define BASE_RECORD_REPLAY_RENDER_INTERFACE_H_
+
+namespace recordreplay {
+
+typedef void (*ResetPaintSurfaceCallback)();
+
+void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface);
+
+void DoResetPaintSurface();
+
+
+
+}  // namespace recordreplay
+
+#endif // BASE_RECORD_REPLAY_RENDER_INTERFACE_H_

--- a/base/record_replay_render_interface.h
+++ b/base/record_replay_render_interface.h
@@ -18,7 +18,9 @@ void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface)
 void DoResetPaintSurface();
 
 typedef const gfx::Size* (*GetCurrentViewportPixelSizeCallback)();
+// This callback is set when the first render surface is created.
 void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb);
+// Get the current surface size in pixels.
 const gfx::Size* GetCurrentViewportPixelSize();
 
 

--- a/base/record_replay_render_interface.h
+++ b/base/record_replay_render_interface.h
@@ -17,11 +17,11 @@ typedef void (*ResetPaintSurfaceCallback)();
 void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface);
 void DoResetPaintSurface();
 
-typedef const gfx::Size* (*GetCurrentViewportPixelSizeCallback)();
+typedef gfx::Size (*GetCurrentViewportPixelSizeCallback)();
 // This callback is set when the first render surface is created.
 void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb);
 // Get the current surface size in pixels.
-const gfx::Size* GetCurrentViewportPixelSize();
+gfx::Size GetCurrentViewportPixelSize();
 
 
 }  // namespace recordreplay

--- a/base/record_replay_render_interface.h
+++ b/base/record_replay_render_interface.h
@@ -6,14 +6,20 @@
 #ifndef BASE_RECORD_REPLAY_RENDER_INTERFACE_H_
 #define BASE_RECORD_REPLAY_RENDER_INTERFACE_H_
 
+
+#include "ui/gfx/geometry/size.h"
+
+using gfx::Size;
+
 namespace recordreplay {
 
 typedef void (*ResetPaintSurfaceCallback)();
-
 void SetResetPaintSurfaceCallback(ResetPaintSurfaceCallback reset_paint_surface);
-
 void DoResetPaintSurface();
 
+typedef const gfx::Size* (*GetCurrentViewportPixelSizeCallback)();
+void SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeCallback cb);
+const gfx::Size* GetCurrentViewportPixelSize();
 
 
 }  // namespace recordreplay

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -243,6 +243,9 @@ static std::atomic<base::WaitableEvent*> gRepaintEvent;
 // Encoded result of repainting.
 static std::atomic<char*> gRepaintResult;
 
+// Real size of |gRepaintResult|.
+static std::atomic<gfx::Size> gDeviceViewportSize;
+
 void OnPaintFinished(const SkPixmap& pixmap) {
   static bool hasPaints = false;
   if (!hasPaints) {
@@ -251,6 +254,10 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   }
 
   gCurrentPixmap = &pixmap;
+  if (gOutputSurface) {
+    // Obtain device size on impl thread.
+    gDeviceViewportSize = gOutputSurface->software_device()->ReplayViewportPixelSize();
+  }
 
   if (HasDivergedFromRecording()) {
     // If we've diverged from the recording then we're probably repainting,
@@ -344,13 +351,8 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
   return gRepaintResult;
 }
 
-const gfx::Size* GetCurrentViewportPixelSizeImpl() {
-  CHECK(IsMainThread());
-
-  if (gOutputSurface) {
-    return &gOutputSurface->software_device()->ReplayViewportPixelSize();
-  }
-  return nullptr;
+gfx::Size GetCurrentViewportPixelSizeImpl() {
+  return gDeviceViewportSize;
 }
 
 } // namespace recordreplay

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -6,6 +6,7 @@
 
 #include "base/base64.h"
 #include "base/record_replay.h"
+#include "base/record_replay_render_interface.h"
 #include "base/strings/stringprintf.h"
 #include "cc/animation/animation_events.h"
 #include "cc/trees/compositor_commit_data.h"
@@ -340,6 +341,13 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
 
   gRepaintEvent = nullptr;
   return gRepaintResult;
+}
+
+const gfx::Size* GetCurrentViewportPixelSize() {
+  if (gOutputSurface) {
+    return &gOutputSurface->software_device()->ReplayViewportPixelSize();
+  }
+  return nullptr;
 }
 
 } // namespace recordreplay

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -67,6 +67,7 @@ static void InitializeRenderer() {
                                         nullptr);
 
   recordreplay::SetResetPaintSurfaceCallback(ResetSurfaceId);
+  recordreplay::SetGetCurrentViewportPixelSizeCallback(GetCurrentViewportPixelSizeImpl);
 }
 
 static std::string SurfaceIdString(const viz::LocalSurfaceId& local_surface_id) {
@@ -343,7 +344,9 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
   return gRepaintResult;
 }
 
-const gfx::Size* GetCurrentViewportPixelSize() {
+const gfx::Size* GetCurrentViewportPixelSizeImpl() {
+  CHECK(IsMainThread());
+
   if (gOutputSurface) {
     return &gOutputSurface->software_device()->ReplayViewportPixelSize();
   }

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -58,6 +58,8 @@ void SetCompositorProxy(cc::ProxyMain* proxy);
 // Called when a compositor proxy has been destroyed and can't be used to trigger repaints.
 void CompositorProxyDestroyed(cc::ProxyMain* proxy);
 
+const gfx::Size* GetCurrentViewportPixelSize();
+
 } // namespace recordreplay
 
 #endif // COMPONENTS_VIZ_SERVICE_DISPLAY_RECORD_REPLAY_RENDER_H_

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -58,7 +58,7 @@ void SetCompositorProxy(cc::ProxyMain* proxy);
 // Called when a compositor proxy has been destroyed and can't be used to trigger repaints.
 void CompositorProxyDestroyed(cc::ProxyMain* proxy);
 
-const gfx::Size* GetCurrentViewportPixelSize();
+const gfx::Size* GetCurrentViewportPixelSizeImpl();
 
 } // namespace recordreplay
 

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -58,7 +58,7 @@ void SetCompositorProxy(cc::ProxyMain* proxy);
 // Called when a compositor proxy has been destroyed and can't be used to trigger repaints.
 void CompositorProxyDestroyed(cc::ProxyMain* proxy);
 
-const gfx::Size* GetCurrentViewportPixelSizeImpl();
+gfx::Size GetCurrentViewportPixelSizeImpl();
 
 } // namespace recordreplay
 

--- a/components/viz/service/display/software_output_device.h
+++ b/components/viz/service/display/software_output_device.h
@@ -83,7 +83,7 @@ class VIZ_SERVICE_EXPORT SoftwareOutputDevice {
   // platform's proposed surface size.
   virtual bool SupportsOverridePlatformSize() const;
 
-  // Expose this so we can compute the correct pixel ratio.
+  // [RUN-2989] Allow Replay commmand handlers to read the viewport size.
   const gfx::Size& ReplayViewportPixelSize() const {
     return viewport_pixel_size_;
   }

--- a/components/viz/service/display/software_output_device.h
+++ b/components/viz/service/display/software_output_device.h
@@ -83,6 +83,11 @@ class VIZ_SERVICE_EXPORT SoftwareOutputDevice {
   // platform's proposed surface size.
   virtual bool SupportsOverridePlatformSize() const;
 
+  // Expose this so we can compute the correct pixel ratio.
+  const gfx::Size& ReplayViewportPixelSize() const {
+    return viewport_pixel_size_;
+  }
+
  protected:
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   raw_ptr<SoftwareOutputDeviceClient> client_ = nullptr;

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -29,6 +29,7 @@ const {
   fromJsCssGetStylesheetByCpdId,
   fromJsCollectEventListeners,
   fromJsDomPerformSearch,
+  getCurrentViewportPixelSize,
 
   // network
   getCurrentNetworkRequestEvent,
@@ -681,7 +682,21 @@ function Pause_getScope({ scope }) {
 }
 
 function Graphics_getDevicePixelRatio() {
-  return { ratio: window?.devicePixelRatio || 0 };
+  // RUN-2989: On Mac, devicePixelRatio is incorrect in the early lifetime
+  // of the process, so we need to compute the actual pixel ratio of hardware
+  // pixels to page pixels.
+  // getCurrentViewportPixelSize
+  const size = getCurrentViewportPixelSize();
+  if (size) {
+    // We only need one.
+    const ratioX = size.width / innerWidth;
+    return {
+      ratio: ratioX
+    };
+  }
+  return {
+    ratio: window?.devicePixelRatio || 0
+  };
 }
 
 
@@ -3308,5 +3323,7 @@ addEventListener("Runtime.executionContextsCleared", () => {
   gExecutionContexts.clear();
 });
 sendCDPMessage("Runtime.enable");
+
+log(`DDBG devicePixelRatio`, devicePixelRatio);
 
 })();

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -688,7 +688,7 @@ function Graphics_getDevicePixelRatio() {
   // getCurrentViewportPixelSize
   const size = getCurrentViewportPixelSize();
   if (size) {
-    // We only need one.
+    // Note: X and Y ratios should be the same.
     const ratioX = size.width / innerWidth;
     return {
       ratio: ratioX

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -685,7 +685,6 @@ function Graphics_getDevicePixelRatio() {
   // RUN-2989: On Mac, devicePixelRatio is incorrect in the early lifetime
   // of the process, so we need to compute the actual pixel ratio of hardware
   // pixels to page pixels.
-  // getCurrentViewportPixelSize
   const size = getCurrentViewportPixelSize();
   if (size) {
     // Note: X and Y ratios should be the same.
@@ -1419,8 +1418,6 @@ ProtocolObjectPreview.prototype = {
           foundProps.add(propKey);
         }
       }
-
-      // log(`************** DDBG fill() C ${[this.unlimitedItems, cdpProperties.result.length, propertiesToFetch].join(", ")}`);
     }
     
     for (const cdpProp of cdpProperties.result) {
@@ -3323,7 +3320,5 @@ addEventListener("Runtime.executionContextsCleared", () => {
   gExecutionContexts.clear();
 });
 sendCDPMessage("Runtime.enable");
-
-log(`DDBG devicePixelRatio`, devicePixelRatio);
 
 })();

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -686,8 +686,10 @@ function Graphics_getDevicePixelRatio() {
   // of the process, so we need to compute the actual pixel ratio of hardware
   // pixels to page pixels.
   const size = getCurrentViewportPixelSize();
-  if (size) {
-    // Note: X and Y ratios should be the same.
+  if (size.width) {
+    // Note1: This size might not yet have been initialized, in which case,
+    //          it will default to {0,0}.
+    // Note2: X and Y ratios should be the same.
     const ratioX = size.width / innerWidth;
     return {
       ratio: ratioX

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -55,10 +55,6 @@ static const char DirectorySeparator = '\\';
 
 static const char *AnnotationHookJSName = "__RECORD_REPLAY_ANNOTATION_HOOK__";
 
-namespace recordreplay {
-extern const gfx::Size* GetCurrentViewportPixelSize();
-}
-
 namespace v8 {
 
 extern void FunctionCallbackRecordReplaySetCommandCallback(const FunctionCallbackInfo<Value>& args);
@@ -99,13 +95,13 @@ extern "C" char* V8RecordReplayReadAssetFileContents(const char* aPath, size_t* 
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
 
-static bool IsGReplayScriptEnabledWhenRecording() {
+static bool IsCommandHandlingEnabledWhenRecording() {
   return !recordreplay::FeatureEnabled("replay-only-command-handling");
 }
 
-static bool IsGReplayScriptEnabled() {
+static bool IsCommandHandlingEnabled() {
   return recordreplay::IsReplaying() ||
-         IsGReplayScriptEnabledWhenRecording();
+         IsCommandHandlingEnabledWhenRecording();
 }
 
 static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
@@ -193,7 +189,7 @@ static String ReadReplayAssetFile(const char* fname) {
 
   // Important: Treat as UTF-8.
   String result = String::FromUTF8(
-    IsGReplayScriptEnabledWhenRecording()
+    IsCommandHandlingEnabledWhenRecording()
       // Recording + Replay.
       ? ReadReplayAssetFileRaw(fname, len).c_str()
       // Replay only.
@@ -878,7 +874,7 @@ static void LogWarningCallback(const v8::FunctionCallbackInfo<v8::Value>& args) 
 void
 RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
                                 v8::Isolate* isolate) {
-  if (v8::IsMainThread() && IsGReplayScriptEnabled()) {
+  if (v8::IsMainThread() && IsCommandHandlingEnabled()) {
     if (!gV8Inspectors) {
       gV8Inspectors = new std::unordered_map<v8::Isolate*,v8_inspector::V8Inspector*>();
       gInspectorData = new std::unordered_map<v8::Isolate*, ContextGroupIdInspectorMap*>();
@@ -1016,7 +1012,7 @@ InspectorData* getInspectorFor(v8::Isolate* isolate, int contextGroupId) {
  */
 v8_inspector::V8InspectorSession* getInspectorSession(v8::Isolate* isolate, int contextGroupId) {
   CHECK(v8::IsMainThread());
-  CHECK(IsGReplayScriptEnabled());
+  CHECK(IsCommandHandlingEnabled());
   CHECK(gV8Inspectors);
 
   v8_inspector::V8Inspector* inspector = (*gV8Inspectors)[isolate];
@@ -2655,7 +2651,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
     localFrame->GetSettings()->SetForceMainWorldInitialization(true);
   }
 
-  if (IsGReplayScriptEnabled()) {
+  if (IsCommandHandlingEnabled()) {
     recordreplay::AutoMarkReplayCode amrc;
     String commandHandlerScript = ReadReplayCommandHandlerScript();
     {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2349,16 +2349,14 @@ static void fromJsEndReplayCode(
 static void fromJsGetCurrentViewportPixelSize(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  const gfx::Size* size = recordreplay::GetCurrentViewportPixelSize();
+  gfx::Size size = recordreplay::GetCurrentViewportPixelSize();
 
-  if (size) {
-    v8::Local<v8::Object> jsSize = v8::Object::New(isolate);
-    SetDataProperty(isolate, jsSize, "width",
-                    v8::Number::New(isolate, size->width()));
-    SetDataProperty(isolate, jsSize, "height",
-                    v8::Number::New(isolate, size->height()));
-    args.GetReturnValue().Set(jsSize);
-  }
+  v8::Local<v8::Object> jsSize = v8::Object::New(isolate);
+  SetDataProperty(isolate, jsSize, "width",
+                  v8::Number::New(isolate, size.width()));
+  SetDataProperty(isolate, jsSize, "height",
+                  v8::Number::New(isolate, size.height()));
+  args.GetReturnValue().Set(jsSize);
 }
 
 /** ###########################################################################

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -15,6 +15,7 @@
 #include "base/json/json_writer.h"
 #include "base/process/process_handle.h"
 #include "base/record_replay.h"
+#include "base/record_replay_render_interface.h"
 #include "content/public/renderer/render_thread.h"
 #include "content/public/renderer/v8_value_converter.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_binding_for_core.h"
@@ -53,6 +54,10 @@ static const char DirectorySeparator = '\\';
 #endif
 
 static const char *AnnotationHookJSName = "__RECORD_REPLAY_ANNOTATION_HOOK__";
+
+namespace recordreplay {
+extern const gfx::Size* GetCurrentViewportPixelSize();
+}
 
 namespace v8 {
 
@@ -2345,6 +2350,21 @@ static void fromJsEndReplayCode(
   recordreplay::ExitReplayCode();
 }
 
+static void fromJsGetCurrentViewportPixelSize(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+
+  const gfx::Size* size = recordreplay::GetCurrentViewportPixelSize();
+
+  if (size) {
+    v8::Local<v8::Object> jsSize = v8::Object::New(isolate);
+    SetDataProperty(isolate, jsSize, "width",
+                    v8::Number::New(isolate, size->width()));
+    SetDataProperty(isolate, jsSize, "height",
+                    v8::Number::New(isolate, size->height()));
+    args.GetReturnValue().Set(jsSize);
+  }
+}
+
 /** ###########################################################################
  * misc
  * ##########################################################################*/
@@ -2567,6 +2587,10 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                       fromJsBeginReplayCode);
   SetFunctionProperty(isolate, args, "endReplayCode",
                       fromJsEndReplayCode);
+
+  // Graphics.
+  SetFunctionProperty(isolate, args, "getCurrentViewportPixelSize",
+                      fromJsGetCurrentViewportPixelSize);
 
   // unsorted Replay stuff
   SetFunctionProperty(


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2989/devicepixelratio-initially-wrong-on-mac-arm#comment-6b6b2b82
* I tested it as explained [here](https://linear.app/replay/issue/RUN-2989/devicepixelratio-initially-wrong-on-mac-arm#comment-3fcef722).