### PR TITLE
[TT-211][TT-199] Mark recordings with their process type + allow multiple `OnRootFrameInit` calls

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'da395915932b91a52c666bb48085248004ea1b22',
+  'v8_revision': '61b17ecbfb9da49bb6b38c4543fb21074749f87b',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '175463f22261d78b890feecca50ec2a696f59d17',
+  'v8_revision': '991933d16a74ce1b196847b2747ce6ea54676507',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '6ab2e8798a86167e7ad32f33f10d308755b5adb8',
+  'v8_revision': '246162f9df674d7e0752dc9e4534dee747fd556c',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -74,6 +74,7 @@
 #include "v8/include/v8.h"
 
 #include "base/record_replay.h"
+#include "third_party/blink/renderer/controller/dev_tools_frontend_impl.h"
 
 namespace blink {
 
@@ -159,6 +160,20 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
   lifecycle_ = next_status;
 }
 
+static const char* RecordReplayGetProcessType(
+  bool isMainWorld, bool isRoot, bool isDevtools) {
+  if (!isMainWorld) {
+    return "extension";
+  }
+  if (isDevtools) {
+    return "devtools";
+  }
+  if (isRoot) {
+    return "root";
+  }
+  return "iframe";
+}
+
 // Record/replay state is initialized along with the first LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
 
@@ -220,12 +235,8 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (world_->IsMainWorld() &&
-      recordreplay::IsRecordingOrReplaying("commands") &&
-      origin &&
+  if (origin &&
       !origin->Host().empty()) {
-    // Initialize and re-initialize Replay state, command handlers and more.
-
     bool initGlobally = !gRecordReplayStateInitialized;
     if (initGlobally) {
       gRecordReplayStateInitialized = true;
@@ -233,30 +244,38 @@ void LocalWindowProxy::Initialize() {
       // After creating the first context that is associated with a non-empty
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints.
-      InitializeRecordReplay(GetIsolate(), GetFrame(), context);
+      InitializeRecordReplay(
+        RecordReplayGetProcessType(world_->IsMainWorld(),
+          GetFrame()->IsOutermostMainFrame(),
+          !!DevToolsFrontendImpl::From(GetFrame())),
+        GetIsolate(), GetFrame(), context
+      );
     }
 
-    bool initFrame = GetFrame()->IsLocalRoot();
-    if (initFrame) {
-      // Root-level navigation event, initially happens before
-      // first checkpoint.
-      OnRootFrameInit(GetIsolate(), GetFrame(), context);
-    }
+    if (world_->IsMainWorld() &&
+      recordreplay::IsRecordingOrReplaying("commands")) {
+      bool initFrame = GetFrame()->IsLocalRoot();
+      if (initFrame) {
+        // Root-level navigation event, initially happens before
+        // first checkpoint.
+        OnRootFrameInit(GetIsolate(), GetFrame(), context);
+      }
 
-    if (initGlobally) {
-      // Create the first checkpoint at which execution can pause.
-      recordreplay::NewCheckpoint();
-      // Initialize some more.
-      InitializeRecordReplayAfterCheckpoint();
-    }
-    
-    if (initFrame) {
-      // Root-level navigation event, after first checkpoint.
-      OnRootFrameInitAfterCheckpoint(GetIsolate(), GetFrame(), context);
-    }
+      if (initGlobally) {
+        // Create the first checkpoint at which execution can pause.
+        recordreplay::NewCheckpoint();
+        // Initialize some more.
+        InitializeRecordReplayAfterCheckpoint();
+      }
+      
+      if (initFrame) {
+        // Root-level navigation event, after first checkpoint.
+        OnRootFrameInitAfterCheckpoint(GetIsolate(), GetFrame(), context);
+      }
 
-    // Event for all new windows.
-    OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
+      // Event for all new windows.
+      OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
+    }
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -161,7 +161,12 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
 }
 
 static const char* RecordReplayGetProcessType(
-  bool isMainWorld, bool isRoot, bool isDevtools) {
+  LocalFrame* frame,
+  scoped_refptr<DOMWrapperWorld> world
+) {
+  bool isMainWorld = world->IsMainWorld();
+  bool isRoot = frame->IsOutermostMainFrame();
+  bool isDevtools = !!DevToolsFrontendImpl::From(frame);
   if (!isMainWorld) {
     return "extension";
   }
@@ -245,9 +250,10 @@ void LocalWindowProxy::Initialize() {
       // origin, we are ready to set up the state used to process driver
       // commands when recording/replaying, and to create checkpoints.
       InitializeRecordReplay(
-        RecordReplayGetProcessType(world_->IsMainWorld(),
-          GetFrame()->IsOutermostMainFrame(),
-          !!DevToolsFrontendImpl::From(GetFrame())),
+        RecordReplayGetProcessType(
+          GetFrame(),
+          world_
+        ),
         GetIsolate(), GetFrame(), context
       );
     }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -91,6 +91,12 @@ extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<
 extern "C" void V8RecordReplayFinishRecording();
 extern "C" void V8RecordReplaySetCrashReason(const char* reason);
 extern "C" char* V8RecordReplayReadAssetFileContents(const char* aPath, size_t* aLength);
+extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
+extern "C" void V8RecordReplayAddMetadata(const char* jsonString);
+extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
+extern "C" void V8RecordReplayRegisterBrowserEventCallback(
+  void (*callback)(const char* name, const char* payload)
+);
 
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
@@ -2419,11 +2425,6 @@ static void InvokeOnAnnotation(const v8::FunctionCallbackInfo<v8::Value>& args) 
   recordreplay::OnAnnotation(*kind, *contents);
 }
 
-extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>));
-extern "C" void V8RecordReplayRegisterBrowserEventCallback(
-  void (*callback)(const char* name, const char* payload)
-);
-
 /**
  * Copied from gin/try_catch.h.
  */
@@ -2613,11 +2614,18 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, args, "checkPersistentId", fromJsCheckPersistentId);
 }
 
-void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
+void InitializeRecordReplay(
+  const char* processType,
+  v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
   V8RecordReplaySetAPIObjectIdCallback(GetBlinkPersistentId);
   gActiveNetworkRequests =
       new std::unordered_map<std::string, NetworkRequestStatus>();
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
+  
+  // Add process type metadata.
+  char buf[256];
+  snprintf(buf, sizeof(buf), "{ \"process\": \"%s\" }", processType);
+  V8RecordReplayAddMetadata(buf);
 }
 
 void InitializeRecordReplayAfterCheckpoint() {
@@ -2672,13 +2680,6 @@ void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8:
       localFrame->IsCrossOriginToParentOrOuterDocument(),
       localFrame->GetDocument()->Url().GetString().Utf8().c_str()
       );
-
-  if (gReplayScriptsAlive) {
-    // Our "V8RecordReplaySetDefaultContext" logic implies a single local
-    // root frame per render process.
-    recordreplay::Warning("ReplayScript Multiple_OnRootFrameInit");
-    return;
-  }
   
   // NOTE: The root `LocalFrame` can change over time.
   gRootLocalFrame = localFrame;
@@ -2727,9 +2728,6 @@ void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8
     parentFrame ? parentFrame->RecordReplayId() : 0
   );
 }
-
-
-extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
 
 static ErrorEvent* gCurrentErrorEvent;
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2623,9 +2623,8 @@ void InitializeRecordReplay(
   gCurrentNetworkStreamData = new std::vector<uint8_t>();
   
   // Add process type metadata.
-  char buf[256];
-  snprintf(buf, sizeof(buf), "{ \"process\": \"%s\" }", processType);
-  V8RecordReplayAddMetadata(buf);
+  std::string metadata = std::string("{ \"process\": \"") + processType + "\" }";
+  V8RecordReplayAddMetadata(metadata.c_str());
 }
 
 void InitializeRecordReplayAfterCheckpoint() {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -14,7 +14,9 @@
 namespace blink {
 // Initialize command state after the first context is created, but before the
 // first checkpoint in the recording is created.
-void InitializeRecordReplay(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
+void InitializeRecordReplay(
+  const char* processType,
+  v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Do any remaining initialization after the first checkpoint is created.
 void InitializeRecordReplayAfterCheckpoint();


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/228
* https://linear.app/replay/issue/TT-211/mark-iframesextensionsdevtools-recordings-with-different-metadata