### PR TITLE
[TT-1155] Don't allow reordering of `Performance.now`

### DIFF
--- a/third_party/blink/renderer/core/timing/performance.idl
+++ b/third_party/blink/renderer/core/timing/performance.idl
@@ -35,7 +35,7 @@
 // should have a default value.
 [Exposed=(Window,Worker)]
 interface Performance : EventTarget {
-    [Affects=Nothing] DOMHighResTimeStamp now();
+    DOMHighResTimeStamp now();
     readonly attribute DOMHighResTimeStamp timeOrigin;
 
     // Performance Timeline


### PR DESCRIPTION
* https://linear.app/replay/issue/TT-1155/[wandb]-mismatch-in-performancenow#comment-ca5a530f