### PR TITLE
Remove some old asserts that I was working on before the pivot

### DIFF
--- a/components/page_load_metrics/renderer/metrics_render_frame_observer.cc
+++ b/components/page_load_metrics/renderer/metrics_render_frame_observer.cc
@@ -60,7 +60,6 @@ class MojoPageTimingSender : public PageTimingSender {
       const absl::optional<blink::MobileFriendliness>& mobile_friendliness,
       uint32_t soft_navigation_count) override {
     DCHECK(page_load_metrics_);
-    mojo::internal::AutoRecordReplayAssertBufferAllocations assertsEnabled("TT-366-1124");
     page_load_metrics_->UpdateTiming(
         limited_sending_mode_ ? CreatePageLoadTiming() : timing->Clone(),
         metadata->Clone(), new_features, std::move(resources),

--- a/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
+++ b/components/page_load_metrics/renderer/page_timing_metrics_sender.cc
@@ -329,12 +329,6 @@ void PageTimingMetricsSender::SendNow() {
     }
   }
 
-  REPLAY_ASSERT(
-      "[TT-366-1366] PageTimingMetricsSender::SendNow %zu %zu %zu %zu",
-      new_features_.size(), resources.size(),
-      (size_t)modified_resources_.size(),
-      (size_t)page_resource_data_use_.size());
-
   sender_->SendTiming(last_timing_, metadata_, std::move(new_features_),
                       std::move(resources), render_data_, last_cpu_timing_,
                       std::move(input_timing_delta_), mobile_friendliness_,

--- a/third_party/blink/common/use_counter/use_counter_feature_tracker.cc
+++ b/third_party/blink/common/use_counter/use_counter_feature_tracker.cc
@@ -35,10 +35,6 @@ bool UseCounterFeatureTracker::Test(const UseCounterFeature& feature) const {
 
 bool UseCounterFeatureTracker::TestAndSet(const UseCounterFeature& feature) {
   bool has_record = Test(feature);
-  REPLAY_ASSERT("[TT-366-1456] UseCounterFeatureTracker::TestAndSet %d %d %u",
-                has_record,
-                feature.type(),
-                feature.value());
   Set(feature, true);
   return has_record;
 }

--- a/third_party/blink/renderer/core/css/parser/css_parser_context.cc
+++ b/third_party/blink/renderer/core/css/parser/css_parser_context.cc
@@ -229,9 +229,6 @@ KURL CSSParserContext::CompleteURL(const String& url) const {
 }
 
 void CSSParserContext::Count(WebFeature feature) const {
-  REPLAY_ASSERT("[TT-366-1467] CSSParserContext::Count feat %d %d",
-                IsUseCounterRecordingEnabled(),
-                feature);
   if (IsUseCounterRecordingEnabled())
     document_->CountUse(feature);
 }
@@ -242,10 +239,6 @@ void CSSParserContext::CountDeprecation(WebFeature feature) const {
 }
 
 void CSSParserContext::Count(CSSParserMode mode, CSSPropertyID property) const {
-  REPLAY_ASSERT("[TT-366-1467] CSSParserContext::Count prop %d %d %d",
-                IsUseCounterRecordingEnabled(),
-                (int)mode,
-                property);
   if (IsUseCounterRecordingEnabled() && IsUseCounterEnabledForMode(mode)) {
     document_->CountProperty(property);
   }

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -8749,9 +8749,6 @@ void Document::CountUse(mojom::WebFeature feature) const {
 }
 
 void Document::CountUse(mojom::WebFeature feature) {
-  REPLAY_ASSERT("[TT-366-1467] Document::CountUse %d %d",
-                !!execution_context_,
-                feature);
   if (execution_context_)
     execution_context_->CountUse(feature);
 }
@@ -8762,9 +8759,6 @@ void Document::CountDeprecation(mojom::WebFeature feature) {
 }
 
 void Document::CountProperty(CSSPropertyID property) const {
-  REPLAY_ASSERT("[TT-366-1467] Document::CountProperty %d %d",
-                !!Loader(),
-                property);
   if (DocumentLoader* loader = Loader()) {
     loader->GetUseCounter().Count(
         property, UseCounterImpl::CSSPropertyType::kDefault, GetFrame());

--- a/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -725,9 +725,6 @@ void LocalDOMWindow::AddInspectorIssue(AuditsIssue issue) {
 }
 
 void LocalDOMWindow::CountUse(mojom::WebFeature feature) {
-  REPLAY_ASSERT("[TT-366-1467] LocalDOMWindow::CountUse %d %d",
-                !!GetFrame(),
-                GetFrame() ? !!GetFrame()->Loader().GetDocumentLoader() : -1);
   if (!GetFrame())
     return;
   if (auto* loader = GetFrame()->Loader().GetDocumentLoader())

--- a/third_party/blink/renderer/core/frame/use_counter_impl.cc
+++ b/third_party/blink/renderer/core/frame/use_counter_impl.cc
@@ -179,12 +179,6 @@ void UseCounterImpl::Count(const UseCounterFeature& feature,
   if (recordreplay::AreEventsDisallowed("UseCounterImpl::Count"))
     return;
 
-  REPLAY_ASSERT("[TT-366-1467] UseCounterImpl::Count %d %u %d %d",
-                !!source_frame,
-                mute_count_,
-                feature.type(),
-                feature.value());
-
   if (!source_frame)
     return;
 


### PR DESCRIPTION
Removing old noisy asserts I needed for (IIRC) 2 sets of divergences:
1. CSS divergences ((dis-)continued in https://github.com/replayio/chromium/pull/1291)
2. V8 serialization (mostly fixed?)