### PR TITLE
[TT-1029] per-recording tab... maybe.

### DIFF
--- a/chrome/app/record_replay_main.cc
+++ b/chrome/app/record_replay_main.cc
@@ -266,9 +266,6 @@ static bool RecordReplayRecordingDisabled(bool cmdline_for_recording) {
       BusyWait();
     return true;
   }
-  if (getenv("RECORD_ALL_CONTENT")) {
-    return false;
-  }
   if (cmdline_for_recording) {
     return false;
   }

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -4315,6 +4315,10 @@ bool RenderProcessHostImpl::MayReuseAndIsSuitable(
 bool RenderProcessHostImpl::MayReuseAndIsSuitable(
     RenderProcessHost* host,
     SiteInstanceImpl* site_instance) {
+  if (site_instance->RecordReplayForRecording()) {
+    return false;
+  }
+
   return MayReuseAndIsSuitable(host, site_instance->GetIsolationContext(),
                                site_instance->GetSiteInfo());
 }

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -1097,9 +1097,13 @@ std::unique_ptr<WebContentsImpl> WebContentsImpl::CreateWithOpener(
   std::unique_ptr<WebContentsImpl> new_contents(
       new WebContentsImpl(params.browser_context));
 
-  // Forward flag indicating that this web-contents is being created
-  // for a replay.io recording.
-  if (params.record_replay_for_recording) {
+  // Forward params flag (and RECORD_ALL_CONTENT env var) indicating that this
+  // web-contents is being created for a replay.io recording.  Ideally we'd
+  // modify the params here to avoid directly setting on `new_contents`, but
+  // it's const here.
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  bool has_record_all_content = env->HasVar("RECORD_ALL_CONTENT");
+  if (params.record_replay_for_recording || has_record_all_content) {
     new_contents->record_replay_for_recording_ = true;
   }
 
@@ -3070,11 +3074,9 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params,
     last_active_time_ = params.last_active_time;
 
   // RecordReplay [RUN-2762]
-  // If the `record_replay_for_recording` flag is set on the params, then
-  // `site_instance` on params should be null.
-  if (params.record_replay_for_recording) {
-    CHECK(params.site_instance.get() == nullptr);
-  }
+  // We don't really need to do this, but just in case, merge
+  // this->record_replay_for_recording_ and params.record_replay_for_recording.
+  record_replay_for_recording_ = record_replay_for_recording_ || params.record_replay_for_recording;
 
   scoped_refptr<SiteInstance> site_instance = params.site_instance;
   if (!site_instance)
@@ -3083,10 +3085,10 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params,
     static_cast<SiteInstanceImpl*>(site_instance.get())
         ->PreventAssociationWithSpareProcess();
   }
-  if (params.record_replay_for_recording) {
+  if (record_replay_for_recording_) {
     // RecordReplay [RUN-2762]
-    // If the `record_replay_for_recording` flag is set on the params, then
-    // we need to tell the site instance that was created that
+    // If the `record_replay_for_recording` flag is set, then
+    // we need to tell tat to the site instance that was created.
     static_cast<SiteInstanceImpl*>(site_instance.get())
         ->PreventAssociationWithSpareProcess();
     static_cast<SiteInstanceImpl*>(site_instance.get())

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -3088,7 +3088,7 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params,
   if (record_replay_for_recording_) {
     // RecordReplay [RUN-2762]
     // If the `record_replay_for_recording` flag is set, then
-    // we need to tell tat to the site instance that was created.
+    // we need to tell that to the site instance that was created.
     static_cast<SiteInstanceImpl*>(site_instance.get())
         ->PreventAssociationWithSpareProcess();
     static_cast<SiteInstanceImpl*>(site_instance.get())


### PR DESCRIPTION
attempt to unify the code paths that `RECORD_ALL_CONTENT` and the record button use, and mix in a bit more work to get toplevel frames to not end up on the same process even if the `SiteInstance` would otherwise permit it.

in its current state it works for this recipe:

1. `$ RECORD_ALL_CONTENTS=1 out/Release/chrome https://github.com/`
2. middle click/cmd-click on the github logo to open more tabs on the same page.
3. check the Task Manager - they should all have different process ids.
4. close all the tabs and run `replayio list` and there should be the correct number of recordings.

One thing that _doesn't_ seem to work.
1. `$ RECORD_ALL_CONTENTS=1 out/Release/chrome`
2. navigate to https://github.com/
3. close the tab and `replayio list`

There will be a recording but it'll have `(untitled)` for the Host field.  presumably because we start with `about:blank` and then navigate away.
