### PR TITLE
Create missing `createResizeObserver` node in the other constructor too

### DIFF
--- a/third_party/blink/renderer/core/resize_observer/resize_observer.cc
+++ b/third_party/blink/renderer/core/resize_observer/resize_observer.cc
@@ -57,6 +57,8 @@ ResizeObserver::ResizeObserver(Delegate* delegate, LocalDOMWindow* window)
     controller_ = ResizeObserverController::From(*window);
     controller_->AddObserver(*this);
   }
+  record_replay_created_node_id_ = recordreplay::NewDependencyGraphNode(
+      "{\"kind\":\"createResizeObserver\"}");
 }
 
 ResizeObserverBoxOptions ResizeObserver::ParseBoxOptions(


### PR DESCRIPTION
Job `operator-run-0a3b274c-f7ec-4d1b-a2e9-337ec4a57ca4#6` run into this - it created an edge with a missing source:
```json
{
  "info": {
    "kind": "creator",
  },
  "kind": "edge",
  "progress": 36216,
  "source": 0,
  "target": 1939
}
```

Given this source id is initialized in the constructor it should always be available... but when I added this, I've missed the  second overload of this constructor :cry: