### PR TITLE
Assert HistoryItem::SetStateObject

### DIFF
--- a/third_party/blink/renderer/core/loader/history_item.cc
+++ b/third_party/blink/renderer/core/loader/history_item.cc
@@ -136,6 +136,10 @@ void HistoryItem::ClearDocumentState() {
 }
 
 void HistoryItem::SetStateObject(scoped_refptr<SerializedScriptValue> object) {
+  recordreplay::Assert(
+    "[TT-492-1184] HistoryItem::SetStateObject %s",
+    object->ToWireString().Ascii().c_str()
+  );
   state_object_ = std::move(object);
 }
 

--- a/third_party/blink/renderer/core/loader/history_item.cc
+++ b/third_party/blink/renderer/core/loader/history_item.cc
@@ -136,10 +136,12 @@ void HistoryItem::ClearDocumentState() {
 }
 
 void HistoryItem::SetStateObject(scoped_refptr<SerializedScriptValue> object) {
-  recordreplay::Assert(
-    "[TT-492-1184] HistoryItem::SetStateObject %s",
-    object->ToWireString().Ascii().c_str()
-  );
+  if (object) {
+    recordreplay::Assert(
+      "[TT-492-1184] HistoryItem::SetStateObject %s",
+      object->ToWireString().Ascii().c_str()
+    );
+  }
   state_object_ = std::move(object);
 }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-492/[vercel]-mismatch-in-framehostproxydidcommitsamedocumentnavigation#comment-84a83175
  * NOTE: It looks like linking to a comment just broke (it used to work fine in the past). For reference:
![image](https://github.com/replayio/chromium/assets/282899/e7bfddb3-0554-4b23-b043-65a66d4592b3)
