### PR TITLE
Assert MojoPageTimingSender and RenderFrameImpl::DidCommitNavigationInternal

### DIFF
--- a/components/page_load_metrics/renderer/metrics_render_frame_observer.cc
+++ b/components/page_load_metrics/renderer/metrics_render_frame_observer.cc
@@ -60,6 +60,7 @@ class MojoPageTimingSender : public PageTimingSender {
       const absl::optional<blink::MobileFriendliness>& mobile_friendliness,
       uint32_t soft_navigation_count) override {
     DCHECK(page_load_metrics_);
+    mojo::internal::AutoRecordReplayAssertBufferAllocations assertsEnabled("TT-366-1124");
     page_load_metrics_->UpdateTiming(
         limited_sending_mode_ ? CreatePageLoadTiming() : timing->Clone(),
         metadata->Clone(), new_features, std::move(resources),

--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -4847,6 +4847,7 @@ void RenderFrameImpl::DidCommitNavigationInternal(
       commit_type, transition, permissions_policy_header,
       document_policy_header, embedding_token);
 
+  mojo::internal::AutoRecordReplayAssertBufferAllocations assertsEnabled("TT-492-1124");
   if (same_document_params) {
     GetFrameHost()->DidCommitSameDocumentNavigation(
         std::move(params), std::move(same_document_params));


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-366/mismatch-in-pageloadmetricsproxyupdatetiming#comment-efb31a8e