### PR TITLE
Add methods to access topmost frame's return value

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '6eff470019582b616b0643ef68da474a4ba92670',
+  'v8_revision': '46b08ca122f338930076e3b824806d9767364540',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0936540bd37441ad14ad76886d396d8fcecf2243',
+  'v8_revision': 'dd79da4d93489d1f8e7ac77aa2ba1d038c93109e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '378577cc29f602e258b718c6ecf468f0e94834ac',
+  'v8_revision': 'cf1845d9b6700a2f43616435320e18065c915178',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'dd79da4d93489d1f8e7ac77aa2ba1d038c93109e',
+  'v8_revision': '378577cc29f602e258b718c6ecf468f0e94834ac',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -25,6 +25,8 @@ const {
   fromJsGetArgumentsInFrame,
   fromJsGetObjectByCdpId,
   fromJsIsBlinkObject,
+  fromJsHasReturnValue,
+  fromJsGetReturnValue,
   fromJsGetNodeIdByCpdId,
   fromJsGetBoxModel,
   fromJsGetMatchedStylesForElement,
@@ -646,7 +648,8 @@ function Pause_getAllFrames() {
   const frames = getStackFrames().map((frame, index) => {
     // Use our own IDs for frames.
     const id = (index++).toString();
-    return createProtocolFrame(id, frame);
+    const topmost = id == 0;
+    return createProtocolFrame(id, frame, topmost);
   });
   return {
     frames: frames.map(f => f.frameId),
@@ -2023,9 +2026,14 @@ function createProtocolLocation(location) {
   }];
 }
 
-function createProtocolFrame(frameId, cdpFrame) {
+function createProtocolFrame(frameId, cdpFrame, topmost) {
   // CDP call frames don't provide detailed type information.
   const type = cdpFrame.functionName ? "call" : "global";
+
+  let returnValue;
+  if (topmost && fromJsHasReturnValue()) {
+    returnValue = createRrpValueRaw(fromJsGetReturnValue());
+  }
 
   return {
     frameId,
@@ -2035,6 +2043,7 @@ function createProtocolFrame(frameId, cdpFrame) {
     location: createProtocolLocation(cdpFrame.location),
     scopeChain: cdpFrame.scopeChain.map(registerCdpScope),
     this: buildRrpObjectFromCdpObject(cdpFrame.this),
+    returnValue,
   };
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1645,8 +1645,6 @@ static void fromJsIsBlinkObject(
  */
 static void fromJsHasReturnValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
-  v8::Isolate* isolate = args.GetIsolate();
-
   v8::Local<v8::Value> return_value;
   bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
 
@@ -1659,8 +1657,6 @@ static void fromJsHasReturnValue(
  */
 static void fromJsGetReturnValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
-  v8::Isolate* isolate = args.GetIsolate();
-
   v8::Local<v8::Value> return_value;
   bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -97,6 +97,7 @@ extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v
 extern "C" void V8RecordReplayRegisterBrowserEventCallback(
   void (*callback)(const char* name, const char* payload)
 );
+extern "C" bool V8RecordReplayCurrentReturnValue(v8::Local<v8::Value>* object);
 
 static const char REPLAY_CDT_PAUSE_OBJECT_GROUP[] =
     "REPLAY_CDT_PAUSE_OBJECT_GROUP";
@@ -1638,6 +1639,36 @@ static void fromJsIsBlinkObject(
   args.GetReturnValue().Set(result);
 }
 
+/**
+ * Return whether there is a return value available for the topmost frame,
+ * when stopped at an "exit" return site.
+ */
+static void fromJsHasReturnValue(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+
+  v8::Local<v8::Object> return_value;
+  bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
+
+  args.GetReturnValue().Set(has_return_value);
+}
+
+/**
+ * When stopped at an "exit" return site, returns the topmost frame's
+ * pending return value.
+ */
+static void fromJsGetReturnValue(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+
+  v8::Local<v8::Object> return_value;
+  bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
+
+  if (has_return_value) {
+    args.GetReturnValue().Set(return_value);
+  }
+}
+
 /** ###########################################################################
  * Networking
  * ##########################################################################*/
@@ -2552,6 +2583,10 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                       fromJsGetObjectByCdpId);
   SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
                       fromJsIsBlinkObject);
+  SetFunctionProperty(isolate, args, "fromJsHasReturnValue",
+                      fromJsHasReturnValue);
+  SetFunctionProperty(isolate, args, "fromJsGetReturnValue",
+                      fromJsGetReturnValue);
 
   // networking
   SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1647,7 +1647,7 @@ static void fromJsHasReturnValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  v8::Local<v8::Object> return_value;
+  v8::Local<v8::Value> return_value;
   bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
 
   args.GetReturnValue().Set(has_return_value);
@@ -1661,7 +1661,7 @@ static void fromJsGetReturnValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  v8::Local<v8::Object> return_value;
+  v8::Local<v8::Value> return_value;
   bool has_return_value = V8RecordReplayCurrentReturnValue(&return_value);
 
   if (has_return_value) {


### PR DESCRIPTION
Goes with https://github.com/replayio/chromium-v8/pull/235

This adds APIs to `__RECORD_REPLAY_ARGUMENTS__` to access the topmost frame returned value and tracks this in generated RRP frames as well.