### PR TITLE
DEPS (v8) + use replayed `new_source_id`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '162524a08eaf17312612bc6cbc7f10b585d4fb82',
+  'v8_revision': '033376220f91d1f9b541288e4a930509c2d5b8bb',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '3767b81c4ffedbe5f14bf4dcf8269af508e6227e',
+  'v8_revision': '162524a08eaf17312612bc6cbc7f10b585d4fb82',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '5e69d807b5e54f89546486c81eedc0ae35d6c819',
+  'v8_revision': '3767b81c4ffedbe5f14bf4dcf8269af508e6227e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -414,7 +414,7 @@ void ChromeClientImpl::AddMessageToConsole(LocalFrame* local_frame,
     mojo::internal::AutoRecordReplayAssertBufferAllocations rraba(
         "RUN-2650-2651");
     local_frame->GetLocalFrameHostRemote().DidAddMessageToConsole(
-        level, message, static_cast<int32_t>(line_number), source_id,
+        level, message, static_cast<int32_t>(line_number), new_source_id,
         new_stack_trace);
   }
 

--- a/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -413,6 +413,9 @@ void ChromeClientImpl::AddMessageToConsole(LocalFrame* local_frame,
   if (!message.IsNull()) {
     mojo::internal::AutoRecordReplayAssertBufferAllocations rraba(
         "RUN-2650-2651");
+    recordreplay::Assert(
+        "[PRO-1150] ChromeClientImpl::AddMessageToConsole message %s",
+        message.Utf8().c_str());
     local_frame->GetLocalFrameHostRemote().DidAddMessageToConsole(
         level, message, static_cast<int32_t>(line_number), new_source_id,
         new_stack_trace);

--- a/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -411,8 +411,6 @@ void ChromeClientImpl::AddMessageToConsole(LocalFrame* local_frame,
       String::FromUTF8(&stack_trace_str[0], stack_trace_str.length());
 
   if (!message.IsNull()) {
-    mojo::internal::AutoRecordReplayAssertBufferAllocations rraba(
-        "RUN-2650-2651");
     recordreplay::Assert(
         "[PRO-1150] ChromeClientImpl::AddMessageToConsole message %s",
         message.Utf8().c_str());


### PR DESCRIPTION
https://linear.app/replay/issue/PRO-1150/analysis-fatal-errors-causing-many-chats-to-fail
pairs with https://github.com/replayio/chromium-v8/pull/272 and https://github.com/replayio/chromium-v8/pull/270