### PR TITLE
[TT-1252] Fix mismatches in DiscardableMemoryImpl::Purge (Part 2)

### DIFF
--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -1388,13 +1388,14 @@ void RenderThreadImpl::SetIsCrossOriginIsolated(bool value) {
   blink::SetIsCrossOriginIsolated(value);
 }
 
-extern "C" void V8RecordReplayBrowserEvent(const char* name, const char* payload);
+extern "C" void V8RecordReplayBrowserEvent(const char* name,
+                                           const char* payload);
 
-void RenderThreadImpl::RecordReplayBrowserEvent(
-    const std::string& name,
-    base::Value::Dict value) {
+void RenderThreadImpl::RecordReplayBrowserEvent(const std::string& name,
+                                                base::Value::Dict value) {
   // Do nothing if not in record/replay mode.
-  if (!recordreplay::IsRecordingOrReplaying("browser-event") || !v8::IsMainThread()) {
+  if (!recordreplay::IsRecordingOrReplaying("browser-event") ||
+      !v8::IsMainThread()) {
     return;
   }
 
@@ -1724,6 +1725,12 @@ void RenderThreadImpl::OnRendererForegrounded() {
 
 void RenderThreadImpl::ReleaseFreeMemory() {
   TRACE_EVENT0("blink", "RenderThreadImpl::ReleaseFreeMemory()");
+
+  if (recordreplay::AreEventsDisallowed() &&
+      recordreplay::FeatureEnabled("leak-references", "ReleaseFreeMemory")) {
+    return;
+  }
+
   base::allocator::ReleaseFreeMemory();
   discardable_memory_allocator_->ReleaseFreeMemory();
 

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -270,7 +270,8 @@ MojoTimeTicks Core::GetTimeTicksNow() {
 MojoResult Core::Close(MojoHandle handle) {
   // Refuse to close handles at non-deterministic points, as this requires a lot
   // of interaction with other mojo components.
-  if (recordreplay::AreEventsDisallowed("Core::Close")) {
+  if (recordreplay::AreEventsDisallowed() &&
+      recordreplay::FeatureEnabled("leak-references", "Core::Close")) {
     return MOJO_RESULT_OK;
   }
 

--- a/mojo/core/ports/node.cc
+++ b/mojo/core/ports/node.cc
@@ -277,7 +277,8 @@ int Node::ClosePort(const PortRef& port_ref) {
   // The set of ports on a node should be the same when recording vs. replaying,
   // so we refuse to close ports when events are disallowed and the calling
   // code runs at non-deterministic points. This will cause ports to leak.
-  if (recordreplay::AreEventsDisallowed("Node::ClosePort")) {
+  if (recordreplay::AreEventsDisallowed() &&
+      recordreplay::FeatureEnabled("leak-references", "Node::ClosePort")) {
     return OK;
   }
   std::vector<std::unique_ptr<UserMessageEvent>> undelivered_messages;

--- a/mojo/public/cpp/bindings/shared_remote.h
+++ b/mojo/public/cpp/bindings/shared_remote.h
@@ -186,7 +186,8 @@ class SharedRemoteBase
       if (!task_runner_->RunsTasksInCurrentSequence()) {
         // Sequenced task runners don't support posting tasks at non-deterministic
         // points when recording/replaying, so leak the remote instead.
-        if (recordreplay::AreEventsDisallowed("RemoteWrapper::DeleteOnCorrectThread")) {
+        if (recordreplay::AreEventsDisallowed() &&
+            recordreplay::FeatureEnabled("leak-references", "RemoteWrapper::DeleteOnCorrectThread")) {
           return;
         }
 


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-1252/[ebaystridehealthfirst]-mismatch-in-discardablememoryimplpurge-part-2#comment-a932733c
* Sneaky: Fix some "leak labels" and a little bit of indentation.