### PR TITLE
Add UKM port-selection divergence asserts

### DIFF
--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -7542,6 +7542,10 @@ ukm::UkmRecorder* Document::UkmRecorder() {
       recorder.InitWithNewPipeAndPassReceiver());
   ukm_recorder_ = std::make_unique<ukm::MojoUkmRecorder>(std::move(recorder));
 
+  recordreplay::Assert("Document::UkmRecorder mint doc=%d sourceId=%lld",
+                       recordreplay::PointerId(this),
+                       (long long)UkmSourceID());
+
   return ukm_recorder_.get();
 }
 

--- a/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/main_thread_scheduler_impl.cc
@@ -2435,6 +2435,10 @@ void MainThreadSchedulerImpl::RecordTaskUkm(
     return;
 
   if (queue && queue->GetFrameScheduler()) {
+    REPLAY_ASSERT(
+        "MainThreadSchedulerImpl::RecordTaskUkm precise frame=%d sourceId=%lld",
+        recordreplay::PointerId(queue->GetFrameScheduler()),
+        queue->GetFrameScheduler()->GetUkmSourceId());
     auto status = RecordTaskUkmImpl(queue, task, task_timing,
                                     queue->GetFrameScheduler(), true);
     UMA_HISTOGRAM_ENUMERATION(
@@ -2450,10 +2454,21 @@ void MainThreadSchedulerImpl::RecordTaskUkm(
   std::sort(page_schedulers.begin(), page_schedulers.end(),
             recordreplay::CompareByPointerId());
 
+  REPLAY_ASSERT("MainThreadSchedulerImpl::RecordTaskUkm fallback count=%zu",
+                page_schedulers.size());
+
+  int i = 0;
   for (PageSchedulerImpl* page_scheduler : page_schedulers) {
-    auto status = RecordTaskUkmImpl(
-        queue, task, task_timing,
-        page_scheduler->SelectFrameForUkmAttribution(), false);
+    FrameSchedulerImpl* frame_scheduler =
+        page_scheduler->SelectFrameForUkmAttribution();
+    REPLAY_ASSERT(
+        "MainThreadSchedulerImpl::RecordTaskUkm fallback i=%d page=%d frame=%d "
+        "sourceId=%lld",
+        i++, recordreplay::PointerId(page_scheduler),
+        frame_scheduler ? recordreplay::PointerId(frame_scheduler) : -1,
+        frame_scheduler ? frame_scheduler->GetUkmSourceId() : int64_t{-1});
+    auto status =
+        RecordTaskUkmImpl(queue, task, task_timing, frame_scheduler, false);
     UMA_HISTOGRAM_ENUMERATION(
         "Scheduler.Experimental.Renderer.UkmRecordingStatus", status,
         UkmRecordingStatus::kCount);

--- a/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/page_scheduler_impl.cc
@@ -855,12 +855,19 @@ FrameSchedulerImpl* PageSchedulerImpl::SelectFrameForUkmAttribution() {
   std::sort(frame_scheduler_vector.begin(), frame_scheduler_vector.end(),
             recordreplay::CompareByPointerId());
 
-  for (FrameSchedulerImpl* frame_scheduler : frame_scheduler_vector) {
-    if (frame_scheduler->GetUkmRecorder()) {
-      return frame_scheduler;
+  int first_non_null = -1;
+  FrameSchedulerImpl* selected = nullptr;
+  for (int i = 0; i < static_cast<int>(frame_scheduler_vector.size()); ++i) {
+    if (frame_scheduler_vector[i]->GetUkmRecorder()) {
+      first_non_null = i;
+      selected = frame_scheduler_vector[i];
+      break;
     }
   }
-  return nullptr;
+  REPLAY_ASSERT(
+      "PageSchedulerImpl::SelectFrameForUkmAttribution size=%zu firstNonNull=%d",
+      frame_scheduler_vector.size(), first_non_null);
+  return selected;
 }
 
 bool PageSchedulerImpl::HasWakeUpBudgetPools() const {


### PR DESCRIPTION
# Problem

* Symptom: ReplayMismatch at `Node::SendUserMessage` assert (`node.cc:435`), `[RUN-2188-3122]`.
  * Pure data-value divergence: x64 `recordedStack == replayedStack`.
  * Asserted value is the local mojo `port_ref.name()` of the UKM `AddEntry` send pipe.
    * recorded `CE27401DDE1A107C.653DBA74AE0AB113` vs replayed `9A2DA3DB57760EAF.14D751CBE168BAA7`.
    * Both halves differ => a DIFFERENT port was used at replay.
* Causal chain (record-time send path):
  * `RecordTaskUkm` selects which document's UKM recorder/pipe to send on.
    * precise branch (`queue->GetFrameScheduler()`) vs fallback over sorted `page_schedulers`.
  * `SelectFrameForUkmAttribution` picks first frame with a non-null recorder.
  * `Document::UkmRecorder()` lazily mints a new mojo pipe on first call => new `PortName`.
    * `PortName` is drawn from `GenerateRandomPortName`'s deterministically-recorded random cache.
  * `MojoUkmRecorder::AddEntry` sends on that pipe => `Node::SendUserMessage` asserts its name.
* Why a different port at replay (the divergence):
  * Random stream is recorded deterministically => NOT a random-byte divergence.
  * Therefore divergence is in selection / consumption-order: which document/page/frame is chosen, or how many pipes were minted before this one (shifting the random-cache index).
  * Root link is unproven and unprovable from replay alone (record-time DOM/page state unknown).

# Solution

* Solution Recipe: do NOT intervene — ASSERT to narrow the divergence.
  * The one matching recipe (`determinism-iteration-ordering` for the `HashSet<...*>` page/frame containers) is ALREADY applied at the root via `recordreplay::CompareByPointerId()`.
  * Adding a second intervention would paper over an unproven root. Instead, instrument the selection slice with replay-deterministic asserts to find the earliest diverging link.
* Implementation (asserts only; replay-deterministic ids/counts/flags, never raw addresses):
  * `RecordTaskUkm` (`main_thread_scheduler_impl.cc`):
    * precise branch: assert chosen `frame` (PointerId) + `sourceId`.
    * fallback branch: assert `page_schedulers.size()`, then per-iteration `i`, `page`, selected `frame`, `sourceId`.
  * `SelectFrameForUkmAttribution` (`page_scheduler_impl.cc`):
    * assert `frame_scheduler_vector.size()` + index of first non-null recorder (`-1` if none).
    * loop restructured to indexed form capturing the first-non-null index (avoids a double `GetUkmRecorder()` call).
  * `Document::UkmRecorder()` (`document.cc`):
    * on each new-pipe mint, assert `doc` (PointerId) + `sourceId`.
    * keyed by document id (not hit-order) since the mint fires on a separate stack/time.
* Why this works:
  * Exposes the divergence's first observable cause — chosen branch, page/frame membership+order, first-non-null index, or pipe-mint count/order — which directly determines which `PortName` cache slot is consumed.
  * Lets a future replay pinpoint the earliest diverging link, confirming or refuting the candidate before any real intervention.

# Raw Data

* Assert: `[RUN-2188-3122] Node::SendUserMessage`.
  * recorded `CE27401DDE1A107C.653DBA74AE0AB113,`
  * replayed `9A2DA3DB57760EAF.14D751CBE168BAA7,`
* Backtrace top: `Node::SendUserMessage` <- `MessagePipeDispatcher::WriteMessage` <- `Core::WriteMessage` <- `Connector::Accept` <- `InterfaceEndpointClient::SendMessage` <- `SendMojoMessage` <- `UkmRecorderInterfaceProxy::AddEntry`.
* linkerdebug (recording `87491b47-0c75-4e40-b992-43342d63b489`):
  * Recorded name minted once via `[RUN-549] Node::AddPortWithName 11871777991682327295 2159563513122551686 14854912392929349756 7295191981708980499`.
  * => legitimate `PortName` from `GenerateRandomPortName`'s 256-entry `crypto::RandBytes` cache; random stream deterministic.
* buildId `linux-chromium-20260421-aa1324dd45b2-0573bb4ca48f`; linkerVersion `linker-linux-15880-0573bb4ca48f`.
* Endpoint: progress `1825579`, checkpoint `430`; backtrace progress `1809050`, checkpoint `426`, thread `1`.
