### PR TITLE
CRASH-0012: WebAudio render divergence diagnostics

### DIFF
--- a/third_party/blink/renderer/modules/webaudio/audio_node_input.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_node_input.cc
@@ -29,6 +29,7 @@
 #include <memory>
 
 #include "base/memory/ptr_util.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/modules/webaudio/audio_node_output.h"
 #include "third_party/blink/renderer/modules/webaudio/audio_node_wiring.h"
 
@@ -141,6 +142,9 @@ scoped_refptr<AudioBus> AudioNodeInput::Pull(AudioBus* in_place_bus,
   DCHECK(GetDeferredTaskHandler().IsAudioThread());
 
   // Handle single connection case.
+  recordreplay::Assert(
+      "AudioNodeInput::Pull connections %u channel_count_mode %d",
+      NumberOfRenderingConnections(), Handler().InternalChannelCountMode());
   if (NumberOfRenderingConnections() == 1 &&
       Handler().InternalChannelCountMode() == AudioHandler::kMax) {
     // The output will optimize processing using inPlaceBus if it's able.
@@ -150,6 +154,8 @@ scoped_refptr<AudioBus> AudioNodeInput::Pull(AudioBus* in_place_bus,
 
   scoped_refptr<AudioBus> internal_summing_bus = InternalSummingBus();
 
+  recordreplay::Assert("AudioNodeInput::Pull connections %u",
+                       NumberOfRenderingConnections());
   if (!NumberOfRenderingConnections()) {
     // At least, generate silence if we're not connected to anything.
     // FIXME: if we wanted to get fancy, we could propagate a 'silent hint' here

--- a/third_party/blink/renderer/modules/webaudio/audio_scheduled_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_scheduled_source_handler.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 
+#include "base/record_replay.h"
 #include "third_party/blink/public/platform/task_type.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/modules/event_modules.h"
@@ -73,6 +74,10 @@ AudioScheduledSourceHandler::UpdateSchedulingInfo(size_t quantum_frame_size,
 
   // If we know the end time and it's already passed, then don't bother doing
   // any more rendering this cycle.
+  recordreplay::Assert(
+      "AudioScheduledSourceHandler::UpdateSchedulingInfo siteA end_time %f "
+      "end_frame %zu quantum_start_frame %zu quantum_end_frame %zu",
+      end_time_, end_frame, quantum_start_frame, quantum_end_frame);
   if (end_time_ != kUnknownTime && end_frame <= quantum_start_frame) {
     Finish();
   }
@@ -152,6 +157,10 @@ AudioScheduledSourceHandler::UpdateSchedulingInfo(size_t quantum_frame_size,
       }
     }
 
+    recordreplay::Assert(
+        "[CRASH-0012] UpdateSchedulingInfo Finish siteB end_time %f "
+        "end_frame %zu quantum_start_frame %zu quantum_end_frame %zu",
+        end_time_, end_frame, quantum_start_frame, quantum_end_frame);
     Finish();
   }
 

--- a/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
@@ -5,6 +5,7 @@
 #include "third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.h"
 
 #include "base/feature_list.h"
+#include "base/record_replay.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/platform/web_audio_latency_hint.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -198,6 +199,9 @@ void RealtimeAudioDestinationHandler::Render(
   // Only pull on the audio graph if we have not stopped the destination.  It
   // takes time for the destination to stop, but we want to stop pulling before
   // the destination has actually stopped.
+  recordreplay::Assert(
+      "RealtimeAudioDestinationHandler::Render allow_pulling_audio_graph %d",
+      IsPullingAudioGraphAllowed());
   if (IsPullingAudioGraphAllowed()) {
     // Renders the graph by pulling all the inputs to this node. This will in
     // turn pull on their inputs, all the way backwards through the graph.


### PR DESCRIPTION
# G1: CRASH-0012 StackNoCommonFrame — WebAudio render diagnostics

* Symptom
  * ReplayMismatch, `StackNoCommonFrame`.
  * Recorded leaf: `PostDelayedTask` under `AudioScheduledSourceHandler::Finish`.
  * Replayed leaf: `RecursiveMutex::TryLock` under `AudioContext::HandlePostRenderTasks`.
  * Both stacks root in the WebAudio render pull.
* Constraint
  * No recording available to prove the first divergent branch.
  * Scope limited to diagnostics per divergence protocol.
* Change
  * Insert `recordreplay::Assert` at each viable candidate branch on the divergent path.
  * Goal: convert the stack mismatch into a data mismatch on the next crash.
  * Files
    * `realtime_audio_destination_handler.cc`: assert `IsPullingAudioGraphAllowed()` before the graph-pull gate.
    * `audio_node_input.cc`: assert connection count + channel-count mode before single-connection and zero-connection gates.
    * `audio_scheduled_source_handler.cc`: assert `end_time_`/frame bounds before the siteA early-`Finish` gate.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackNoCommonFrame
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $DETERMINATOR_DIR/issues/crash-0012/crash-report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* You can read $DETERMINATOR_DIR/issues/crash-0012/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260709-3fc067f1c293-ed87c3d17b52
* linkerVersion: linker-linux-16006-ed87c3d17b52
* recordingId: 43044b45-33a0-4131-b320-dd20902a8fdc

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "SaplingBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 451101,
      "checkpoint": 26
    },
    "getResumeData": [
      "annotations",
      "bookmarks",
      "consoleMessages",
      "events",
      "networkRequestEvents",
      "networkRequests",
      "networkStreamEvents",
      "sources",
      "widgetEvents"
    ]
  },
  "recorded": "TaskQueueImpl::TaskRunner::PostDelayedTask 4813",
  "replayed": "OrderedLock atomic 1312",
  "threadId": 15,
  "backtrace": {
    "progress": 392062,
    "threadId": 15,
    "checkpoint": 21
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "base::sequence_manager::internal::TaskQueueImpl::TaskRunner::PostDelayedTask(base::Location.const&,.base::OnceCallback<void.()>,.base::TimeDelta)+79",
    "base::TaskRunner::PostTask(base::Location.const&,.base::OnceCallback<void.()>)+39",
    "blink::AudioScheduledSourceHandler::Finish()+319",
    "blink::AudioScheduledSourceHandler::UpdateSchedulingInfo(unsigned.long,.blink::AudioBus*)+793",
    "blink::OscillatorHandler::Process(unsigned.int)+130",
    "blink::AudioHandler::ProcessIfNecessary(unsigned.int)+409",
    "blink::AudioNodeOutput::Pull(blink::AudioBus*,.unsigned.int)+88"
  ],
  "replayedStack": [
    "WTF::RecursiveMutex::TryLock()+34",
    "blink::AudioContext::HandlePostRenderTasks()+21",
    "blink::RealtimeAudioDestinationHandler::Render(blink::AudioBus*,.unsigned.int,.blink::AudioIOPosition.const&,.blink::AudioCallbackMetric.const&)+479",
    "blink::AudioDestination::RequestRender(unsigned.long,.unsigned.long,.double,.double,.unsigned.long)+603",
    "blink::AudioDestination::Render(blink::WebVector<float*>.const&,.unsigned.int,.double,.double,.unsigned.long)+940",
    "content::RendererWebAudioDeviceImpl::Render(base::TimeDelta,.base::TimeTicks,.int,.media::AudioBus*)+402",
    "media::SilentSinkSuspender::Render(base::TimeDelta,.base::TimeTicks,.int,.media::AudioBus*)+646",
    "media::AudioOutputDeviceThreadCallback::Process(unsigned.int)+238"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 100,
    "stack": [
      "WTF::RecursiveMutex::unlock()+135",
      "blink::AudioNode::Dispose()+228",
      "blink::AudioNode::InvokePreFinalizer(cppgc::LivenessBroker.const&,.void*)+44",
      "cppgc::internal::PreFinalizerHandler::InvokePreFinalizers()+167",
      "cppgc::internal::HeapBase::ExecutePreFinalizers()+39",
      "v8::internal::CppHeap::TraceEpilogue()+210",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+3404",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::Heap::HandleGCRequest()+223",
      "v8::internal::StackGuard::HandleInterrupts()+626",
      "v8::internal::Runtime_StackGuard(int,.unsigned.long*,.v8::internal::Isolate*)+314"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1783711025207.8083,
    "wasRecording": true
  }
]
```

# Basic Facts

## FrameCandidates

* `blink::AudioNodeOutput::Pull(blink::AudioBus*,.unsigned.int)+88`
  * location: `blink::AudioNodeOutput::Pull` at `third_party/blink/renderer/modules/webaudio/audio_node_output.cc:140`
  * code: `Handler().ProcessIfNecessary(frames_to_process);`
* `blink::RealtimeAudioDestinationHandler::Render(blink::AudioBus*,.unsigned.int,.blink::AudioIOPosition.const&,.blink::AudioCallbackMetric.const&)+479`
  * location: `blink::RealtimeAudioDestinationHandler::Render` at `third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc:230`
  * code: `context->HandlePostRenderTasks();`

## DivergentPathSegments

### Root: AudioNodeOutput::Pull

```cpp
// Root (recorded): AudioNodeOutput::Pull+88
void AudioNodeOutput::Pull(...) {
  // AudioHandler::ProcessIfNecessary+409 (recorded)
  Handler().ProcessIfNecessary(frames_to_process);
    // [Branch] RECORDED: not-taken
    if (!IsInitialized()) return;
    // [Branch] RECORDED: taken
    if (last_processing_time_ != current_time) {
      ...
      // [Branch] RECORDED: else-arm
      if (silent_inputs && PropagatesSilence()) {
        SilenceOutputs();
        ProcessOnlyAudioParams(frames_to_process);
      } else {
        UnsilenceOutputs();
        // OscillatorHandler::Process+130 (recorded)
        Process(frames_to_process);
          // [Branch] RECORDED: not-taken
          if (!IsInitialized() || !output_bus->NumberOfChannels()) {
            output_bus->Zero();
            return;
          }
          // [Branch] RECORDED: not-taken
          if (!try_locker.is_acquired()) {
            output_bus->Zero();
            return;
          }
          // [Branch] RECORDED: not-taken
          if (!periodic_wave_.Get()) {
            output_bus->Zero();
            return;
          }
          // AudioScheduledSourceHandler::UpdateSchedulingInfo+793 (recorded)
          UpdateSchedulingInfo(frames_to_process, output_bus);
            // [Branch] CANDIDATE
            if (end_time_ != kUnknownTime && end_frame <= quantum_start_frame) {
              // AudioScheduledSourceHandler::Finish+319 (recorded)
              Finish();
                FinishWithoutOnEnded();
                // base::TaskRunner::PostTask+39 (recorded)
                PostCrossThreadTask(*task_runner_, FROM_HERE, ...);
                  // TaskQueueImpl::TaskRunner::PostDelayedTask+79 (recorded)
                  task_runner.PostTask(...); // <<< RECORDED LEAF
            }
            // [Branch] NOT-ASSERTABLE
            if (state == UNSCHEDULED_STATE || state == FINISHED_STATE ||
                start_frame >= quantum_end_frame) {
              output_bus->Zero();
              return;
            }
            // [Branch] NOT-ASSERTABLE
            if (!non_silent_frames_to_process) {
              output_bus->Zero();
              return;
            }
            // [Branch] NOT-ASSERTABLE
            if (end_time_ != kUnknownTime && end_frame >= quantum_start_frame &&
                end_frame < quantum_end_frame) {
              Finish();
            }
      }
    }
}
```

### Root: AudioOutputDeviceThreadCallback::Process

```cpp
// Root (replayed): AudioOutputDeviceThreadCallback::Process+238
void AudioOutputDeviceThreadCallback::Process(...) {
  // SilentSinkSuspender::Render+646 (replayed)
  render_callback_->Render(delay, delay_timestamp, frames_skipped, output_bus_.get());
    // [Branch] REPLAYED: not-taken
    if (is_using_fake_sink_ && dest) {
      dest->Zero();
      return dest->frames();
    }
    if (!dest) {
      dest = buffers_after_silence_.back().get();
    } else {
      // [Branch] REPLAYED: not-taken
      if (!buffers_after_silence_.empty()) {
        buffers_after_silence_.front()->CopyTo(dest);
        return dest->frames();
      }
    }
    // RendererWebAudioDeviceImpl::Render+402 (replayed)
    callback_->Render(delay, delay_timestamp, prior_frames_skipped, dest);
      // AudioDestination::Render+940 (replayed)
      client_callback_->Render(web_audio_dest_data_, dest->frames(), ...);
        // [Branch] REPLAYED: not-taken
        if (!fifo_ || fifo_->length() < number_of_frames) return;
        // [Branch] REPLAYED: else-arm
        if (worklet_task_runner_) {
          PostCrossThreadTask(*worklet_task_runner_, ..., RequestRender(...));
        } else {
          // AudioDestination::RequestRender+603 (replayed)
          RequestRender(...);
        }
          // [Branch] REPLAYED: not-taken
          if (!locker.is_acquired()) return;
          // [Branch] REPLAYED: not-taken
          if (device_state_ != DeviceState::kRunning) return;
          // [Branch] REPLAYED: taken
          for (; pushed_frames < frames_to_render; ) {
            // [Branch] REPLAYED: else-arm
            if (resampler_) {
              resampler_->ResampleInternal(...);
            } else {
              // RealtimeAudioDestinationHandler::Render+479 (replayed)
              callback_.Render(render_bus_.get(), RenderQuantumFrames(), ...);
            }
              // [Branch] REPLAYED: not-taken
              if (!context) return;
              // [Branch] REPLAYED: not-taken
              if (!IsInitialized()) {
                destination_bus->Zero();
                return;
              }
              // [Branch] CANDIDATE
              if (IsPullingAudioGraphAllowed()) {
                // AudioNodeInput::Pull
                Input(0).Pull(destination_bus, number_of_frames);
                  // [Branch] CANDIDATE
                  if (NumberOfRenderingConnections() == 1 &&
                      Handler().InternalChannelCountMode() == AudioHandler::kMax) {
                    // AudioNodeOutput::Pull+88 (recorded)
                    return output->Pull(...);
                  }
                  // [Branch] CANDIDATE
                  if (!NumberOfRenderingConnections()) {
                    internal_summing_bus->Zero();
                    return internal_summing_bus;
                  }
                  // else: SumAllConnections -> output->Pull(...)
                // AudioNodeOutput::Pull+88 (recorded) -> ProcessIfNecessary -> Process
                // -> UpdateSchedulingInfo (see Root: AudioNodeOutput::Pull for full gates)
                  // [Branch] CANDIDATE
                  if (end_time_ != kUnknownTime && end_frame <= quantum_start_frame) {
                    Finish(); // <<< RECORDED LEAF path
                  }
              } else {
                destination_bus->Zero();
              }
              // AudioContext::HandlePostRenderTasks+21 (replayed)
              context->HandlePostRenderTasks();
                // WTF::RecursiveMutex::TryLock+34 (replayed)
                TryLock(); // <<< REPLAYED LEAF
          }
}
```

## NewCandidates

* `RealtimeAudioDestinationHandler::Render` `IsPullingAudioGraphAllowed`
  * location: `blink::RealtimeAudioDestinationHandler::Render` at `third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc:206`
  * code: before `if (IsPullingAudioGraphAllowed())`
  * provenance:
    * Assert already present at `:202`.
    * Drop `[CRASH-0012]` prefix.
    * Keep `IsPullingAudioGraphAllowed()`.
    * Not-taken → skip `Input(0).Pull` → `HandlePostRenderTasks` → replayed leaf.
* `AudioNodeInput::Pull` single-connection in-place
  * location: `blink::AudioNodeInput::Pull` at `third_party/blink/renderer/modules/webaudio/audio_node_input.cc:144`
  * code: before
    ```
    if (NumberOfRenderingConnections() == 1 &&
        Handler().InternalChannelCountMode() == AudioHandler::kMax)
    ```
  * provenance:
    * Gates `AudioNodeOutput::Pull` on this input.
    * Assert `NumberOfRenderingConnections()`, `Handler().InternalChannelCountMode()`.
* `AudioNodeInput::Pull` zero-connections silence
  * location: `blink::AudioNodeInput::Pull` at `third_party/blink/renderer/modules/webaudio/audio_node_input.cc:153`
  * code: before `if (!NumberOfRenderingConnections())`
  * provenance:
    * Taken → silence.
    * No `output->Pull` / `Finish` / `PostDelayedTask`.
    * Continues to `HandlePostRenderTasks` → replayed leaf.
    * Assert `NumberOfRenderingConnections()`.
* `AudioScheduledSourceHandler::UpdateSchedulingInfo` siteA early-`Finish`
  * location: `blink::AudioScheduledSourceHandler::UpdateSchedulingInfo` at `third_party/blink/renderer/modules/webaudio/audio_scheduled_source_handler.cc:77`
  * code: before `if (end_time_ != kUnknownTime && end_frame <= quantum_start_frame)`
  * provenance:
    * Relocate existing inside-arm Assert to before the `if`.
    * Drop `[CRASH-0012]` prefix.
    * Keep `end_time_`, `end_frame`, `quantum_start_frame`, `quantum_end_frame`.
    * Taken → `Finish()` → `PostDelayedTask` → recorded leaf.
    * Inside-arm Assert is skipped when not taken.
