### PR TITLE
Have Mac ARM tests also depend on the Mac x86 build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -209,6 +209,7 @@ steps:
     build:
       commit: "${REPLAY_BACKEND_REV}"
     depends_on:
+      - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
 
   - label: "📝 Live Tests"
@@ -236,6 +237,7 @@ steps:
   - label: "📝 E2E Tests (macos-arm64)"
     trigger: "runtime-fe-end-to-end-tests"
     depends_on:
+      - "build-chromium-mac-x86_64"
       - "build-chromium-mac-arm64"
     build:
       env:


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-1486/runtime-macos-tests-on-arm-fail-if-x86-build-hasnt-finished-on-time#comment-8c60acb1