### PR TITLE
Update DEPS for disabling missing execution warning

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0118fe6ebde7b73db902d87845cb8f5bf9e2cf10',
+  'v8_revision': '20ec58f35eca48a22d2fe25009f73a58acb76a64',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
Goes with https://github.com/replayio/chromium-v8/pull/259