### PR TITLE
crash-0006: make AudioNode orphan-handler add GC-timing-independent

### DIFF
--- a/third_party/blink/renderer/modules/webaudio/audio_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_node.cc
@@ -90,10 +90,15 @@ void AudioNode::Dispose() {
   // being processed, the handler must be added.  If the context is suspended,
   // the handler still needs to be added in case the context is resumed.
   DCHECK(context());
-  if (context()->IsPullingAudioGraph() ||
-      context()->ContextState() == BaseAudioContext::kSuspended) {
-    context()->GetDeferredTaskHandler().AddRenderingOrphanHandler(
-        std::move(handler_));
+  // Skip the GC-controlled orphan-handler mutation read by the audio thread.
+  if (!(recordreplay::AreEventsDisallowed() &&
+        recordreplay::IsRecordingOrReplaying("leak-references",
+                                             "AudioNode::Dispose"))) {
+    if (context()->IsPullingAudioGraph() ||
+        context()->ContextState() == BaseAudioContext::kSuspended) {
+      context()->GetDeferredTaskHandler().AddRenderingOrphanHandler(
+          std::move(handler_));
+    }
   }
 
   // Notify the inspector that this node is going away. The actual clean up


### PR DESCRIPTION
# Problem

* Symptom: ReplayMismatch divergence.
  * Recorded `TaskQueueImpl::TaskRunner::PostDelayedTask 81274`.
  * Replayed `OrderedLock atomic 28363`.
  * Thread 14, checkpoint 584, progress 103632873.
* Both record and replay are inside the same `if(TryLock())` critical section.
  * `RealtimeAudioDestinationHandler::Render` -> `AudioContext::HandlePostRenderTasks` -> `RequestToDeleteHandlersOnMainThread`.
  * Divergence is a branch INSIDE the critical section, not a lock race.
* The branch that diverges reads ONE piece of state: the orphan-handler list.
  * `deferred_task_handler.cc:348-351` quick-exit in `RequestToDeleteHandlersOnMainThread`.
  * Branch condition reads `rendering_orphan_handlers_.empty()`.
  * Record: list non-empty -> falls through -> `PostCrossThreadTask` -> `PostDelayedTask`.
  * Replay: list empty -> early-return -> reaches `unlock()` -> `OrderedLock atomic`.
  * So the divergence is fully determined by whether `rendering_orphan_handlers_` is empty at this point.
* That list has exactly ONE producer, and it runs at a non-deterministic time.
  * Only `AddRenderingOrphanHandler` pushes onto `rendering_orphan_handlers_`.
  * Its only caller of interest is `AudioNode::Dispose()` at `audio_node.cc:93-97`.
  * `Dispose()` runs as a cppgc pre-finalizer, i.e. during GC.
  * GC timing is non-deterministic between record and replay.
  * Therefore the list is populated at different times in record vs replay, flipping the branch above.
* => `AddRenderingOrphanHandler` in `Dispose()` is the target.
  * It is the single GC-timing-dependent input to the diverging branch.
  * Confirmed by warning: `Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]` on the `AudioNode::Dispose` pre-finalizer stack.

# Solution

* Recipe: `determinism-leak-memory`, skip-subset shape.
  * Skip the GC-controlled cross-thread mutation when run as a pre-finalizer.
* Implementation:
  * `audio_node.cc`: guard the `AddRenderingOrphanHandler` block.
  * Skip only when `AreEventsDisallowed() && IsRecordingOrReplaying("leak-references", "AudioNode::Dispose")`.
  * Mirrors existing `ClearContextFromOrphanHandlers` guard in `deferred_task_handler.cc:388-394`.
* Why it works:
  * The only GC-timing-dependent input to the diverging branch is `rendering_orphan_handlers_`.
  * Skipping the add during GC makes that list GC-timing-independent.
  * `handler_` is still released by `~AudioNode`, so no real leak of the handler.
  * Pre-finalizer runs only on dead objects, so skipping the add is side-effect-safe.

# Raw Data

* buildId: linux-chromium-20260626-9aa456976e8d-bbef03887da6
* linkerVersion: linker-linux-15936-bbef03887da6
* recordingId: e25f96b0-df71-4fa2-b2e0-6e7adc1c8acc
* Crash core:
  * why=Mismatch, category=CreateDiffRoot.
  * recorded=`TaskQueueImpl::TaskRunner::PostDelayedTask 81274`.
  * replayed=`OrderedLock atomic 28363`.
  * threadId=14, checkpoint=584, progress=103632873.
* Recorded stack:
  * `TaskQueueImpl::TaskRunner::PostDelayedTask+79`
  * `TaskRunner::PostTask+39`
  * `DeferredTaskHandler::RequestToDeleteHandlersOnMainThread+418`
  * `AudioContext::HandlePostRenderTasks+61`
  * `RealtimeAudioDestinationHandler::Render+479`
* Replayed stack:
  * `RecursiveMutex::unlock()+135`
  * `RealtimeAudioDestinationHandler::Render+479`
  * `AudioDestination::RequestRender+603`
* Warning:
  * `Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]`, count 100.
  * Stack: `AudioNode::Dispose()+194` <- `InvokePreFinalizer` <- `PreFinalizerHandler::InvokePreFinalizers` <- `CppHeap::TraceEpilogue` <- `Heap::CollectGarbage`.
