### PR TITLE
Keep DOMTaskQueue alive until DOMScheduler GC

### DIFF
--- a/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
+++ b/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
@@ -51,11 +51,10 @@ void DOMScheduler::ContextDestroyed() {
     signal_to_task_queue_map_.size());
 
   fixed_priority_task_queues_.clear();
-  signal_to_task_queue_map_.clear();
-
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  // Keep queue alive via pinned signal until DOMScheduler itself is GC-collected.
+  if (!recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
                                             "DOMScheduler")) {
-    replay_strong_signal_.clear();
+    signal_to_task_queue_map_.clear();
   }
 }
 


### PR DESCRIPTION
# Problem

* Crash: `BudgetPool::RemoveThrottler` mismatch on `PointerId(throttler)`.
  * Recorded `4855` vs replayed `2118`.
  * Byte-identical stacks, value-only divergence.
* Diverging ordinal traces to a `DOMTaskQueue` destroyed at a non-deterministic cppgc lazy-sweep point.
  * Its teardown `(Un)RegisterPointer`s, perturbing the ordinal stream.
  * Warning confirms it: queue dtor fires inside `Sweeper::SweepForAllocationIfRunning`.
* Should already be prevented by a previous intervention, tagged `avoid-weak-pointers`.
  * `DOMScheduler` holds queues in `signal_to_task_queue_map_`, keyed by a **weak** signal ref.
    * Weak-key GC is what frees the queue at a divergent point.
  * A previous intervention pins each signal in `replay_strong_signal_`.
    * Keeps the weak key alive, thus the strong-valued queue alive.
* Defect: `ContextDestroyed` clears both the map and the signal pins.
  * Queue loses its last strong refs before the `DOMScheduler` is collected.
  * Queue then swept non-deterministically.
  * Reproduces the exact divergence the intervention was meant to remove.

# Solution

* In `ContextDestroyed`, under replay: skip clearing the map and the signal pins.
  * Signal stays pinned, so the queue lives until the `DOMScheduler` itself is GC-collected.
  * Defers the queue dtor past the non-deterministic sweep window.
* Correctness-safe.
  * Detached queue is inert.
    * `IsThrottled()` is false once detached.
  * Throttler id fixed at construction.
    * Keep-alive only defers teardown, never changes the id.
  * Leak bounded by the `DOMScheduler` lifetime.

# Raw data

## Mismatch

```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "recorded": "[TT-1465-1466] BudgetPool::RemoveThrottler 4855",
  "replayed": "[TT-1465-1466] BudgetPool::RemoveThrottler 2118",
  "threadId": 1,
  "backtrace": { "progress": 1173310, "threadId": 1, "checkpoint": 326 },
  "stack": [
    "blink::scheduler::BudgetPool::RemoveThrottler(base::TimeTicks, blink::scheduler::TaskQueueThrottler*)+173",
    "blink::scheduler::FrameSchedulerImpl::RemoveThrottleableQueueFromBudgetPools(blink::scheduler::MainThreadTaskQueue*)+129",
    "blink::scheduler::FrameSchedulerImpl::~FrameSchedulerImpl()+131",
    "blink::LocalFrame::DetachImpl(blink::FrameDetachType)+1337",
    "blink::Frame::Detach(blink::FrameDetachType)+115",
    "blink::Frame::SwapImpl(blink::WebFrame*, mojo::PendingAssociatedRemote<blink::mojom::blink::RemoteFrameHost>, mojo::PendingAssociatedReceiver<blink::mojom::blink::RemoteFrame>)+234"
  ]
}
```

## Warning

```json
{
  "text": "Recording assertion with events disallowed: [TT-1465] FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed 2108 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
  "count": 12,
  "stack": [
    "blink::scheduler::FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed(blink::scheduler::MainThreadTaskQueue*)+46",
    "blink::scheduler::MainThreadWebSchedulingTaskQueueImpl::~MainThreadWebSchedulingTaskQueueImpl()+119",
    "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*, unsigned long, v8::base::TimeDelta)+507",
    "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&, unsigned long, cppgc::internal::AlignVal, unsigned short)+307",
    "blink::Document::EnsurePaintLocationDataValidForNode(blink::Node const*, blink::DocumentUpdateReason)+121",
    "blink::Element::getBoundingClientRect()+57"
  ],
  "threadId": 1,
  "processId": 3,
  "wasRecording": true
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
