### PR TITLE
crash-0013: Assert ParkableString aging reschedule and per-string status

### DIFF
--- a/third_party/blink/renderer/platform/bindings/parkable_string.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string.cc
@@ -12,6 +12,8 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/process/memory.h"
+#include "base/record_replay.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/synchronization/lock.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
@@ -398,6 +400,10 @@ ParkableStringImpl::AgeOrParkResult ParkableStringImpl::MaybeAgeOrParkString() {
 
   Status status = CurrentStatus();
   Age age = metadata_->age_;
+  recordreplay::Assert(
+      "ParkableStringImpl::MaybeAgeOrParkString digest=%s status=%d age=%d",
+      base::HexEncode(digest()->data(), digest()->size()).c_str(),
+      static_cast<int>(status), static_cast<int>(age));
   if (age == Age::kYoung) {
     if (status == Status::kUnreferencedExternally)
       metadata_->age_ = MakeOlder(age);

--- a/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
@@ -10,6 +10,7 @@
 #include "base/bind.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/record_replay.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
 #include "base/trace_event/memory_allocator_dump.h"
@@ -373,6 +374,8 @@ void ParkableStringManager::AgeStringsAndPark() {
   // is important to make sure that this will not reschedule tasks forever.
   bool reschedule = (!unparked_strings_.empty() || !parked_strings_.empty()) &&
                     can_make_progress;
+  recordreplay::Assert("ParkableStringManager::AgeStringsAndPark reschedule %d",
+                       reschedule);
   if (reschedule)
     ScheduleAgingTaskIfNeeded();
 }


### PR DESCRIPTION
# Summary

* G1: ParkableString aging reschedule mismatch
  * Symptom
    * StackCommonFrame mismatch at order 228014.
    * Recorded leaf: `ParkableStringManager::ScheduleAgingTaskIfNeeded` → `PostDelayedTask`.
    * Replayed leaf: `MainThreadSchedulerImpl::PerformMicrotaskCheckpoint`.
  * Proven same task
    * `lastNonHitAssert` selected `AgeStringsAndPark` on both sides.
    * Divergence is inside the task body.
  * Causal chain
    * Recorded path takes `if (reschedule)` then posts the next aging task.
    * Replayed path skips that and reaches post-task microtask checkpoint.
    * `reschedule` depends on `can_make_progress`.
    * `can_make_progress` aggregates per-string `MaybeAgeOrParkString` results.
    * Those results depend on live `CurrentStatus()` / `HasOneRef()` / lock-depth.
    * Preceding GC finalizer warnings show destructor timing differed record vs replay.
  * Intervention
    * Assert `reschedule` in `AgeStringsAndPark`.
    * Assert `digest`/`status`/`age` in `MaybeAgeOrParkString`.
    * Goal: convert control-flow mismatch into a data mismatch that localizes the diverging string.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/crash-report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* You can read $DETERMINATOR_DIR/issues/crash-0013/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260709-3fc067f1c293-ed87c3d17b52
* linkerVersion: linker-linux-16006-ed87c3d17b52
* recordingId: 38041e0f-e8da-4418-8da8-cfc8d0f14a5c

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 228014,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 14604974,
      "checkpoint": 15
    }
  },
  "recorded": "TaskQueueImpl::TaskRunner::PostDelayedTask 20",
  "replayed": "[RUN-2056-2298] MainThreadSchedulerImpl::PerformMicrotaskCheckpoint 53 1 1",
  "threadId": 1,
  "backtrace": {
    "progress": 13165313,
    "threadId": 1,
    "checkpoint": 13
  },
  "recordedStack": [
    "_ZN12recordreplay6AssertEPKcz+141",
    "_ZN4base16sequence_manager8internal13TaskQueueImpl10TaskRunner15PostDelayedTaskERKNS_8LocationENS_12OnceCallbackIFvvEEENS_9TimeDeltaE+79",
    "_ZN5blink21ParkableStringManager25ScheduleAgingTaskIfNeededEv+205",
    "_ZN5blink21ParkableStringManager17AgeStringsAndParkEv+287",
    "_ZN4base13TaskAnnotator11RunTaskImplERNS_11PendingTaskE+257",
    "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl10DoWorkImplEPNS_7LazyNowE+1001",
    "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl6DoWorkEv+127",
    "_ZThn200_N4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl6DoWorkEv+21"
  ],
  "replayedStack": [
    "_ZN12recordreplay6AssertEPKcz+141",
    "_ZN5blink9scheduler23MainThreadSchedulerImpl26PerformMicrotaskCheckpointEv+59",
    "_ZN5blink9scheduler23MainThreadSchedulerImpl15OnTaskCompletedEN4base7WeakPtrINS0_19MainThreadTaskQueueEEERKNS2_16sequence_manager4TaskEPNS6_9TaskQueue10TaskTimingEPNS2_7LazyNowE+46",
    "_ZN5blink9scheduler19MainThreadTaskQueue15OnTaskCompletedERKN4base16sequence_manager4TaskEPNS3_9TaskQueue10TaskTimingEPNS2_7LazyNowE+110",
    "_ZN4base16sequence_manager8internal13TaskQueueImpl15OnTaskCompletedERKNS0_4TaskEPNS0_9TaskQueue10TaskTimingEPNS_7LazyNowE+65",
    "_ZN4base16sequence_manager8internal19SequenceManagerImpl20NotifyDidProcessTaskEPNS2_13ExecutingTaskEPNS_7LazyNowE+210",
    "_ZThn8_N4base16sequence_manager8internal19SequenceManagerImpl10DidRunTaskERNS_7LazyNowE+141",
    "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl10DoWorkImplEPNS_7LazyNowE+1078"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recording assertion with events disallowed: Managed::Destructor 1 [EventsDisallowed:Heap::CollectGarbage]",
    "count": 21,
    "stack": [
      "_ZN2v812recordreplay6AssertEPKcz+149",
      "_ZN2v88internal7ManagedINS_13WasmStreamingEE10DestructorEPv+31",
      "_ZN2v88internal12_GLOBAL__N_132ManagedObjectFinalizerSecondPassERKNS_16WeakCallbackInfoIvEE+39",
      "_ZN2v88internal13GlobalHandles32InvokeSecondPassPhantomCallbacksEv+416",
      "_ZN2v88internal4Heap14CollectGarbageENS0_15AllocationSpaceENS0_23GarbageCollectionReasonENS_15GCCallbackFlagsE+217",
      "_ZN2v88internal13HeapAllocator33AllocateRawWithLightRetrySlowPathEiNS0_14AllocationTypeENS0_16AllocationOriginENS0_19AllocationAlignmentE+1998",
      "_ZN2v88internal13HeapAllocator34AllocateRawWithRetryOrFailSlowPathEiNS0_14AllocationTypeENS0_16AllocationOriginENS0_19AllocationAlignmentE+36",
      "_ZN2v88internal7Factory15NewFillerObjectEiNS0_19AllocationAlignmentENS0_14AllocationTypeENS0_16AllocationOriginE+1037",
      "_ZN2v88internal33Runtime_AllocateInYoungGenerationEiPmPNS0_7IsolateE+253"
    ],
    "progress": 11123567,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 8,
    "absoluteTime": 1783596992022.4104,
    "wasRecording": false
  },
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 10,
    "stack": [
      "_ZN3WTF14RecursiveMutex6unlockEv+135",
      "_ZN5blink9AudioNode7DisposeEv+228",
      "_ZN5blink9AudioNode18InvokePreFinalizerERKN5cppgc14LivenessBrokerEPv+44",
      "_ZN5cppgc8internal19PreFinalizerHandler19InvokePreFinalizersEv+214",
      "_ZN5cppgc8internal8HeapBase20ExecutePreFinalizersEv+39",
      "_ZN2v88internal7CppHeap13TraceEpilogueEv+210",
      "_ZN2v88internal4Heap24PerformGarbageCollectionENS0_16GarbageCollectorENS0_23GarbageCollectionReasonEPKcNS_15GCCallbackFlagsE+3404",
      "_ZN2v88internal4Heap14CollectGarbageENS0_15AllocationSpaceENS0_23GarbageCollectionReasonENS_15GCCallbackFlagsE+2397",
      "_ZN2v88internal4Heap15HandleGCRequestEv+223",
      "_ZN2v88internal10StackGuard16HandleInterruptsEv+626",
      "_ZN2v88internal18Runtime_StackGuardEiPmPNS0_7IsolateE+314"
    ],
    "threadId": 1,
    "processId": 2,
    "absoluteTime": 1783596972174.1165,
    "wasRecording": true
  }
]
```

# Basic Facts

## FrameCandidates

* `_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl10DoWorkImplEPNS_7LazyNowE+1001`
  * location: `ThreadControllerWithMessagePumpImpl::DoWorkImpl` at `$REPLAY_DIR/chromium/src/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:458`
  * code: `task_annotator_.RunTask("ThreadControllerImpl::RunTask", selected_task->task, ...);`
* `_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl10DoWorkImplEPNS_7LazyNowE+1078`
  * location: `ThreadControllerWithMessagePumpImpl::DoWorkImpl` at `$REPLAY_DIR/chromium/src/base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:469`
  * code: `main_thread_only().task_source->DidRunTask(lazy_now_after_run_task);`

## DivergentPathSegments

### Root: ThreadControllerWithMessagePumpImpl::DoWorkImpl

```cpp
// Root (both stacks): ThreadControllerWithMessagePumpImpl::DoWorkImpl
// recorded +1001 / replayed +1078
void ThreadControllerWithMessagePumpImpl::DoWorkImpl(LazyNow* continuation_lazy_now) {
  ...
  // TaskAnnotator::RunTaskImpl+257
  task_annotator_.RunTask("ThreadControllerImpl::RunTask", selected_task->task, ...);
  void TaskAnnotator::RunTaskImpl(PendingTask& pending_task) {
    ...
    // invokes bound task -> ParkableStringManager::AgeStringsAndPark+287
    std::move(pending_task.task).Run();
    void ParkableStringManager::AgeStringsAndPark() {
      ...
      // [Branch] RECORDED: taken
      if (reschedule)
        // ParkableStringManager::ScheduleAgingTaskIfNeeded+205
        ScheduleAgingTaskIfNeeded();
    }
    void ParkableStringManager::ScheduleAgingTaskIfNeeded() {
      // [Branch] RECORDED: else-arm
      if (!CompressionEnabled()) return;
      // [Branch] RECORDED: else-arm
      if (has_pending_aging_task_) return;
      ...
      // TaskQueueImpl::TaskRunner::PostDelayedTask+79
      task_runner_->PostDelayedTask(FROM_HERE,
          base::BindOnce(&ParkableStringManager::AgeStringsAndPark, ...),
          delay); // <<< RECORDED LEAF
    }
  }

  LazyNow lazy_now_after_run_task(time_source_);
  main_thread_only().task_source->DidRunTask(lazy_now_after_run_task);
  void SequenceManagerImpl::DidRunTask(LazyNow& lazy_now) {
    // SequenceManagerImpl::NotifyDidProcessTask+210
    NotifyDidProcessTask(&executing_task, &lazy_now);
  }
  void SequenceManagerImpl::NotifyDidProcessTask(ExecutingTask* executing_task, LazyNow* time_after_task) {
    // [Branch] REPLAYED: else-arm
    if (!executing_task->task_queue->GetShouldNotifyObservers())
      return;
    // [Branch] REPLAYED: taken
    if (task_timing.has_wall_time())
      // TaskQueueImpl::OnTaskCompleted+65
      executing_task->task_queue->OnTaskCompleted(
          executing_task->pending_task, &task_timing, time_after_task);
  }
  void TaskQueueImpl::OnTaskCompleted(const Task& task, TaskTiming* task_timing, LazyNow* lazy_now) {
    // [Branch] REPLAYED: taken
    if (!main_thread_only().on_task_completed_handler.is_null())
      // MainThreadTaskQueue::OnTaskCompleted+110
      main_thread_only().on_task_completed_handler.Run(task, task_timing, lazy_now);
  }
  void MainThreadTaskQueue::OnTaskCompleted(const Task& task, TaskTiming* task_timing, LazyNow* lazy_now) {
    // [Branch] REPLAYED: taken
    if (main_thread_scheduler_)
      // MainThreadSchedulerImpl::OnTaskCompleted+46
      main_thread_scheduler_->OnTaskCompleted(weak_ptr_factory_.GetWeakPtr(), task, task_timing, lazy_now);
  }
  void MainThreadSchedulerImpl::OnTaskCompleted(WeakPtr<MainThreadTaskQueue> queue, const Task& task, TaskTiming* task_timing, LazyNow* lazy_now) {
    // MainThreadSchedulerImpl::PerformMicrotaskCheckpoint+59
    PerformMicrotaskCheckpoint(); // <<< REPLAYED LEAF
  }
}
```

## Suggested Cause of Action

* No matching `PossibleInterventions` recipe — root not yet proven; narrow with an Assert first.
* `lastNonHitAssert` (order 228012, `DoWorkImpl #6 236 0 1`) proves the same task (id 236, `ParkableStringManager::AgeStringsAndPark`) was selected on both record and replay.
  * → divergence is inside the task body, before the recorded `PostDelayedTask` call, not in task selection.
* Of the three early-return checks in the `DivergentPathSegments`, only one is still unproven and Assert-able:
  * `CompressionEnabled()` (PSM.cc:381) — already proven true both sides (F1/F2, `DCHECK` at function entry). Do NOT Assert; redundant.
  * `has_pending_aging_task_` (PSM.cc:384) — already proven false both sides (F3, unconditionally reset just before, synchronous). Do NOT Assert; redundant.
  * `reschedule` (PSM.cc:376, in `AgeStringsAndPark`) — unproven, passes `[InvalidAssertValues]` (plain local bool, no address/driver-value/DisallowEvents/PassThrough/sync-code issue).
* Add one Assert in `$REPLAY_DIR/chromium/src/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc` (aka PSM.cc):
  * `ParkableStringManager::AgeStringsAndPark`, before `if (reschedule)` (:376): Assert `reschedule`.
* Goal: convert this control-flow mismatch into a data mismatch confirming `reschedule` diverges, then trace its provenance into `can_make_progress`/`ParkableStringImpl::CurrentStatus()` (F4-F7) — the per-string live ref-count/lock-depth state implicated by `DominantWarning`'s GC-driven destructor activity.

## DominantWarning

* Both reported Warnings, tagged `[EventsDisallowed:Heap::CollectGarbage]`, same thread (1), same process (2), at/before checkpoint 8 — strictly precede the mismatch (backtrace checkpoint 13 / order 228014):
  * `Recording assertion with events disallowed: Managed::Destructor 1` (`wasRecording:false`, i.e. seen on replay) — v8 `Managed<WasmStreaming>::Destructor` invoked as a second-pass phantom callback during `Heap::CollectGarbage` (via `Runtime_AllocateInYoungGeneration`).
  * `Ordered lock with events disallowed atomic` (`wasRecording:true`, i.e. seen on record) — `AudioNode::Dispose` invoked as a cppgc pre-finalizer during `Heap::CollectGarbage` (via `Runtime_StackGuard`'s interrupt-driven GC).
* Dependency on the mismatch:
  * Both warnings show GC-driven object destructor/pre-finalizer callbacks firing on the same thread, in the same narrow window immediately preceding the mismatching Assert — exactly the kind of activity (object teardown, ref-releasing) that can change a JS/DOM object's live reference count.
  * The mismatch's control-flow divergence traces back (per `DivergentPathSegments`/Facts F4–F7) to `ParkableStringImpl::CurrentStatus()`, which is driven by `string_.Impl()->HasOneRef()` — i.e. exactly the kind of live ref-count state that finalizer/destructor callbacks like `AudioNode::Dispose` or `Managed<>::Destructor` mutate when they run.
  * One warning is `wasRecording:true` and the other `wasRecording:false`, i.e. GC-triggered destructor timing differed between the two sides — directly consistent with, and sufficient to explain, a differing ref-count/status snapshot at the moment `AgeStringsAndPark` evaluates `can_make_progress`.

# Facts

* Paths: PSM.cc = `$REPLAY_DIR/chromium/src/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc`; PSM.h = same dir `parkable_string_manager.h`; PS.cc = same dir `parkable_string.cc`; PS.h = same dir `parkable_string.h`.
* [F1] Read PSM.cc:44,164,273,342,381,404 (`rg CompressionEnabled`): `AgeStringsAndPark` (PSM.cc:341) starts with `DCHECK(CompressionEnabled())` — proves `CompressionEnabled()` true on both record and replay whenever this function runs.
* [F2] `ScheduleAgingTaskIfNeeded`'s `if (!CompressionEnabled()) return;` (PSM.cc:381) is reached synchronously from `AgeStringsAndPark`, no intervening flag change (F1). `CompressionEnabled()` = `base::FeatureList::IsEnabled(features::kCompressParkableStrings)` (PSM.cc:44), startup-fixed → deterministic.
  * → proven identical (else-arm) both sides; NOT a viable Assert/divergence candidate.
* [F3] Read PSM.cc:341-399: `has_pending_aging_task_` unconditionally set `false` at PSM.cc:344 (first stmt of `AgeStringsAndPark`), only re-set `true` at PSM.cc:399 inside `ScheduleAgingTaskIfNeeded`, *after* its own `if (has_pending_aging_task_) return;` check (PSM.cc:384). Synchronous/single-threaded, nothing intervenes.
  * → proven `false`/not-taken both sides; NOT a viable Assert/divergence candidate.
* [F4] Read PSM.cc:341-374 and PSM.h:159-160: `reschedule` (PSM.cc:372-373) = `(!unparked_strings_.empty() || !parked_strings_.empty()) && can_make_progress`. Since `can_make_progress` only flips true inside the loops enumerating those same maps (`EnumerateStrings`, PSM.cc:58-66), the emptiness checks are redundant with the loop bodies — `reschedule`'s only real unproven dependency is `can_make_progress`, itself from `ParkableStringImpl::MaybeAgeOrParkString()` (PSM.cc:349-361). No DCHECK constrains it — the only viable divergence candidate of the three early-return checks.
* [F5] `rg CanParkNow` + read PS.cc:519-524: `CanParkNow()` returns `false` whenever `recordreplay::IsRecordingOrReplaying("no-park-strings")` (comment: never park strings during R/R — unparking can happen non-deterministically, e.g. during script compilation, and perform file accesses).
  * → during R/R, `CanParkNow()` unconditionally `false`.
* [F6] Read PS.cc:376-413 (`MaybeAgeOrParkString`) and :437-441 (`ParkInternal`): the `age==Age::kOld && CanParkNow()` branch (PS.cc:404, `ParkInternal(kCompress)`) never taken during R/R (F5); `ParkInternal()` itself `DCHECK(CanParkNow())` (PS.cc:441) — no path parks a string out-of-band during R/R.
  * → during R/R no new string moves into `parked_strings_` (only via `ParkInternal`→`OnParked()`→`MoveString`, per `rg MoveString|OnParked` in PSM.cc); `parked_strings_` only holds strings parked pre-R/R.
  * → during R/R, per-string `MaybeAgeOrParkString()` yields `kSuccessOrTransientFailure` (`can_make_progress=true`) whenever: `background_task_in_progress_` true (early return, PS.cc:382-383); OR `is_parked()` true (PS.cc:386-395, always succeeds — either `ParkInternal(kToDisk)` or just `MakeOlder` aging); OR not parked with `age==kYoung && status==kUnreferencedExternally` (ages via `MakeOlder`, PS.cc:399-400, then falls to final return); OR the final fallback (PS.cc:406-409, reached whenever not early-returned) which succeeds UNLESS `status==kTooManyReferences`.
  * → net: `can_make_progress` is `false` only if EVERY enumerated string (excluding `background_task_in_progress_`/`is_parked()` ones) has `CurrentStatus()==kTooManyReferences`; one string flipping status away from `kTooManyReferences` (or into `is_parked()`/bg-task state) flips the aggregate.
* [F7] Read PS.cc:499-518 (`CurrentStatus`): precedence `kLocked` (`metadata_->lock_depth_!=0`) > `kUnreferencedExternally` (`string_.IsNull()`) > `kTooManyReferences` (`!string_.Impl()->HasOneRef()`) > else `kUnreferencedExternally`.
  * → status (hence `can_make_progress`, hence `reschedule`) depends on live JS/DOM ref-count (`HasOneRef()`) and lock-depth of each string at the exact moment `AgeStringsAndPark` runs — live/mutable per-string state, not an aggregate.
* [F8] `rg recordreplay|IsRecordingOrReplaying` in PS.cc/PSM.cc: only hit is the `CanParkNow()` guard (F5); no existing Replay determinism guard or per-string Assert/diagnostic infrastructure on `lock_depth_`, `HasOneRef()`, ref-counting, `MaybeAgeOrParkString`, or `CurrentStatus` in either file — any per-string trace would be new instrumentation.
* [F9] Crash-report Warnings (same thread 1, checkpoints 8 and 13, both before backtrace.checkpoint 13 / mismatch checkpoint 15): `Heap::CollectGarbage`-triggered "events disallowed" violations — `Managed::Destructor` (v8 second-pass phantom callback) and `AudioNode::Dispose` (cppgc pre-finalizer) — prove GC/finalization activity occurs on this thread in this timeframe, the kind of activity that mutates string ref-counts (`HasOneRef`) feeding `CurrentStatus()` (F7). No direct causal proof (different call chains) ties them to one specific string in `unparked_strings_`/`parked_strings_`.
* [F10] `rg EnumerateStrings|unparked_strings_|parked_strings_` in PSM.cc: membership of `unparked_strings_`/`parked_strings_` only changes via explicit `Add`/`Remove`/`MoveString` tied to ParkableString construction/destruction and parking-state transitions; no other mutation path in this file.
* [F11] Read PSM.cc:58-66 (`EnumerateStrings`) + PSM.cc:347-348: `unparked_strings_`/`parked_strings_` are `StringMap`s keyed by `ParkableStringImpl::digest()` (a `SecureDigest`, PS.h) — already a stable, deterministic per-string key, needs no additional RecordReplayId/PointerId treatment to identify "which string" in a finer-grained diagnostic.

# Solution

* [Done] In PSM.cc `ParkableStringManager::AgeStringsAndPark`, before `if (reschedule)` (:376): add Assert `reschedule`. [F4]
  * Hints: [F4] identifies `reschedule` as the only unproven/viable divergence candidate.
  * Steps:
    * Insert an Assert on `reschedule` immediately before the `if (reschedule)` check at PSM.cc:376.
  * Implementation:
    * Added `#include "base/record_replay.h"` (not previously included in this file).
* [Done] In PS.cc `ParkableStringImpl::MaybeAgeOrParkString`, after `status`/`age` computed, before `if (age == Age::kYoung)`: Assert `digest()`, `status`, `age`. [F6][F7][F9][F11]
  * Hints: [F6][F7] show `can_make_progress` aggregates per-string `CurrentStatus()`; a top-level Assert on `reschedule` can't localize which string diverges. [F11] `digest()` is a stable deterministic per-string key. Placed here (not in PSM.cc's enumeration loop) because `metadata_->lock_` is already held and `status`/`age` are the branch inputs for the age/status arms.
  * Steps:
    * Insert an Assert immediately before `if (age == Age::kYoung)` on `digest()`, `status`, and `age`.
  * Implementation:
    * Restored original early-return/`return status == …` control flow; no exit consolidation.
    * Added `#include "base/record_replay.h"` and `#include "base/strings/string_number_conversions.h"`; `digest()` via `base::HexEncode`.
