### PR TITLE
Make `observers_` in `ImageResourceContent` strong

### DIFF
--- a/third_party/blink/renderer/core/loader/image_loader.cc
+++ b/third_party/blink/renderer/core/loader/image_loader.cc
@@ -612,9 +612,8 @@ void ImageLoader::DoUpdateFromElement(
     }
 
     recordreplay::Assert(
-        "[RUN-658-1381] ImageLoader::DoUpdateFromElement %d %s",
-        element_->RecordReplayId(),
-        image_source_url.IsNull() ? "(null)" : image_source_url.Utf8().c_str());
+        "[TT-418-1118] ImageLoader::DoUpdateFromElement A %d",
+        element_->RecordReplayId());
 
     new_image_content = ImageResourceContent::Fetch(params, document.Fetcher());
 
@@ -635,6 +634,15 @@ void ImageLoader::DoUpdateFromElement(
   ImageResourceContent* old_image_content = image_content_.Get();
   if (old_image_content != new_image_content)
     RejectPendingDecodes(update_type);
+
+  recordreplay::Assert(
+      "[TT-418-1118] ImageLoader::DoUpdateFromElement B %d %d %d %d",
+      update_behavior,
+      !!old_image_content,
+      new_image_content == old_image_content,
+      !!element_->GetLayoutObject(),
+      element_->GetLayoutObject() && element_->GetLayoutObject()->IsImage()
+  );
 
   if (update_behavior == kUpdateSizeChanged && element_->GetLayoutObject() &&
       element_->GetLayoutObject()->IsImage() &&
@@ -676,6 +684,8 @@ void ImageLoader::DoUpdateFromElement(
       old_image_content->RemoveObserver(this);
     }
   }
+
+  recordreplay::Assert("[TT-418-1118] ImageLoader::DoUpdateFromElement C");
 
   if (LayoutImageResource* image_resource = GetLayoutImageResource())
     image_resource->ResetAnimation();
@@ -939,6 +949,15 @@ void ImageLoader::UpdateLayoutObject() {
   // is a complete image.  This prevents flickering in the case where a dynamic
   // change is happening between two images.
   ImageResourceContent* cached_image_content = image_resource->CachedImage();
+
+  recordreplay::Assert(
+      "[TT-418-1118] ImageLoader::UpdateLayoutObject %d %d %d %d",
+      !!cached_image_content,
+      !!image_complete_,
+      image_content_ == cached_image_content,
+      !!cached_image_content
+  );
+
   if (image_content_ != cached_image_content &&
       (image_complete_ || !cached_image_content))
     image_resource->SetImageResource(image_content_.Get());

--- a/third_party/blink/renderer/core/loader/image_loader.cc
+++ b/third_party/blink/renderer/core/loader/image_loader.cc
@@ -636,10 +636,11 @@ void ImageLoader::DoUpdateFromElement(
     RejectPendingDecodes(update_type);
 
   recordreplay::Assert(
-      "[TT-418-1118] ImageLoader::DoUpdateFromElement B %d %d %d %d",
+      "[TT-418-1118] ImageLoader::DoUpdateFromElement B %d %d %d layout=%d %d",
       update_behavior,
       !!old_image_content,
       new_image_content == old_image_content,
+
       !!element_->GetLayoutObject(),
       element_->GetLayoutObject() && element_->GetLayoutObject()->IsImage()
   );

--- a/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
+++ b/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
@@ -115,6 +115,8 @@ void ImageResourceContent::Trace(Visitor* visitor) const {
   visitor->Trace(info_);
   visitor->Trace(observers_);
   visitor->Trace(finished_observers_);
+  visitor->Trace(replay_strong_observers_);
+  visitor->Trace(replay_strong_finished_observers_);
   ImageObserver::Trace(visitor);
   MediaTiming::Trace(visitor);
 }
@@ -128,6 +130,11 @@ void ImageResourceContent::HandleObserverFinished(
     if (it != observers_.end()) {
       observers_.erase(it);
       finished_observers_.insert(observer);
+      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+                                               "ImageResourceContent")) {
+        replay_strong_observers_.erase(replay_strong_observers_.find(observer));
+        replay_strong_finished_observers_.insert(observer);
+      }
     }
   }
   observer->ImageNotifyFinished(this);
@@ -143,6 +150,11 @@ void ImageResourceContent::AddObserver(ImageResourceObserver* observer) {
     ProhibitAddRemoveObserverInScope prohibit_add_remove_observer_in_scope(
         this);
     observers_.insert(observer);
+    
+    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+                                              "ImageResourceContent")) {
+      replay_strong_observers_.insert(observer);
+    }
   }
 
   if (info_->IsCacheValidator())
@@ -166,10 +178,20 @@ void ImageResourceContent::RemoveObserver(ImageResourceObserver* observer) {
   if (it != observers_.end()) {
     fully_erased = observers_.erase(it) && finished_observers_.find(observer) ==
                                                finished_observers_.end();
+    
+    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+                                              "ImageResourceContent")) {
+      replay_strong_observers_.erase(replay_strong_observers_.find(observer));
+    }
   } else {
     it = finished_observers_.find(observer);
     DCHECK(it != finished_observers_.end());
     fully_erased = finished_observers_.erase(it);
+    
+    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+                                              "ImageResourceContent")) {
+      replay_strong_finished_observers_.erase(replay_strong_finished_observers_.find(observer));
+    }
   }
   DidRemoveObserver();
   if (fully_erased)

--- a/third_party/blink/renderer/core/loader/resource/image_resource_content.h
+++ b/third_party/blink/renderer/core/loader/resource/image_resource_content.h
@@ -270,6 +270,8 @@ class CORE_EXPORT ImageResourceContent final
 
   HeapHashCountedSet<WeakMember<ImageResourceObserver>> observers_;
   HeapHashCountedSet<WeakMember<ImageResourceObserver>> finished_observers_;
+  HeapHashCountedSet<Member<ImageResourceObserver>> replay_strong_observers_;
+  HeapHashCountedSet<Member<ImageResourceObserver>> replay_strong_finished_observers_;
 
 #if DCHECK_IS_ON()
   bool is_update_image_being_called_ = false;


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-418/mismatch-in-blinkgraphicscontextdrawimage#comment-946fe3f1