### PR TITLE
pass branch/commit to the chromium-build pipeline as well

### DIFF
--- a/replay_build_scripts/build-pipeline.py
+++ b/replay_build_scripts/build-pipeline.py
@@ -7,18 +7,18 @@ def read_commit_hash(file_path):
         return file.read().strip()
 
 
-def generate_buildkite_pipeline(commit_hash):
+def generate_buildkite_pipeline(backend_commit_hash):
     """Generates a Buildkite pipeline with a dynamic commit hash in JSON format."""
 
     # driver_revision is the first 12 characters of the commit hash.
-    driver_revision = commit_hash.split()[0][:12]
+    driver_revision = backend_commit_hash.split()[0][:12]
     pipeline = {
         "steps": [
             {
                 "trigger": "build-driver-linker",
                 "key": "build-driver-linker",
                 "build": {
-                    "commit": commit_hash,
+                    "commit": backend_commit_hash,
                     "message": "Triggered from chromium: ${BUILDKITE_MESSAGE}",
                 },
             },
@@ -26,6 +26,8 @@ def generate_buildkite_pipeline(commit_hash):
                 "trigger": "chromium-build",
                 "build": {
                     "env": {"DRIVER_REVISION": driver_revision},
+                    "branch": "${BUILDKITE_BRANCH}",
+                    "commit": "${BUILDKITE_COMMIT}",
                 },
                 "depends_on": ["build-driver-linker"],
             },
@@ -35,8 +37,8 @@ def generate_buildkite_pipeline(commit_hash):
 
 
 def main():
-    commit_hash = read_commit_hash("REPLAY_BACKEND_REV")
-    pipeline_json = generate_buildkite_pipeline(commit_hash)
+    backend_commit_hash = read_commit_hash("REPLAY_BACKEND_REV")
+    pipeline_json = generate_buildkite_pipeline(backend_commit_hash)
     print(pipeline_json)
 
 

--- a/replay_build_scripts/build-pipeline.py
+++ b/replay_build_scripts/build-pipeline.py
@@ -26,6 +26,7 @@ def generate_buildkite_pipeline(backend_commit_hash):
                 "trigger": "chromium-build",
                 "build": {
                     "env": {"DRIVER_REVISION": driver_revision},
+                    "message": "${BUILDKITE_MESSAGE}",
                     "branch": "${BUILDKITE_BRANCH}",
                     "commit": "${BUILDKITE_COMMIT}",
                 },


### PR DESCRIPTION
the branch I think is mostly unnecessary but it'll cause the build to show up in the right spot in the build list (right now everything looks like it's happening on `master`.