### PR TITLE
[TT-186] Don't call SkFont::getPath divergently

### DIFF
--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -602,6 +602,10 @@ void ExitReplayCode() {
   V8RecordReplayExitReplayCode();
 }
 
+bool AreEventsUnavailable(const char* why) {
+  return AreEventsDisallowed(why) || HasDivergedFromRecording();
+}
+
 AutoMarkReplayCode::AutoMarkReplayCode() {
   V8RecordReplayEnterReplayCode();
 }

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -76,8 +76,7 @@ void BeginDisallowEventsWithLabel(const char* label);
 void EndDisallowEvents();
 
 // Whether we are in a code path that we have explicitely identified as
-// divergent. Those are generally code paths that either belong to the runtime
-// or Replay's intermittent command handling.
+// divergent.
 bool AreEventsDisallowed(const char* why = nullptr);
 
 void EnterReplayCode();

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -75,8 +75,9 @@ void BeginDisallowEventsWithLabel(const char* label);
 
 void EndDisallowEvents();
 
-// Whether we are temporarily in a code path that we have explicitely 
-// identified as divergent.
+// Whether we are in a code path that we have explicitely identified as
+// divergent. Those are generally code paths that either belong to the runtime
+// or Replay's intermittent command handling.
 bool AreEventsDisallowed(const char* why = nullptr);
 
 void EnterReplayCode();

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -74,6 +74,9 @@ void BeginDisallowEvents();
 void BeginDisallowEventsWithLabel(const char* label);
 
 void EndDisallowEvents();
+
+// Whether we are temporarily in a code path that we have explicitely 
+// identified as divergent.
 bool AreEventsDisallowed(const char* why = nullptr);
 
 void EnterReplayCode();
@@ -99,6 +102,13 @@ struct AutoDisallowEvents {
   ~AutoDisallowEvents() { EndDisallowEvents(); }
 };
 
+// Whether we have intentionally diverged from recording at a pause point.
+// After diverging, we:
+// 1. Cannot interact with the recording stream any longer.
+// 2. Are guaranteed that no runToPoint will follow.
+// 
+// The above two constraints allow us to execute arbitrary code without fear
+// of causing downstream divergences.
 bool HasDivergedFromRecording();
 bool AllowSideEffects();
 
@@ -122,6 +132,10 @@ void Crash(const char* format, ...);
 
 // Return whether record/replay specific scripts are executing.
 bool IsInReplayCode(const char* why = nullptr);
+
+// Return whether we are in a divergent code segment where we cannot
+// read/write the recording stream.
+bool AreEventsUnavailable(const char* why = nullptr);
 
 
 // Mark a region where record/replay specific scripts are executing.

--- a/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_map.cc
@@ -38,7 +38,7 @@ scoped_refptr<FontFallbackList> FontFallbackMap::Get(
 }
 
 void FontFallbackMap::Remove(const FontDescription& font_description) {
-    if (recordreplay::IsRecordingOrReplaying("FontFallbackMap::Remove")) {
+    if (recordreplay::IsRecordingOrReplaying("leak-references","FontFallbackMap::Remove")) {
     // [RUN-3109] Leak FontFallbackList.
     return;
   }
@@ -53,7 +53,7 @@ void FontFallbackMap::Remove(const FontDescription& font_description) {
 }
 
 void FontFallbackMap::InvalidateAll() {
-    if (recordreplay::AreEventsDisallowed("FontFallbackMap::InvalidateAll")) {
+    if (recordreplay::AreEventsDisallowed("leak-references")) {
     // Leak fallback_list_for_description_ contents.
     return;
   }
@@ -91,7 +91,7 @@ void FontFallbackMap::InvalidateInternal(Predicate predicate) {
 
 void FontFallbackMap::FontsNeedUpdate(FontSelector*,
                                       FontInvalidationReason reason) {
-  if (recordreplay::AreEventsDisallowed("FontFallbackMap::FontsNeedUpdate")) {
+  if (recordreplay::AreEventsDisallowed("leak-references")) {
     // Leak fallback_list_for_description_ contents to avoid divergence down the
     // road.
     return;

--- a/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
@@ -9,6 +9,8 @@
 #include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkPath.h"
 
+#include "base/record_replay.h"
+
 namespace blink {
 
 namespace {

--- a/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
@@ -92,7 +92,7 @@ void SkFontGetGlyphExtentsForHarfBuzz(const SkFont& font,
   // on Mac, https://bugs.chromium.org/p/skia/issues/detail?id=5328
   SkPath path;
   if (
-    !recordreplay::AreEventsDisallowed("divergent-update") &&
+    !recordreplay::AreEventsUnavailable("divergent-update") &&
     font.getPath(glyph, &path)
   ) {
     sk_bounds = path.getBounds();
@@ -122,7 +122,7 @@ void SkFontGetBoundsForGlyph(const SkFont& font, Glyph glyph, SkRect* bounds) {
   // on Mac, https://bugs.chromium.org/p/skia/issues/detail?id=5328
   SkPath path;
   if (
-    !recordreplay::AreEventsDisallowed("divergent-update") &&
+    !recordreplay::AreEventsUnavailable("divergent-update") &&
     font.getPath(glyph, &path)
   ) {
     *bounds = path.getBounds();

--- a/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/skia_text_metrics.cc
@@ -89,7 +89,10 @@ void SkFontGetGlyphExtentsForHarfBuzz(const SkFont& font,
   // TODO(drott): Remove this once we have better metrics bounds
   // on Mac, https://bugs.chromium.org/p/skia/issues/detail?id=5328
   SkPath path;
-  if (font.getPath(glyph, &path)) {
+  if (
+    !recordreplay::AreEventsDisallowed("divergent-update") &&
+    font.getPath(glyph, &path)
+  ) {
     sk_bounds = path.getBounds();
   } else {
     font.getBounds(&glyph, 1, &sk_bounds, nullptr);
@@ -116,7 +119,10 @@ void SkFontGetBoundsForGlyph(const SkFont& font, Glyph glyph, SkRect* bounds) {
   // TODO(drott): Remove this once we have better metrics bounds
   // on Mac, https://bugs.chromium.org/p/skia/issues/detail?id=5328
   SkPath path;
-  if (font.getPath(glyph, &path)) {
+  if (
+    !recordreplay::AreEventsDisallowed("divergent-update") &&
+    font.getPath(glyph, &path)
+  ) {
     *bounds = path.getBounds();
   } else {
     // Fonts like Apple Color Emoji have no paths, fall back to bounds here.


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-186/[repaintgraphics]-unknown-call-ctfontcreatepathforglyph#comment-a9f4b47f