### PR TITLE
Add `forceCheckpoint` JS API

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd05979790fe3df0d05db0aa4a7ef62456edd6892',
+  'v8_revision': 'e2e638f2de6d098838de4a922437ad13ba52bafc',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/base/record_replay.cc
+++ b/base/record_replay.cc
@@ -86,6 +86,7 @@ namespace recordreplay {
   Macro(V8RecordReplayOrderedLock, (int lock), (lock))                  \
   Macro(V8RecordReplayOrderedUnlock, (int lock), (lock))                \
   Macro(V8RecordReplayNewCheckpoint, (), ())                            \
+  Macro(V8RecordReplayNewCheckpointFlushed, (), ())                     \
   Macro(V8RecordReplayOnAnnotation,                                     \
         (const char* kind, const char* contents),                       \
         (kind, contents))                                               \
@@ -360,6 +361,10 @@ void OrderedUnlock(int lock) {
 
 void NewCheckpoint() {
   V8RecordReplayNewCheckpoint();
+}
+
+void NewCheckpointFlushed() {
+  V8RecordReplayNewCheckpointFlushed();
 }
 
 uint64_t NewBookmark() {

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -60,6 +60,7 @@ struct AutoOrderedLock {
 
 void InvalidateRecording(const char* why);
 void NewCheckpoint();
+void NewCheckpointFlushed();
 
 uint64_t NewBookmark();
 void OnAnnotation(const char* kind, const char* contents);

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -18,6 +18,7 @@ const {
   setClearPauseDataCallback,
   addNewScriptHandler,
   getCurrentError,
+  forceCheckpoint,
 
   layoutDom,
 
@@ -3300,6 +3301,7 @@ Object.assign(__RECORD_REPLAY__, {
   getFrameArgumentsArray,
   getCurrentEvaluateFrame,
   replayEval,
+  forceCheckpoint,
   forTestingSerializeValueToArray
 });
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -681,6 +681,17 @@ static void LogWarningCallback(const v8::FunctionCallbackInfo<v8::Value>& args) 
   recordreplay::Warning("%s", *text);
 }
 
+static void ForceCheckpointCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  CHECK(args.Length() == 0 && "must be called without arguments");
+  if (recordreplay::IsInReplayCode("forceCheckpoint")) {
+    return;
+  }
+
+  // Use a flushed checkpoint so explicit test checkpoints are not dropped by
+  // the normal time-based checkpoint throttle.
+  recordreplay::NewCheckpointFlushed();
+}
+
 void
 RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
                                 v8::Isolate* isolate) {
@@ -2613,6 +2624,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, args, "getPersistentId", fromJsGetPersistentId);
   SetFunctionProperty(isolate, args, "checkPersistentId", fromJsCheckPersistentId);
   SetFunctionProperty(isolate, args, "getProgressCounter", fromJsGetProgressCounter);
+  SetFunctionProperty(isolate, args, "forceCheckpoint", ForceCheckpointCallback);
   SetFunctionProperty(isolate, args, "registerRootFrameScript",
                       fromJsRegisterRootFrameScript);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -681,7 +681,7 @@ static void LogWarningCallback(const v8::FunctionCallbackInfo<v8::Value>& args) 
   recordreplay::Warning("%s", *text);
 }
 
-static void ForceCheckpointCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+static void fromJsForceCheckpoint(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 0 && "must be called without arguments");
   if (recordreplay::IsInReplayCode("forceCheckpoint")) {
     return;
@@ -2624,7 +2624,7 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   SetFunctionProperty(isolate, args, "getPersistentId", fromJsGetPersistentId);
   SetFunctionProperty(isolate, args, "checkPersistentId", fromJsCheckPersistentId);
   SetFunctionProperty(isolate, args, "getProgressCounter", fromJsGetProgressCounter);
-  SetFunctionProperty(isolate, args, "forceCheckpoint", ForceCheckpointCallback);
+  SetFunctionProperty(isolate, args, "forceCheckpoint", fromJsForceCheckpoint);
   SetFunctionProperty(isolate, args, "registerRootFrameScript",
                       fromJsRegisterRootFrameScript);
 


### PR DESCRIPTION
pairs with https://github.com/replayio/chromium-v8/pull/286

I need this to force checkpoints at times for my deterministic tests that need to reason about progress and frame steps and how those are *laid out* within checkpoints. I basically need to create a "cutoff" point from which I could reason about small JS samples. This allows me to ignore whatever happened (and how checkpoints were auto-created) before that cutoff point.