### PR TITLE
[TT-859] disable these startup info bars

### DIFF
--- a/chrome/browser/ui/startup/bad_flags_prompt.cc
+++ b/chrome/browser/ui/startup/bad_flags_prompt.cc
@@ -63,7 +63,10 @@ static const char* kBadFlags[] = {
     sandbox::policy::switches::kDisableGpuSandbox,
     sandbox::policy::switches::kDisableSeccompFilterSandbox,
     sandbox::policy::switches::kDisableSetuidSandbox,
-    sandbox::policy::switches::kNoSandbox,
+    // [TT-859] remove this switch from the list chrome complains about in an info bar,
+    // until/unless we can re-enable the sandbox and remove the flag.
+    // sandbox::policy::switches::kNoSandbox,
+
 #if BUILDFLAG(IS_WIN)
     sandbox::policy::switches::kAllowThirdPartyModules,
 #endif

--- a/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chrome/browser/ui/startup/infobar_utils.cc
@@ -113,8 +113,9 @@ void AddInfoBarsIfNecessary(Browser* browser,
     infobars::ContentInfoBarManager* infobar_manager =
         infobars::ContentInfoBarManager::FromWebContents(web_contents);
 
-    if (!google_apis::HasAPIKeyConfigured())
-      GoogleApiKeysInfoBarDelegate::Create(infobar_manager);
+    // [TT-859] disable the api key delegate (which displays the banner in the infobar.)
+    // if (!google_apis::HasAPIKeyConfigured())
+    //   GoogleApiKeysInfoBarDelegate::Create(infobar_manager);
 
     if (ObsoleteSystem::IsObsoleteNowOrSoon()) {
       PrefService* local_state = g_browser_process->local_state();


### PR DESCRIPTION
we might get a place where we can re-enable them both, but for the time being they're pretty obnoxious.

see https://linear.app/replay/issue/TT-859/chromium-banners