### PR TITLE
Assert `PageTimingMetricsSender::SendNow` and `CanvasAsyncBlobCreator::CreateBlobAndReturnResult`

### DIFF
--- a/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
+++ b/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
@@ -329,6 +329,12 @@ void PageTimingMetricsSender::SendNow() {
     }
   }
 
+  REPLAY_ASSERT(
+      "[TT-366-1366] PageTimingMetricsSender::SendNow %zu %zu %zu %zu",
+      new_features_.size(), resources.size(),
+      (size_t)modified_resources_.size(),
+      (size_t)page_resource_data_use_.size());
+
   sender_->SendTiming(last_timing_, metadata_, std::move(new_features_),
                       std::move(resources), render_data_, last_cpu_timing_,
                       std::move(input_timing_delta_), mobile_friendliness_,

--- a/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
+++ b/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
@@ -454,6 +454,9 @@ void CanvasAsyncBlobCreator::ForceEncodeRowsOnCurrentThread() {
 void CanvasAsyncBlobCreator::CreateBlobAndReturnResult() {
   RecordIdleTaskStatusHistogram(idle_task_status_);
 
+  REPLAY_ASSERT(
+      "[TT-362-1366] CanvasAsyncBlobCreator::CreateBlobAndReturnResult %u",
+      encoded_image_.size());
   Blob* result_blob = Blob::Create(encoded_image_.data(), encoded_image_.size(),
                                    ImageEncodingMimeTypeName(mime_type_));
   if (function_type_ == kHTMLCanvasToBlobCallback) {


### PR DESCRIPTION
Asserts for two different divergences:
* https://linear.app/replay/issue/TT-366/[vercel]-mismatch-in-pageloadmetricsproxyupdatetiming#comment-704550b1
* https://linear.app/replay/issue/TT-362/[tldraw]-ensureconsistentmessagesize-in-blobregistryproxyregister#comment-096e158e