### PR TITLE
Introduce eternalized state object for aggregating instrumentation data and a hook to register root frame scripts

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2620,7 +2620,13 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
         nullptr, localFrame->GetDocument()->Url().GetString().Utf8().c_str());
   }
 
-  // 2. Initialize React and Redux Devtools stubs.
+  // 2. Initialize registered root frame scripts
+  for (const auto& script : GetRegisteredRootFrameScripts()) {
+    recordreplay::AutoDisallowEvents disallow("RunRegisteredRootFrameScripts");
+    RunScript(isolate, context, script.c_str(), kInternalScriptURL);
+  }
+
+  // 3. Initialize React and Redux Devtools stubs.
   if (recordreplay::FeatureEnabled("react-devtools-backend") &&
       !TestEnv("RECORD_REPLAY_DISABLE_REACT_DEVTOOLS")) {
     // Note: We use a special URL for the react devtools as this script needs
@@ -2628,11 +2634,6 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
     // its frames.
     RunScript(isolate, context, gReactDevtoolsScript, "record-replay-react-devtools");
     RunScript(isolate, context, gReduxDevtoolsScript, "record-replay-redux-devtools");
-  }
-
-  for (const auto& script : GetRegisteredRootFrameScripts()) {
-    recordreplay::AutoDisallowEvents disallow("RunRegisteredRootFrameScripts");
-    blink::RunScript(isolate, context, script.c_str(), kInternalScriptURL);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -875,7 +875,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
 
-  recordreplay::AutoDisallowEvents disallow("SendCDPMessage");;
+  recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();
   absl::optional<int> contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
@@ -2631,6 +2631,7 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
   }
 
   for (const auto& script : GetRegisteredRootFrameScripts()) {
+    recordreplay::AutoDisallowEvents disallow("RunRegisteredRootFrameScripts");
     blink::RunScript(isolate, context, script.c_str(), kInternalScriptURL);
   }
 }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2368,24 +2368,8 @@ static void fromJsRegisterRootFrameScript(
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
 
-  v8::Isolate* isolate = args.GetIsolate();
-
-  auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
-
-  if (!contextGroupId.has_value()) {
-    recordreplay::Warning(
-        "fromJsRegisterRootFrameScript - no valid context id");
-    args.GetReturnValue().Set(v8::Boolean::New(isolate, false));
-    return;
-  }
-
-  auto context = isolate->GetCurrentContext();
-
   v8::String::Utf8Value script(args.GetIsolate(), args[0]);
-  RunScript(isolate, context, *script, kInternalScriptURL);
-
   GetRegisteredRootFrameScripts().emplace_back(*script);
-  args.GetReturnValue().Set(v8::Boolean::New(isolate, true));
 }
 
 static bool TestEnv(const char* env) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -47,6 +47,7 @@
 #include <array>
 #include <fstream>
 #include <string>
+#include <vector>
 #include "crypto/secure_hash.h"
 #include "crypto/sha2.h"
 
@@ -622,6 +623,7 @@ const char* gOnNewWindowScript = R""""(
   //      __RECORD_REPLAY__?
   window.__RECORD_REPLAY__ = window.top.__RECORD_REPLAY__;
   window.__RECORD_REPLAY_ARGUMENTS__ = window.top.__RECORD_REPLAY_ARGUMENTS__;
+  window.__RECORD_REPLAY_ETERNAL_STATE__ = window.top.__RECORD_REPLAY_ETERNAL_STATE__;
 })()
 )"""";
 
@@ -889,9 +891,6 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
       // Construct our error result.
       std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
       error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
-      if (auto* method = messageDict->FindString("method")) {
-        error->SetStringKey("method", *method);
-      }
       error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
 
       base::DictionaryValue result;
@@ -1044,6 +1043,33 @@ static void fromJsCheckPersistentId(const v8::FunctionCallbackInfo<v8::Value>& a
                                                  args.GetIsolate()->GetCurrentContext(),
                                                  args[0]);
   }
+}
+
+static std::vector<std::string> gRegisteredRootFrameScripts;
+
+static void fromJsRegisterRootFrameScript(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "must be called with a single string");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
+
+  if (!contextGroupId.has_value()) {
+    recordreplay::Warning(
+        "fromJsRegisterRootFrameScript - no valid context id");
+    args.GetReturnValue().Set(v8::Boolean::New(isolate, false));
+    return;
+  }
+
+  auto context = isolate->GetCurrentContext();
+
+  v8::String::Utf8Value script(args.GetIsolate(), args[0]);
+  RunScript(isolate, context, *script, InternalScriptURL);
+
+  gRootFrameScripts.emplace_back(*script);
+  args.GetReturnValue().Set(v8::Boolean::New(isolate, true));
 }
 
 static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -2360,8 +2386,7 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
-static v8::Eternal<v8::Object>* gRecordReplayObj;
-static v8::Eternal<v8::Object>* gRecordReplayArgsObj;
+static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
 static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -2370,131 +2395,132 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  if (gRecordReplayObj == nullptr) {
-    gRecordReplayObj =
+  v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
+
+  v8::Local<v8::Object> args = v8::Object::New(isolate);
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
+                 args);
+
+  DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
+                 ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
+
+  DefineProperty(
+      isolate, args, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
+      v8::Boolean::New(isolate,
+                       TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE")));
+
+  DefineProperty(isolate, args, "CDPERROR_MISSINGCONTEXT",
+                 v8::Number::New(isolate, (double)CDPERROR_MISSINGCONTEXT));
+
+  DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
+                 v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
+
+  SetFunctionProperty(isolate, args, "log", LogCallback);
+  SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
+  SetFunctionProperty(isolate, args, "warning", LogWarningCallback);
+
+  // CDP debugger functionality
+  SetFunctionProperty(isolate, args, "fromJsIsReplayScriptAlive",
+                      fromJsIsReplayScriptAlive);
+  SetFunctionProperty(isolate, args, "hasDiverged",
+                      fromJsHasDiverged);
+  SetFunctionProperty(isolate, args, "setCDPMessageCallback",
+                      SetCDPMessageCallback);
+  SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
+  SetFunctionProperty(isolate, args, "setCommandCallback",
+                      v8::FunctionCallbackRecordReplaySetCommandCallback);
+
+  SetFunctionProperty(isolate, args, "layoutDom", LayoutDom);
+
+  // Object Util
+  SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
+                      fromJsMakeDebuggeeValue);
+  SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
+                      fromJsGetArgumentsInFrame);
+  SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
+                      fromJsGetObjectByCdpId);
+  SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
+                      fromJsIsBlinkObject);
+  SetFunctionProperty(isolate, args, "fromJsHasReturnValue",
+                      fromJsHasReturnValue);
+  SetFunctionProperty(isolate, args, "fromJsGetReturnValue",
+                      fromJsGetReturnValue);
+
+  // networking
+  SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
+                      GetCurrentNetworkRequestEvent);
+  SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
+                      GetCurrentNetworkStreamData);
+
+  // DOM, blink, API stuff
+  // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
+  //                     jsGetObjectIdForAnyObject);
+  // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
+  // jsPreviewBlinkObjectForObjectId);
+  SetFunctionProperty(isolate, args, "fromJsGetNodeIdByCpdId", fromJsGetNodeIdByCpdId);
+  SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
+  SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForElement",
+                      fromJsGetMatchedStylesForElement);
+  SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
+                      fromJsCssGetStylesheetByCpdId);
+  SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
+                      fromJsCollectEventListeners);
+  SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
+                      fromJsDomPerformSearch);
+  SetFunctionProperty(isolate, args, "getFunctionBytecode",
+                      fromJsGetFunctionBytecode);
+
+  // Replay meta.
+  DefineProperty(isolate, args, "IsReplaying",
+                 v8::Boolean::New(isolate, recordreplay::IsReplaying()));
+  SetFunctionProperty(isolate, args, "beginReplayCode",
+                      fromJsBeginReplayCode);
+  SetFunctionProperty(isolate, args, "endReplayCode",
+                      fromJsEndReplayCode);
+
+  // Graphics.
+  SetFunctionProperty(isolate, args, "getCurrentViewportPixelSize",
+                      fromJsGetCurrentViewportPixelSize);
+
+  // unsorted Replay stuff
+  SetFunctionProperty(
+      isolate, args, "setClearPauseDataCallback",
+      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+  SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
+  SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
+  SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
+  SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
+                      WriteToRecordingDirectory);
+  SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
+  SetFunctionProperty(isolate, args, "addNewScriptHandler",
+                      v8::FunctionCallbackRecordReplayAddNewScriptHandler);
+  SetFunctionProperty(isolate, args, "getScriptSource",
+                      v8::FunctionCallbackRecordReplayGetScriptSource);
+
+  SetFunctionProperty(isolate, args, "recordingDirectoryFileExists",
+                      RecordingDirectoryFileExists);
+  SetFunctionProperty(isolate, args, "readFromRecordingDirectory",
+                      ReadFromRecordingDirectory);
+  SetFunctionProperty(isolate, args, "getRecordingFilePath",
+                      GetRecordingFilePath);
+  SetFunctionProperty(isolate, args, "getPersistentId", fromJsGetPersistentId);
+  SetFunctionProperty(isolate, args, "checkPersistentId", fromJsCheckPersistentId);
+  SetFunctionProperty(isolate, args, "getProgressCounter", fromJsGetProgressCounter);
+  SetFunctionProperty(isolate, args, "registerRootFrameScript",
+                      fromJsRegisterRootFrameScript);
+
+  // exported for tests
+  SetFunctionProperty(
+    isolate, args, "forTestingSerializeValueToArray",
+    ForTestingSerializeValueToArray);
+
+  if (gRecordReplayEternalState == nullptr) {
+    gRecordReplayEternalState =
         new v8::Eternal<v8::Object>(isolate, v8::Object::New(isolate));
   }
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
-                 gRecordReplayObj->Get(isolate));
-
-  if (gRecordReplayArgsObj == nullptr) {
-    v8::Local<v8::Object> args = v8::Object::New(isolate);
-    gRecordReplayArgsObj = new v8::Eternal<v8::Object>(isolate, args);
-
-    DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
-                   ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
-
-    DefineProperty(
-        isolate, args, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
-        v8::Boolean::New(isolate,
-                         TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE")));
-
-    DefineProperty(isolate, args, "CDPERROR_MISSINGCONTEXT",
-                   v8::Number::New(isolate, (double)CDPERROR_MISSINGCONTEXT));
-
-    DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
-                   v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
-
-    SetFunctionProperty(isolate, args, "log", LogCallback);
-    SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
-    SetFunctionProperty(isolate, args, "warning", LogWarningCallback);
-
-    // CDP debugger functionality
-    SetFunctionProperty(isolate, args, "fromJsIsReplayScriptAlive",
-                        fromJsIsReplayScriptAlive);
-    SetFunctionProperty(isolate, args, "hasDiverged", fromJsHasDiverged);
-    SetFunctionProperty(isolate, args, "setCDPMessageCallback",
-                        SetCDPMessageCallback);
-    SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
-    SetFunctionProperty(isolate, args, "setCommandCallback",
-                        v8::FunctionCallbackRecordReplaySetCommandCallback);
-
-    SetFunctionProperty(isolate, args, "layoutDom", LayoutDom);
-
-    // Object Util
-    SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
-                        fromJsMakeDebuggeeValue);
-    SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
-                        fromJsGetArgumentsInFrame);
-    SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
-                        fromJsGetObjectByCdpId);
-    SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
-                        fromJsIsBlinkObject);
-    SetFunctionProperty(isolate, args, "fromJsHasReturnValue",
-                        fromJsHasReturnValue);
-    SetFunctionProperty(isolate, args, "fromJsGetReturnValue",
-                        fromJsGetReturnValue);
-
-    // networking
-    SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
-                        GetCurrentNetworkRequestEvent);
-    SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
-                        GetCurrentNetworkStreamData);
-
-    // DOM, blink, API stuff
-    // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
-    //                     jsGetObjectIdForAnyObject);
-    // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
-    // jsPreviewBlinkObjectForObjectId);
-    SetFunctionProperty(isolate, args, "fromJsGetNodeIdByCpdId",
-                        fromJsGetNodeIdByCpdId);
-    SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
-    SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForElement",
-                        fromJsGetMatchedStylesForElement);
-    SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
-                        fromJsCssGetStylesheetByCpdId);
-    SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
-                        fromJsCollectEventListeners);
-    SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
-                        fromJsDomPerformSearch);
-    SetFunctionProperty(isolate, args, "getFunctionBytecode",
-                        fromJsGetFunctionBytecode);
-
-    // Replay meta.
-    DefineProperty(isolate, args, "IsReplaying",
-                   v8::Boolean::New(isolate, recordreplay::IsReplaying()));
-    SetFunctionProperty(isolate, args, "beginReplayCode",
-                        fromJsBeginReplayCode);
-    SetFunctionProperty(isolate, args, "endReplayCode", fromJsEndReplayCode);
-
-    // Graphics.
-    SetFunctionProperty(isolate, args, "getCurrentViewportPixelSize",
-                        fromJsGetCurrentViewportPixelSize);
-
-    // unsorted Replay stuff
-    SetFunctionProperty(
-        isolate, args, "setClearPauseDataCallback",
-        v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-    SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
-    SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
-    SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
-    SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
-                        WriteToRecordingDirectory);
-    SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
-    SetFunctionProperty(isolate, args, "addNewScriptHandler",
-                        v8::FunctionCallbackRecordReplayAddNewScriptHandler);
-    SetFunctionProperty(isolate, args, "getScriptSource",
-                        v8::FunctionCallbackRecordReplayGetScriptSource);
-
-    SetFunctionProperty(isolate, args, "recordingDirectoryFileExists",
-                        RecordingDirectoryFileExists);
-    SetFunctionProperty(isolate, args, "readFromRecordingDirectory",
-                        ReadFromRecordingDirectory);
-    SetFunctionProperty(isolate, args, "getRecordingFilePath",
-                        GetRecordingFilePath);
-    SetFunctionProperty(isolate, args, "getPersistentId",
-                        fromJsGetPersistentId);
-    SetFunctionProperty(isolate, args, "checkPersistentId",
-                        fromJsCheckPersistentId);
-    SetFunctionProperty(isolate, args, "getProgressCounter",
-                        fromJsGetProgressCounter);
-
-    // exported for tests
-    SetFunctionProperty(isolate, args, "forTestingSerializeValueToArray",
-                        ForTestingSerializeValueToArray);
-  }
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gRecordReplayArgsObj->Get(isolate));
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ETERNAL_STATE__",
+                 gRecordReplayEternalState->Get(isolate));
 }
 
 void InitializeRecordReplay(
@@ -2598,6 +2624,10 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
     // its frames.
     RunScript(isolate, context, gReactDevtoolsScript, "record-replay-react-devtools");
     RunScript(isolate, context, gReduxDevtoolsScript, "record-replay-redux-devtools");
+  }
+
+  for (const auto& script : gRegisteredRootFrameScripts) {
+    blink::RunScript(isolate, context, script.c_str(), InternalScriptURL);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -84,6 +84,10 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
 #define CDPERROR_NOTALIVE 1002
 
 namespace blink {
+
+// This URL will prevent the script from being reported to the recorder.
+constexpr const char* kInternalScriptURL = "record-replay-internal";
+
 // using RemoteObjectIdTypeRaw = v8_inspector::String16;
 // The actual type for RemoteObjectId
 using RemoteObjectIdTypeRaw = std::u16string;
@@ -1045,7 +1049,10 @@ static void fromJsCheckPersistentId(const v8::FunctionCallbackInfo<v8::Value>& a
   }
 }
 
-static std::vector<std::string> gRegisteredRootFrameScripts;
+static std::vector<std::string>& GetRegisteredRootFrameScripts() {
+  static std::vector<std::string>* scripts = new std::vector<std::string>();
+  return *scripts;
+}
 
 static void fromJsRegisterRootFrameScript(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -1066,9 +1073,9 @@ static void fromJsRegisterRootFrameScript(
   auto context = isolate->GetCurrentContext();
 
   v8::String::Utf8Value script(args.GetIsolate(), args[0]);
-  RunScript(isolate, context, *script, InternalScriptURL);
+  RunScript(isolate, context, *script, kInternalScriptURL);
 
-  gRootFrameScripts.emplace_back(*script);
+  GetRegisteredRootFrameScripts().emplace_back(*script);
   args.GetReturnValue().Set(v8::Boolean::New(isolate, true));
 }
 
@@ -2552,13 +2559,10 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   // Initialize __RECORD_REPLAY__ things.
   InitializeRecordReplayApiObjects(isolate, localFrame);
 
-  // This URL will prevent the script from being reported to the recorder.
-  const char* InternalScriptURL = "record-replay-internal";
-
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
     recordreplay::AutoMarkReplayCode amrc;
-    RunScript(isolate, context, ReadReplaySourcemapHandlerScript().Utf8().c_str(), InternalScriptURL);
+    RunScript(isolate, context, ReadReplaySourcemapHandlerScript().Utf8().c_str(), kInternalScriptURL);
   }
 
   if (recordreplay::FeatureEnabled("force-main-world-initialization")) {
@@ -2574,7 +2578,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
       recordreplay::AutoDisallowEvents disallow("InitializeReplayScripts");
 
       // Run `commandHandlerScript`.
-      RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), InternalScriptURL);
+      RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), kInternalScriptURL);
     }
   }
 }
@@ -2626,8 +2630,8 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
     RunScript(isolate, context, gReduxDevtoolsScript, "record-replay-redux-devtools");
   }
 
-  for (const auto& script : gRegisteredRootFrameScripts) {
-    blink::RunScript(isolate, context, script.c_str(), InternalScriptURL);
+  for (const auto& script : GetRegisteredRootFrameScripts()) {
+    blink::RunScript(isolate, context, script.c_str(), kInternalScriptURL);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1054,31 +1054,6 @@ static std::vector<std::string>& GetRegisteredRootFrameScripts() {
   return *scripts;
 }
 
-static void fromJsRegisterRootFrameScript(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "must be called with a single string");
-
-  v8::Isolate* isolate = args.GetIsolate();
-
-  auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
-
-  if (!contextGroupId.has_value()) {
-    recordreplay::Warning(
-        "fromJsRegisterRootFrameScript - no valid context id");
-    args.GetReturnValue().Set(v8::Boolean::New(isolate, false));
-    return;
-  }
-
-  auto context = isolate->GetCurrentContext();
-
-  v8::String::Utf8Value script(args.GetIsolate(), args[0]);
-  RunScript(isolate, context, *script, kInternalScriptURL);
-
-  GetRegisteredRootFrameScripts().emplace_back(*script);
-  args.GetReturnValue().Set(v8::Boolean::New(isolate, true));
-}
-
 static void GetCurrentError(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 
@@ -2386,6 +2361,31 @@ static void RunScript(v8::Isolate* isolate, v8::Local<v8::Context> context, cons
     recordreplay::Crash("Replay RunScript INIT failed: %s",
       GetStackTrace(isolate, try_catch).c_str());
   }
+}
+
+static void fromJsRegisterRootFrameScript(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "must be called with a single string");
+
+  v8::Isolate* isolate = args.GetIsolate();
+
+  auto contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
+
+  if (!contextGroupId.has_value()) {
+    recordreplay::Warning(
+        "fromJsRegisterRootFrameScript - no valid context id");
+    args.GetReturnValue().Set(v8::Boolean::New(isolate, false));
+    return;
+  }
+
+  auto context = isolate->GetCurrentContext();
+
+  v8::String::Utf8Value script(args.GetIsolate(), args[0]);
+  RunScript(isolate, context, *script, kInternalScriptURL);
+
+  GetRegisteredRootFrameScripts().emplace_back(*script);
+  args.GetReturnValue().Set(v8::Boolean::New(isolate, true));
 }
 
 static bool TestEnv(const char* env) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2345,8 +2345,8 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
-static v8::Eternal<v8::Object> gRecordReplayObj;
-static v8::Eternal<v8::Object> gRecordReplayArgsObj;
+static v8::Eternal<v8::Object>* gRecordReplayObj;
+static v8::Eternal<v8::Object>* gRecordReplayArgsObj;
 
 static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -2355,16 +2355,17 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  if (gRecordReplayObj->IsEmpty()) {
-    gRecordReplayObj.Set(isolate, v8::Object::New(isolate));
+  if (gRecordReplayObj == nullptr) {
+    gRecordReplayObj =
+        new v8::Eternal<v8::Object>(isolate, v8::Object::New(isolate));
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
-                 gRecordReplayObj.Get(isolate));
+                 gRecordReplayObj->Get(isolate));
 
-  if (gRecordReplayArgsObj != nullptr) {
+  if (gRecordReplayArgsObj == nullptr) {
     v8::Local<v8::Object> args = v8::Object::New(isolate);
-    gRecordReplayArgsObj.Set(isolate, args);
-    
+    gRecordReplayArgsObj = new v8::Eternal<v8::Object>(isolate, args);
+
     DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
                    ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
 
@@ -2478,7 +2479,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                         ForTestingSerializeValueToArray);
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gRecordReplayArgsObj.Get(isolate));
+                 gRecordReplayArgsObj->Get(isolate));
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2355,128 +2355,130 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  if (gRecordReplayObj != nullptr) {
-    gRecordReplayObj = v8::Object::New(isolate);
+  if (gRecordReplayObj->IsEmpty()) {
+    gRecordReplayObj.Set(isolate, v8::Object::New(isolate));
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
-                 gRecordReplayObj);
+                 gRecordReplayObj->Get(isolate));
 
   if (gRecordReplayArgsObj != nullptr) {
-    gRecordReplayArgsObj = v8::Object::New(isolate);
-    DefineProperty(isolate, gRecordReplayArgsObj, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
+    v8::Local<v8::Object> args = v8::Object::New(isolate);
+    gRecordReplayArgsObj->Set(isolate, args);
+    
+    DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
                    ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
 
     DefineProperty(
-        isolate, gRecordReplayArgsObj, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
+        isolate, args, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
         v8::Boolean::New(isolate,
                          TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE")));
 
-    DefineProperty(isolate, gRecordReplayArgsObj, "CDPERROR_MISSINGCONTEXT",
+    DefineProperty(isolate, args, "CDPERROR_MISSINGCONTEXT",
                    v8::Number::New(isolate, (double)CDPERROR_MISSINGCONTEXT));
 
-    DefineProperty(isolate, gRecordReplayArgsObj, "CDPERROR_NOTALIVE",
+    DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
                    v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
 
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "log", LogCallback);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "logTrace", LogTraceCallback);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "warning", LogWarningCallback);
+    SetFunctionProperty(isolate, args, "log", LogCallback);
+    SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
+    SetFunctionProperty(isolate, args, "warning", LogWarningCallback);
 
     // CDP debugger functionality
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsIsReplayScriptAlive",
+    SetFunctionProperty(isolate, args, "fromJsIsReplayScriptAlive",
                         fromJsIsReplayScriptAlive);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "hasDiverged", fromJsHasDiverged);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "setCDPMessageCallback",
+    SetFunctionProperty(isolate, args, "hasDiverged", fromJsHasDiverged);
+    SetFunctionProperty(isolate, args, "setCDPMessageCallback",
                         SetCDPMessageCallback);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "sendCDPMessage", SendCDPMessage);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "setCommandCallback",
+    SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
+    SetFunctionProperty(isolate, args, "setCommandCallback",
                         v8::FunctionCallbackRecordReplaySetCommandCallback);
 
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "layoutDom", LayoutDom);
+    SetFunctionProperty(isolate, args, "layoutDom", LayoutDom);
 
     // Object Util
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsMakeDebuggeeValue",
+    SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
                         fromJsMakeDebuggeeValue);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetArgumentsInFrame",
+    SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
                         fromJsGetArgumentsInFrame);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetObjectByCdpId",
+    SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
                         fromJsGetObjectByCdpId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsIsBlinkObject",
+    SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
                         fromJsIsBlinkObject);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsHasReturnValue",
+    SetFunctionProperty(isolate, args, "fromJsHasReturnValue",
                         fromJsHasReturnValue);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetReturnValue",
+    SetFunctionProperty(isolate, args, "fromJsGetReturnValue",
                         fromJsGetReturnValue);
 
     // networking
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentNetworkRequestEvent",
+    SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
                         GetCurrentNetworkRequestEvent);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentNetworkStreamData",
+    SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
                         GetCurrentNetworkStreamData);
 
     // DOM, blink, API stuff
-    // SetFunctionProperty(isolate, gRecordReplayArgsObj, "jsGetObjectIdForAnyObject",
+    // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
     //                     jsGetObjectIdForAnyObject);
-    // SetFunctionProperty(isolate, gRecordReplayArgsObj, "jsPreviewBlinkObjectForObjectId",
+    // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
     // jsPreviewBlinkObjectForObjectId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetNodeIdByCpdId",
+    SetFunctionProperty(isolate, args, "fromJsGetNodeIdByCpdId",
                         fromJsGetNodeIdByCpdId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetBoxModel", fromJsGetBoxModel);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetMatchedStylesForElement",
+    SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
+    SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForElement",
                         fromJsGetMatchedStylesForElement);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsCssGetStylesheetByCpdId",
+    SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
                         fromJsCssGetStylesheetByCpdId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsCollectEventListeners",
+    SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
                         fromJsCollectEventListeners);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsDomPerformSearch",
+    SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
                         fromJsDomPerformSearch);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getFunctionBytecode",
+    SetFunctionProperty(isolate, args, "getFunctionBytecode",
                         fromJsGetFunctionBytecode);
 
     // Replay meta.
-    DefineProperty(isolate, gRecordReplayArgsObj, "IsReplaying",
+    DefineProperty(isolate, args, "IsReplaying",
                    v8::Boolean::New(isolate, recordreplay::IsReplaying()));
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "beginReplayCode",
+    SetFunctionProperty(isolate, args, "beginReplayCode",
                         fromJsBeginReplayCode);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "endReplayCode", fromJsEndReplayCode);
+    SetFunctionProperty(isolate, args, "endReplayCode", fromJsEndReplayCode);
 
     // Graphics.
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentViewportPixelSize",
+    SetFunctionProperty(isolate, args, "getCurrentViewportPixelSize",
                         fromJsGetCurrentViewportPixelSize);
 
     // unsorted Replay stuff
     SetFunctionProperty(
-        isolate, gRecordReplayArgsObj, "setClearPauseDataCallback",
+        isolate, args, "setClearPauseDataCallback",
         v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentError", GetCurrentError);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getRecordingId", GetRecordingId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "sha256DigestHex", SHA256DigestHex);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "writeToRecordingDirectory",
+    SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
+    SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
+    SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
+    SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
                         WriteToRecordingDirectory);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "addRecordingEvent", AddRecordingEvent);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "addNewScriptHandler",
+    SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
+    SetFunctionProperty(isolate, args, "addNewScriptHandler",
                         v8::FunctionCallbackRecordReplayAddNewScriptHandler);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getScriptSource",
+    SetFunctionProperty(isolate, args, "getScriptSource",
                         v8::FunctionCallbackRecordReplayGetScriptSource);
 
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "recordingDirectoryFileExists",
+    SetFunctionProperty(isolate, args, "recordingDirectoryFileExists",
                         RecordingDirectoryFileExists);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "readFromRecordingDirectory",
+    SetFunctionProperty(isolate, args, "readFromRecordingDirectory",
                         ReadFromRecordingDirectory);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getRecordingFilePath",
+    SetFunctionProperty(isolate, args, "getRecordingFilePath",
                         GetRecordingFilePath);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getPersistentId",
+    SetFunctionProperty(isolate, args, "getPersistentId",
                         fromJsGetPersistentId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "checkPersistentId",
+    SetFunctionProperty(isolate, args, "checkPersistentId",
                         fromJsCheckPersistentId);
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getProgressCounter",
+    SetFunctionProperty(isolate, args, "getProgressCounter",
                         fromJsGetProgressCounter);
 
     // exported for tests
-    SetFunctionProperty(isolate, gRecordReplayArgsObj, "forTestingSerializeValueToArray",
+    SetFunctionProperty(isolate, args, "forTestingSerializeValueToArray",
                         ForTestingSerializeValueToArray);
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gRecordReplayArgsObj);
+                 gRecordReplayArgsObj->Get(isolate););
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2356,14 +2356,14 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                       InvokeOnAnnotation);
 
   if (gRecordReplayObj->IsEmpty()) {
-    gRecordReplayObj->Set(isolate, v8::Object::New(isolate));
+    gRecordReplayObj.Set(isolate, v8::Object::New(isolate));
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
-                 gRecordReplayObj->Get(isolate));
+                 gRecordReplayObj.Get(isolate));
 
   if (gRecordReplayArgsObj != nullptr) {
     v8::Local<v8::Object> args = v8::Object::New(isolate);
-    gRecordReplayArgsObj->Set(isolate, args);
+    gRecordReplayArgsObj.Set(isolate, args);
     
     DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
                    ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
@@ -2478,7 +2478,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                         ForTestingSerializeValueToArray);
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gRecordReplayArgsObj->Get(isolate));
+                 gRecordReplayArgsObj.Get(isolate));
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -877,6 +877,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
       // Construct our error result.
       std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
       error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
+      error->SetStringKey("method", messageDict->FindString("method"));
       error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
 
       base::DictionaryValue result;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -123,16 +123,28 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
     return nullptr;
   }
 
-  LocalFrame *f = currentWindow->GetFrame();
+  LocalFrame* f = currentWindow->GetFrame();
   if (!f || f->IsDetached() || f->IsProvisional()) {
-    recordreplay::Print("[RuntimeError] GetLocalFrameRoot: window has no frame.");
+    recordreplay::Print(
+        "[RuntimeError] GetLocalFrameRoot: window has no usable frame. "
+        "win=%d frame=%d isDetached=%d isProvisional=%d "
+        "isMainFrame=%d isLocalRoot=%d url=%s",
+        currentWindow->RecordReplayId(), (f ? f->RecordReplayId() : -1),
+        f ? f->IsDetached() : -1, f ? f->IsProvisional() : -1,
+        f ? f->IsMainFrame() : -1, f ? f->IsLocalRoot() : -1,
+        (f && f->GetDocument())
+            ? f->GetDocument()->Url().GetString().Utf8().c_str()
+            : "<no-doc>");
     return nullptr;
   }
 
   LocalFrame& root = f->LocalFrameRoot();
 
   if (root.IsDetached() || root.IsProvisional()) {
-    recordreplay::Print("[RuntimeError] GetLocalFrameRoot: root is detached or provisional.");
+    recordreplay::Print(
+        "[RuntimeError] GetLocalFrameRoot: root is detached or provisional "
+        "frame=%d.",
+        root->RecordReplayId());
     return nullptr;
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2345,6 +2345,9 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
+static v8::Eternal<v8::Object>* gRecordReplayObj;
+static v8::Eternal<v8::Object>* gRecordReplayArgsObj;
+
 static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
@@ -2352,123 +2355,128 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
+  if (gRecordReplayObj != nullptr) {
+    gRecordReplayObj = v8::Object::New(isolate);
+  }
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
+                 gRecordReplayObj);
 
-  v8::Local<v8::Object> args = v8::Object::New(isolate);
+  if (gRecordReplayArgsObj != nullptr) {
+    gRecordReplayArgsObj = v8::Object::New(isolate);
+    DefineProperty(isolate, gRecordReplayArgsObj, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
+                   ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
+
+    DefineProperty(
+        isolate, gRecordReplayArgsObj, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
+        v8::Boolean::New(isolate,
+                         TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE")));
+
+    DefineProperty(isolate, gRecordReplayArgsObj, "CDPERROR_MISSINGCONTEXT",
+                   v8::Number::New(isolate, (double)CDPERROR_MISSINGCONTEXT));
+
+    DefineProperty(isolate, gRecordReplayArgsObj, "CDPERROR_NOTALIVE",
+                   v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
+
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "log", LogCallback);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "logTrace", LogTraceCallback);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "warning", LogWarningCallback);
+
+    // CDP debugger functionality
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsIsReplayScriptAlive",
+                        fromJsIsReplayScriptAlive);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "hasDiverged", fromJsHasDiverged);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "setCDPMessageCallback",
+                        SetCDPMessageCallback);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "sendCDPMessage", SendCDPMessage);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "setCommandCallback",
+                        v8::FunctionCallbackRecordReplaySetCommandCallback);
+
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "layoutDom", LayoutDom);
+
+    // Object Util
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsMakeDebuggeeValue",
+                        fromJsMakeDebuggeeValue);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetArgumentsInFrame",
+                        fromJsGetArgumentsInFrame);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetObjectByCdpId",
+                        fromJsGetObjectByCdpId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsIsBlinkObject",
+                        fromJsIsBlinkObject);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsHasReturnValue",
+                        fromJsHasReturnValue);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetReturnValue",
+                        fromJsGetReturnValue);
+
+    // networking
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentNetworkRequestEvent",
+                        GetCurrentNetworkRequestEvent);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentNetworkStreamData",
+                        GetCurrentNetworkStreamData);
+
+    // DOM, blink, API stuff
+    // SetFunctionProperty(isolate, gRecordReplayArgsObj, "jsGetObjectIdForAnyObject",
+    //                     jsGetObjectIdForAnyObject);
+    // SetFunctionProperty(isolate, gRecordReplayArgsObj, "jsPreviewBlinkObjectForObjectId",
+    // jsPreviewBlinkObjectForObjectId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetNodeIdByCpdId",
+                        fromJsGetNodeIdByCpdId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetBoxModel", fromJsGetBoxModel);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsGetMatchedStylesForElement",
+                        fromJsGetMatchedStylesForElement);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsCssGetStylesheetByCpdId",
+                        fromJsCssGetStylesheetByCpdId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsCollectEventListeners",
+                        fromJsCollectEventListeners);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "fromJsDomPerformSearch",
+                        fromJsDomPerformSearch);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getFunctionBytecode",
+                        fromJsGetFunctionBytecode);
+
+    // Replay meta.
+    DefineProperty(isolate, gRecordReplayArgsObj, "IsReplaying",
+                   v8::Boolean::New(isolate, recordreplay::IsReplaying()));
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "beginReplayCode",
+                        fromJsBeginReplayCode);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "endReplayCode", fromJsEndReplayCode);
+
+    // Graphics.
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentViewportPixelSize",
+                        fromJsGetCurrentViewportPixelSize);
+
+    // unsorted Replay stuff
+    SetFunctionProperty(
+        isolate, gRecordReplayArgsObj, "setClearPauseDataCallback",
+        v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getCurrentError", GetCurrentError);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getRecordingId", GetRecordingId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "sha256DigestHex", SHA256DigestHex);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "writeToRecordingDirectory",
+                        WriteToRecordingDirectory);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "addRecordingEvent", AddRecordingEvent);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "addNewScriptHandler",
+                        v8::FunctionCallbackRecordReplayAddNewScriptHandler);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getScriptSource",
+                        v8::FunctionCallbackRecordReplayGetScriptSource);
+
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "recordingDirectoryFileExists",
+                        RecordingDirectoryFileExists);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "readFromRecordingDirectory",
+                        ReadFromRecordingDirectory);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getRecordingFilePath",
+                        GetRecordingFilePath);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getPersistentId",
+                        fromJsGetPersistentId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "checkPersistentId",
+                        fromJsCheckPersistentId);
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "getProgressCounter",
+                        fromJsGetProgressCounter);
+
+    // exported for tests
+    SetFunctionProperty(isolate, gRecordReplayArgsObj, "forTestingSerializeValueToArray",
+                        ForTestingSerializeValueToArray);
+  }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 args);
-
-  DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
-                 ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
-
-  DefineProperty(
-      isolate, args, "RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE",
-      v8::Boolean::New(isolate,
-                       TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_CACHE")));
-
-  DefineProperty(isolate, args, "CDPERROR_MISSINGCONTEXT",
-                 v8::Number::New(isolate, (double)CDPERROR_MISSINGCONTEXT));
-
-  DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
-                 v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
-
-  SetFunctionProperty(isolate, args, "log", LogCallback);
-  SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
-  SetFunctionProperty(isolate, args, "warning", LogWarningCallback);
-
-  // CDP debugger functionality
-  SetFunctionProperty(isolate, args, "fromJsIsReplayScriptAlive",
-                      fromJsIsReplayScriptAlive);
-  SetFunctionProperty(isolate, args, "hasDiverged",
-                      fromJsHasDiverged);
-  SetFunctionProperty(isolate, args, "setCDPMessageCallback",
-                      SetCDPMessageCallback);
-  SetFunctionProperty(isolate, args, "sendCDPMessage", SendCDPMessage);
-  SetFunctionProperty(isolate, args, "setCommandCallback",
-                      v8::FunctionCallbackRecordReplaySetCommandCallback);
-
-  SetFunctionProperty(isolate, args, "layoutDom", LayoutDom);
-
-  // Object Util
-  SetFunctionProperty(isolate, args, "fromJsMakeDebuggeeValue",
-                      fromJsMakeDebuggeeValue);
-  SetFunctionProperty(isolate, args, "fromJsGetArgumentsInFrame",
-                      fromJsGetArgumentsInFrame);
-  SetFunctionProperty(isolate, args, "fromJsGetObjectByCdpId",
-                      fromJsGetObjectByCdpId);
-  SetFunctionProperty(isolate, args, "fromJsIsBlinkObject",
-                      fromJsIsBlinkObject);
-  SetFunctionProperty(isolate, args, "fromJsHasReturnValue",
-                      fromJsHasReturnValue);
-  SetFunctionProperty(isolate, args, "fromJsGetReturnValue",
-                      fromJsGetReturnValue);
-
-  // networking
-  SetFunctionProperty(isolate, args, "getCurrentNetworkRequestEvent",
-                      GetCurrentNetworkRequestEvent);
-  SetFunctionProperty(isolate, args, "getCurrentNetworkStreamData",
-                      GetCurrentNetworkStreamData);
-
-  // DOM, blink, API stuff
-  // SetFunctionProperty(isolate, args, "jsGetObjectIdForAnyObject",
-  //                     jsGetObjectIdForAnyObject);
-  // SetFunctionProperty(isolate, args, "jsPreviewBlinkObjectForObjectId",
-  // jsPreviewBlinkObjectForObjectId);
-  SetFunctionProperty(isolate, args, "fromJsGetNodeIdByCpdId", fromJsGetNodeIdByCpdId);
-  SetFunctionProperty(isolate, args, "fromJsGetBoxModel", fromJsGetBoxModel);
-  SetFunctionProperty(isolate, args, "fromJsGetMatchedStylesForElement",
-                      fromJsGetMatchedStylesForElement);
-  SetFunctionProperty(isolate, args, "fromJsCssGetStylesheetByCpdId",
-                      fromJsCssGetStylesheetByCpdId);
-  SetFunctionProperty(isolate, args, "fromJsCollectEventListeners",
-                      fromJsCollectEventListeners);
-  SetFunctionProperty(isolate, args, "fromJsDomPerformSearch",
-                      fromJsDomPerformSearch);
-  SetFunctionProperty(isolate, args, "getFunctionBytecode",
-                      fromJsGetFunctionBytecode);
-
-  // Replay meta.
-  DefineProperty(isolate, args, "IsReplaying",
-                 v8::Boolean::New(isolate, recordreplay::IsReplaying()));
-  SetFunctionProperty(isolate, args, "beginReplayCode",
-                      fromJsBeginReplayCode);
-  SetFunctionProperty(isolate, args, "endReplayCode",
-                      fromJsEndReplayCode);
-
-  // Graphics.
-  SetFunctionProperty(isolate, args, "getCurrentViewportPixelSize",
-                      fromJsGetCurrentViewportPixelSize);
-
-  // unsorted Replay stuff
-  SetFunctionProperty(
-      isolate, args, "setClearPauseDataCallback",
-      v8::FunctionCallbackRecordReplaySetClearPauseDataCallback);
-  SetFunctionProperty(isolate, args, "getCurrentError", GetCurrentError);
-  SetFunctionProperty(isolate, args, "getRecordingId", GetRecordingId);
-  SetFunctionProperty(isolate, args, "sha256DigestHex", SHA256DigestHex);
-  SetFunctionProperty(isolate, args, "writeToRecordingDirectory",
-                      WriteToRecordingDirectory);
-  SetFunctionProperty(isolate, args, "addRecordingEvent", AddRecordingEvent);
-  SetFunctionProperty(isolate, args, "addNewScriptHandler",
-                      v8::FunctionCallbackRecordReplayAddNewScriptHandler);
-  SetFunctionProperty(isolate, args, "getScriptSource",
-                      v8::FunctionCallbackRecordReplayGetScriptSource);
-
-  SetFunctionProperty(isolate, args, "recordingDirectoryFileExists",
-                      RecordingDirectoryFileExists);
-  SetFunctionProperty(isolate, args, "readFromRecordingDirectory",
-                      ReadFromRecordingDirectory);
-  SetFunctionProperty(isolate, args, "getRecordingFilePath",
-                      GetRecordingFilePath);
-  SetFunctionProperty(isolate, args, "getPersistentId", fromJsGetPersistentId);
-  SetFunctionProperty(isolate, args, "checkPersistentId", fromJsCheckPersistentId);
-  SetFunctionProperty(isolate, args, "getProgressCounter", fromJsGetProgressCounter);
-
-  // exported for tests
-  SetFunctionProperty(
-    isolate, args, "forTestingSerializeValueToArray",
-    ForTestingSerializeValueToArray);
+                 gRecordReplayArgsObj);
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2356,7 +2356,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                       InvokeOnAnnotation);
 
   if (gRecordReplayObj->IsEmpty()) {
-    gRecordReplayObj.Set(isolate, v8::Object::New(isolate));
+    gRecordReplayObj->Set(isolate, v8::Object::New(isolate));
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__",
                  gRecordReplayObj->Get(isolate));

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -877,7 +877,9 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
       // Construct our error result.
       std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
       error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
-      error->SetStringKey("method", messageDict->FindString("method"));
+      if (auto* method = messageDict->FindString("method")) {
+        error->SetStringKey("method", *method);
+      }
       error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
 
       base::DictionaryValue result;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2345,8 +2345,8 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
-static v8::Eternal<v8::Object>* gRecordReplayObj;
-static v8::Eternal<v8::Object>* gRecordReplayArgsObj;
+static v8::Eternal<v8::Object> gRecordReplayObj;
+static v8::Eternal<v8::Object> gRecordReplayArgsObj;
 
 static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2478,7 +2478,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                         ForTestingSerializeValueToArray);
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gRecordReplayArgsObj->Get(isolate););
+                 gRecordReplayArgsObj->Get(isolate));
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -144,7 +144,7 @@ static LocalFrame* GetLocalFrameRoot(v8::Isolate* isolate) {
     recordreplay::Print(
         "[RuntimeError] GetLocalFrameRoot: root is detached or provisional "
         "frame=%d.",
-        root->RecordReplayId());
+        root.RecordReplayId());
     return nullptr;
   }
 


### PR DESCRIPTION
https://linear.app/replay/issue/PRO-1135/linker-page-navigation-causes-instrumentengine-to-fail-cannot-read
goes hand in hand with https://github.com/replayio/backend/pull/11030