### PR TITLE
[TT-1117] reset chromium to BUILDKITE_COMMIT, not BUILDKITE_BRANCH

### DIFF
--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -166,8 +166,8 @@ export function updateBackendRepo() {
 
 export function updateChromiumRepo() {
   const chromium = process.cwd();
-  const branch = process.env["BUILDKITE_BRANCH"];
-  updateRepo(chromium, `origin/${branch}`);
+  const rev = process.env["BUILDKITE_COMMIT"];
+  updateRepo(chromium, rev);
 
   const deps = getChromiumDeps();
 


### PR DESCRIPTION
it's possible for builds to be relative slow/backed up, and for multiple master commits to land before we get to the point where we run `git reset`.

Make sure we aren't building the newest commit, and are instead building the commit we think we are.