### PR TITLE
Ensure we get repaints when requested.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,24 +149,24 @@ steps:
   #     - "build_id/macOS/arm64/**"
   #   # TODO(dmiller): enable rbe on Windows
   # - label: "Build chromium - Windows"
-    key: "build-chromium-windows"
-    depends_on: "preflight-checks"
-    timeout_in_minutes: 60
-    plugins:
-      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
-    command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
-    env:
-      RBE_service: simpsonite.cluster.engflow.com:443
-      RBE_service_no_auth: true
-      RBE_use_application_default_credentials: true
-      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=windows"
-      - "queue=runtime"
-    artifact_paths:
-      - "build_id/windows/x86_64/**"
-    soft_fail: true
+    # key: "build-chromium-windows"
+    # depends_on: "preflight-checks"
+    # timeout_in_minutes: 60
+    # plugins:
+    #   - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
+    # command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
+    # env:
+    #   RBE_service: simpsonite.cluster.engflow.com:443
+    #   RBE_service_no_auth: true
+    #   RBE_use_application_default_credentials: true
+    #   RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
+    # agents:
+    #   - "runtimeType=chromiumbuild"
+    #   - "os=windows"
+    #   - "queue=runtime"
+    # artifact_paths:
+    #   - "build_id/windows/x86_64/**"
+    # soft_fail: true
 
   # - label: "Verify cross-arch build integrity :sleuth_or_spy:"
   #   key: "verify-cross-arch-pak-sizes"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,151 +68,149 @@ steps:
       - "queue=runtime"
     artifact_paths:
       - "build_id/linux/x86_64/**"
-  # - label: "Build chromium - Mac (x86)"
-  #   key: "build-chromium-mac-x86_64"
-  #   depends_on: "preflight-checks"
-  #   timeout_in_minutes: 60
-  #   plugins:
-  #     - thedyrt/skip-checkout#v0.1.1:
-  #         cd: /Users/administrator/chromium/src
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         region: us-east-2
-  #         env:
-  #           BUILDEVENT_APIKEY: honeycomb-api-key
-  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-  #         file:
-  #           - path: "/Users/administrator/chromium/engflow.crt"
-  #             secret-id: engflow-certificate
-  #           - path: "/Users/administrator/chromium/engflow.key"
-  #             secret-id: engflow-key
-  #     - replayio/buildevents#76b6f57: ~
-  #   commands:
-  #     - "be_cmd git-fetch-all -- git fetch --all"
-  #     - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-  #     - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-  #     - "pushd ../backend"
-  #     - "be_cmd buck2-kill -- buckle kill"
-  #     - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-x86_64"
-  #     - "popd"
-  #   env:
-  #     RBE_service: simpsonite.cluster.engflow.com:443
-  #     RBE_service_no_auth: true
-  #     RBE_use_application_default_credentials: true
-  #     RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
-  #     RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
-  #     RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-  #   agents:
-  #     - "runtimeType=chromiumbuild"
-  #     - "os=macos"
-  #     - "queue=runtime"
-  #   artifact_paths:
-  #     - "build_id/macOS/x86_64/**"
-  # - label: "Build chromium - Mac (arm64)"
-  #   key: "build-chromium-mac-arm64"
-  #   depends_on: "preflight-checks"
-  #   timeout_in_minutes: 60
-  #   plugins:
-  #     - thedyrt/skip-checkout#v0.1.1:
-  #         cd: /Users/administrator/chromium/src
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         region: us-east-2
-  #         env:
-  #           BUILDEVENT_APIKEY: honeycomb-api-key
-  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-  #         file:
-  #           - path: "/Users/administrator/chromium/engflow.crt"
-  #             secret-id: engflow-certificate
-  #           - path: "/Users/administrator/chromium/engflow.key"
-  #             secret-id: engflow-key
-  #     - replayio/buildevents#76b6f57: ~
-  #   commands:
-  #     - "be_cmd git-fetch-all -- git fetch --all"
-  #     - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-  #     - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-  #     - "pushd ../backend"
-  #     - "be_cmd buck2-kill -- buckle kill"
-  #     - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-arm64"
-  #     - "popd"
-  #   env:
-  #     RBE_service: simpsonite.cluster.engflow.com:443
-  #     RBE_service_no_auth: true
-  #     RBE_use_application_default_credentials: true
-  #     RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
-  #     RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
-  #     REPLAY_BUILD_ARM: true
-  #     RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-  #   agents:
-  #     - "runtimeType=chromiumbuild"
-  #     - "os=macos"
-  #     - "queue=runtime"
-  #   artifact_paths:
-  #     - "build_id/macOS/arm64/**"
-  #   # TODO(dmiller): enable rbe on Windows
-  # - label: "Build chromium - Windows"
-    # key: "build-chromium-windows"
-    # depends_on: "preflight-checks"
-    # timeout_in_minutes: 60
-    # plugins:
-    #   - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
-    # command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
-    # env:
-    #   RBE_service: simpsonite.cluster.engflow.com:443
-    #   RBE_service_no_auth: true
-    #   RBE_use_application_default_credentials: true
-    #   RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
-    # agents:
-    #   - "runtimeType=chromiumbuild"
-    #   - "os=windows"
-    #   - "queue=runtime"
-    # artifact_paths:
-    #   - "build_id/windows/x86_64/**"
-    # soft_fail: true
+  - label: "Build chromium - Mac (x86)"
+    key: "build-chromium-mac-x86_64"
+    depends_on: "preflight-checks"
+    timeout_in_minutes: 60
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /Users/administrator/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+          file:
+            - path: "/Users/administrator/chromium/engflow.crt"
+              secret-id: engflow-certificate
+            - path: "/Users/administrator/chromium/engflow.key"
+              secret-id: engflow-key
+      - replayio/buildevents#76b6f57: ~
+    commands:
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-x86_64"
+      - "popd"
+    env:
+      RBE_service: simpsonite.cluster.engflow.com:443
+      RBE_service_no_auth: true
+      RBE_use_application_default_credentials: true
+      RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
+      RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
+      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=macos"
+      - "queue=runtime"
+    artifact_paths:
+      - "build_id/macOS/x86_64/**"
+  - label: "Build chromium - Mac (arm64)"
+    key: "build-chromium-mac-arm64"
+    depends_on: "preflight-checks"
+    timeout_in_minutes: 60
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /Users/administrator/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+          file:
+            - path: "/Users/administrator/chromium/engflow.crt"
+              secret-id: engflow-certificate
+            - path: "/Users/administrator/chromium/engflow.key"
+              secret-id: engflow-key
+      - replayio/buildevents#76b6f57: ~
+    commands:
+      - "be_cmd git-fetch-all -- git fetch --all"
+      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+      - "pushd ../backend"
+      - "be_cmd buck2-kill -- buckle kill"
+      - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-arm64"
+      - "popd"
+    env:
+      RBE_service: simpsonite.cluster.engflow.com:443
+      RBE_service_no_auth: true
+      RBE_use_application_default_credentials: true
+      RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
+      RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
+      REPLAY_BUILD_ARM: true
+      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=macos"
+      - "queue=runtime"
+    artifact_paths:
+      - "build_id/macOS/arm64/**"
+    # TODO(dmiller): enable rbe on Windows
+  - label: "Build chromium - Windows"
+    key: "build-chromium-windows"
+    depends_on: "preflight-checks"
+    timeout_in_minutes: 60
+    plugins:
+      - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
+    command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
+    env:
+      RBE_service: simpsonite.cluster.engflow.com:443
+      RBE_service_no_auth: true
+      RBE_use_application_default_credentials: true
+      RECORD_REPLAY_BACKEND_DIR: "C:\\Users\\Administrator\\chromium\\backend"
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=windows"
+      - "queue=runtime"
+    artifact_paths:
+      - "build_id/windows/x86_64/**"
+    soft_fail: true
 
-  # - label: "Verify cross-arch build integrity :sleuth_or_spy:"
-  #   key: "verify-cross-arch-pak-sizes"
-  #   commands:
-  #     - "be_cmd download-macos-arm64-gclient_entries -- buildkite-agent artifact download build_id/macOS/arm64/entries ."
-  #     - "be_cmd download-macos-x86_64-gclient_entries -- buildkite-agent artifact download build_id/macOS/x86_64/entries ."
-  #     - "be_cmd macos-diff-gclient-entries -- diff -u build_id/macOS/arm64/entries build_id/macOS/x86_64/entries"
-  #     - "be_cmd download-macos-arm64-pak-sizes -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
-  #     - "be_cmd download-macos-x86_64-pak-sizes -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
-  #     - "be_cmd macos-diff-pak-sizes -- diff -u build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
-  #   depends_on:
-  #     - "build-chromium-mac-x86_64"
-  #     - "build-chromium-mac-arm64"
-  #   plugins:
-  #     - thedyrt/skip-checkout#v0.1.1:
-  #         cd: /home/ubuntu/chromium/src
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         region: us-east-2
-  #         env:
-  #           BUILDEVENT_APIKEY: honeycomb-api-key
-  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-  #     - replayio/buildevents#76b6f57: ~
-  #   agents:
-  #     - "runtimeType=chromiumbuild"
-  #     - "os=linux"
-  #     - "queue=runtime"
+  - label: "Verify cross-arch build integrity :sleuth_or_spy:"
+    key: "verify-cross-arch-pak-sizes"
+    commands:
+      - "be_cmd download-macos-arm64-gclient_entries -- buildkite-agent artifact download build_id/macOS/arm64/entries ."
+      - "be_cmd download-macos-x86_64-gclient_entries -- buildkite-agent artifact download build_id/macOS/x86_64/entries ."
+      - "be_cmd macos-diff-gclient-entries -- diff -u build_id/macOS/arm64/entries build_id/macOS/x86_64/entries"
+      - "be_cmd download-macos-arm64-pak-sizes -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
+      - "be_cmd download-macos-x86_64-pak-sizes -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
+      - "be_cmd macos-diff-pak-sizes -- diff -u build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
+    depends_on:
+      - "build-chromium-mac-x86_64"
+      - "build-chromium-mac-arm64"
+    plugins:
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /home/ubuntu/chromium/src
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#76b6f57: ~
+    agents:
+      - "runtimeType=chromiumbuild"
+      - "os=linux"
+      - "queue=runtime"
 
-  # - label: "Trigger Live Tests :hammer:"
-  #   trigger: "testing-runtime-e2e"
-  #   depends_on:
-  #     - "build-chromium-linux-x86_64"
-  #     - "build-chromium-mac-x86_64"
-  #     - "build-chromium-mac-arm64"
+  - label: "Trigger Live Tests :hammer:"
+    trigger: "testing-runtime-e2e"
+    depends_on:
+      - "build-chromium-linux-x86_64"
+      - "build-chromium-mac-x86_64"
+      - "build-chromium-mac-arm64"
 
-  # - label: "Trigger Metabase Tests :hammer:"
-  #   trigger: "testing-runtime-metabase"
-  #   depends_on:
-  #     - "build-chromium-linux-x86_64"
+  - label: "Trigger Metabase Tests :hammer:"
+    trigger: "testing-runtime-metabase"
+    depends_on:
+      - "build-chromium-linux-x86_64"
 
   - label: "Trigger FE E2E Tests (linux-x86_64) :hammer:"
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:
       - "build-chromium-linux-x86_64"
     build:
-      branch:
-        cklochek/wait_for_source_panel
       env:
         OS: "linux"
         ARCH: "x86_64"
@@ -223,23 +221,23 @@ steps:
         # this is passed as a git URL which the replay plugin expects and parses
         RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
-  # - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
-  #   soft_fail: true
-  #   trigger: "runtime-fe-end-to-end-tests"
-  #   depends_on:
-  #     - "build-chromium-mac-arm64"
-  #   build:
-  #     env:
-  #       OS: "macos"
-  #       ARCH: "arm64"
-  #       RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
-  #       RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
-  #       RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"
-  #       RECORD_REPLAY_METADATA_SOURCE_MERGE_ID: "${BUILDKITE_PULL_REQUEST}"
-  #       # this is passed as a git URL which the replay plugin expects and parses
-  #       RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
-  #       # This is used by packages/e2e-tests/playwright.config.ts
-  #       CI: "1"
+  - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
+    soft_fail: true
+    trigger: "runtime-fe-end-to-end-tests"
+    depends_on:
+      - "build-chromium-mac-arm64"
+    build:
+      env:
+        OS: "macos"
+        ARCH: "arm64"
+        RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
+        RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
+        RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"
+        RECORD_REPLAY_METADATA_SOURCE_MERGE_ID: "${BUILDKITE_PULL_REQUEST}"
+        # this is passed as a git URL which the replay plugin expects and parses
+        RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+        # This is used by packages/e2e-tests/playwright.config.ts
+        CI: "1"
 
   # wait for all steps above, but also continue if they fail
   - wait: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,87 +68,87 @@ steps:
       - "queue=runtime"
     artifact_paths:
       - "build_id/linux/x86_64/**"
-  - label: "Build chromium - Mac (x86)"
-    key: "build-chromium-mac-x86_64"
-    depends_on: "preflight-checks"
-    timeout_in_minutes: 60
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /Users/administrator/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-          file:
-            - path: "/Users/administrator/chromium/engflow.crt"
-              secret-id: engflow-certificate
-            - path: "/Users/administrator/chromium/engflow.key"
-              secret-id: engflow-key
-      - replayio/buildevents#76b6f57: ~
-    commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-x86_64"
-      - "popd"
-    env:
-      RBE_service: simpsonite.cluster.engflow.com:443
-      RBE_service_no_auth: true
-      RBE_use_application_default_credentials: true
-      RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
-      RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
-      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
-    artifact_paths:
-      - "build_id/macOS/x86_64/**"
-  - label: "Build chromium - Mac (arm64)"
-    key: "build-chromium-mac-arm64"
-    depends_on: "preflight-checks"
-    timeout_in_minutes: 60
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /Users/administrator/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-          file:
-            - path: "/Users/administrator/chromium/engflow.crt"
-              secret-id: engflow-certificate
-            - path: "/Users/administrator/chromium/engflow.key"
-              secret-id: engflow-key
-      - replayio/buildevents#76b6f57: ~
-    commands:
-      - "be_cmd git-fetch-all -- git fetch --all"
-      - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
-      - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
-      - "pushd ../backend"
-      - "be_cmd buck2-kill -- buckle kill"
-      - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-arm64"
-      - "popd"
-    env:
-      RBE_service: simpsonite.cluster.engflow.com:443
-      RBE_service_no_auth: true
-      RBE_use_application_default_credentials: true
-      RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
-      RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
-      REPLAY_BUILD_ARM: true
-      RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=macos"
-      - "queue=runtime"
-    artifact_paths:
-      - "build_id/macOS/arm64/**"
-    # TODO(dmiller): enable rbe on Windows
-  - label: "Build chromium - Windows"
+  # - label: "Build chromium - Mac (x86)"
+  #   key: "build-chromium-mac-x86_64"
+  #   depends_on: "preflight-checks"
+  #   timeout_in_minutes: 60
+  #   plugins:
+  #     - thedyrt/skip-checkout#v0.1.1:
+  #         cd: /Users/administrator/chromium/src
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         region: us-east-2
+  #         env:
+  #           BUILDEVENT_APIKEY: honeycomb-api-key
+  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+  #         file:
+  #           - path: "/Users/administrator/chromium/engflow.crt"
+  #             secret-id: engflow-certificate
+  #           - path: "/Users/administrator/chromium/engflow.key"
+  #             secret-id: engflow-key
+  #     - replayio/buildevents#76b6f57: ~
+  #   commands:
+  #     - "be_cmd git-fetch-all -- git fetch --all"
+  #     - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+  #     - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+  #     - "pushd ../backend"
+  #     - "be_cmd buck2-kill -- buckle kill"
+  #     - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-x86_64"
+  #     - "popd"
+  #   env:
+  #     RBE_service: simpsonite.cluster.engflow.com:443
+  #     RBE_service_no_auth: true
+  #     RBE_use_application_default_credentials: true
+  #     RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
+  #     RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
+  #     RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+  #   agents:
+  #     - "runtimeType=chromiumbuild"
+  #     - "os=macos"
+  #     - "queue=runtime"
+  #   artifact_paths:
+  #     - "build_id/macOS/x86_64/**"
+  # - label: "Build chromium - Mac (arm64)"
+  #   key: "build-chromium-mac-arm64"
+  #   depends_on: "preflight-checks"
+  #   timeout_in_minutes: 60
+  #   plugins:
+  #     - thedyrt/skip-checkout#v0.1.1:
+  #         cd: /Users/administrator/chromium/src
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         region: us-east-2
+  #         env:
+  #           BUILDEVENT_APIKEY: honeycomb-api-key
+  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+  #         file:
+  #           - path: "/Users/administrator/chromium/engflow.crt"
+  #             secret-id: engflow-certificate
+  #           - path: "/Users/administrator/chromium/engflow.key"
+  #             secret-id: engflow-key
+  #     - replayio/buildevents#76b6f57: ~
+  #   commands:
+  #     - "be_cmd git-fetch-all -- git fetch --all"
+  #     - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+  #     - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
+  #     - "pushd ../backend"
+  #     - "be_cmd buck2-kill -- buckle kill"
+  #     - "be_cmd buck2-build -- buckle build -c replay.driver_revision=$$DRIVER_REVISION --console simple //:chromium --target-platforms=//:macos-arm64"
+  #     - "popd"
+  #   env:
+  #     RBE_service: simpsonite.cluster.engflow.com:443
+  #     RBE_service_no_auth: true
+  #     RBE_use_application_default_credentials: true
+  #     RBE_tls_client_auth_cert: /Users/administrator/chromium/engflow.crt
+  #     RBE_tls_client_auth_key: /Users/administrator/chromium/engflow.key
+  #     REPLAY_BUILD_ARM: true
+  #     RECORD_REPLAY_BACKEND_DIR: /Users/administrator/chromium/backend
+  #   agents:
+  #     - "runtimeType=chromiumbuild"
+  #     - "os=macos"
+  #     - "queue=runtime"
+  #   artifact_paths:
+  #     - "build_id/macOS/arm64/**"
+  #   # TODO(dmiller): enable rbe on Windows
+  # - label: "Build chromium - Windows"
     key: "build-chromium-windows"
     depends_on: "preflight-checks"
     timeout_in_minutes: 60
@@ -168,49 +168,51 @@ steps:
       - "build_id/windows/x86_64/**"
     soft_fail: true
 
-  - label: "Verify cross-arch build integrity :sleuth_or_spy:"
-    key: "verify-cross-arch-pak-sizes"
-    commands:
-      - "be_cmd download-macos-arm64-gclient_entries -- buildkite-agent artifact download build_id/macOS/arm64/entries ."
-      - "be_cmd download-macos-x86_64-gclient_entries -- buildkite-agent artifact download build_id/macOS/x86_64/entries ."
-      - "be_cmd macos-diff-gclient-entries -- diff -u build_id/macOS/arm64/entries build_id/macOS/x86_64/entries"
-      - "be_cmd download-macos-arm64-pak-sizes -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
-      - "be_cmd download-macos-x86_64-pak-sizes -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
-      - "be_cmd macos-diff-pak-sizes -- diff -u build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
-    depends_on:
-      - "build-chromium-mac-x86_64"
-      - "build-chromium-mac-arm64"
-    plugins:
-      - thedyrt/skip-checkout#v0.1.1:
-          cd: /home/ubuntu/chromium/src
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#76b6f57: ~
-    agents:
-      - "runtimeType=chromiumbuild"
-      - "os=linux"
-      - "queue=runtime"
+  # - label: "Verify cross-arch build integrity :sleuth_or_spy:"
+  #   key: "verify-cross-arch-pak-sizes"
+  #   commands:
+  #     - "be_cmd download-macos-arm64-gclient_entries -- buildkite-agent artifact download build_id/macOS/arm64/entries ."
+  #     - "be_cmd download-macos-x86_64-gclient_entries -- buildkite-agent artifact download build_id/macOS/x86_64/entries ."
+  #     - "be_cmd macos-diff-gclient-entries -- diff -u build_id/macOS/arm64/entries build_id/macOS/x86_64/entries"
+  #     - "be_cmd download-macos-arm64-pak-sizes -- buildkite-agent artifact download build_id/macOS/arm64/pak-sizes ."
+  #     - "be_cmd download-macos-x86_64-pak-sizes -- buildkite-agent artifact download build_id/macOS/x86_64/pak-sizes ."
+  #     - "be_cmd macos-diff-pak-sizes -- diff -u build_id/macOS/arm64/pak-sizes build_id/macOS/x86_64/pak-sizes"
+  #   depends_on:
+  #     - "build-chromium-mac-x86_64"
+  #     - "build-chromium-mac-arm64"
+  #   plugins:
+  #     - thedyrt/skip-checkout#v0.1.1:
+  #         cd: /home/ubuntu/chromium/src
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         region: us-east-2
+  #         env:
+  #           BUILDEVENT_APIKEY: honeycomb-api-key
+  #           BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+  #     - replayio/buildevents#76b6f57: ~
+  #   agents:
+  #     - "runtimeType=chromiumbuild"
+  #     - "os=linux"
+  #     - "queue=runtime"
 
-  - label: "Trigger Live Tests :hammer:"
-    trigger: "testing-runtime-e2e"
-    depends_on:
-      - "build-chromium-linux-x86_64"
-      - "build-chromium-mac-x86_64"
-      - "build-chromium-mac-arm64"
+  # - label: "Trigger Live Tests :hammer:"
+  #   trigger: "testing-runtime-e2e"
+  #   depends_on:
+  #     - "build-chromium-linux-x86_64"
+  #     - "build-chromium-mac-x86_64"
+  #     - "build-chromium-mac-arm64"
 
-  - label: "Trigger Metabase Tests :hammer:"
-    trigger: "testing-runtime-metabase"
-    depends_on:
-      - "build-chromium-linux-x86_64"
+  # - label: "Trigger Metabase Tests :hammer:"
+  #   trigger: "testing-runtime-metabase"
+  #   depends_on:
+  #     - "build-chromium-linux-x86_64"
 
   - label: "Trigger FE E2E Tests (linux-x86_64) :hammer:"
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:
       - "build-chromium-linux-x86_64"
     build:
+      branch:
+        cklochek/wait_for_source_panel
       env:
         OS: "linux"
         ARCH: "x86_64"
@@ -221,23 +223,23 @@ steps:
         # this is passed as a git URL which the replay plugin expects and parses
         RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
-  - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
-    soft_fail: true
-    trigger: "runtime-fe-end-to-end-tests"
-    depends_on:
-      - "build-chromium-mac-arm64"
-    build:
-      env:
-        OS: "macos"
-        ARCH: "arm64"
-        RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
-        RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
-        RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"
-        RECORD_REPLAY_METADATA_SOURCE_MERGE_ID: "${BUILDKITE_PULL_REQUEST}"
-        # this is passed as a git URL which the replay plugin expects and parses
-        RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
-        # This is used by packages/e2e-tests/playwright.config.ts
-        CI: "1"
+  # - label: "Trigger FE E2E Tests (macos-arm64) :hammer:"
+  #   soft_fail: true
+  #   trigger: "runtime-fe-end-to-end-tests"
+  #   depends_on:
+  #     - "build-chromium-mac-arm64"
+  #   build:
+  #     env:
+  #       OS: "macos"
+  #       ARCH: "arm64"
+  #       RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE: "${BUILDKITE_MESSAGE}"
+  #       RECORD_REPLAY_METADATA_SOURCE_COMMIT_ID: "${BUILDKITE_COMMIT}"
+  #       RECORD_REPLAY_METADATA_SOURCE_BRANCH: "${BUILDKITE_BRANCH}"
+  #       RECORD_REPLAY_METADATA_SOURCE_MERGE_ID: "${BUILDKITE_PULL_REQUEST}"
+  #       # this is passed as a git URL which the replay plugin expects and parses
+  #       RUNTIME_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+  #       # This is used by packages/e2e-tests/playwright.config.ts
+  #       CI: "1"
 
   # wait for all steps above, but also continue if they fail
   - wait: ~

--- a/cc/scheduler/scheduler.cc
+++ b/cc/scheduler/scheduler.cc
@@ -16,12 +16,14 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/trace_event/trace_event.h"
 #include "base/trace_event/traced_value.h"
+#include "base/record_replay.h"
 #include "cc/base/devtools_instrumentation.h"
 #include "cc/metrics/begin_main_frame_metrics.h"
 #include "cc/metrics/compositor_frame_reporting_controller.h"
 #include "cc/metrics/compositor_timing_history.h"
 #include "components/power_scheduler/power_mode_arbiter.h"
 #include "components/viz/common/frame_sinks/delay_based_time_source.h"
+#include "components/viz/service/display/record_replay_render.h"
 #include "services/tracing/public/cpp/perfetto/macros.h"
 #include "third_party/perfetto/protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.pbzero.h"
 
@@ -713,7 +715,7 @@ void Scheduler::BeginImplFrame(const viz::BeginFrameArgs& args,
     base::AutoReset<bool> mark_inside(&inside_scheduled_action_, true);
 
     begin_impl_frame_tracker_.Start(args);
-    state_machine_.OnBeginImplFrame(args.frame_id, args.animate_only);
+    state_machine_.OnBeginImplFrame(args.frame_id, args.animate_only, args.replay_force_draw);
     compositor_timing_history_->WillBeginImplFrame(args, now);
     compositor_frame_reporting_controller_->WillBeginImplFrame(args);
     bool has_damage =
@@ -773,7 +775,13 @@ void Scheduler::ScheduleBeginImplFrameDeadline() {
     }
     case DeadlineMode::REGULAR:
       // We are animating the active tree but we're also waiting for commit.
-      new_deadline = begin_impl_frame_tracker_.Current().deadline;
+
+      // This deadline is derived from time-since-reboot, which means if we're replaying on
+      // something vastly different from recording, we might see times deep into the future,
+      // which will block our ability to render divergent frames.
+      if (!recordreplay::HasDivergedFromRecording()) {
+        new_deadline = begin_impl_frame_tracker_.Current().deadline;
+      }
       break;
     case DeadlineMode::IMMEDIATE:
       // Avoid using Now() for immediate deadlines because it's expensive, and
@@ -983,6 +991,9 @@ void Scheduler::ProcessScheduledActions() {
         break;
       case SchedulerStateMachine::Action::DRAW_FORCED:
         DrawForced();
+        if (state_machine_.ClearReplayForceDraw()) {
+          recordreplay::OnRepaintFinished();
+        }
         break;
       case SchedulerStateMachine::Action::DRAW_ABORT:
         // No action is actually performed, but this allows the state machine to

--- a/cc/scheduler/scheduler_state_machine.cc
+++ b/cc/scheduler/scheduler_state_machine.cc
@@ -363,9 +363,7 @@ bool SchedulerStateMachine::ShouldDraw() const {
   // aborted draw to keep things moving. If we are not waiting for the first
   // draw however, we don't want to abort for no reason.
   if (PendingDrawsShouldBeAborted())
-    if (replay_force_draw_) {
     return active_tree_needs_first_draw_;
-  }
 
   // Do not draw more than once in the deadline. Aborted draws are ok because
   // those are effectively nops.

--- a/cc/scheduler/scheduler_state_machine.cc
+++ b/cc/scheduler/scheduler_state_machine.cc
@@ -363,24 +363,29 @@ bool SchedulerStateMachine::ShouldDraw() const {
   // aborted draw to keep things moving. If we are not waiting for the first
   // draw however, we don't want to abort for no reason.
   if (PendingDrawsShouldBeAborted())
+    if (replay_force_draw_) {
     return active_tree_needs_first_draw_;
+  }
 
   // Do not draw more than once in the deadline. Aborted draws are ok because
   // those are effectively nops.
-  if (did_draw_)
+  if (!replay_force_draw_ && did_draw_) {
     return false;
+  }
 
   // Don't draw if an early check determined the frame does not have damage.
-  if (skip_draw_)
+  if (!replay_force_draw_ && skip_draw_) {
     return false;
+  }
 
   // Don't draw if we are waiting on the first commit after a surface.
   if (layer_tree_frame_sink_state_ != LayerTreeFrameSinkState::ACTIVE)
     return false;
 
   // Do not queue too many draws.
-  if (IsDrawThrottled())
+  if (!replay_force_draw_ && IsDrawThrottled()) {
     return false;
+  }
 
   // Except for the cases above, do not draw outside of the BeginImplFrame
   // deadline.
@@ -404,7 +409,7 @@ bool SchedulerStateMachine::ShouldDraw() const {
   if (forced_redraw_state_ == ForcedRedrawOnTimeoutState::WAITING_FOR_DRAW)
     return true;
 
-  return needs_redraw_;
+  return replay_force_draw_ || needs_redraw_;
 }
 
 bool SchedulerStateMachine::ShouldActivateSyncTree() const {
@@ -706,6 +711,9 @@ SchedulerStateMachine::Action SchedulerStateMachine::NextAction() const {
   if (ShouldCommit())
     return Action::COMMIT;
   if (ShouldDraw()) {
+    if (replay_force_draw_) {
+      return Action::DRAW_FORCED;
+    }
     if (PendingDrawsShouldBeAborted())
       return Action::DRAW_ABORT;
     else if (forced_redraw_state_ ==
@@ -1237,7 +1245,8 @@ bool SchedulerStateMachine::ProactiveBeginFrameWanted() const {
 }
 
 void SchedulerStateMachine::OnBeginImplFrame(const viz::BeginFrameId& frame_id,
-                                             bool animate_only) {
+                                             bool animate_only,
+                                             bool replay_force_draw) {
   begin_impl_frame_state_ = BeginImplFrameState::INSIDE_BEGIN_FRAME;
   current_frame_number_++;
   begin_frame_is_animate_only_ = animate_only;
@@ -1259,6 +1268,8 @@ void SchedulerStateMachine::OnBeginImplFrame(const viz::BeginFrameId& frame_id,
   did_commit_during_frame_ = false;
   did_invalidate_layer_tree_frame_sink_ = false;
   did_perform_impl_side_invalidation_ = false;
+
+  replay_force_draw_ = replay_force_draw;
 }
 
 void SchedulerStateMachine::OnBeginImplFrameDeadline() {

--- a/cc/scheduler/scheduler_state_machine.h
+++ b/cc/scheduler/scheduler_state_machine.h
@@ -185,7 +185,8 @@ class CC_EXPORT SchedulerStateMachine {
   // Indicates that the system has entered and left a BeginImplFrame callback.
   // The scheduler will not draw more than once in a given BeginImplFrame
   // callback nor send more than one BeginMainFrame message.
-  void OnBeginImplFrame(const viz::BeginFrameId& frame_id, bool animate_only);
+  void OnBeginImplFrame(const viz::BeginFrameId& frame_id, bool animate_only, 
+      bool replay_force_draw = false);
   // Indicates that the scheduler has entered the draw phase. The scheduler
   // will not draw more than once in a single draw phase.
   // TODO(sunnyps): Rename OnBeginImplFrameDeadline to OnDraw or similar.
@@ -371,6 +372,12 @@ class CC_EXPORT SchedulerStateMachine {
 
   bool resourceless_draw() const { return resourceless_draw_; }
 
+  bool ClearReplayForceDraw() {
+    bool result = replay_force_draw_; 
+    replay_force_draw_ = false;
+    return result;
+  }
+
  protected:
   bool BeginFrameRequiredForAction() const;
   bool BeginFrameNeededForVideo() const;
@@ -510,6 +517,8 @@ class CC_EXPORT SchedulerStateMachine {
 
   // Number of consecutive BeginMainFrames that were aborted without updates.
   int aborted_begin_main_frame_count_ = 0;
+
+  bool replay_force_draw_ = false;
 };
 
 }  // namespace cc

--- a/cc/trees/proxy_impl.cc
+++ b/cc/trees/proxy_impl.cc
@@ -1029,16 +1029,16 @@ void ProxyImpl::RecordReplayRepaint() {
   // a new frame in the scheduler directly, which will hopefully be sufficient to perform
   // a paint shortly with the special repaint sequence number that will cause the main
   // thread to be notified about the repaint result.
+  base::TimeTicks now = base::TimeTicks::Now();
   viz::BeginFrameArgs args = viz::BeginFrameArgs::Create(BEGINFRAME_FROM_HERE,
                                                          viz::BeginFrameArgs::kManualSourceId,
                                                          RepaintSequenceNumber,
-                                                         base::TimeTicks::Now(),
-                                                         base::TimeTicks(),
+                                                         now,
+                                                         now,
                                                          viz::BeginFrameArgs::DefaultInterval(),
-                                                         viz::BeginFrameArgs::NORMAL);
+                                                         viz::BeginFrameArgs::NORMAL, 
+                                                         true /*replay_force_draw*/);
   scheduler_->OnBeginFrameDerivedImpl(args);
-
-  recordreplay::OnRepaintFinished();
 }
 
 }  // namespace cc

--- a/cc/trees/proxy_main.cc
+++ b/cc/trees/proxy_main.cc
@@ -140,6 +140,13 @@ void ProxyMain::DidCompletePageScaleAnimation() {
 
 void ProxyMain::BeginMainFrame(
     std::unique_ptr<BeginMainFrameAndCommitState> begin_main_frame_state) {
+  
+  BeginMainFrameWithBlocking(std::move(begin_main_frame_state), false);
+}
+
+void ProxyMain::BeginMainFrameWithBlocking(
+    std::unique_ptr<BeginMainFrameAndCommitState> begin_main_frame_state,
+    bool force_blocking) {
   if (recordreplay::IsRecordingOrReplaying("notify-paints")) {
     recordreplay::SetCompositorProxy(this);
   }
@@ -435,7 +442,7 @@ void ProxyMain::BeginMainFrame(
   // point of view, but asynchronously performed on the impl thread,
   // coordinated by the Scheduler.
   CommitTimestamps commit_timestamps;
-  bool blocking = !base::FeatureList::IsEnabled(features::kNonBlockingCommit);
+  bool blocking = force_blocking || !base::FeatureList::IsEnabled(features::kNonBlockingCommit);
   {
     TRACE_EVENT_WITH_FLOW0("viz,benchmark",
                            "MainFrame.NotifyReadyToCommitOnMain",

--- a/cc/trees/proxy_main.h
+++ b/cc/trees/proxy_main.h
@@ -64,6 +64,8 @@ class CC_EXPORT ProxyMain : public Proxy {
   void DidCompletePageScaleAnimation();
   void BeginMainFrame(
       std::unique_ptr<BeginMainFrameAndCommitState> begin_main_frame_state);
+  void BeginMainFrameWithBlocking(
+      std::unique_ptr<BeginMainFrameAndCommitState> begin_main_frame_state, bool force_blocking);
   void DidCompleteCommit(CommitTimestamps);
   void DidPresentCompositorFrame(
       uint32_t frame_token,

--- a/components/viz/common/frame_sinks/begin_frame_args.cc
+++ b/components/viz/common/frame_sinks/begin_frame_args.cc
@@ -144,14 +144,15 @@ BeginFrameArgs BeginFrameArgs::Create(BeginFrameArgs::CreationLocation location,
                                       base::TimeTicks frame_time,
                                       base::TimeTicks deadline,
                                       base::TimeDelta interval,
-                                      BeginFrameArgs::BeginFrameArgsType type) {
+                                      BeginFrameArgs::BeginFrameArgsType type,
+                                      bool replay_force_draw) {
   DCHECK_NE(type, BeginFrameArgs::INVALID);
 #ifdef NDEBUG
   return BeginFrameArgs(source_id, sequence_number, frame_time, deadline,
                         interval, type);
 #else
   BeginFrameArgs args = BeginFrameArgs(source_id, sequence_number, frame_time,
-                                       deadline, interval, type);
+                                       deadline, interval, type, replay_force_draw);
   args.created_from = location;
   return args;
 #endif

--- a/components/viz/common/frame_sinks/begin_frame_args.cc
+++ b/components/viz/common/frame_sinks/begin_frame_args.cc
@@ -117,7 +117,8 @@ BeginFrameArgs::BeginFrameArgs()
     : frame_time(base::TimeTicks::Min()),
       deadline(base::TimeTicks::Min()),
       interval(base::Microseconds(-1)),
-      frame_id(BeginFrameId(0, kInvalidFrameNumber)) {}
+      frame_id(BeginFrameId(0, kInvalidFrameNumber)),
+      replay_force_draw(false) {}
 
 BeginFrameArgs::~BeginFrameArgs() = default;
 
@@ -126,12 +127,14 @@ BeginFrameArgs::BeginFrameArgs(uint64_t source_id,
                                base::TimeTicks frame_time,
                                base::TimeTicks deadline,
                                base::TimeDelta interval,
-                               BeginFrameArgs::BeginFrameArgsType type)
+                               BeginFrameArgs::BeginFrameArgsType type,
+                               bool force_draw)
     : frame_time(frame_time),
       deadline(deadline),
       interval(interval),
       frame_id(BeginFrameId(source_id, sequence_number)),
-      type(type) {
+      type(type),
+      replay_force_draw(force_draw) {
   DCHECK_LE(kStartingFrameNumber, sequence_number);
 }
 
@@ -149,7 +152,7 @@ BeginFrameArgs BeginFrameArgs::Create(BeginFrameArgs::CreationLocation location,
   DCHECK_NE(type, BeginFrameArgs::INVALID);
 #ifdef NDEBUG
   return BeginFrameArgs(source_id, sequence_number, frame_time, deadline,
-                        interval, type);
+                        interval, type, replay_force_draw);
 #else
   BeginFrameArgs args = BeginFrameArgs(source_id, sequence_number, frame_time,
                                        deadline, interval, type, replay_force_draw);

--- a/components/viz/common/frame_sinks/begin_frame_args.h
+++ b/components/viz/common/frame_sinks/begin_frame_args.h
@@ -154,7 +154,8 @@ struct VIZ_COMMON_EXPORT BeginFrameArgs {
                                base::TimeTicks frame_time,
                                base::TimeTicks deadline,
                                base::TimeDelta interval,
-                               BeginFrameArgsType type);
+                               BeginFrameArgsType type,
+                               bool replay_force_redraw = false);
 
   // This is the default interval assuming 60Hz to use to avoid sprinkling the
   // code with magic numbers.
@@ -238,6 +239,8 @@ struct VIZ_COMMON_EXPORT BeginFrameArgs {
   // code still assumes `deadline` is a multiple of `interval` from
   // `frame_time`.
   absl::optional<PossibleDeadlines> possible_deadlines;
+
+  bool replay_force_draw;
 
  private:
   BeginFrameArgs(uint64_t source_id,

--- a/components/viz/common/frame_sinks/begin_frame_args.h
+++ b/components/viz/common/frame_sinks/begin_frame_args.h
@@ -240,7 +240,7 @@ struct VIZ_COMMON_EXPORT BeginFrameArgs {
   // `frame_time`.
   absl::optional<PossibleDeadlines> possible_deadlines;
 
-  bool replay_force_draw;
+  bool replay_force_draw = false;
 
  private:
   BeginFrameArgs(uint64_t source_id,
@@ -248,7 +248,8 @@ struct VIZ_COMMON_EXPORT BeginFrameArgs {
                  base::TimeTicks frame_time,
                  base::TimeTicks deadline,
                  base::TimeDelta interval,
-                 BeginFrameArgsType type);
+                 BeginFrameArgsType type,
+                 bool replay_force_draw);
 };
 
 // Sent by a BeginFrameObserver as acknowledgment of completing a BeginFrame.

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -232,9 +232,6 @@ void OnReadyToCommit() {
 static const char* gRepaintMimeType;
 static int gRepaintJPEGQuality;
 
-// Event to signal when layout has been comitted.
-static std::atomic<base::WaitableEvent*> gRepaintLayoutCommitEvent;
-
 // Event to signal when repainting has finished.
 static std::atomic<base::WaitableEvent*> gRepaintEvent;
 
@@ -265,16 +262,12 @@ void OnPaintFinished(const SkPixmap& pixmap) {
   gCurrentPixmap = nullptr;
 }
 
-void OnRepaintLayoutCommitted() {
-  CHECK(HasDivergedFromRecording());
-  if (gRepaintLayoutCommitEvent) {
-    gRepaintLayoutCommitEvent.load()->Signal();
-  }
-}
-
 void OnRepaintFinished() {
-  CHECK(HasDivergedFromRecording());
-  gRepaintEvent.load()->Signal();
+  base::WaitableEvent* e = gRepaintEvent.load();
+  if (e != nullptr) {
+    CHECK(HasDivergedFromRecording());
+    e->Signal();
+  }
 }
 
 static cc::ProxyMain* gCurrentCompositorProxy;
@@ -308,35 +301,18 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
       new cc::BeginMainFrameAndCommitState);
   begin_main_frame_state->mutator_events = std::make_unique<cc::AnimationEvents>();
   begin_main_frame_state->commit_data = std::make_unique<cc::CompositorCommitData>();
-  gCurrentCompositorProxy->BeginMainFrame(std::move(begin_main_frame_state));
 
-  // RUN-2643: https://linear.app/replay/issue/RUN-2643
-  //
-  // FIXME: This is not the final fix for this.  We're waiting here in lieu of
-  // an explicit wake-up event.  If we fire the `RecordReplayRepaint` below too
-  // early, it runs before the layout above has finished committing all the
-  // necessary draw calls to the compositor.
-  //
-  // Places where we have already tried adding an explicit wake-up signal from
-  // but which didn't work:
-  //   * ProxyImpl::BeginMainFrame
-  //   * ProxyImpl::NotifyReadyToCommitOnImpl
-  //   * ProxyImpl::ScheduledActionCommit
-  //   * ProxyImpl::ScheduledActionPostCommit
-  //
-  // When we fix this properly, we need to insert a call to explicitly
-  // wake-up this thread by calling `OnRepaintLayoutCommitted` above.
-  base::WaitableEvent layoutCommittedEvent;
-  gRepaintLayoutCommitEvent = &layoutCommittedEvent;
-  layoutCommittedEvent.TimedWait(base::Milliseconds(100));
-  gRepaintLayoutCommitEvent = nullptr;
+  gCurrentCompositorProxy->BeginMainFrameWithBlocking(std::move(begin_main_frame_state), true);
 
   // Trigger a new frame on the compositor thread.
   gCurrentCompositorProxy->RecordReplayRepaint();
 
   // Wait for the repainting frame to complete.
-  bool signaled = event.TimedWait(base::Milliseconds(500));
-  CHECK(signaled);
+  bool signaled = event.TimedWait(base::Milliseconds(3000));
+  if (!signaled) {
+    Print("Failed waiting to get a repaint.");
+    gRepaintResult = nullptr;
+  }
 
   gRepaintEvent = nullptr;
   return gRepaintResult;

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -45,9 +45,6 @@ bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_
 // Called on the compositor thread when painting to the software output device has finished.
 void OnPaintFinished(const SkPixmap& pixmap);
 
-// Called on the compositor thread when repainting layout has comitted.
-void OnRepaintLayoutCommitted();
-
 // Called on the compositor thread when repainting has finished, which may or may not
 // have actually performed a paint.
 void OnRepaintFinished();

--- a/components/viz/service/display/record_replay_render_nop.cc
+++ b/components/viz/service/display/record_replay_render_nop.cc
@@ -25,8 +25,6 @@ bool PopulateSkBitmapWithResource(SkBitmap* sk_bitmap, viz::ResourceId resource_
 
 void OnPaintFinished(const SkPixmap& pixmap) {}
 
-void OnRepaintLayoutCommitted() {}
-
 void OnRepaintFinished() {}
 
 void SetCompositorProxy(cc::ProxyMain* proxy) {}

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -19,6 +19,8 @@ const {
   addNewScriptHandler,
   getCurrentError,
 
+  layoutDom,
+
   fromJsMakeDebuggeeValue,
   fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
@@ -280,6 +282,7 @@ const CommandCallbacks = {
   "Pause.getObjectPreview": Pause_getObjectPreview,
   "Pause.getObjectProperty": Pause_getObjectProperty,
   "Pause.getScope": Pause_getScope,
+  "DOM.forceLayout": DOM_forceLayout,
   "DOM.getDocument": DOM_getDocument,
   "DOM.getAllBoundingClientRects": DOM_getAllBoundingClientRects,
   "DOM.getBoundingClientRect": DOM_getBoundingClientRect,
@@ -2062,6 +2065,14 @@ function createRrpScope(scopeId) {
     functionName: cdpScope.name || undefined,
     bindings,
   };
+}
+
+/** ###########################################################################
+ * {@link DOM_forceLayout}
+ * ##########################################################################*/
+function DOM_forceLayout() {
+  layoutDom();
+  return {};
 }
 
 /** ###########################################################################

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1556,6 +1556,13 @@ static void fromJsMakeDebuggeeValue(
   args.GetReturnValue().SetNull();
 }
 
+static void LayoutDom(
+  const v8::FunctionCallbackInfo<v8::Value>& args) {
+  if (gRootLocalFrame) {
+    gRootLocalFrame->GetDocument()->UpdateStyleAndLayout(DocumentUpdateReason::kUnknown);
+  }
+}
+
 static void fromJsGetArgumentsInFrame(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
@@ -2525,6 +2532,8 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
   SetFunctionProperty(isolate, args, "setCommandCallback",
                       v8::FunctionCallbackRecordReplaySetCommandCallback);
+
+  SetFunctionProperty(isolate, args, "layoutDom", LayoutDom);
 
   // Object Util
   SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",


### PR DESCRIPTION
1. Extend chromium to allow us to manually block on the compositor doing layout (this functionality already existed, just needed to expose it.)
2. Carefully add a flag to the compositor scheduler that allows us to insist to it that, no, we really want you to try to draw right now, even if a draw was already submitted.
3. Deal with a replay issue where the compositor scheduler can end up waiting for a draw that's far in the future if the time it was dealing with during the recording is wildly different that what is seen during replay (this is high perf. time-since-reboot.)
4. Add the ability to force a dom layout to ensure the compositor has something to draw with.