### PR TITLE
Convert LayerTreeHost::WaitForCommitCompletion Hang into Crash

### DIFF
--- a/base/synchronization/waitable_event_mac.cc
+++ b/base/synchronization/waitable_event_mac.cc
@@ -172,7 +172,7 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
                                         .InMillisecondsRoundedUp()))) {
     recordreplay::Print("DDBG TimedWait %d %d %d",
       (int)timeout,
-      (int)rcv_size
+      (int)rcv_size,
       (int)sizeof(timeout)
     );
     kr = mach_msg(&msg.header, options, 0, rcv_size, receive_right_->Name(),

--- a/base/synchronization/waitable_event_mac.cc
+++ b/base/synchronization/waitable_event_mac.cc
@@ -170,6 +170,11 @@ bool WaitableEvent::TimedWait(const TimeDelta& wait_delta) {
                                     (end_time -
                                      subtle::TimeTicksNowIgnoringOverride())
                                         .InMillisecondsRoundedUp()))) {
+    recordreplay::Print("DDBG TimedWait %d %d %d",
+      (int)timeout,
+      (int)rcv_size
+      (int)sizeof(timeout)
+    );
     kr = mach_msg(&msg.header, options, 0, rcv_size, receive_right_->Name(),
                   timeout, MACH_PORT_NULL);
   }

--- a/cc/trees/layer_tree_host.cc
+++ b/cc/trees/layer_tree_host.cc
@@ -454,7 +454,15 @@ void LayerTreeHost::WaitForCommitCompletion(bool for_protected_sequence) const {
   if (commit_completion_event_) {
     TRACE_EVENT0("cc", "LayerTreeHost::WaitForCommitCompletion");
     base::ElapsedTimer timer;
-    commit_completion_event_->Wait();
+    if (recordreplay::AreEventsUnavailable()) {
+      // [TT-250] Convert this hang into a crash.
+      bool signaled = commit_completion_event_->TimedWait(base::Seconds(3));
+      if (!signaled) {
+        recordreplay::Crash("[TT-250] LayerTreeHost::WaitForCommitCompletion failed.");
+      }
+    } else {
+      commit_completion_event_->Wait();
+    }
     commit_completion_event_ = nullptr;
     if (for_protected_sequence) {
       waited_for_protected_sequence_ = true;

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -321,7 +321,7 @@ static char* PaintWhenDiverged(const char* mime_type, int jpeg_quality) {
   gCurrentCompositorProxy->RecordReplayRepaint();
 
   // Wait for the repainting frame to complete.
-  bool signaled = event.TimedWait(base::Milliseconds(3000));
+  bool signaled = event.TimedWait(base::Milliseconds(321));
   if (!signaled) {
     Print("[RuntimeError] Failed waiting to get a repaint.");
     gRepaintResult = nullptr;


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-250/[1-thread-hang]-timedwait-in-proxymainbeginmainframe-→#comment-05f5546a