### PR TITLE
[RUN-3361] trigger the runtime-command-tests pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -239,11 +239,9 @@ steps:
         # This is used by packages/e2e-tests/playwright.config.ts
         CI: "1"
 
-  - label: "Trigger Runtime Command Tests :hammer:"
+  - label: "Trigger Runtime Command Tests (macos-arm64) :hammer:"
     trigger: "runtime-command-tests"
     depends_on:
-      - "build-chromium-linux-x86_64"
-      - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
 
   # wait for all steps above, but also continue if they fail

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -239,6 +239,13 @@ steps:
         # This is used by packages/e2e-tests/playwright.config.ts
         CI: "1"
 
+  - label: "Trigger Runtime Command Tests :hammer:"
+    trigger: "runtime-command-tests"
+    depends_on:
+      - "build-chromium-linux-x86_64"
+      - "build-chromium-mac-x86_64"
+      - "build-chromium-mac-arm64"
+
   # wait for all steps above, but also continue if they fail
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
Run our command handler tests on macos-arm64 only (for the time being).  99.9% of the work was done in the backend repo as a whole bunch of PRs (see RUN-3361 for the list).  This one just triggers the pipeline I've added there.