### PR TITLE
Order WTF::RecursiveMutex::owner_ for deterministic replay

### DIFF
--- a/third_party/blink/renderer/platform/wtf/threading_primitives.h
+++ b/third_party/blink/renderer/platform/wtf/threading_primitives.h
@@ -35,6 +35,7 @@
 
 #include "base/check_op.h"
 #include "base/gtest_prod_util.h"
+#include "base/record_replay_ordered_atomic.h"
 #include "base/synchronization/lock.h"
 #include "base/thread_annotations.h"
 #include "base/threading/platform_thread.h"
@@ -59,7 +60,8 @@ class LOCKABLE WTF_EXPORT RecursiveMutex {
   void AssertAcquired() const ASSERT_EXCLUSIVE_LOCK() {
     // TS_UNCHECKED_READ: Either we are the owner and then the value can be
     // read, or we aren't, and we are guaranteed to not see our own thread ID.
-    DCHECK_EQ(TS_UNCHECKED_READ(owner_), base::PlatformThread::CurrentId());
+    DCHECK_EQ(TS_UNCHECKED_READ(owner_).load_unordered(),
+              base::PlatformThread::CurrentId());
   }
   bool TryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true);
 
@@ -73,7 +75,7 @@ class LOCKABLE WTF_EXPORT RecursiveMutex {
 
   base::Lock lock_;
   // Atomic only used to avoid load shearing.
-  std::atomic<base::PlatformThreadId> owner_ GUARDED_BY(lock_) =
+  recordreplay::OrderedAtomic<base::PlatformThreadId> owner_ GUARDED_BY(lock_) =
       base::kInvalidThreadId;
   uint64_t lock_depth_ GUARDED_BY(lock_) = 0;
 


### PR DESCRIPTION
# Problems

* `WTF::RecursiveMutex` diverges between recording and replay on the WebAudio render thread.
  * `TryLock` returns a different result across replay.
* The mutex is only partially ordered.
  * Its inner `base::Lock` is named and replay-ordered, but its `owner_` thread-id atomic is not.
  * `owner_` is read and written with `memory_order_relaxed`, outside replay ordering.
* The culprit is one line in `RecursiveMutex::TryLock`.
  * `if ((owner_.load(std::memory_order_relaxed) == thread_id) || lock_.Try()) {`
  * `owner_` is the left operand of the short-circuit `||`, so a divergent load skips the ordered `lock_.Try()` and desyncs the per-thread events stream.

# Solution

* Order `owner_` through the existing replay atomic wrapper.
  * Change its type to `recordreplay::OrderedAtomic<base::PlatformThreadId>`; call sites are unchanged.
* Rationale.
  * `owner_` was the last unordered atomic on the lock path, and its cost matches the already-ordered `base::Lock`.
  * Events are allowed at these call sites, so the ordered load is safe; events-disallowed paths use lock id 0 and stay no-ops.
