### PR TITLE
[TT-1140] disable metabase pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -211,11 +211,6 @@ steps:
       - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
 
-  - label: "Trigger Metabase Tests :hammer:"
-    trigger: "testing-runtime-metabase"
-    depends_on:
-      - "build-chromium-linux-x86_64"
-
   - label: "Trigger FE E2E Tests (linux-x86_64) :hammer:"
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:


### PR DESCRIPTION
The pipeline still exists in the metabase repo, but we won't be running it for the foreseeable future.