### PR TITLE
fix `replay launch` usage in the CLI

### DIFF
--- a/cc/trees/proxy_main.cc
+++ b/cc/trees/proxy_main.cc
@@ -53,8 +53,8 @@ ProxyMain::ProxyMain(LayerTreeHost* layer_tree_host,
   DCHECK(task_runner_provider_);
   DCHECK(IsMainThread());
   
-  recordreplay::InitPaintCallback();
   if (recordreplay::IsRecordingOrReplaying("notify-paints")) {
+    recordreplay::InitPaintCallback();
     recordreplay::SetCompositorProxy(this);
   }
 }


### PR DESCRIPTION
don't call `recordreplay::InitPaintCallback` (which calls `V8RecordReplaySetPaintCallback`, where the crash actually happens) if we aren't recording/replaying.