### PR TITLE
[TT-492] serialize to an array instead of a utf8 string

### DIFF
--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -45,7 +45,7 @@ const {
   REPLAY_CDT_PAUSE_OBJECT_GROUP,
 
   // for testing
-  forTestingSerializeValueToString
+  forTestingSerializeValueToArray
 
 } = __RECORD_REPLAY_ARGUMENTS__;
 
@@ -3277,7 +3277,7 @@ Object.assign(__RECORD_REPLAY__, {
   getFrameArgumentsArray,
   getCurrentEvaluateFrame,
   replayEval,
-  forTestingSerializeValueToString
+  forTestingSerializeValueToArray
 });
 
 /** ###########################################################################

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1579,9 +1579,10 @@ static void LayoutDom(
   }
 }
 
-static void ForTestingSerializeValueToString(
+static void ForTestingSerializeValueToArray(
   const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   CHECK(args.Length() == 1 &&
         "must be called with a single value");
@@ -1592,9 +1593,14 @@ static void ForTestingSerializeValueToString(
     SerializedScriptValue::Serialize(
       isolate, value,
       SerializedScriptValue::SerializeOptions(), ASSERT_NO_EXCEPTION);
-  v8::Local<v8::String> s = ToV8String(isolate, serializedValue->ToWireString().Utf8().c_str());
+  base::span<const uint8_t> data = serializedValue->GetWireData();
 
-  args.GetReturnValue().Set(s);
+  v8::Local<v8::Array> result = v8::Array::New(isolate);
+  for (size_t i = 0; i < data.size(); ++i) {
+    result->Set(context, i, v8::Number::New(isolate, data[i])).Check();
+  }
+
+  args.GetReturnValue().Set(result);
 }
 
 static void fromJsGetArgumentsInFrame(
@@ -2672,8 +2678,8 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
 
   // exported for tests
   SetFunctionProperty(
-    isolate, args, "forTestingSerializeValueToString",
-    ForTestingSerializeValueToString);
+    isolate, args, "forTestingSerializeValueToArray",
+    ForTestingSerializeValueToArray);
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1597,7 +1597,7 @@ static void ForTestingSerializeValueToArray(
 
   v8::Local<v8::Array> result = v8::Array::New(isolate);
   for (size_t i = 0; i < data.size(); ++i) {
-    result->Set(context, i, v8::Number::New(isolate, data[i])).Check();
+    result->Set(context, (uint32_t)i, v8::Number::New(isolate, data[i])).Check();
   }
 
   args.GetReturnValue().Set(result);


### PR DESCRIPTION
The previous version of this (in #1251) generated a utf-8 string that we _could_ test against but the test itself was worthless.  Have it generate an array of the byte values so in the test we can probe around in the data looking for specific bytes.