### PR TITLE
[TT-932] Fix recorder crash in `NavigationURLLoaderImpl::OnReceiveRedirect`

### DIFF
--- a/content/browser/loader/navigation_url_loader_impl.cc
+++ b/content/browser/loader/navigation_url_loader_impl.cc
@@ -977,7 +977,7 @@ void NavigationURLLoaderImpl::OnReceiveRedirect(
       (int) global_request_id_.request_id
     );
     dict.Set("requestId", request_id);
-    dict.Set("originalUrl", url_chain_.size() > 0 ? url_chain_[0].spec() : base::EmptyString());
+    dict.Set("originalUrl", url_.spec());
     dict.Set("requestMethod", resource_request_->method);
     dict.Set("requestUrl", redirect_info.new_url.spec());
 

--- a/content/browser/loader/navigation_url_loader_impl.cc
+++ b/content/browser/loader/navigation_url_loader_impl.cc
@@ -977,7 +977,7 @@ void NavigationURLLoaderImpl::OnReceiveRedirect(
       (int) global_request_id_.request_id
     );
     dict.Set("requestId", request_id);
-    dict.Set("originalUrl", url_chain_[0].spec());
+    dict.Set("originalUrl", url_chain_.size() > 0 ? url_chain_[0].spec() : base::EmptyString());
     dict.Set("requestMethod", resource_request_->method);
     dict.Set("requestUrl", redirect_info.new_url.spec());
 

--- a/content/browser/loader/navigation_url_loader_impl.cc
+++ b/content/browser/loader/navigation_url_loader_impl.cc
@@ -977,7 +977,8 @@ void NavigationURLLoaderImpl::OnReceiveRedirect(
       (int) global_request_id_.request_id
     );
     dict.Set("requestId", request_id);
-    dict.Set("originalUrl", url_.spec());
+    dict.Set("originalUrl", url_chain_.size() > 0 ? url_chain_[0].spec()
+                                                  : url_.spec());
     dict.Set("requestMethod", resource_request_->method);
     dict.Set("requestUrl", redirect_info.new_url.spec());
 


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-932/recorder-crash-in-urlloaderclientstubaccept-fetcheventrespondwith#comment-b41db005
* Triggered a manual build (because GitHub is broken): https://buildkite.com/replay/chromium-build/builds/3832