### PR TITLE
Allow string codegen in CommandCallback (Trusted Types)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd9e8f47fcd3f4d722217ebcf65767def42e22098',
+  'v8_revision': '8efdf32702d68b59fd95852537f6512aefd0c68e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '8efdf32702d68b59fd95852537f6512aefd0c68e',
+  'v8_revision': 'fb945358c450cd62347b2dd190d1e2f430d0646c',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/290

# Summary

* G1: Trusted Types blocks runtime-owned command eval
  * Pages with a rejecting Trusted Types `default` policy make `Target.evaluatePrivileged` throw.
  * That surfaces as `{is_error:true}` and the linker `Die`s.
  * Fix: temporarily allow string codegen in `CommandCallback`, same as V8 Inspector.

# Problem

## G1: Trusted Types blocks runtime-owned command eval

* Symptom
  * `Target.evaluatePrivileged` on Cloudflare Turnstile throws:
    * `EvalError: Refused to evaluate a string as JavaScript because this document requires 'Trusted Type' assignment.`
  * Linker then crashes via `Command.cpp` on `is_error`.
* Causal chain
  * Page installs Trusted Types `default` policy that rejects arbitrary scripts.
  * Linker dispatches command → `CommandCallback` → JS `commandCallback` → `eval(expression)`.
  * Blink `CodeGenerationCheckCallbackInMainThread` runs Trusted Types checks.
  * Policy rejects → `EvalError` → `{is_error:true}` → `Die`.
* Gap vs Inspector
  * V8 Inspector sets `AllowCodeGenerationFromStrings(true)` around evaluate.
  * That short-circuits before the Trusted Types callback.
  * `CommandCallback` did not.

# Solution

## G1: Trusted Types blocks runtime-owned command eval

* Recipe
  * Mirror Inspector’s string-codegen allow around runtime-owned command dispatch.
* Implementation
  * In `v8/src/debug/debug.cc` `CommandCallback`:
    * RAII `AutoAllowCodeGenerationFromStrings` on the current context.
    * Set allow if currently false.
    * Restore on exit.
* Why this works
  * V8 skips the Trusted Types callback when string codegen is allowed.
  * Covers raw `eval` in command handlers, including `Target.evaluatePrivileged`.

# Raw Data

* buildId: `linux-chromium-20260709-3fc067f1c293-ed87c3d17b52`
* linkerVersion: `linker-linux-16006-ed87c3d17b52`
* recordingId: `defa52c6-d700-43a7-8137-746fe0140743`