### PR TITLE
Leak SVGImage Page during GC sweep to fix AllPages() membership divergence

### DIFF
--- a/third_party/blink/renderer/core/page/page.cc
+++ b/third_party/blink/renderer/core/page/page.cc
@@ -1030,9 +1030,9 @@ void Page::WillBeDestroyed() {
   page_visibility_observer_set_.Clear();
 
   if (recordreplay::AreEventsDisallowed("Page::WillBeDestroyed")) {
-    // If the dtor is called during GC (usually from |~SVGImage|),
-    // we leak the scheduler, so the finalizer does not touch the recording
-    // stream.
+    // If the dtor is called during GC (usually from |~SVGImage|):
+    // leak the scheduler, to avoid calling
+    // MainThreadSchedulerImpl::RemovePageScheduler.
     // https://linear.app/replay/issue/RUN-1347#comment-bc4e3f9d
     PageScheduler* s = page_scheduler_.release();
 

--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -76,11 +76,13 @@
 #include "third_party/blink/renderer/platform/graphics/paint/paint_canvas.h"
 #include "third_party/blink/renderer/platform/graphics/paint/paint_record.h"
 #include "third_party/blink/renderer/platform/graphics/paint/paint_record_builder.h"
+#include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/instrumentation/histogram.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
 #include "third_party/blink/renderer/platform/scheduler/public/main_thread.h"
 #include "third_party/blink/renderer/platform/scheduler/public/main_thread_scheduler.h"
+#include "third_party/blink/renderer/platform/wtf/std_lib_extras.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/geometry/skia_conversions.h"
@@ -221,16 +223,32 @@ SVGImage::~SVGImage() {
     agent_group_scheduler_.release();
 
   if (page_) {
-    // It is safe to allow UA events within this scope, because event
-    // dispatching inside the SVG image's document doesn't trigger JavaScript
-    // execution. All script execution is forbidden when an SVG is loaded as an
-    // image subresource - see SetScriptEnabled in SVGImage::DataChanged().
-    EventDispatchForbiddenScope::AllowUserAgentEvents allow_events;
-    // Store m_page in a local variable, clearing m_page, so that
-    // SVGImageChromeClient knows we're destructed.
-    Page* current_page = page_.Release();
-    // Break both the loader and view references to the frame
-    current_page->WillBeDestroyed();
+    // Leak the Page during nondeterministic GC sweep: WillBeDestroyed() would
+    // erase it from AllPages(), diverging membership at iteration time.
+    if (recordreplay::AreEventsDisallowed("~SVGImage")) {
+      DEFINE_STATIC_LOCAL(Persistent<HeapHashSet<Member<Page>>>, leaked_pages,
+                          (MakeGarbageCollected<HeapHashSet<Member<Page>>>()));
+      leaked_pages->insert(page_.Release());
+      // Null dangling image_ that WillBeDestroyed() would have cleared (UAF).
+      chrome_client_->ChromeDestroyed();
+      // Warn once if the leak grows large.
+      if (leaked_pages->size() == 500) {
+        recordreplay::Warning(
+            "[~SVGImage] Possible performance bottleneck detected: created and "
+            "discarded more than 500 SVGImages.");
+      }
+    } else {
+      // It is safe to allow UA events within this scope, because event
+      // dispatching inside the SVG image's document doesn't trigger JavaScript
+      // execution. All script execution is forbidden when an SVG is loaded as an
+      // image subresource - see SetScriptEnabled in SVGImage::DataChanged().
+      EventDispatchForbiddenScope::AllowUserAgentEvents allow_events;
+      // Store m_page in a local variable, clearing m_page, so that
+      // SVGImageChromeClient knows we're destructed.
+      Page* current_page = page_.Release();
+      // Break both the loader and view references to the frame
+      current_page->WillBeDestroyed();
+    }
   }
 
   // Verify that page teardown destroyed the Chrome

--- a/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.h
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.h
@@ -79,6 +79,8 @@ class CORE_EXPORT SVGImageChromeClient final : public EmptyChromeClient {
     kSuspendedWithAnimationPending,
   } timeline_state_;
 
+  friend class SVGImage;
+
   FRIEND_TEST_ALL_PREFIXES(SVGImageTest, TimelineSuspendAndResume);
   FRIEND_TEST_ALL_PREFIXES(SVGImageTest, ResetAnimation);
   FRIEND_TEST_ALL_PREFIXES(SVGImageSimTest, PageVisibilityHiddenToVisible);


### PR DESCRIPTION
# Problem

* Symptom: replay diverged at `LocalFrameView::SetUseColorAdjustBackground` assert — `this` PointerId recorded `12226` vs replayed `3557` (different `LocalFrameView`).
* Causal chain:
  * SVGImage-backed non-ordinary `Page`'s sole strong root is `SVGImage::page_` (`Persistent<Page>`).
  * `~SVGImage` runs from a cppgc finalizer during a nondeterministic allocation-triggered sweep (`SweepForAllocationIfRunning`).
    * It drops that root via `page_.Release()` → `Page::WillBeDestroyed()`.
  * `Page::WillBeDestroyed()` does `AllPages().erase(this)`.
    * `AllPages()` holds `WeakMember<Page>`, so Page *lifetime* (not the erase) controls membership; sweep timing is nondeterministic.
  * Later `setEmulatedMedia` → `Page::PlatformColorsChanged` iterates `AllPages()` + each page's frame tree.
    * Divergent membership ⇒ different `LocalFrame`/document/view visited.
  * → `StyleEngine::UpdateColorSchemeBackground` materializes a divergent `view` → `SetUseColorAdjustBackground` assert fires.

# Solution

* Recipe: `determinism-leak-memory` — keep the Page alive so `AllPages()` membership is deterministic at iteration time.
* Implementation (`svg_image.cc`, events-disallowed/GC path only):
  * Instead of `Page::WillBeDestroyed()`, move the Page into a static `Persistent<HeapHashSet<Member<Page>>>` (leak it).
  * Call `chrome_client_->ChromeDestroyed()` to null `image_`.
    * `WillBeDestroyed()` is skipped, so its `ChromeDestroyed()` no longer runs; without this, the retained Page's `chrome_client_->image_` is a dangling `SVGImage*` → UAF when the leaked Page is revisited (e.g. `ScheduleAnimation` → `image_->MaybeAnimated()`).
  * `page.cc`: comment-only clarification of the existing scheduler-leak rationale.
* Why it works:
  * Leaking the Page keeps it (and its `main_frame_`/frame tree) permanently in `AllPages()` ⇒ membership + visited-frame set deterministic across record/replay.
  * Iteration order is already deterministic (`PageHash` on `RecordReplayId`); only membership diverged, and only on the GC path.
  * Nulling `image_` matches normal teardown; all `SVGImageChromeClient` consumers are null-guarded once `image_==nullptr`, and upholds the trailing `DCHECK(!chrome_client_ || !chrome_client_->GetImage())`.
  * Non-GC (normal) teardown path is unchanged.

# Raw Data

* Crash: `Mismatch`, `runToPoint` checkpoint 67.
  * recorded `[RUN-1436] LocalFrameView::SetUseColorAdjustBackground 12226` vs replayed `3557`.
  * Stack: `setEmulatedMedia` → `Page::PlatformColorsChanged` → `StyleEngine::UpdateColorSchemeBackground` → `LocalFrameView::SetUseColorAdjustBackground`.
* Warning (`wasRecording:true`, `EventsDisallowed`):
  * `SVGImage::~SVGImage` → `Page::WillBeDestroyed` → `PageSchedulerImpl::BreakLinkages`, run from `Sweeper::SweepForAllocationIfRunning` (allocation-triggered cppgc sweep).
* recordingId: `a54a3b1f-09c3-4c93-9a82-263b81be2bd3`
* buildId: `linux-chromium-20260626-9aa456976e8d-bbef03887da6`
