### PR TITLE
[TT-802] extend recordreplay::IsRecordingOrReplaying check around more initialization

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -241,7 +241,7 @@ void LocalWindowProxy::Initialize() {
   }
 
   if (recordreplay::IsRecordingOrReplaying("commands") &&
-      (origin && !origin->Host().empty())) {
+      origin && !origin->Host().empty()) {
     bool initGlobally = !gRecordReplayStateInitialized;
     if (initGlobally) {
       gRecordReplayStateInitialized = true;

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -240,8 +240,8 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (origin &&
-      !origin->Host().empty()) {
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
+      (origin && !origin->Host().empty())) {
     bool initGlobally = !gRecordReplayStateInitialized;
     if (initGlobally) {
       gRecordReplayStateInitialized = true;
@@ -258,8 +258,7 @@ void LocalWindowProxy::Initialize() {
       );
     }
 
-    if (world_->IsMainWorld() &&
-      recordreplay::IsRecordingOrReplaying("commands")) {
+    if (world_->IsMainWorld()) {
       bool initFrame = GetFrame()->IsLocalRoot();
       if (initFrame) {
         // Root-level navigation event, initially happens before


### PR DESCRIPTION
https://linear.app/replay/issue/TT-802/macos-chromium-crashes-on-start