### PR TITLE
[TT-185] Move up paint-related initialization

### DIFF
--- a/cc/trees/proxy_main.cc
+++ b/cc/trees/proxy_main.cc
@@ -52,6 +52,8 @@ ProxyMain::ProxyMain(LayerTreeHost* layer_tree_host,
   TRACE_EVENT0("cc", "ProxyMain::ProxyMain");
   DCHECK(task_runner_provider_);
   DCHECK(IsMainThread());
+  
+  recordreplay::InitPaintCallback();
 }
 
 ProxyMain::~ProxyMain() {

--- a/cc/trees/proxy_main.cc
+++ b/cc/trees/proxy_main.cc
@@ -54,6 +54,9 @@ ProxyMain::ProxyMain(LayerTreeHost* layer_tree_host,
   DCHECK(IsMainThread());
   
   recordreplay::InitPaintCallback();
+  if (recordreplay::IsRecordingOrReplaying("notify-paints")) {
+    recordreplay::SetCompositorProxy(this);
+  }
 }
 
 ProxyMain::~ProxyMain() {

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -216,6 +216,15 @@ static std::atomic<size_t> gCurrentPaintBookmark;
 // Bookmark for the last point where a paint was committed on the main thread.
 static size_t gLastCommitBookmark;
 
+void InitPaintCallback() {
+  static bool hasPaints = false;
+  if (!hasPaints) {
+    hasPaints = true;
+    recordreplay::Print("DDBG InitPaintCallback");
+    V8RecordReplaySetPaintCallback(PaintCallback);
+  }
+}
+
 void OnCommitPaint() {
   // Record/replay state has to be initialized before the first paint
   // starts, as a checkpoint must have been taken.
@@ -244,12 +253,6 @@ static std::atomic<char*> gRepaintResult;
 static std::atomic<gfx::Size> gDeviceViewportSize;
 
 void OnPaintFinished(const SkPixmap& pixmap) {
-  static bool hasPaints = false;
-  if (!hasPaints) {
-    hasPaints = true;
-    V8RecordReplaySetPaintCallback(PaintCallback);
-  }
-
   gCurrentPixmap = &pixmap;
   if (gOutputSurface) {
     // Obtain device size on impl thread.

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -220,7 +220,6 @@ void InitPaintCallback() {
   static bool hasPaints = false;
   if (!hasPaints) {
     hasPaints = true;
-    recordreplay::Print("DDBG InitPaintCallback");
     V8RecordReplaySetPaintCallback(PaintCallback);
   }
 }
@@ -324,7 +323,7 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
   // Wait for the repainting frame to complete.
   bool signaled = event.TimedWait(base::Milliseconds(3000));
   if (!signaled) {
-    Print("Failed waiting to get a repaint.");
+    Print("[RuntimeError] Failed waiting to get a repaint.");
     gRepaintResult = nullptr;
   }
 

--- a/components/viz/service/display/record_replay_render.h
+++ b/components/viz/service/display/record_replay_render.h
@@ -23,6 +23,9 @@ namespace recordreplay {
 // can then be encoded to base64 images and reported to the record/replay
 // driver and sent to clients inspecting the recording.
 
+// Initialize relevant render logic.
+void InitPaintCallback();
+
 // Called on the main thread when changes have been committed to the layer tree
 // and the thread is about to block until the compositor thread is ready to commit.
 void OnCommitPaint();

--- a/components/viz/service/display/record_replay_render_nop.cc
+++ b/components/viz/service/display/record_replay_render_nop.cc
@@ -9,6 +9,8 @@
 
 namespace recordreplay {
 
+void InitPaintCallback() {}
+
 void OnCommitPaint() {}
 
 void OnReadyToCommit() {}


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-185/[repaintgraphics]-repaints-early-in-the-recording-dont-work#comment-31bf508b