### PR TITLE
[TT-1422] Disable `cors` checks when `IsInReplayCode`

### DIFF
--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -21,21 +21,29 @@ const {
   RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE,
 } = __RECORD_REPLAY_ARGUMENTS__;
 
-const cache = {};
+const fetchPromiseCache = {};
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Fetching ${url} failed with status code ${response.status} (${response.statusText})`);
+  }
+  return await response.text();
+}
 
 // Provide a cache for urls, salted with the supplied hash.  Practically, this
 // means if the script content changes at the url, we will re-download the resource.
-async function getCachedResource(url, hash) {
+async function fetchTextWithCache(url, hash) {
   const key = `${url}:${hash}`;
-  if (cache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
-    return cache[key];
+  if (fetchPromiseCache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
+    return fetchPromiseCache[key];
   }
 
   log(`fetching sourcemap resource ${key}`);
 
-  const res = await fetchText(url);
-  cache[key] = res;
-  return res;
+  const resPromise = fetchText(url);
+  fetchPromiseCache[key] = resPromise;
+  return resPromise;
 }
 
 addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
@@ -54,13 +62,13 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     return;
 
   const scriptSource = getScriptSource(scriptId);
-  const scriptHash = sha256DigestHex(scriptSource);
+  const generatedScriptHash = sha256DigestHex(scriptSource);
 
   const { sourceMapURL, sourceMapBaseURL } = urls;
 
   let sourceMap;
   try {
-    sourceMap = await getCachedResource(sourceMapURL, scriptHash);
+    sourceMap = await fetchTextWithCache(sourceMapURL, generatedScriptHash);
   } catch (err) {
     log(`[RuntimeError] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
   }
@@ -68,7 +76,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     return;
   }
 
-  const id = scriptHash;
+  const id = generatedScriptHash;
   const name = `sourcemap-${id}.map`;
   const lookupName = `sourcemap-${id}.lookup`;
 
@@ -82,6 +90,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   }
 
   if (!sources) {
+    // Sources did not exist or changed.
     writeToRecordingDirectory(name, sourceMap);
 
     sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
@@ -95,7 +104,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     id,
     url: sourceMapURL,
     baseURL: sourceMapBaseURL,
-    targetContentHash: `sha256:${scriptHash}`,
+    targetContentHash: `sha256:${generatedScriptHash}`,
     targetURLHash: sourceURL ? makeAPIHash(sourceURL) : undefined,
     targetMapURLHash: makeAPIHash(sourceMapURL),
     timestamp: DateNow(),
@@ -104,7 +113,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   for (const { offset, url } of sources) {
     let sourceContent;
     try {
-      sourceContent = await getCachedResource(url, scriptHash);
+      sourceContent = await fetchTextWithCache(url, generatedScriptHash);
     } catch (err) {
       log(`[RuntimeError][sourcemaps] Failed to read original source ${url}: ${err.message}`);
       continue;
@@ -128,14 +137,6 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     warning(`[RuntimeError][sourcemaps] Exception - ${err?.stack || err}`);
   }
 });
-
-async function fetchText(url) {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Fetching ${url} failed with status code ${response.status} (${response.statusText})`);
-  }
-  return await response.text();
-}
 
 function makeAPIHash(content) {
   assert(typeof content === "string");

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -3,7 +3,7 @@
 (() => {
 
 // Avoid monkey patching.
-const fetch = window.fetch;
+const { fetch, URL, Error } = window;
 const DateNow = Date.now;
 
 const {
@@ -36,9 +36,8 @@ async function fetchText(url) {
 async function fetchTextWithCache(url, hash) {
   const key = `${url}:${hash}`;
   if (fetchPromiseCache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
-    // The first caller will finish this.
-    // Tell the second caller not to re-try this.
-    return null;
+    // Return past or on-going work item.
+    return fetchPromiseCache[key];
   }
 
   log(`[sourcemaps] Fetching sourcemap resource ${key}`);
@@ -48,19 +47,7 @@ async function fetchTextWithCache(url, hash) {
   return resPromise;
 }
 
-// let testRan = 0;
-
 addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
-  // if (!testRan) {
-  //   testRan = 1;
-  //   // Test: This fetch should work, independent on where we call it from!
-  //   try {
-  //     const res = await fetchTextWithCache("https://prod-cdn.superblocks.com/static/js/44415.fa3fd847.js.map", "");
-  //     log(`✅ DDBG Test SUCCESS - ${res}`);
-  //   } catch (err) {
-  //     log(`❌ DDBG Test FAILED - ${err.stack}`);
-  //   }
-  // }
   try {
   if (!relativeSourceMapURL || relativeSourceMapURL.startsWith("data:"))
     return;
@@ -87,7 +74,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     log(`[RuntimeError][sourcemaps] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
   }
   if (!sourceMap) {
-    // Download failed or someone is already processing these.
+    // Download failed or nothing there.
     return;
   }
 
@@ -135,7 +122,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
       log(`[RuntimeError][sourcemaps] Failed to read original source ${url}: ${err.message}`);
     }
     if (!sourceContent) {
-      // Download failed or someone is already processing these.
+      // Download failed or nothing there.
       continue;
     }
     const hash = sha256DigestHex(sourceContent);

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -36,7 +36,9 @@ async function fetchText(url) {
 async function fetchTextWithCache(url, hash) {
   const key = `${url}:${hash}`;
   if (fetchPromiseCache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
-    return fetchPromiseCache[key];
+    // The first caller will finish this.
+    // Tell the second caller not to re-try this.
+    return null;
   }
 
   log(`[sourcemaps] Fetching sourcemap resource ${key}`);
@@ -85,6 +87,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     log(`[RuntimeError][sourcemaps] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
   }
   if (!sourceMap) {
+    // Download failed or someone is already processing these.
     return;
   }
 
@@ -102,7 +105,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   }
 
   if (!sources) {
-    // Sources did not exist or changed.
+    // Sources changed or did not exist.
     writeToRecordingDirectory(name, sourceMap);
 
     sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
@@ -130,6 +133,9 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
       sourceContent = await fetchTextWithCache(url, generatedScriptHash);
     } catch (err) {
       log(`[RuntimeError][sourcemaps] Failed to read original source ${url}: ${err.message}`);
+    }
+    if (!sourceContent) {
+      // Download failed or someone is already processing these.
       continue;
     }
     const hash = sha256DigestHex(sourceContent);

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -95,7 +95,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     // Sources changed or did not exist.
     writeToRecordingDirectory(name, sourceMap);
 
-    sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
+    sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL);
     writeToRecordingDirectory(lookupName, JSON.stringify(sources));
   }
 

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -39,14 +39,26 @@ async function fetchTextWithCache(url, hash) {
     return fetchPromiseCache[key];
   }
 
-  log(`fetching sourcemap resource ${key}`);
+  log(`[sourcemaps] Fetching sourcemap resource ${key}`);
 
   const resPromise = fetchText(url);
   fetchPromiseCache[key] = resPromise;
   return resPromise;
 }
 
+// let testRan = 0;
+
 addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
+  // if (!testRan) {
+  //   testRan = 1;
+  //   // Test: This fetch should work, independent on where we call it from!
+  //   try {
+  //     const res = await fetchTextWithCache("https://prod-cdn.superblocks.com/static/js/44415.fa3fd847.js.map", "");
+  //     log(`✅ DDBG Test SUCCESS - ${res}`);
+  //   } catch (err) {
+  //     log(`❌ DDBG Test FAILED - ${err.stack}`);
+  //   }
+  // }
   try {
   if (!relativeSourceMapURL || relativeSourceMapURL.startsWith("data:"))
     return;
@@ -70,7 +82,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   try {
     sourceMap = await fetchTextWithCache(sourceMapURL, generatedScriptHash);
   } catch (err) {
-    log(`[RuntimeError] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
+    log(`[RuntimeError][sourcemaps] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
   }
   if (!sourceMap) {
     return;
@@ -96,6 +108,8 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
     sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
     writeToRecordingDirectory(lookupName, JSON.stringify(sources));
   }
+
+  log(`[sourcemaps] Wrote sourcemap to file. Found ${sources.length} unresolved sources for "${sourceMapURL}". Downloading...`);
 
   addRecordingEvent(JSON.stringify({
     kind: "sourcemapAdded",
@@ -133,6 +147,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
       timestamp: DateNow(),
     }));
   }
+  log(`[sourcemaps] Finished downloading ${sources.length} sources for "${sourceMapURL}".`);
   } catch (err) {
     warning(`[RuntimeError][sourcemaps] Exception - ${err?.stack || err}`);
   }

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -1,0 +1,248 @@
+// Script which sets a handler for collecting source maps from scripts in the
+// recording. Runs when recording/replaying if source map collection is enabled.
+(() => {
+
+// Avoid monkey patching.
+const fetch = window.fetch;
+const DateNow = Date.now;
+
+const {
+  log,
+  warning,
+  getRecordingId,
+  sha256DigestHex,
+  writeToRecordingDirectory,
+  addRecordingEvent,
+  addNewScriptHandler,
+  getScriptSource,
+  recordingDirectoryFileExists,
+  readFromRecordingDirectory,
+  getRecordingFilePath,
+  RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE,
+} = __RECORD_REPLAY_ARGUMENTS__;
+
+const cache = {};
+
+// Provide a cache for urls, salted with the supplied hash.  Practically, this
+// means if the script content changes at the url, we will re-download the resource.
+async function getCachedResource(url, hash) {
+  const key = `${url}:${hash}`;
+  if (cache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
+    return cache[key];
+  }
+
+  log(`fetching sourcemap resource ${key}`);
+
+  const res = await fetchText(url);
+  cache[key] = res;
+  return res;
+}
+
+addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
+  try {
+  if (!relativeSourceMapURL || relativeSourceMapURL.startsWith("data:"))
+    return;
+
+  const recordingId = getRecordingId();
+  if (!recordingId) {
+    // The recording has been invalidated.
+    return;
+  }
+
+  const urls = getSourceMapURLs(sourceURL, relativeSourceMapURL);
+  if (!urls)
+    return;
+
+  const scriptSource = getScriptSource(scriptId);
+  const scriptHash = sha256DigestHex(scriptSource);
+
+  const { sourceMapURL, sourceMapBaseURL } = urls;
+
+  let sourceMap;
+  try {
+    sourceMap = await getCachedResource(sourceMapURL, scriptHash);
+  } catch (err) {
+    log(`[RuntimeError] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
+  }
+  if (!sourceMap) {
+    return;
+  }
+
+  const id = scriptHash;
+  const name = `sourcemap-${id}.map`;
+  const lookupName = `sourcemap-${id}.lookup`;
+
+  let sources;
+  if (recordingDirectoryFileExists(name) && recordingDirectoryFileExists(lookupName)) {
+    try {
+      sources = JSON.parse(readFromRecordingDirectory(lookupName));
+    } catch (err) {
+      log(`[RuntimeError][sourcemaps] Failed to load sourcemaps from file: ${lookupName} - ${err.message}`);
+    }
+  }
+
+  if (!sources) {
+    writeToRecordingDirectory(name, sourceMap);
+
+    sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
+    writeToRecordingDirectory(lookupName, JSON.stringify(sources));
+  }
+
+  addRecordingEvent(JSON.stringify({
+    kind: "sourcemapAdded",
+    path: getRecordingFilePath(name),
+    recordingId,
+    id,
+    url: sourceMapURL,
+    baseURL: sourceMapBaseURL,
+    targetContentHash: `sha256:${scriptHash}`,
+    targetURLHash: sourceURL ? makeAPIHash(sourceURL) : undefined,
+    targetMapURLHash: makeAPIHash(sourceMapURL),
+    timestamp: DateNow(),
+  }));
+
+  for (const { offset, url } of sources) {
+    let sourceContent;
+    try {
+      sourceContent = await getCachedResource(url, scriptHash);
+    } catch (err) {
+      log(`[RuntimeError][sourcemaps] Failed to read original source ${url}: ${err.message}`);
+      continue;
+    }
+    const hash = sha256DigestHex(sourceContent);
+    const name = `source-${hash}`;
+
+    if (!recordingDirectoryFileExists(name)) {
+      writeToRecordingDirectory(name, sourceContent);
+    }
+    addRecordingEvent(JSON.stringify({
+      kind: "originalSourceAdded",
+      path: getRecordingFilePath(name),
+      recordingId,
+      parentId: id,
+      parentOffset: offset,
+      timestamp: DateNow(),
+    }));
+  }
+  } catch (err) {
+    warning(`[RuntimeError][sourcemaps] Exception - ${err?.stack || err}`);
+  }
+});
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Fetching ${url} failed with status code ${response.status} (${response.statusText})`);
+  }
+  return await response.text();
+}
+
+function makeAPIHash(content) {
+  assert(typeof content === "string");
+  const digestHex = sha256DigestHex(content);
+  return "sha256:" + digestHex;
+}
+
+function collectUnresolvedSourceMapResources(mapText, mapURL) {
+  let obj;
+  let sourceOffset = 0;
+
+  function logError(msg) {
+    log(`[RuntimeError][sourcemaps] ${msg} (${mapURL}:${sourceOffset})`);
+  }
+
+  try {
+    obj = JSON.parse(mapText);
+    if (typeof obj !== "object" || !obj) {
+      return [];
+    }
+  } catch (err) {
+    logError(`Exception parsing sourcemap JSON (${mapURL}): ${err?.message || err}`);
+    return [];
+  }
+
+  const unresolvedSources = [];
+  if (obj.version !== 3) {
+    logError("Invalid sourcemap version: " + obj.version);
+    return [];
+  }
+
+  if (obj.sources != null) {
+    const { sourceRoot, sources, sourcesContent } = obj;
+
+    if (Array.isArray(sources)) {
+      for (let i = 0; i < sources.length; i++) {
+        const offset = sourceOffset++;
+
+        if (
+          !Array.isArray(sourcesContent) ||
+          typeof sourcesContent[i] !== "string"
+        ) {
+          let url = sources[i];
+          if (typeof sourceRoot === "string" && sourceRoot) {
+            url = sourceRoot.replace(/\/?/, "/") + url;
+          }
+          let sourceURL;
+          try {
+            sourceURL = new URL(url, mapURL).toString();
+          } catch {
+            logError("Unable to compute original source URL: " + url);
+            continue;
+          }
+
+          unresolvedSources.push({
+            offset,
+            url: sourceURL,
+          });
+        }
+      }
+    } else {
+      logError("Invalid sourcemap sources list");
+    }
+  }
+
+  return unresolvedSources;
+}
+
+function assert(v, msg = "") {
+  if (!v) {
+    const m = `Assertion failed when handling command (${msg})`;
+    log(`[RuntimeError] ${m} - ${Error().stack}`);
+    throw new Error(m);
+  }
+}
+
+function getSourceMapURLs(sourceURL, relativeSourceMapURL) {
+  let sourceBaseURL;
+  if (typeof sourceURL === "string" && isValidBaseURL(sourceURL)) {
+    sourceBaseURL = sourceURL;
+  } else if (window?.location?.href && isValidBaseURL(window?.location?.href)) {
+    sourceBaseURL = window.location.href;
+  }
+
+  let sourceMapURL;
+  try {
+    sourceMapURL = new URL(relativeSourceMapURL, sourceBaseURL).toString();
+  } catch (err) {
+    log("Failed to process sourcemap url: " + err.message);
+    return null;
+  }
+
+  // If the map was a data: URL or something along those lines, we want
+  // to resolve paths in the map relative to the overall base.
+  const sourceMapBaseURL =
+    isValidBaseURL(sourceMapURL) ? sourceMapURL : sourceBaseURL;
+
+  return { sourceMapURL, sourceMapBaseURL };
+}
+
+function isValidBaseURL(url) {
+  try {
+    new URL("", url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+})();

--- a/replay_build_scripts/lint.mjs
+++ b/replay_build_scripts/lint.mjs
@@ -24,7 +24,7 @@ function findMatches(text /*: string*/, regex /*: RegExp*/) {
 function extractNamedScriptBlock(
   text /*: string*/,
   start /*: number*/,
-  end /*: number*/,
+  end /*: number*/
 ) {
   const lines = text.split("\n");
   const name = lines[start].split(" ")[2];
@@ -66,7 +66,10 @@ function calculateStatsPerFile(messages) {
   return stat;
 }
 
-async function lintScript(fpath, { name, text } /*: { name: string, text: string }*/) {
+async function lintScript(
+  fpath,
+  { name, text } /*: { name: string, text: string }*/
+) {
   const messages = linter.verify(text, {
     parserOptions: {
       ecmaVersion: 2023,
@@ -135,22 +138,34 @@ async function lintScript(fpath, { name, text } /*: { name: string, text: string
   return { errorCount, fatalErrorCount, warningCount };
 }
 
+const AssetFiles = [
+  "replay_command_handlers.js",
+  "replay_sourcemap_handler.js",
+];
+
+let totalErrorCount = 0;
+let totalWarningCount = 0;
+
 async function main() {
   await lintFile(
     path.join(
       ROOT_DIR,
-      "third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc",
+      "third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc"
     ),
     /R""""\(/g,
     /\)""""/g
   );
 
-  await lintFile(
-    path.join(
-      ROOT_DIR,
-      "replay-assets/replay_command_handlers.js",
-    )
-  );
+  for (const jsFile of AssetFiles) {
+    await lintFile(path.join(ROOT_DIR, "replay-assets/" + jsFile));
+  }
+
+  const bad = !!totalErrorCount;
+  console.log(`\n${bad ? '❌' : '✅'} Final Result:\n  ${totalErrorCount} errors\n  ${totalWarningCount} warnings`);
+  console.groupEnd();
+  if (bad) {
+    process.exit(1);
+  }
 }
 
 async function lintFile(fpath, startRegex, endRegex) {
@@ -161,15 +176,19 @@ async function lintFile(fpath, startRegex, endRegex) {
     const lineNumbers = findMatches(replayText, startRegex);
     const endLineNumbers = findMatches(replayText, endRegex);
     if (lineNumbers?.length != endLineNumbers?.length) {
-      throw new Error(`Lint failed in ${fpath} - start and end line numbers don't match: ${lineNumbers?.length} != ${endLineNumbers?.length}`);
+      throw new Error(
+        `Lint failed in ${fpath} - start and end line numbers don't match: ${lineNumbers?.length} != ${endLineNumbers?.length}`
+      );
     }
     // console.log("lintFile", lineNumbers?.length, endLineNumbers?.length);
     jsTextBlocks = lineNumbers.map((lineNumber, index) =>
-      extractNamedScriptBlock(replayText, lineNumber, endLineNumbers[index]),
+      extractNamedScriptBlock(replayText, lineNumber, endLineNumbers[index])
     );
 
     if (!jsTextBlocks.length) {
-      throw new Error(`Invalid regexes or file path. Could not find js text block in ${fpath}.`);
+      throw new Error(
+        `Invalid regexes or file path. Could not find js text block in ${fpath}.`
+      );
     }
   } else {
     jsTextBlocks = [{ text: replayText }];
@@ -185,11 +204,10 @@ async function lintFile(fpath, startRegex, endRegex) {
     warningCount += blockWarningCount;
   }
 
-  console.log(`Total counts: ${errorCount} errors, ${warningCount} warnings`);
+  console.log(`Stats: ${errorCount} errors, ${warningCount} warnings`);
+  totalErrorCount += errorCount;
+  totalWarningCount += warningCount;
   console.groupEnd();
-  if (errorCount > 0) {
-    process.exit(1);
-  }
 }
 
 main();

--- a/services/network/cors/cors_url_loader.cc
+++ b/services/network/cors/cors_url_loader.cc
@@ -1021,7 +1021,6 @@ void CorsURLLoader::SetCorsFlagIfNeeded() {
   if (HasSpecialAccessToDestination())
     return;
 
-  // if (request_.url.host() == "prod-cdn.superblocks.com") {
   if (options_ & mojom::kURLLoadOptionReplayRequest) {
     return;
   }

--- a/services/network/cors/cors_url_loader.cc
+++ b/services/network/cors/cors_url_loader.cc
@@ -1021,6 +1021,10 @@ void CorsURLLoader::SetCorsFlagIfNeeded() {
   if (HasSpecialAccessToDestination())
     return;
 
+  // if (request_.url.host() == "prod-cdn.superblocks.com") {
+  if (options_ & mojom::kURLLoadOptionReplayRequest) {
+    return;
+  }
   fetch_cors_flag_ = true;
 }
 

--- a/services/network/public/mojom/url_loader_factory.mojom
+++ b/services/network/public/mojom/url_loader_factory.mojom
@@ -54,6 +54,9 @@ const uint32 kURLLoadOptionAsCorsPreflight = 128;
 // default if the security state is unknown.
 const uint32 kURLLoadOptionBlockLocalRequest = 256;
 
+// [TT-1422] Ignore CORS and other limitations for Replay fetch requests.
+const uint32 kURLLoadOptionReplayRequest = 512;
+
 // URLLoaderFactory is an interface for requesting URLs. It creates URLLoader
 // instances. One URLLoader instance can load one URL.
 interface URLLoaderFactory {

--- a/third_party/blink/common/loader/throttling_url_loader.cc
+++ b/third_party/blink/common/loader/throttling_url_loader.cc
@@ -511,6 +511,11 @@ void ThrottlingURLLoader::Start(
     }
   }
 
+  if (recordreplay::IsInReplayCode()) {
+    // [TT-1422] Special treatment for Replay-only requests.
+    options |= network::mojom::kURLLoadOptionReplayRequest;
+  }
+
   start_info_ = std::make_unique<StartInfo>(factory, request_id, options,
                                             url_request, std::move(task_runner),
                                             std::move(cors_exempt_header_list));

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -13,6 +13,7 @@
 #include "base/base64.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
+#include "base/path_service.h"
 #include "base/process/process_handle.h"
 #include "base/record_replay.h"
 #include "base/record_replay_paint_surface.h"
@@ -176,20 +177,39 @@ typedef std::unordered_map<int, InspectorData*> ContextGroupIdInspectorMap;
 std::unordered_map<v8::Isolate*, ContextGroupIdInspectorMap*>* gInspectorData = nullptr;
 std::unordered_map<v8::Isolate*, v8_inspector::V8Inspector*>* gV8Inspectors = nullptr;
 
-static std::string ReadReplayAssetFileRaw(const char* filename, size_t& len) {
-  const char* scriptDir = getenv("RECORD_REPLAY_ASSETS_DIRECTORY");
-  if (!scriptDir) {
-    recordreplay::Crash("ReadReplayAssetFileRaw failed: RECORD_REPLAY_ASSETS_DIRECTORY not provided");
-  }
+static std::string ReadReplayAssetFile(const char* filename, size_t& len) {
+  base::FilePath binPath;
+  std::string assetsDir;
 
-  std::string fpath = std::string(scriptDir) + std::string("/") + filename;
+  if (getenv("RECORD_REPLAY_ASSETS_DIRECTORY")) {
+    assetsDir = getenv("RECORD_REPLAY_ASSETS_DIRECTORY");
+  } else if (base::PathService::Get(base::FILE_EXE, &binPath)) {
+    // PathService::Get(base::DIR_EXE, result);
+    auto assetRoot = binPath.DirName();
+#if BUILDFLAG(IS_MAC)
+    // NOTE: We have to go up by 9 directories on Mac -
+    // E.g.:
+    // Replay-Chromium.app/Contents/Frameworks/Chromium Framework.framework/Versions/108.0.5359.0/Helpers/Chromium Helper (Renderer).app/Contents/MacOS/replay-assets/replay_sourcemap_handler.js
+    assetRoot = assetRoot.AppendASCII("../../../../../../../../..");
+#endif
+    assetsDir = assetRoot.AppendASCII("replay-assets").AsUTF8Unsafe();
+  }
+  if (!assetsDir.length()) {
+    recordreplay::Crash("ReadReplayAssetFile failed: Neither base::FILE_EXE nor RECORD_REPLAY_ASSETS_DIRECTORY provided.");
+  }
+  std::string fpath = assetsDir + std::string("/") + filename;
   std::ifstream ifs(fpath);
   std::stringstream ss;
   ss << ifs.rdbuf();
   std::string s = ss.str();
   len = s.length();
+  recordreplay::Print("ReadReplayAssetFile from '%s' (%zu)",
+    fpath.c_str(),
+    len);
   if (!len) {
-    recordreplay::Crash("ReadReplayAssetFileRaw failed: %s", fpath.c_str());
+    recordreplay::Crash("ReadReplayAssetFile (\"%s\") failed: %s",
+      fpath.c_str(),
+      strerror(errno));
   }
   return s;
 }
@@ -198,10 +218,21 @@ static String ReadReplayAssetFile(const char* fname) {
   size_t len;
 
   // Important: Treat as UTF-8.
+  String result = String::FromUTF8(ReadReplayAssetFile(fname, len).c_str(), len);
+  if (!len) {
+    recordreplay::Crash("ReadReplayAssetFile failed: %s", fname);
+  }
+  return result;
+}
+
+static String ReadReplayCommandAssetFile(const char* fname) {
+  size_t len;
+
+  // Important: Treat as UTF-8.
   String result = String::FromUTF8(
     IsCommandHandlingEnabledWhenRecording()
       // Recording + Replay.
-      ? ReadReplayAssetFileRaw(fname, len).c_str()
+      ? ReadReplayAssetFile(fname, len).c_str()
       // Replay only.
       : V8RecordReplayReadAssetFileContents(fname, &len),
     len
@@ -212,268 +243,13 @@ static String ReadReplayAssetFile(const char* fname) {
   return result;
 }
 
-// static
-String ReadReplayCommandHandlerScript() {
-  return ReadReplayAssetFile("replay_command_handlers.js");
+static String ReadReplaySourcemapHandlerScript() {
+  return ReadReplayAssetFile("replay_sourcemap_handler.js");
 }
 
-
-/** ###########################################################################
- * gSourceMapScript
- * ##########################################################################*/
-
-// Script which sets a handler for collecting source maps from scripts in the
-// recording. Runs when recording/replaying if source map collection is enabled.
-const char* gSourceMapScript = R""""(
-//js
-(() => {
-
-// Avoid monkey patching.
-const fetch = window.fetch;
-const DateNow = Date.now;
-
-const {
-  log,
-  warning,
-  getRecordingId,
-  sha256DigestHex,
-  writeToRecordingDirectory,
-  addRecordingEvent,
-  addNewScriptHandler,
-  getScriptSource,
-  recordingDirectoryFileExists,
-  readFromRecordingDirectory,
-  getRecordingFilePath,
-  RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE,
-} = __RECORD_REPLAY_ARGUMENTS__;
-
-const cache = {};
-
-// Provide a cache for urls, salted with the supplied hash.  Practically, this
-// means if the script content changes at the url, we will re-download the resource.
-async function getCachedResource(url, hash) {
-  const key = `${url}:${hash}`;
-  if (cache[key] && !RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE) {
-    return cache[key];
-  }
-
-  log(`fetching sourcemap resource ${key}`);
-
-  const res = await fetchText(url);
-  cache[key] = res;
-  return res;
+static String ReadReplayCommandHandlerScript() {
+  return ReadReplayCommandAssetFile("replay_command_handlers.js");
 }
-
-addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
-  try {
-  if (!relativeSourceMapURL || relativeSourceMapURL.startsWith("data:"))
-    return;
-
-  const recordingId = getRecordingId();
-  if (!recordingId) {
-    // The recording has been invalidated.
-    return;
-  }
-
-  const urls = getSourceMapURLs(sourceURL, relativeSourceMapURL);
-  if (!urls)
-    return;
-
-  const scriptSource = getScriptSource(scriptId);
-  const scriptHash = sha256DigestHex(scriptSource);
-
-  const { sourceMapURL, sourceMapBaseURL } = urls;
-
-  let sourceMap;
-  try {
-    sourceMap = await getCachedResource(sourceMapURL, scriptHash);
-  } catch (err) {
-    log(`[RuntimeError] Failed to read sourcemap ${sourceMapURL}: ${err.message}`);
-  }
-  if (!sourceMap) {
-    return;
-  }
-
-  const id = scriptHash;
-  const name = `sourcemap-${id}.map`;
-  const lookupName = `sourcemap-${id}.lookup`;
-
-  let sources;
-  if (recordingDirectoryFileExists(name) && recordingDirectoryFileExists(lookupName)) {
-    try {
-      sources = JSON.parse(readFromRecordingDirectory(lookupName));
-    } catch (err) {
-      log(`[RuntimeError][sourcemaps] Failed to load sourcemaps from file: ${lookupName} - ${err.message}`);
-    }
-  }
-
-  if (!sources) {
-    writeToRecordingDirectory(name, sourceMap);
-
-    sources = collectUnresolvedSourceMapResources(sourceMap, sourceMapURL, sourceURL);
-    writeToRecordingDirectory(lookupName, JSON.stringify(sources));
-  }
-
-  addRecordingEvent(JSON.stringify({
-    kind: "sourcemapAdded",
-    path: getRecordingFilePath(name),
-    recordingId,
-    id,
-    url: sourceMapURL,
-    baseURL: sourceMapBaseURL,
-    targetContentHash: `sha256:${scriptHash}`,
-    targetURLHash: sourceURL ? makeAPIHash(sourceURL) : undefined,
-    targetMapURLHash: makeAPIHash(sourceMapURL),
-    timestamp: DateNow(),
-  }));
-
-  for (const { offset, url } of sources) {
-    let sourceContent;
-    try {
-      sourceContent = await getCachedResource(url, scriptHash);
-    } catch (err) {
-      log(`[RuntimeError][sourcemaps] Failed to read original source ${url}: ${err.message}`);
-      continue;
-    }
-    const hash = sha256DigestHex(sourceContent);
-    const name = `source-${hash}`;
-
-    if (!recordingDirectoryFileExists(name)) {
-      writeToRecordingDirectory(name, sourceContent);
-    }
-    addRecordingEvent(JSON.stringify({
-      kind: "originalSourceAdded",
-      path: getRecordingFilePath(name),
-      recordingId,
-      parentId: id,
-      parentOffset: offset,
-      timestamp: DateNow(),
-    }));
-  }
-  } catch (err) {
-    warning(`[RuntimeError][sourcemaps] Exception - ${err?.stack || err}`);
-  }
-});
-
-async function fetchText(url) {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Fetching ${url} failed with status code ${response.status} (${response.statusText})`);
-  }
-  return await response.text();
-}
-
-function makeAPIHash(content) {
-  assert(typeof content === "string");
-  const digestHex = sha256DigestHex(content);
-  return "sha256:" + digestHex;
-}
-
-function collectUnresolvedSourceMapResources(mapText, mapURL) {
-  let obj;
-  let sourceOffset = 0;
-
-  function logError(msg) {
-    log(`[RuntimeError][sourcemaps] ${msg} (${mapURL}:${sourceOffset})`);
-  }
-
-  try {
-    obj = JSON.parse(mapText);
-    if (typeof obj !== "object" || !obj) {
-      return [];
-    }
-  } catch (err) {
-    logError(`Exception parsing sourcemap JSON (${mapURL}): ${err?.message || err}`);
-    return [];
-  }
-
-  const unresolvedSources = [];
-  if (obj.version !== 3) {
-    logError("Invalid sourcemap version: " + obj.version);
-    return [];
-  }
-
-  if (obj.sources != null) {
-    const { sourceRoot, sources, sourcesContent } = obj;
-
-    if (Array.isArray(sources)) {
-      for (let i = 0; i < sources.length; i++) {
-        const offset = sourceOffset++;
-
-        if (
-          !Array.isArray(sourcesContent) ||
-          typeof sourcesContent[i] !== "string"
-        ) {
-          let url = sources[i];
-          if (typeof sourceRoot === "string" && sourceRoot) {
-            url = sourceRoot.replace(/\/?/, "/") + url;
-          }
-          let sourceURL;
-          try {
-            sourceURL = new URL(url, mapURL).toString();
-          } catch {
-            logError("Unable to compute original source URL: " + url);
-            continue;
-          }
-
-          unresolvedSources.push({
-            offset,
-            url: sourceURL,
-          });
-        }
-      }
-    } else {
-      logError("Invalid sourcemap sources list");
-    }
-  }
-
-  return unresolvedSources;
-}
-
-function assert(v, msg = "") {
-  if (!v) {
-    const m = `Assertion failed when handling command (${msg})`;
-    log(`[RuntimeError] ${m} - ${Error().stack}`);
-    throw new Error(m);
-  }
-}
-
-function getSourceMapURLs(sourceURL, relativeSourceMapURL) {
-  let sourceBaseURL;
-  if (typeof sourceURL === "string" && isValidBaseURL(sourceURL)) {
-    sourceBaseURL = sourceURL;
-  } else if (window?.location?.href && isValidBaseURL(window?.location?.href)) {
-    sourceBaseURL = window.location.href;
-  }
-
-  let sourceMapURL;
-  try {
-    sourceMapURL = new URL(relativeSourceMapURL, sourceBaseURL).toString();
-  } catch (err) {
-    log("Failed to process sourcemap url: " + err.message);
-    return null;
-  }
-
-  // If the map was a data: URL or something along those lines, we want
-  // to resolve paths in the map relative to the overall base.
-  const sourceMapBaseURL =
-    isValidBaseURL(sourceMapURL) ? sourceMapURL : sourceBaseURL;
-
-  return { sourceMapURL, sourceMapBaseURL };
-}
-
-function isValidBaseURL(url) {
-  try {
-    new URL("", url);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-})();
-
-)"""";
 
 // Script that injects React DevTools "stub" functions to capture
 // marker annotations while recording, for use in later processing
@@ -937,8 +713,7 @@ static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& arg
 }
 
 static void SendMessageToFrontend(const v8_inspector::StringView& message) {
-  recordreplay::AutoDisallowEvents disallow(
-      "RecordReplay_SendMessageToFrontend");
+  recordreplay::AutoDisallowEvents disallow("RecordReplay_SendMessageToFrontend");
   CHECK(v8::IsMainThread());
 
   CHECK(gCDPMessageCallback);
@@ -2719,7 +2494,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
     recordreplay::AutoMarkReplayCode amrc;
-    RunScript(isolate, context, gSourceMapScript, InternalScriptURL);
+    RunScript(isolate, context, ReadReplaySourcemapHandlerScript().Utf8().c_str(), InternalScriptURL);
   }
 
   if (recordreplay::FeatureEnabled("force-main-world-initialization")) {

--- a/third_party/blink/renderer/core/fetch/fetch_manager.cc
+++ b/third_party/blink/renderer/core/fetch/fetch_manager.cc
@@ -578,6 +578,12 @@ void FetchManager::Loader::Start() {
   }
 
   const KURL& url = fetch_request_data_->Url();
+
+  if (recordreplay::IsInReplayCode()) {
+    // [TT-1422] Always allow |fetch| from Replay code.
+    PerformSchemeFetch();
+    return;
+  }
   // "- |request|'s url's origin is same origin with |request|'s origin,
   //    |request|'s tainted origin flag is unset, and the CORS flag is unset"
   // Note tainted origin flag is always unset here.


### PR DESCRIPTION
* Sneaky changes:
  * Move from my halted TT-1112 PR: Move `replay_sourcemap_handler` to its own file, to avoid conflicts.
  * Improve sourcemap fetching optimization: Also cache the promises, not just the results.
* https://linear.app/replay/issue/TT-1422/superblocks-is-missing-sourcemaps#comment-bec15afa
* NOTE: Best to read this PR patch-by-patch:
  * [Move sourcemap script to its own file](https://github.com/replayio/chromium/pull/1276/commits/ea015252bac41032ec14a00afa4174403a9fd165)
  * [The rest](https://github.com/replayio/chromium/pull/1276/files/ea015252bac41032ec14a00afa4174403a9fd165..1784ebb1440fe94cc2bab5f7a45b81e52e8e72bd):
    * Improved sourcemap fetching.
    * The core of this patch: Disable `cors` checks when `IsInReplayCode.