### PR TITLE
build: don't use 'latest' driver build when checking for metadata in upload step

### DIFF
--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -618,7 +618,7 @@ function computeBuildId(
     const driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
 
     const driverArchive = `${currentPlatform()}-recordreplay.tgz`;
-    const driverRevision = driverRevisionIsSet
+    driverRevision = driverRevisionIsSet
       ? driverRevision
       : fs.readFileSync("REPLAY_BACKEND_REV", "utf8");
     // NOTE(dmiller): we seem to always download the x86 driver here but that's OK because we're just using

--- a/replay_build_scripts/upload_build_artifacts.mjs
+++ b/replay_build_scripts/upload_build_artifacts.mjs
@@ -618,10 +618,12 @@ function computeBuildId(
     const driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
 
     const driverArchive = `${currentPlatform()}-recordreplay.tgz`;
-    let downloadArchive = driverArchive;
-    if (driverRevisionIsSet) {
-      downloadArchive = `${currentPlatform()}-recordreplay-${driverRevision}.tgz`;
-    }
+    const driverRevision = driverRevisionIsSet
+      ? driverRevision
+      : fs.readFileSync("REPLAY_BACKEND_REV", "utf8");
+    // NOTE(dmiller): we seem to always download the x86 driver here but that's OK because we're just using
+    // the archive to check the date and revision in the metadata JSON file.
+    const downloadArchive = `${currentPlatform()}-recordreplay-${driverRevision.trim().substring(0, 12)}.tgz`;
     spawnChecked(
       "curl",
       [


### PR DESCRIPTION
Fixes TT-1447