### PR TITLE
Allow override `contextGroupId` to be set for `SendCDPMessage`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9084d10659483752806e8894bc6e100f82aaa4c4',
+  'v8_revision': 'd3d396a40672bce063b630c69c201fca9fe16401',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd3d396a40672bce063b630c69c201fca9fe16401',
+  'v8_revision': '34a6d6c5a6a91e7f6da7d1edfe4c0f91c7d50406',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -782,6 +782,21 @@ struct InspectorChannel final : public v8_inspector::V8Inspector::Channel {
   void flushProtocolNotifications() final {}
 };
 
+static absl::optional<int> gContextGroupIdForSendCDPMessage;
+
+extern "C" void SetContextGroupIdForSendCDPMessage(int contextGroupId) {
+  CHECK(v8::IsMainThread());
+  CHECK_GT(contextGroupId, 0);
+  CHECK(!gContextGroupIdForSendCDPMessage.has_value());
+  gContextGroupIdForSendCDPMessage = contextGroupId;
+}
+
+extern "C" void ClearContextGroupIdForSendCDPMessage() {
+  CHECK(v8::IsMainThread());
+  CHECK(gContextGroupIdForSendCDPMessage.has_value());
+  gContextGroupIdForSendCDPMessage.reset();
+}
+
 absl::optional<int> GetCurrentContextGroupIdForIsolate(v8::Isolate* isolate) {
   LocalFrame* local_frame_root = GetLocalFrameRoot(isolate);
 
@@ -878,7 +893,10 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();
-  absl::optional<int> contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
+  absl::optional<int> contextGroupId = gContextGroupIdForSendCDPMessage;
+  if (!contextGroupId.has_value()) {
+    contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
+  }
 
   // It can be the case that we simply don't have a context group id (a local frame) at this
   // time; just log it and inform the client.


### PR DESCRIPTION
pairs with https://github.com/replayio/chromium-v8/pull/281

This fixes a hard crash. I root caused this with rr. I'm 100% confident that the message gets dispatched for the correct `contextGroupId` through `forEachSession` -> `messageAdded` -> `reportToFrontend`. The problem is that our "inspector" isn't bound to a specific `contextGroupId` (unlike the normal devtools/inspectors). We instead derive the current `contextGroupId` from the root's frame and use that for all object previews etc. As it turns out, that's not always correct because the old context might still be alive and not fully collected after navigation and that old context might still even produce console messages. 

The failure sequence was:

1. A console message was dispatched by V8 through inspector sessions in **context group 1**.
2. Replay received that event through `Runtime.consoleAPICalled` and later read it via `Target.getCurrentMessageContents`.
3. `Manifest.cpp` then tried to preview an object argument from that message using `Pause.getObjectPreview`.
4. The preview path eventually issued `Runtime.getProperties`.
5. That preview command was routed through an inspector session in **context group 2**, not the original group 1.
6. V8 then tried to resolve the object id via `getContext(2, 1)`.
7. That failed with `Cannot find context with specified id`, because the object had originated on the group-1 side.
8. Replay did not gracefully handle that failure, and the linker crashed.

In short:

> The console object id was created on the group-1 side, but later preview was routed through a group-2 session.

### rr / runtime facts

- We confirmed a navigation teardown called `resetContextGroup(2)`.
- We confirmed later console dispatch still used `wrapArguments -> getContext(1, 1)`.
- We confirmed later remote-object resolution switched to `findInjectedScript -> getContext(2, 1)`.
- We confirmed the non-fatal precursor warnings came from that miss:
  - `Cannot find context with specified id B 2 1`
  - `getObjectByCdpId - Failed to look up cdpId`
- We confirmed those warnings occurred at:
  - `checkpoint 86`
  - `progress 726710`
- We confirmed the fatal preview path also reached `getContext(2, 1)` through:
  - `V8RuntimeAgentImpl::getProperties`
  - `InjectedScript::ObjectScope::findInjectedScript`
  - `V8InspectorSessionImpl::findInjectedScript`
- We captured different session pointers on the two sides:
  - dispatch-side `reportToFrontend(..., session, ...)`
  - fatal preview-side `ObjectScope::findInjectedScript(session)`
- We confirmed console dispatch is selected by `forEachSession(1, ...)`.
- We confirmed that `forEachSession(1, ...)` directly leads into `reportToFrontend(..., session, ...)`.

### source-level facts

- `Runtime.consoleAPICalled` carries the object args and `executionContextId`, but not an explicit `contextGroupId`.
- `Target.getCurrentMessageContents()` just replays `gLastConsoleAPICall.args`; it does not invent new object ids.
- `Manifest.cpp` also does not invent the bad object id; it only asks to preview it.
- Replay preview uses generic `sendCDPMessage(...)` / unwrap helpers rather than preserving the original inspector session.
- In `record_replay_interface.cc`, both preview and unwrap paths recompute routing from:
  - `GetCurrentContextGroupIdForIsolate(isolate)`
  - `GetLocalFrameRoot(isolate)`
  - `getInspectorSession(isolate, contextGroupId)`
- We proved this live in rr on the preview path:
  - `blink::SendCDPMessage(...)`
  - `blink::GetLocalFrameRoot(isolate)`
  - `blink::getInspectorSession(isolate, 2)`


## Root-Cause Conclusion

Replay’s preview/object-resolution path does not preserve the originating inspector session/context group from console dispatch. Instead, it recomputes the routing session from the isolate’s current frame-root-derived context group, which after navigation can be different.

<details>
<summary>Crash Report</summary>

```json
{
  "why": "ServerProcessCrash",
  "controlId": "b7d7e809-20f3-4234-be78-3a631b404b52",
  "sessionIds": [
    "2496aa47-e695-4455-830a-008508fc8be4"
  ],
  "recordingId": "73f4faac-87f8-41b2-a7ba-51e0100d8ce1",
  "buildId": "macOS-chromium-20260408-656ed1ab5f65-600bb3286213",
  "architecture": "arm",
  "linkerVersion": "linker-macOS-15794-600bb3286213",
  "forTest": false,
  "description": "{\"operatorId\":\"\",\"requestId\":\"\"}",
  "recordingAssertionsDisabled": false,
  "recordingFeaturesDisabled": [],
  "manualLinkerVersionOverride": "",
  "process": {
    "backtrace": {
      "threadId": 1,
      "frames": [
        "LZ4_decompress_fast_extDict(char.const*,.char*,.int,.void.const*,.unsigned.long)+76",
        "RunToPointHandler::Start(Json::Value.const&)+2983",
        "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+761",
        "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187",
        "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185",
        "v8_inspector::V8Console::Error(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+347",
        "v8::internal::(anonymous.namespace)::ConsoleCall(v8::internal::Isolate*,.v8::internal::BuiltinArguments.const&,.void.(v8::debug::ConsoleDelegate::*)(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&))+730",
        "v8::internal::Builtin_ConsoleError(int,.unsigned.long*,.v8::internal::Isolate*)+74",
        "0x10079ff15df8",
        "0x10079fe8baac",
        "0x10079fe8baac",
        "0x10079fec45bb",
        "0x10079ff6f7b8",
        "0x10079feb42b3",
        "0x10079fe8a007",
        "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3257",
        "v8::internal::(anonymous.namespace)::InvokeWithTryCatch(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+81",
        "v8::internal::Execution::TryRunMicrotasks(v8::internal::Isolate*,.v8::internal::MicrotaskQueue*)+85",
        "v8::internal::MicrotaskQueue::RunMicrotasks(v8::internal::Isolate*)+417",
        "v8::internal::MicrotaskQueue::PerformCheckpointInternal(v8::Isolate*)+70",
        "blink::scheduler::MainThreadSchedulerImpl::PerformMicrotaskCheckpoint()+73",
        "blink::scheduler::MainThreadSchedulerImpl::OnTaskCompleted(base::WeakPtr<blink::scheduler::MainThreadTaskQueue>,.base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+46",
        "blink::scheduler::MainThreadTaskQueue::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+110",
        "base::sequence_manager::internal::TaskQueueImpl::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+65",
        "base::sequence_manager::internal::SequenceManagerImpl::NotifyDidProcessTask(base::sequence_manager::internal::SequenceManagerImpl::ExecutingTask*,.base::LazyNow*)+210",
        "non-virtual.thunk.to.base::sequence_manager::internal::SequenceManagerImpl::DidRunTask(base::LazyNow&)+141",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1008",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
        "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
        "base::MessagePumpCFRunLoopBase::RunWork()+96",
        "void.recordreplay::Compose<&(void.PtrArg<(Ptr)6,.0ul>(recordreplay::CallContext&)),.&(void.recordreplay::CStringArg<1ul>(recordreplay::CallContext&)),.&(void.recordreplay::ScalarArg<2ul,.8ul>(recordreplay::CallContext&)),.&(void.PtrOutParam<(Ptr)0,.3ul>(recordreplay::CallContext&)),.&(void.recordreplay::CopyFontDataFromArgToOutParam<0ul,.3ul>(recordreplay::CallContext&)),.&(recordreplay::ScalarRval(recordreplay::CallContext&)),.&(recordreplay::CallPassThroughIfUnknown(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&))>(recordreplay::CallContext&)+77",
        "recordreplay::ELFBinary::ProcessRelocation(unsigned.long,.unsigned.long,.long)+199",
        "void.recordreplay::Compose<&(void.PtrArg<(Ptr)32,.0ul>(recordreplay::CallContext&)),.&(void.recordreplay::CStringArg<1ul>(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&))>(recordreplay::CallContext&)+46",
        "recordreplay::CStringArrayRval(recordreplay::CallContext&)+731",
        "0x10016f1784a8",
        "base::MessagePumpNSRunLoop::DoRun(base::MessagePump::Delegate*)+110",
        "base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*)+165",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
        "base::RunLoop::Run(base::Location.const&)+421",
        "content::RendererMain(content::MainFunctionParams)+1411",
        "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+626",
        "content::ContentMainRunnerImpl::Run()+626",
        "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+1964",
        "content::ContentMain(content::ContentMainParams)+96",
        "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+328",
        "headless::RunChildProcessIfNeeded(int,.char.const**)+304",
        "headless::HeadlessShellMain(int,.char.const**)+56",
        "_ChromeMain+312",
        "Chromium.Helper.(Renderer)+4294970474",
        "recordreplay::OnBookmarkHit(Json::Value.const&,.unsigned.long,.bool)+509",
        "_fini+8820",
        "_fini+4645",
        "(nil)"
      ],
      "onstack": [
        "LZ4_decompress_fast_extDict(char.const*,.char*,.int,.void.const*,.unsigned.long)+76",
        "Json::Value::resolveReference(char.const*)+527",
        "RunToPointHandler::Start(Json::Value.const&)+2983",
        "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+736",
        "Chromium.Framework+171164601",
        "new_g_object_ref_sink(void*)",
        "linker+1164806",
        "InstructionPointerToStringMaybeLabeled(void*)+809",
        "_fini+7372",
        "v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+1203",
        "v8_inspector::V8Console::Error(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+180",
        "Chromium.Framework+195556624",
        "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+761",
        "void.std::Cr::__function::__policy_invoker<void.(v8_inspector::V8InspectorSessionImpl*)>::__call_impl<std::Cr::__function::__default_alloc_func<v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)::$_0,.void.(v8_inspector::V8InspectorSessionImpl*)>.>(std::Cr::__function::__policy_storage.const*,.v8_inspector::V8InspectorSessionImpl*)",
        "Chromium.Framework+177905368",
        "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187",
        "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185",
        "Chromium.Framework+195555792",
        "v8_inspector::V8Console::Error(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+347",
        "_fini+44995",
        "v8_inspector::V8Console::Error(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)",
        "v8::internal::(anonymous.namespace)::ConsoleCall(v8::internal::Isolate*,.v8::internal::BuiltinArguments.const&,.void.(v8::debug::ConsoleDelegate::*)(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&))+730",
        "v8::internal::Builtin_ConsoleError(int,.unsigned.long*,.v8::internal::Isolate*)+74",
        "v8::internal::Builtin_ConsoleError(int,.unsigned.long*,.v8::internal::Isolate*)",
        "v8::internal::Runtime_PromiseHookBefore(int,.unsigned.long*,.v8::internal::Isolate*)+205",
        "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3257",
        "linker+2297240",
        "_fini+27340",
        "linker+3867432",
        "linker+3867264",
        "_fini+44995",
        "linker+3867264",
        "InstructionPointerToStringMaybeLabeled(void*)+809",
        "Chromium.Framework+195552160",
        "v8::MicrotasksScope::PerformCheckpoint(v8::Isolate*)+58",
        "blink::scheduler::MainThreadSchedulerImpl::PerformMicrotaskCheckpoint()+73",
        "blink::scheduler::MainThreadSchedulerImpl::OnTaskCompleted(base::WeakPtr<blink::scheduler::MainThreadTaskQueue>,.base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+46",
        "blink::scheduler::MainThreadTaskQueue::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+110",
        "base::sequence_manager::internal::TaskQueueImpl::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+65",
        "v8::internal::(anonymous.namespace)::InvokeWithTryCatch(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+81",
        "Chromium.Framework+195554384",
        "v8::internal::Execution::TryRunMicrotasks(v8::internal::Isolate*,.v8::internal::MicrotaskQueue*)+85",
        "Chromium.Helper.(Renderer)+2478456832",
        "Chromium.Helper.(Renderer)+2478456832",
        "linker+3867137",
        "v8::internal::MicrotaskQueue::RunMicrotasks(v8::internal::Isolate*)+417",
        "_fini+44428",
        "StackSample::AddToProfile().const+709",
        "v8::internal::MicrotaskQueue::PerformCheckpointInternal(v8::Isolate*)+70",
        "blink::scheduler::MainThreadSchedulerImpl::PerformMicrotaskCheckpoint()+73",
        "blink::scheduler::MainThreadSchedulerImpl::OnTaskCompleted(base::WeakPtr<blink::scheduler::MainThreadTaskQueue>,.base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+46",
        "blink::scheduler::MainThreadTaskQueue::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+110",
        "base::sequence_manager::internal::TaskQueueImpl::OnTaskCompleted(base::sequence_manager::Task.const&,.base::sequence_manager::TaskQueue::TaskTiming*,.base::LazyNow*)+65",
        "base::sequence_manager::internal::SequenceManagerImpl::NotifyDidProcessTask(base::sequence_manager::internal::SequenceManagerImpl::ExecutingTask*,.base::LazyNow*)+210",
        "Chromium.Framework+196463944",
        "SetInstrumentationEnabled(bool)+330",
        "Chromium.Framework+196463944",
        "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+315",
        "mojo::SimpleWatcher::Context::Notify(unsigned.int,.MojoHandleSignalsState,.unsigned.int)+383",
        "non-virtual.thunk.to.base::sequence_manager::internal::SequenceManagerImpl::DidRunTask(base::LazyNow&)+141",
        "Chromium.Framework+189482296",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1008",
        "Chromium.Framework+196471096",
        "Chromium.Framework+196471096",
        "Chromium.Framework+196471096",
        "Chromium.Framework+195555008",
        "recordreplay::RegionHitsMap::AddFunction(unsigned.long,.unsigned.long)+89",
        "linker+1130882",
        "Chromium.Framework+195554320",
        "recordreplay::AddPerformanceExecutionPoint(char.const*,.char.const*,.unsigned.int,.unsigned.int)+845",
        "EnsureCheckpointData(unsigned.int)+593",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
        "linker+1124275",
        "base::sequence_manager::internal::ThreadController::RunLevelTracker::OnWorkEnded(base::LazyNow&)+48",
        "Chromium.Framework+196471096",
        "linker+1389024",
        "linker+1124275",
        "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
        "Chromium.Framework+189483736",
        "base::MessagePumpCFRunLoopBase::RunWork()+96",
        "base::MessagePumpCFRunLoopBase::RunWorkSource(void*)",
        "linker+1124275",
        "void.recordreplay::Compose<&(void.PtrArg<(Ptr)6,.0ul>(recordreplay::CallContext&)),.&(void.recordreplay::CStringArg<1ul>(recordreplay::CallContext&)),.&(void.recordreplay::ScalarArg<2ul,.8ul>(recordreplay::CallContext&)),.&(void.PtrOutParam<(Ptr)0,.3ul>(recordreplay::CallContext&)),.&(void.recordreplay::CopyFontDataFromArgToOutParam<0ul,.3ul>(recordreplay::CallContext&)),.&(recordreplay::ScalarRval(recordreplay::CallContext&)),.&(recordreplay::CallPassThroughIfUnknown(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&))>(recordreplay::CallContext&)+77",
        "linker+1130882",
        "Chromium.Framework+185346427",
        "recordreplay::ELFBinary::ProcessRelocation(unsigned.long,.unsigned.long,.long)+199",
        "linker+1388496",
        "void.recordreplay::Compose<&(void.PtrArg<(Ptr)32,.0ul>(recordreplay::CallContext&)),.&(void.recordreplay::CStringArg<1ul>(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&)),.&(recordreplay::CallNoOp(recordreplay::CallContext&))>(recordreplay::CallContext&)+46",
        "recordreplay::CStringArrayRval(recordreplay::CallContext&)+731",
        "linker+1124275",
        "Chromium.Framework+185346413",
        "Chromium.Framework+185346427",
        "Chromium.Framework+185346427",
        "linker+1124275",
        "base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*)+165",
        "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
        "Chromium.Framework+196471096",
        "base::RunLoop::Run(base::Location.const&)+421",
        "base::SampleVectorBase::Accumulate(int,.int)+58",
        "Chromium.Framework+189479936"
      ],
      "progress": 726710,
      "checkpoint": 86
    },
    "why": "LinkerFatalError",
    "threadId": 1,
    "text": "Command error id bf555f1c-2333-4e0c-ac4a-cd5a9db3ba7b; triggering crash: {\"code\":-32000,\"errorId\":\"bf555f1c-2333-4e0c-ac4a-cd5a9db3ba7b\",\"is_error\":true,\"message\":\"Cannot find context with specified id (-32000)\",\"stack\":[\"Error: Cannot find context with specified id (-32000)\",\"    at sendCDPMessage (record-replay-internal:230:11)\",\"    at ProtocolObjectPreview.fill (record-replay-internal:1404:25)\",\"    at createPauseObject (record-replay-internal:1171:83)\",\"    at Object.Pause_getObjectPreview [as Pause.getObjectPreview] (record-replay-internal:680:22)\",\"    at executeCommand (record-replay-internal:332:42)\",\"    at commandCallback (record-replay-internal:344:12)\"]}",
    "file": "src/cpp/shared/Command.cpp",
    "line": 110,
    "manifest": {
      "kind": "runToPoint",
      "endpoint": {
        "checkpoint": 87,
        "progress": 889687
      },
      "getResumeData": [
        "annotations",
        "bookmarks",
        "consoleMessages",
        "events",
        "networkRequestEvents",
        "networkRequests",
        "networkStreamEvents",
        "sources",
        "widgetEvents"
      ]
    },
    "category": "SaplingBranch"
  },
  "processNonFatal": {
    "why": "MissingReport",
    "threadId": 0,
    "category": "SaplingBranch"
  },
  "warnings": [
    {
      "wasRecording": false,
      "threadId": 1,
      "text": "[RUN-2486-2498] Cannot find context with specified id B 2 1 [EventsDisallowed:recordreplay::SendCommand]",
      "progress": 705563,
      "checkpoint": 84,
      "processId": 40,
      "absoluteTime": 1784725548856.9102,
      "stack": [
        "v8::recordreplay::Warning(char.const*,....)+154",
        "v8_inspector::V8InspectorSessionImpl::findInjectedScript(int,.v8_inspector::InjectedScript*&)+161",
        "v8_inspector::V8DebuggerAgentImpl::currentCallFrames(v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.std::Cr::unique_ptr<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>.>.>,.std::Cr::default_delete<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>.>.>.>.>*)+482",
        "v8_inspector::V8DebuggerAgentImpl::getCallFrames(v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.std::Cr::unique_ptr<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>.>.>,.std::Cr::default_delete<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Debugger::CallFrame,.std::Cr::default_delete<v8_inspector::protocol::Debugger::CallFrame>.>.>.>.>.>*)+102",
        "v8_inspector::protocol::Debugger::DomainDispatcherImpl::getCallFrames(v8_crdtp::Dispatchable.const&)+295",
        "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
        "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+612",
        "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+407",
        "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+263",
        "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+921",
        "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
      ],
      "count": 8
    },
    {
      "wasRecording": false,
      "threadId": 1,
      "text": "getObjectByCdpId - Failed to look up cdpId: Cannot find context with specified id [EventsDisallowed:recordreplay::SendCommand]",
      "progress": 726710,
      "checkpoint": 86,
      "processId": 40,
      "absoluteTime": 1784725548982.6797,
      "stack": [
        "recordreplay::Warning(char.const*,....)+155",
        "blink::getObjectByCdpId(v8::Isolate*,.v8_inspector::StringView.const&,.v8::Local<v8::Object>&)+234",
        "blink::fromJsGetObjectByCdpId(v8::FunctionCallbackInfo<v8::Value>.const&)+229",
        "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+263",
        "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+921",
        "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
      ],
      "count": 4
    },
    {
      "wasRecording": false,
      "threadId": 1,
      "text": "Recorded value with events disallowed ErrorUtils::FormatStackTrace [EventsDisallowed:recordreplay::SendCommand]",
      "progress": 726710,
      "checkpoint": 86,
      "processId": 40,
      "absoluteTime": 1784725548984.3179,
      "stack": [
        "v8::recordreplay::RecordReplayString(char.const*,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>&)+80",
        "v8::internal::ErrorUtils::FormatStackTrace(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSObject>,.v8::internal::Handle<v8::internal::Object>)+4312",
        "v8::internal::ErrorUtils::GetFormattedStack(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSObject>)+1121",
        "v8::internal::Accessors::ErrorStackGetter(v8::Local<v8::Name>,.v8::PropertyCallbackInfo<v8::Value>.const&)+56",
        "v8::internal::PropertyCallbackArguments::CallAccessorGetter(v8::internal::Handle<v8::internal::AccessorInfo>,.v8::internal::Handle<v8::internal::Name>)+276",
        "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+993",
        "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
        "v8::internal::LoadIC::Load(v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Name>,.bool,.v8::internal::Handle<v8::internal::Object>)+2457",
        "v8::internal::Runtime_LoadIC_Miss(int,.unsigned.long*,.v8::internal::Isolate*)+495"
      ],
      "count": 1
    },
    {
      "wasRecording": false,
      "threadId": 1,
      "text": "Recorded bytes with events disallowed ErrorUtils::FormatStackTrace [EventsDisallowed:recordreplay::SendCommand]",
      "progress": 726710,
      "checkpoint": 86,
      "processId": 40,
      "absoluteTime": 1784725548984.3518,
      "stack": [
        "v8::internal::ErrorUtils::FormatStackTrace(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSObject>,.v8::internal::Handle<v8::internal::Object>)+4312",
        "v8::internal::ErrorUtils::GetFormattedStack(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSObject>)+1121",
        "v8::internal::Accessors::ErrorStackGetter(v8::Local<v8::Name>,.v8::PropertyCallbackInfo<v8::Value>.const&)+56",
        "v8::internal::PropertyCallbackArguments::CallAccessorGetter(v8::internal::Handle<v8::internal::AccessorInfo>,.v8::internal::Handle<v8::internal::Name>)+276",
        "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+993",
        "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
        "v8::internal::LoadIC::Load(v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Name>,.bool,.v8::internal::Handle<v8::internal::Object>)+2457",
        "v8::internal::Runtime_LoadIC_Miss(int,.unsigned.long*,.v8::internal::Isolate*)+495"
      ],
      "count": 1
    }
  ],
  "processId": 40
}

```

</details>