### PR TITLE
Roll v8: JS applicationDataMismatch tail + valid JSON

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '41899d01d218b849cd99e99291736ccd5da84af5',
+  'v8_revision': 'afa06880addd850e8467024ed146963fc3b8ee82',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '34a6d6c5a6a91e7f6da7d1edfe4c0f91c7d50406',
+  'v8_revision': '41899d01d218b849cd99e99291736ccd5da84af5',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
# Problem

* Crash reports' JS-divergence signal (`applicationDataMismatch`) dropped the target-progress frame and was not valid JSON.

# Solution

* Roll `v8_revision` to `afa06880` (replayio/chromium-v8 master, PR #284 merged).
* v8 PR: https://github.com/replayio/chromium-v8/pull/284

🤖 Generated with [Claude Code](https://claude.com/claude-code)