### PR TITLE
Don't assert on JS stack in `DOMURL::searchParams`

### DIFF
--- a/third_party/blink/renderer/core/url/dom_url.cc
+++ b/third_party/blink/renderer/core/url/dom_url.cc
@@ -97,10 +97,8 @@ String DOMURL::CreatePublicURL(ExecutionContext* execution_context,
 URLSearchParams* DOMURL::searchParams() {
   if (!search_params_) {
     if (recordreplay::IsRecordingOrReplaying() && !recordreplay::AreAssertsDisabled()) {
-      std::string stack;
-      recordreplay::GetCurrentJSStack(&stack);
-      recordreplay::Assert("[RUN-2324-2325] DOMURL::searchParams %s stack=%s",
-                           Url().GetString().Utf8().c_str(), stack.c_str());
+      recordreplay::Assert("[RUN-2324-2325] DOMURL::searchParams %s",
+                           Url().GetString().Utf8().c_str());
     }
 
     search_params_ = URLSearchParams::Create(Url().Query(), this);


### PR DESCRIPTION
`operator-run-6e074d01-a3a4-4573-9dfe-4c523dce0c34#1` hit this assert in the instrument engine. The instrument engine changes the source code so we can't ever assert on the JS stack. We should always replay it but then asserting on a replayed stack wouldn't make any sense. So the only thing we can do is to remove this.