### PR TITLE
[TT-8] fix crash on second/further recordings using toolbar button

### DIFF
--- a/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.cc
+++ b/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.cc
@@ -38,7 +38,6 @@ RecordReplayToolbarButton::RecordReplayToolbarButton(Browser* browser)
                                         base::Unretained(this))),
       browser_(browser),
       web_contents_(nullptr),
-      post_recording_web_contents_(nullptr),
       web_contents_observer_(nullptr),
       recordreplay_contents_(nullptr) {
   SetVectorIcons(kRecordReplayIcon, kRecordReplayIcon);
@@ -137,8 +136,6 @@ void RecordReplayToolbarButton::StopRecording() {
     return;
   }
 
-  EnsurePostRecordingWebContents();
-
   TabStripModel* tab_strip_model = browser_->tab_strip_model();
   int index = tab_strip_model->GetIndexOfWebContents(web_contents_);
   if (index == TabStripModel::kNoTab) {
@@ -155,7 +152,7 @@ void RecordReplayToolbarButton::StopRecording() {
 
 void RecordReplayToolbarButton::RecordingTabDestroyed() {
   if (web_contents_) {
-    EnsurePostRecordingWebContents();
+    CreatePostRecordingWebContents();
     web_contents_ = nullptr;
     web_contents_observer_.release();
   }
@@ -170,19 +167,18 @@ void RecordReplayToolbarButton::RefreshIconState() {
   }
 }
 
-void RecordReplayToolbarButton::EnsurePostRecordingWebContents() {
-  if (!post_recording_web_contents_) {
-    content::WebContents::CreateParams new_params(web_contents_->GetBrowserContext());
-    std::unique_ptr<content::WebContents> post_recording_web_contents(
-      content::WebContents::Create(new_params));
-    post_recording_web_contents_ = post_recording_web_contents.get();
-    TabStripModel* tab_strip_model = browser_->tab_strip_model();
-    tab_strip_model->AppendWebContents(std::move(post_recording_web_contents), true);
-  }
+void RecordReplayToolbarButton::CreatePostRecordingWebContents() {
+  content::WebContents::CreateParams new_params(web_contents_->GetBrowserContext());
+  std::unique_ptr<content::WebContents> post_recording_web_contents(
+    content::WebContents::Create(new_params));
+  TabStripModel* tab_strip_model = browser_->tab_strip_model();
 
   // TODO: Make this URL point to `app.replay.io` URL for the recording.
+  // TODO: this should also maybe be done via WebContents::CreateParams if it can?
   GURL url = GURL("https://app.replay.io");
-  post_recording_web_contents_->GetController().LoadURL(url, content::Referrer(),
+  post_recording_web_contents->GetController().LoadURL(url, content::Referrer(),
                                               ui::PAGE_TRANSITION_TYPED,
                                               std::string());
+
+  tab_strip_model->AppendWebContents(std::move(post_recording_web_contents), true);
 }

--- a/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.h
+++ b/chrome/browser/ui/views/toolbar/record_replay_toolbar_button.h
@@ -29,11 +29,10 @@ class RecordReplayToolbarButton: public ToolbarButton {
   void RecordingTabDestroyed();
 
   void RefreshIconState();
-  void EnsurePostRecordingWebContents();
+  void CreatePostRecordingWebContents();
 
   const raw_ptr<Browser> browser_;
   content::WebContents* web_contents_;
-  content::WebContents* post_recording_web_contents_;
   std::unique_ptr<RecordReplayToolbarButtonWebContentsObserver>
     web_contents_observer_;
   // our hidden webcontent running business/auth logic.


### PR DESCRIPTION
Recipe for crash before this PR:

1. open any url and click record button.
2. stop the recording.  replay devtools should open.
3. open a new tab, then close the tab with devtools in it.
4. start a new recording.
5. stop that new recording - should crash 100%

The crash is due to us holding onto `post_recording_web_contents_` (the contents of a `unique_ptr` we `std::move` to the tab strip model, and shouldn't maintain a reference to.)  Closing the tab in step 3 destroys that web contents, and step 5 attempts to reuse it.

We needed to keep ahold of it because `EnsurePostRecordingWebContents` is called twice when a recording is stopped (it calls it itself, and also destroys the tab - with the tab destroy callback also calling `EnsurePostRecordingWebContents`.)

Instead rely on the fact that stopping a recording always destroys the tab, and remove the call in `StopRecording`.  At that point, remove `post_recording_web_contents_`, and change the name of the method to `CreatePostRecordingWebContents`.