### PR TITLE
Don't treat <select> popup as record/replay root frame

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -57,6 +57,7 @@
 #include "third_party/blink/renderer/core/inspector/inspector_task_runner.h"
 #include "third_party/blink/renderer/core/inspector/main_thread_debugger.h"
 #include "third_party/blink/renderer/core/loader/frame_loader.h"
+#include "third_party/blink/renderer/core/page/page.h"
 #include "third_party/blink/renderer/core/script/modulator.h"
 #include "third_party/blink/renderer/platform/bindings/dom_wrapper_world.h"
 #include "third_party/blink/renderer/platform/bindings/extensions_registry.h"
@@ -245,7 +246,9 @@ void LocalWindowProxy::Initialize() {
     bool initGlobally = !gRecordReplayStateInitialized;
 
     // Whether this is the relative root frame of this process.
-    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld();
+    // IsOrdinary() excludes internal pages like the in-process <select> popup.
+    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
+                       GetFrame()->GetPage() && GetFrame()->GetPage()->IsOrdinary();
     if (initGlobally) {
       gRecordReplayStateInitialized = true;
 


### PR DESCRIPTION
# Problem

- Symptom: `OnRootFrameInit` runs when opening a `<select>` dropdown.
  - Should never happen for a popup menu.
- Causal chain:
  - `<select>` on Linux desktop renders in-process.
    - `InternalPopupMenu` inside a `WebPagePopupImpl`.
  - Popup creates its own `Page` and opener-less `LocalFrame`.
    - `Page::CreateNonOrdinary` at web_page_popup_impl.cc:124.
    - frame `Init` with `opener=nullptr` at web_page_popup_impl.cc:406.
  - Popup frame has no parent.
    - `IsLocalRoot()` is true.
    - main-world context, `IsMainWorld()` is true.
  - So `isMainFrame` at local_window_proxy.cc:248 is wrongly true.
  - Popup empty doc inherits opener origin.
    - non-empty host.
    - passes the `origin && !origin->Host().empty()` gate.
    - enters the record/replay block and calls `OnRootFrameInit`.
  - `OnRootFrameInit` for the popup:
    - overwrites `gRootLocalFrame`.
    - resets paint surface.
    - re-runs command-handler / sourcemap init.

# Solution

- Solution Recipe: gate `isMainFrame` on `Page::IsOrdinary()`.
- Implementation:
  - local_window_proxy.cc:248.
    ```cpp
    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
                       GetFrame()->GetPage() && GetFrame()->GetPage()->IsOrdinary();
    ```
  - Add include `core/page/page.h`.
- Why does this work?
  - `IsOrdinary()` is false for `CreateNonOrdinary` pages.
    - covers the `<select>` popup.
  - `IsOrdinary()` is true for real user pages.
    - real root frames still take the branch.
