### PR TITLE
[TT-1119] clear artifacts earlier

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,7 @@ steps:
     commands:
       - "be_cmd git-fetch-all -- git fetch --all"
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd clean-artifacts-dir -- node replay_build_scripts/clean_artifacts.mjs"
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "pushd ../backend"
       - "be_cmd buck2-kill -- buck2 kill"
@@ -89,6 +90,7 @@ steps:
     commands:
       - "be_cmd git-fetch-all -- git fetch --all"
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd clean-artifacts-dir -- node replay_build_scripts/clean_artifacts.mjs"
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "pushd ../backend"
       - "be_cmd buck2-kill -- buckle kill"
@@ -128,6 +130,7 @@ steps:
     commands:
       - "be_cmd git-fetch-all -- git fetch --all"
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd clean-artifacts-dir -- node replay_build_scripts/clean_artifacts.mjs"
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "pushd ../backend"
       - "be_cmd buck2-kill -- buckle kill"
@@ -154,7 +157,14 @@ steps:
     timeout_in_minutes: 60
     plugins:
       - https://github.com/jazzdan/skip-checkout-buildkite-plugin.git#jazzdan/windows-support: ~
-    command: "cd C:\\Users\\Administrator\\chromium\\src && git fetch --all && git reset --hard origin/$BUILDKITE_BRANCH && node replay_build_scripts/update-all-repos.mjs && node buildWindows.mjs &&  node replay_build_scripts/upload_build_artifacts.mjs"
+    commands:
+      - "cd C:\\Users\\Administrator\\chromium\\src"
+      - "git fetch --all"
+      - "git reset --hard origin/$BUILDKITE_BRANCH"
+      - "node replay_build_scripts/clean_artifacts.mjs"
+      - "node replay_build_scripts/update-all-repos.mjs"
+      - "node buildWindows.mjs"
+      - "node replay_build_scripts/upload_build_artifacts.mjs"
     env:
       RBE_service: simpsonite.cluster.engflow.com:443
       RBE_service_no_auth: true

--- a/replay_build_scripts/clean_artifacts.mjs
+++ b/replay_build_scripts/clean_artifacts.mjs
@@ -1,0 +1,8 @@
+import fs from "fs";
+import { getArtifactDir } from "./common.mjs";
+
+function main() {
+  fs.rmSync(getArtifactDir(), { force: true, recursive: true });
+}
+
+main();

--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -223,3 +223,12 @@ export function getBackendDir() {
     process.env.RECORD_REPLAY_BACKEND_DIR || path.join(__dirname, "..", "..")
   );
 }
+
+export function getArtifactDir() {
+  return path.join(
+    process.env.BUILDKITE_BUILD_CHECKOUT_PATH || "./",
+    "build_id",
+    currentPlatform(),
+    outputArchitecture()
+  );
+}

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -6,8 +6,8 @@ import {
   log,
   spawnChecked,
   Platform,
-  outputArchitecture,
   getBackendDir,
+  getArtifactDir,
 } from "./common.mjs";
 import { readSymbols } from "./symbolication.mjs";
 
@@ -17,12 +17,7 @@ const S3DevBucket = "recordreplay-us-east-2-dev";
 const S3Website = "recordreplay-website";
 
 const BUILDKITE_BUILD_ID_ARTIFACT = "build_id";
-const BUILDKITE_ARTIFACT_DIRECTORY = path.join(
-  process.env.BUILDKITE_BUILD_CHECKOUT_PATH || "./",
-  "build_id",
-  currentPlatform(),
-  outputArchitecture()
-);
+const BUILDKITE_ARTIFACT_DIRECTORY = getArtifactDir();
 
 // If this env var is set, we then we (also) use this as our cue that
 // we're building on a developer's machine, and will run some different
@@ -101,11 +96,9 @@ function copyBuildFiles(dstDir) {
 
   for (const file of fs.readdirSync(outDir)) {
     if (shouldCopyFile(file)) {
-      fs.cpSync(
-        path.join(outDir, file),
-        path.join(dstDir, file),
-        { recursive: true }
-      );
+      fs.cpSync(path.join(outDir, file), path.join(dstDir, file), {
+        recursive: true,
+      });
     }
   }
   fs.cpSync(path.join(outDir, "locales"), path.join(dstDir, "locales"), {
@@ -334,10 +327,7 @@ function prepareMacOSBinaries(buildId) {
   }
 
   // Clean up.
-  fs.renameSync(
-    appPath,
-    path.join(outdir, "Chromium.app")
-  );
+  fs.renameSync(appPath, path.join(outdir, "Chromium.app"));
 
   // Move things into place.
   fs.cpSync(buildIdDmgArchive, dmgArchive);
@@ -445,7 +435,6 @@ function buildkiteStuff(
 
   // Write the build_id artifact.  This is how buildkite agents will know which build
   // to download from S3: by first downloading this file.
-  fs.rmSync(BUILDKITE_ARTIFACT_DIRECTORY, { force: true, recursive: true });
   fs.mkdirSync(BUILDKITE_ARTIFACT_DIRECTORY, { recursive: true });
   fs.writeFileSync(
     path.join(BUILDKITE_ARTIFACT_DIRECTORY, BUILDKITE_BUILD_ID_ARTIFACT),
@@ -753,7 +742,7 @@ async function buildSymbolsArchive(
 
 const buildIdExtension =
   process.env["BUILDKITE_BRANCH"] !==
-    process.env["BUILDKITE_PIPELINE_DEFAULT_BRANCH"]
+  process.env["BUILDKITE_PIPELINE_DEFAULT_BRANCH"]
     ? "-dev"
     : process.env["LOCAL_DEVELOPER_BUILD_EXTENSION"] || "";
 const useARM = !!process.env.REPLAY_BUILD_ARM;


### PR DESCRIPTION
pull the `rm -rf $artifact-dir` out of the `upload_build_artifacts.mjs` step and use it in the new `clean_artifacts.mjs` step which happens at the beginning of the build.

still not perfect, but should get us closer to never uploading artifacts we shouldn't (from a previous build, e.g.)

see https://linear.app/replay/issue/TT-1119