### PR TITLE
Instrument style-resolution branches to localize a record/replay divergence

### DIFF
--- a/third_party/blink/renderer/core/css/css_numeric_literal_value.cc
+++ b/third_party/blink/renderer/core/css/css_numeric_literal_value.cc
@@ -249,9 +249,16 @@ String CSSNumericLiteralValue::CustomCSSText() const {
       constexpr int kMaxInteger = 999999;
       double value = To<CSSNumericLiteralValue>(this)->DoubleValue();
       // If the value is small integer, go the fast path.
-      if (value < kMinInteger || value > kMaxInteger ||
-          std::trunc(value) != value) {
-        if (std::isinf(value) || std::isnan(value)) {
+      bool is_non_integer_or_out_of_range =
+          value < kMinInteger || value > kMaxInteger ||
+          std::trunc(value) != value;
+      recordreplay::Assert("[RUN-2424-3239] CSSNumericLiteralValue::CustomCSSText %d",
+                            is_non_integer_or_out_of_range);
+      if (is_non_integer_or_out_of_range) {
+        bool is_inf_or_nan = std::isinf(value) || std::isnan(value);
+        recordreplay::Assert("[RUN-2424-3240] CSSNumericLiteralValue::CustomCSSText inf/nan %d",
+                              is_inf_or_nan);
+        if (is_inf_or_nan) {
           text = FormatInfinityOrNaN(value, UnitTypeToString(GetType()));
         } else {
           text = FormatNumber(value, UnitTypeToString(GetType()));

--- a/third_party/blink/renderer/core/css/element_rule_collector.cc
+++ b/third_party/blink/renderer/core/css/element_rule_collector.cc
@@ -31,6 +31,7 @@
 #include "third_party/blink/renderer/core/css/element_rule_collector.h"
 
 #include "base/containers/span.h"
+#include "base/record_replay.h"
 #include "base/substring_set_matcher/substring_set_matcher.h"
 #include "base/trace_event/common/trace_event_common.h"
 #include "third_party/blink/renderer/core/css/cascade_layer_map.h"
@@ -490,6 +491,8 @@ namespace {
 
 base::span<const Attribute> GetAttributes(const Element& element,
                                           bool need_style_synchronized) {
+  recordreplay::Assert("[RUN-2424-3237] GetAttributes need_style_synchronized %d",
+                        need_style_synchronized);
   if (need_style_synchronized) {
     const AttributeCollection collection = element.Attributes();
     return {collection.data(), collection.size()};
@@ -571,6 +574,8 @@ void ElementRuleCollector::CollectMatchingRules(
       }
     }
   }
+  recordreplay::Assert("[RUN-2424-3236] CollectMatchingRules has_any_attr_rules %d",
+                        has_any_attr_rules);
   if (has_any_attr_rules) {
     // HTML documents have case-insensitive attribute matching
     // (so we need to lowercase), non-HTML documents have

--- a/third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc
+++ b/third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc
@@ -28,6 +28,7 @@
 
 #include "third_party/blink/renderer/core/css/resolver/scoped_style_resolver.h"
 
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/animation/document_timeline.h"
 #include "third_party/blink/renderer/core/css/cascade_layer_map.h"
 #include "third_party/blink/renderer/core/css/counter_style_map.h"
@@ -225,18 +226,26 @@ void ScopedStyleResolver::KeyframesRulesAdded(const TreeScope& tree_scope) {
 
 template <class Func>
 void ScopedStyleResolver::ForAllStylesheets(const Func& func) {
+  recordreplay::Assert("[RUN-2424-3232] ForAllStylesheets empty %d",
+                        style_sheets_.empty());
   if (style_sheets_.empty()) {
     return;
   }
 
   MatchRequest match_request{&scope_->RootNode()};
+  recordreplay::Assert("[RUN-2424-3233] ForAllStylesheets size %d",
+                        style_sheets_.size());
   for (auto sheet : style_sheets_) {
     match_request.AddRuleset(&sheet->Contents()->GetRuleSet(), sheet);
+    recordreplay::Assert("[RUN-2424-3234] ForAllStylesheets IsFull %d",
+                          match_request.IsFull());
     if (match_request.IsFull()) {
       func(match_request);
       match_request.ClearAfterMatching();
     }
   }
+  recordreplay::Assert("[RUN-2424-3235] ForAllStylesheets IsEmpty %d",
+                        !match_request.IsEmpty());
   if (!match_request.IsEmpty()) {
     func(match_request);
   }

--- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
+++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
@@ -598,6 +598,8 @@ static void MatchVTTRules(const Element& element,
 static void MatchElementScopeRules(const Element& element,
                                    ScopedStyleResolver* element_scope_resolver,
                                    ElementRuleCollector& collector) {
+  recordreplay::Assert("[RUN-2424-3230] MatchElementScopeRules %d",
+                        !!element_scope_resolver);
   if (element_scope_resolver) {
     collector.ClearMatchedRules();
     element_scope_resolver->CollectMatchingElementScopeRules(collector);
@@ -605,6 +607,10 @@ static void MatchElementScopeRules(const Element& element,
   }
 
   MatchVTTRules(element, collector);
+  recordreplay::Assert(
+      "[RUN-2424-3231] MatchElementScopeRules inline style %d",
+      element.IsStyledElement() && element.InlineStyle() &&
+          collector.GetPseudoId() == kPseudoIdNone);
   if (element.IsStyledElement() && element.InlineStyle() &&
       collector.GetPseudoId() == kPseudoIdNone) {
     // Do not add styles depending on style attributes to the
@@ -1293,6 +1299,10 @@ void StyleResolver::ApplyBaseStyleNoCache(
   }
 
   // TODO(obrufau): support styling nested pseudo-elements
+  recordreplay::Assert(
+      "[RUN-2424-3229] StyleResolver::ApplyBaseStyleNoCache %d",
+      style_request.rules_to_include == StyleRequest::kUAOnly ||
+          (style_request.IsPseudoStyleRequest() && element->IsPseudoElement()));
   if (style_request.rules_to_include == StyleRequest::kUAOnly ||
       (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())) {
     MatchUARules(*element, collector);
@@ -1363,6 +1373,8 @@ void StyleResolver::ApplyBaseStyle(
     StyleCascade& cascade) {
   DCHECK(style_request.pseudo_id != kPseudoIdFirstLineInherited);
 
+  recordreplay::Assert("[RUN-2424-3005] StyleResolver::ApplyBaseStyle %d",
+                        state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state));
   if (state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)) {
     const ComputedStyle* animation_base_computed_style =
         CachedAnimationBaseComputedStyle(state);
@@ -1395,6 +1407,10 @@ void StyleResolver::ApplyBaseStyle(
     return;
   }
 
+  recordreplay::Assert(
+      "[RUN-2424-3228] StyleResolver::ApplyBaseStyle incremental %d",
+      !style_recalc_context.parent_forces_recalc &&
+          CanApplyInlineStyleIncrementally(element, state, style_request));
   if (!style_recalc_context.parent_forces_recalc &&
       CanApplyInlineStyleIncrementally(element, state, style_request)) {
     // We are in a situation where we can reuse the old style

--- a/third_party/blink/renderer/core/css/style_property_serializer.cc
+++ b/third_party/blink/renderer/core/css/style_property_serializer.cc
@@ -26,6 +26,7 @@
 #include <bitset>
 
 #include "base/memory/values_equivalent.h"
+#include "base/record_replay.h"
 #include "third_party/blink/renderer/core/animation/css/css_animation_data.h"
 #include "third_party/blink/renderer/core/css/css_custom_property_declaration.h"
 #include "third_party/blink/renderer/core/css/css_grid_template_areas_value.h"
@@ -222,6 +223,8 @@ String StylePropertySerializer::AsText() const {
 
   unsigned size = property_set_.PropertyCount();
   unsigned num_decls = 0;
+  recordreplay::Assert("[RUN-2424-3241] StylePropertySerializer::AsText size %u",
+                        size);
   for (unsigned n = 0; n < size; ++n) {
     if (!property_set_.ShouldProcessPropertyAt(n))
       continue;

--- a/third_party/blink/renderer/core/dom/element.cc
+++ b/third_party/blink/renderer/core/dom/element.cc
@@ -1102,6 +1102,8 @@ bool Element::HasAttributeIgnoringNamespace(
 }
 
 void Element::SynchronizeAllAttributes() const {
+  recordreplay::Assert("[RUN-2424-3238] Element::SynchronizeAllAttributes %d",
+                        !!GetElementData());
   if (!GetElementData())
     return;
   // NOTE: AnyAttributeMatches in selector_checker.cc currently assumes that all
@@ -3819,6 +3821,8 @@ scoped_refptr<ComputedStyle> Element::StyleForLayoutObject(
     element_animations->CssAnimations().ClearPendingUpdate();
 
   bool has_custom_style_callbacks = HasCustomStyleCallbacks();
+  recordreplay::Assert("[RUN-2424-3227] Element::StyleForLayoutObject %d",
+    has_custom_style_callbacks);
   scoped_refptr<ComputedStyle> style =
       has_custom_style_callbacks
           ? CustomStyleForLayoutObject(style_recalc_context)


### PR DESCRIPTION
# Summary

* Diagnostics-only change: no behavior change.
  * Converts a `StackNoCommonFrame` control-flow divergence into a data divergence.
* Symptom
  * Record vs. replay diverge with no common stack frame during author-rule style matching.
  * Recorded leaf: `CSSNumericLiteralValue::CustomCSSText`.
  * Replayed leaf: `MatchResult::FinishAddingAuthorRulesForTreeScope`.
* Approach
  * Add `recordreplay::Assert` on every branch condition along the shared call path.
    * From `Element::StyleForLayoutObject` down to the two divergent leaves.
  * The first assert to fire will pinpoint the exact diverging branch.
* Scope
  * 6 files, style resolution / rule collection / CSS serialization.
  * Null-check branches assert the boolean result only, never the pointer value.


# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackNoCommonFrame
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/crash-report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* You can read /home/domi/replay/determinator/workspaces/issues/crash-0016/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260709-3fc067f1c293-ed87c3d17b52
* linkerVersion: linker-linux-16006-ed87c3d17b52
* recordingId: d125c6d8-520f-442d-b00a-29fff61577a4

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "SaplingBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 39333,
      "checkpoint": 5
    },
    "getResumeData": [
      "annotations",
      "bookmarks",
      "consoleMessages",
      "events",
      "networkRequestEvents",
      "networkRequests",
      "networkStreamEvents",
      "sources",
      "widgetEvents"
    ]
  },
  "recorded": "Value CSSNumericLiteralValue::CustomCSSText",
  "replayed": "[RUN-2424-3053] MatchResult::FinishAddingAuthorRulesForTreeScope 1",
  "threadId": 1,
  "backtrace": {
    "progress": 28821,
    "threadId": 1,
    "checkpoint": 4
  },
  "recordedStack": [
    "recordreplay::RecordReplayString(char.const*,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>&)+37",
    "blink::CSSNumericLiteralValue::CustomCSSText().const+618",
    "blink::StylePropertySerializer::AsText().const+1720",
    "blink::CSSPropertyValueSet::AsText().const+45",
    "blink::Element::SynchronizeStyleAttributeInternal().const+82",
    "blink::Element::SynchronizeAllAttributes().const+43",
    "blink::ElementRuleCollector::CollectMatchingRules(blink::MatchRequest.const&)+3437",
    "blink::ScopedStyleResolver::CollectMatchingElementScopeRules(blink::ElementRuleCollector&)+321"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::MatchResult::FinishAddingAuthorRulesForTreeScope(blink::TreeScope.const&)+113",
    "blink::StyleResolver::MatchAuthorRules(blink::Element.const&,.blink::ScopedStyleResolver*,.blink::ElementRuleCollector&)+826",
    "blink::StyleResolver::MatchAllRules(blink::StyleResolverState&,.blink::ElementRuleCollector&,.bool)+244",
    "blink::StyleResolver::ApplyBaseStyleNoCache(blink::Element*,.blink::StyleRecalcContext.const&,.blink::StyleRequest.const&,.blink::StyleResolverState&,.blink::StyleCascade&)+874",
    "blink::StyleResolver::ResolveStyle(blink::Element*,.blink::StyleRecalcContext.const&,.blink::StyleRequest.const&)+489",
    "blink::Element::OriginalStyleForLayoutObject(blink::StyleRecalcContext.const&)+141",
    "blink::Element::StyleForLayoutObject(blink::StyleRecalcContext.const&)+89"
  ]
}
```

# Basic Facts

## FrameCandidates

* `blink::ScopedStyleResolver::CollectMatchingElementScopeRules(blink::ElementRuleCollector&)+321`
  * location: `blink::ScopedStyleResolver::CollectMatchingElementScopeRules` at `third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc:248`
  * code: `collector.CollectMatchingRules(match_request);`
* `blink::StyleResolver::MatchAuthorRules(blink::Element.const&,.blink::ScopedStyleResolver*,.blink::ElementRuleCollector&)+826`
  * location: `blink::MatchElementScopeRules` (inlined into `StyleResolver::MatchAuthorRules`) at `third_party/blink/renderer/core/css/resolver/style_resolver.cc:625`
  * code: `collector.FinishAddingAuthorRulesForTreeScope(`

## DivergentPathSegments

### Root: `blink::Element::StyleForLayoutObject`

```cpp
// blink::Element::StyleForLayoutObject(blink::StyleRecalcContext const&)+89
scoped_refptr<ComputedStyle> Element::StyleForLayoutObject(
    const StyleRecalcContext& style_recalc_context) {
  ...
  // [Branch] CANDIDATE
  scoped_refptr<ComputedStyle> style =
      has_custom_style_callbacks
          ? CustomStyleForLayoutObject(style_recalc_context)
          // blink::Element::OriginalStyleForLayoutObject(blink::StyleRecalcContext const&)+141
          : OriginalStyleForLayoutObject(style_recalc_context);
  ...
}

// blink::Element::OriginalStyleForLayoutObject(blink::StyleRecalcContext const&)+141
scoped_refptr<ComputedStyle> Element::OriginalStyleForLayoutObject(
    const StyleRecalcContext& style_recalc_context) {
  // blink::StyleResolver::ResolveStyle(blink::Element*,.blink::StyleRecalcContext.const&,.blink::StyleRequest.const&)+489
  return GetDocument().GetStyleResolver().ResolveStyle(this,
                                                       style_recalc_context);
}

// blink::StyleResolver::ResolveStyle(blink::Element*, blink::StyleRecalcContext const&, blink::StyleRequest const&)+489
scoped_refptr<ComputedStyle> StyleResolver::ResolveStyle(
    Element* element,
    const StyleRecalcContext& style_recalc_context,
    const StyleRequest& style_request) {
  recordreplay::Assert("[RUN-2424-3005] StyleResolver::ResolveStyle %d %d", ...);
  ...
  StyleResolverState state(GetDocument(), *element, &style_recalc_context,
                           style_request);
  STACK_UNINITIALIZED StyleCascade cascade(state);

  // ApplyBaseStyle(...) [not on either reported stack, but on path to ApplyBaseStyleNoCache]
  ApplyBaseStyle(element, style_recalc_context, style_request, state, cascade);
  ...
}

// blink::StyleResolver::ApplyBaseStyle(blink::Element*, blink::StyleRecalcContext const&, blink::StyleRequest const&, blink::StyleResolverState&, blink::StyleCascade&) [not on either stack]
void StyleResolver::ApplyBaseStyle(
    Element* element,
    const StyleRecalcContext& style_recalc_context,
    const StyleRequest& style_request,
    StyleResolverState& state,
    StyleCascade& cascade) {
  // [Branch] CANDIDATE
  if (state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)) {
    ...
    return;
  }

  // [Branch] CANDIDATE
  if (!style_recalc_context.parent_forces_recalc &&
      CanApplyInlineStyleIncrementally(element, state, style_request)) {
    ...
    return;
  }

  // None of the caches applied, so we need a full recalculation.
  // blink::StyleResolver::ApplyBaseStyleNoCache(...)+874
  ApplyBaseStyleNoCache(element, style_recalc_context, style_request, state,
                        cascade);
}

// blink::StyleResolver::ApplyBaseStyleNoCache(blink::Element*,.blink::StyleRecalcContext.const&,.blink::StyleRequest.const&,.blink::StyleResolverState&,.blink::StyleCascade&)+874
void StyleResolver::ApplyBaseStyleNoCache(
    Element* element,
    const StyleRecalcContext& style_recalc_context,
    const StyleRequest& style_request,
    StyleResolverState& state,
    StyleCascade& cascade) {
  ...
  ElementRuleCollector collector(state.ElementContext(), style_recalc_context,
                                 ...);
  ...
  // [Branch] CANDIDATE
  if (style_request.rules_to_include == StyleRequest::kUAOnly ||
      (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())) {
    MatchUARules(*element, collector);
  } else {
    // blink::StyleResolver::MatchAllRules(blink::StyleResolverState&,.blink::ElementRuleCollector&,.bool)+244
    MatchAllRules(
        state, collector,
        style_request.matching_behavior != kMatchAllRulesExcludingSMIL);
  }
  ...
}

// blink::StyleResolver::MatchAllRules(blink::StyleResolverState&,.blink::ElementRuleCollector&,.bool)+244
void StyleResolver::MatchAllRules(StyleResolverState& state,
                                  ElementRuleCollector& collector,
                                  bool include_smil_properties) {
  Element& element = state.GetElement();
  MatchUARules(element, collector);
  MatchUserRules(collector);
  MatchPresentationalHints(state, collector);

  ScopedStyleResolver* element_scope_resolver = ScopedResolverFor(element);
  // blink::StyleResolver::MatchAuthorRules(blink::Element.const&,.blink::ScopedStyleResolver*,.blink::ElementRuleCollector&)+826
  MatchAuthorRules(element, element_scope_resolver, collector);
  ...
}

// blink::StyleResolver::MatchAuthorRules(blink::Element.const&,.blink::ScopedStyleResolver*,.blink::ElementRuleCollector&)+826
void StyleResolver::MatchAuthorRules(
    const Element& element,
    ScopedStyleResolver* element_scope_resolver,
    ElementRuleCollector& collector) {
  MatchHostAndCustomElementRules(element, collector);
  MatchSlottedRules(element, collector);
  // MatchElementScopeRules(...) [inlined into MatchAuthorRules, per FrameCandidates location]
  MatchElementScopeRules(element, element_scope_resolver, collector);
  MatchPseudoPartRules(element, collector);
}

// static void MatchElementScopeRules(const Element&, ScopedStyleResolver*, ElementRuleCollector&) [inlined into MatchAuthorRules]
static void MatchElementScopeRules(const Element& element,
                                   ScopedStyleResolver* element_scope_resolver,
                                   ElementRuleCollector& collector) {
  // [Branch] CANDIDATE
  if (element_scope_resolver) {
    collector.ClearMatchedRules();
    // blink::ScopedStyleResolver::CollectMatchingElementScopeRules(blink::ElementRuleCollector&)+321
    element_scope_resolver->CollectMatchingElementScopeRules(collector);
    collector.SortAndTransferMatchedRules();
  }

  MatchVTTRules(element, collector);
  // [Branch] CANDIDATE
  if (element.IsStyledElement() && element.InlineStyle() &&
      collector.GetPseudoId() == kPseudoIdNone) {
    bool is_inline_style_cacheable = !element.InlineStyle()->IsMutable();
    collector.AddElementStyleProperties(element.InlineStyle(),
                                        is_inline_style_cacheable,
                                        true /* is_inline_style */);
  }

  // blink::MatchResult::FinishAddingAuthorRulesForTreeScope(blink::TreeScope.const&)+113
  collector.FinishAddingAuthorRulesForTreeScope(          // <<< REPLAYED LEAF
      element_scope_resolver ? element_scope_resolver->GetTreeScope()
                             : element.GetTreeScope());
}

// blink::ScopedStyleResolver::CollectMatchingElementScopeRules(blink::ElementRuleCollector&)+321
void ScopedStyleResolver::CollectMatchingElementScopeRules(
    ElementRuleCollector& collector) {
  // ForAllStylesheets(func) [inlined template]
  ForAllStylesheets([&collector](const MatchRequest& match_request) {
    // blink::ElementRuleCollector::CollectMatchingRules(blink::MatchRequest.const&)+3437
    collector.CollectMatchingRules(match_request);
  });
}

// template<class Func> void ScopedStyleResolver::ForAllStylesheets(const Func&) [inlined]
template <class Func>
void ScopedStyleResolver::ForAllStylesheets(const Func& func) {
  // [Branch] CANDIDATE
  if (style_sheets_.empty()) {
    return;
  }

  MatchRequest match_request{&scope_->RootNode()};
  // [Branch] CANDIDATE
  for (auto sheet : style_sheets_) {
    match_request.AddRuleset(&sheet->Contents()->GetRuleSet(), sheet);
    // [Branch] CANDIDATE
    if (match_request.IsFull()) {
      func(match_request);
      match_request.ClearAfterMatching();
    }
  }
  // [Branch] CANDIDATE
  if (!match_request.IsEmpty()) {
    func(match_request);
  }
}

// blink::ElementRuleCollector::CollectMatchingRules(blink::MatchRequest.const&)+3437
void ElementRuleCollector::CollectMatchingRules(
    const MatchRequest& match_request) {
  ...
  // [Branch] CANDIDATE
  if (has_any_attr_rules) {
    ...
    // GetAttributes(element, need_style_synchronized) [inlined, anonymous namespace]
    base::span<const Attribute> attributes =
        GetAttributes(element, need_style_synchronized);
    ...
  }
}

// GetAttributes(const Element&, bool) [inlined, anonymous namespace]
base::span<const Attribute> GetAttributes(const Element& element,
                                          bool need_style_synchronized) {
  // [Branch] CANDIDATE
  if (need_style_synchronized) {
    // blink::Element::Attributes() const [inlined]
    const AttributeCollection collection = element.Attributes();
    return {collection.data(), collection.size()};
  } else {
    const AttributeCollection collection =
        element.AttributesWithoutStyleUpdate();
    return {collection.data(), collection.size()};
  }
}

// blink::Element::Attributes() const [inlined]
inline AttributeCollection Element::Attributes() const {
  // [Branch] NOT-ASSERTABLE downstream, redundant
  if (!GetElementData())
    return AttributeCollection();
  // blink::Element::SynchronizeAllAttributes().const+43
  SynchronizeAllAttributes();
  return GetElementData()->Attributes();
}

// blink::Element::SynchronizeAllAttributes().const+43
void Element::SynchronizeAllAttributes() const {
  // [Branch] CANDIDATE
  if (!GetElementData())
    return;
  // [Branch] NOT-ASSERTABLE downstream, redundant
  if (GetElementData()->style_attribute_is_dirty()) {
    DCHECK(IsStyledElement());
    // blink::Element::SynchronizeStyleAttributeInternal().const+82
    SynchronizeStyleAttributeInternal();
  }
  SynchronizeAllAttributesExceptStyle();
}

// blink::Element::SynchronizeStyleAttributeInternal().const+82
void Element::SynchronizeStyleAttributeInternal() const {
  ...
  const CSSPropertyValueSet* inline_style = InlineStyle();
  // [Branch] NOT-ASSERTABLE redundant, downstream-covered
  const_cast<Element*>(this)->SetSynchronizedLazyAttribute(
      html_names::kStyleAttr,
      // blink::CSSPropertyValueSet::AsText().const+45
      inline_style ? AtomicString(inline_style->AsText()) : g_empty_atom);
}

// blink::CSSPropertyValueSet::AsText().const+45
String CSSPropertyValueSet::AsText() const {
  // blink::StylePropertySerializer::AsText().const+1720
  return StylePropertySerializer(*this).AsText();
}

// blink::StylePropertySerializer::AsText().const+1720
String StylePropertySerializer::AsText() const {
  ...
  // [Branch] CANDIDATE
  for (unsigned n = 0; n < size; ++n) {
    ...
    switch (property_id) {
      ...
      default:
        break;
    }
    ...
    result.Append(GetPropertyText(name,
                                  // blink::CSSNumericLiteralValue::CustomCSSText().const+618
                                  property.Value()->CssText(),
                                  property.IsImportant(), num_decls++));
  }
  ...
}

// blink::CSSNumericLiteralValue::CustomCSSText().const+618
String CSSNumericLiteralValue::CustomCSSText() const {
  String text;
  // [Branch] CANDIDATE
  switch (GetType()) {
    ...
    case UnitType::kPixels:
    ...
    case UnitType::kContainerMax: {
      double value = To<CSSNumericLiteralValue>(this)->DoubleValue();
      // [Branch] CANDIDATE
      if (value < kMinInteger || value > kMaxInteger ||
          std::trunc(value) != value) {
        // [Branch] CANDIDATE
        if (std::isinf(value) || std::isnan(value)) {
          text = FormatInfinityOrNaN(value, UnitTypeToString(GetType()));
        } else {
          text = FormatNumber(value, UnitTypeToString(GetType()));

          // [Branch] NOT-ASSERTABLE replay-driver-value
          if (!recordreplay::AreEventsDisallowed()) {
            // [RUN-1918] Workaround divergent floating point sprintf.
            std::string textStr = text.Ascii();
            // recordreplay::RecordReplayString(char.const*,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>&)+37
            recordreplay::RecordReplayString("CSSNumericLiteralValue::CustomCSSText", textStr);   // <<< RECORDED LEAF
            text = String::FromUTF8(&textStr[0], textStr.length());
          }
        }
      } else {
        ...
      }
    } break;
    default:
      NOTREACHED();
      break;
  }
  return text;
}
```

## NewCandidates

* Element::StyleForLayoutObject custom-style-callbacks branch
  * location: `blink::Element::StyleForLayoutObject` at `third_party/blink/renderer/core/dom/element.cc` (near `+89` offset)
  * code: `has_custom_style_callbacks ? CustomStyleForLayoutObject(style_recalc_context) : OriginalStyleForLayoutObject(style_recalc_context)`
  * provenance:
    * `Element::StyleForLayoutObject` branches on `has_custom_style_callbacks` to pick `CustomStyleForLayoutObject` vs. `OriginalStyleForLayoutObject`.
      * Both reported stacks (`recordedStack`/`replayedStack`) pass through `OriginalStyleForLayoutObject` further up, meaning this branch executes strictly before the mismatch site.
    * `OriginalStyleForLayoutObject` calls `StyleResolver::ResolveStyle`, which hits `recordreplay::Assert("[RUN-2424-3005] StyleResolver::ResolveStyle ...")`.
    * `ResolveStyle` calls `ApplyBaseStyle` → `ApplyBaseStyleNoCache` → `MatchAllRules` → `MatchAuthorRules` → `MatchElementScopeRules`, ending at `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site (replayed leaf).

* StylePropertySerializer::AsText property-count loop bound
  * location: `blink::StylePropertySerializer::AsText` at `third_party/blink/renderer/core/css/style_property_serializer.cc:225`
  * code: `for (unsigned n = 0; n < size; ++n) {`
  * provenance:
    * `StylePropertySerializer::AsText()` iterates `size` (declaration/property count) times, and its loop body calls `property.Value()->CssText()`.
    * `CssText()` dispatches to `CSSNumericLiteralValue::CustomCSSText()`, which is the function containing the recorded leaf (`recordreplay::RecordReplayString("CSSNumericLiteralValue::CustomCSSText", ...)`).
    * If `size` (or per-iteration `property_id`/`n`) diverges between record and replay, the loop could execute a different number of iterations or visit different properties before reaching the mismatched call, directly explaining a stack/data mismatch at the `CustomCSSText` site.
    * If recorded/replayed disagree on `has_custom_style_callbacks`, the recorded side could diverge into a completely different call (`CustomStyleForLayoutObject`) while replay proceeds down the `OriginalStyleForLayoutObject` path (or vice versa), which would explain the `StackNoCommonFrame` mismatch.

* ApplyBaseStyle cache-reuse branch
  * location: `blink::StyleResolver::ApplyBaseStyle` at `third_party/blink/renderer/core/css/resolver/style_resolver.cc:1366`
  * code: `if (state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)) {`
  * provenance:
    * `ApplyBaseStyle` is called from `StyleResolver::ResolveStyle` (which hits `recordreplay::Assert("[RUN-2424-3005] StyleResolver::ResolveStyle ...")`), and is on the path to both reported stacks' further frames.
    * If this branch is taken, `ApplyBaseStyle` returns early (reusing the cached base style) and never reaches `ApplyBaseStyleNoCache` → `MatchAllRules` → `MatchAuthorRules` → `MatchElementScopeRules` → `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site (replayed leaf).
    * If recorded and replayed disagree on `state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)`, one side would take the early-return cache-reuse path while the other proceeds into `ApplyBaseStyleNoCache` and its author-rule-matching call chain, which would explain the `StackNoCommonFrame` mismatch (divergent stacks with no common frame past this point).

* ApplyBaseStyle inline-style-incremental branch
  * location: `blink::StyleResolver::ApplyBaseStyle` at `third_party/blink/renderer/core/css/resolver/style_resolver.cc` (inline-style-incremental check, after the cache-reuse branch)
  * code: `if (!style_recalc_context.parent_forces_recalc && CanApplyInlineStyleIncrementally(element, state, style_request)) {`
  * provenance:
    * `ApplyBaseStyle` is called from `StyleResolver::ResolveStyle`, which hits `recordreplay::Assert("[RUN-2424-3005] StyleResolver::ResolveStyle ...")`.
    * This branch is evaluated after the cache-reuse branch but still strictly before `ApplyBaseStyleNoCache` → `MatchAllRules` → `MatchAuthorRules` → `MatchElementScopeRules` → `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site (replayed leaf).
    * If recorded and replayed disagree on `!style_recalc_context.parent_forces_recalc && CanApplyInlineStyleIncrementally(element, state, style_request)`, one side would take the early-return incremental-style path while the other proceeds into `ApplyBaseStyleNoCache` and its author-rule-matching call chain, which would explain the `StackNoCommonFrame` mismatch (divergent stacks with no common frame past this point).

* ApplyBaseStyleNoCache UA-only-vs-author-rules branch
  * location: `blink::StyleResolver::ApplyBaseStyleNoCache` at `third_party/blink/renderer/core/css/resolver/style_resolver.cc`
  * code: `if (style_request.rules_to_include == StyleRequest::kUAOnly || (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())) { MatchUARules(*element, collector); } else { MatchAllRules(state, collector, ...); }`
  * provenance:
    * `ApplyBaseStyleNoCache` is reached via `ResolveStyle` → `ApplyBaseStyle` (past the cache-reuse and inline-incremental early returns) and is directly on the path to both reported stacks.
    * This branch decides whether to call `MatchUARules` only, or to call `MatchAllRules` (which is what proceeds into `MatchAuthorRules` → `MatchElementScopeRules` → `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site / replayed leaf).
    * If recorded and replayed disagree on `style_request.rules_to_include == StyleRequest::kUAOnly || (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())`, one side would take the UA-only-rules path (skipping author-rule matching entirely) while the other proceeds into `MatchAllRules` and its author-rule-matching call chain, which would explain the `StackNoCommonFrame` mismatch.

* MatchElementScopeRules element_scope_resolver null-check branch
  * location: `MatchElementScopeRules` (inlined into `StyleResolver::MatchAuthorRules`) at `third_party/blink/renderer/core/css/resolver/style_resolver.cc:625` (near `+826` offset)
  * code: `if (element_scope_resolver) {`
  * provenance:
    * `MatchElementScopeRules` is reached via `MatchAllRules` → `MatchAuthorRules`, directly on the path to both reported stacks.
    * If `element_scope_resolver` is non-null, the taken arm calls `collector.ClearMatchedRules()` then `element_scope_resolver->CollectMatchingElementScopeRules(collector)` (matching the recorded stack's `ScopedStyleResolver::CollectMatchingElementScopeRules` → `ElementRuleCollector::CollectMatchingRules` frames) before `collector.SortAndTransferMatchedRules()`.
    * Either arm falls through to `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site (replayed leaf).
    * If recorded and replayed disagree on whether `element_scope_resolver` is null, the recorded side could take the non-null arm (descending into `CollectMatchingElementScopeRules` → `CollectMatchingRules`, matching its reported stack) while the replayed side takes the null arm and skips straight to `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* MatchElementScopeRules inline-style AddElementStyleProperties branch
  * location: `MatchElementScopeRules` (inlined into `StyleResolver::MatchAuthorRules`) at `third_party/blink/renderer/core/css/resolver/style_resolver.cc` (after the `element_scope_resolver` null-check, before `FinishAddingAuthorRulesForTreeScope`)
  * code: `if (element.IsStyledElement() && element.InlineStyle() && collector.GetPseudoId() == kPseudoIdNone) { ... collector.AddElementStyleProperties(...); }`
  * provenance:
    * `MatchElementScopeRules` is reached via `MatchAllRules` → `MatchAuthorRules`, directly on the path to both reported stacks.
    * This branch is evaluated after `MatchVTTRules` and strictly before `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site (replayed leaf).
    * If recorded and replayed disagree on `element.IsStyledElement() && element.InlineStyle() && collector.GetPseudoId() == kPseudoIdNone`, one side would call `collector.AddElementStyleProperties(...)` (mutating collected rules/state) while the other skips it, before both converge on `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.


* ForAllStylesheets style_sheets_.empty() early-return branch
  * location: `blink::ScopedStyleResolver::ForAllStylesheets` (template, inlined) at `third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc`
  * code: `if (style_sheets_.empty()) { return; }`
  * provenance:
    * `ForAllStylesheets` is called from `ScopedStyleResolver::CollectMatchingElementScopeRules`, which is called from `MatchElementScopeRules`'s `element_scope_resolver` non-null arm (recorded stack frame `ScopedStyleResolver::CollectMatchingElementScopeRules(blink::ElementRuleCollector&)+321`).
    * If `style_sheets_.empty()` is true, `ForAllStylesheets` returns immediately without ever invoking `func` (i.e. without calling `collector.CollectMatchingRules(match_request)`), skipping straight back up to `collector.SortAndTransferMatchedRules()` and then `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site.
    * If recorded and replayed disagree on `style_sheets_.empty()`, one side would call into `CollectMatchingRules` (matching the recorded stack's deeper frame `ElementRuleCollector::CollectMatchingRules(...)+3437`) while the other returns early and proceeds directly to `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* ForAllStylesheets style_sheets_ loop iteration count
  * location: `blink::ScopedStyleResolver::ForAllStylesheets` (template, inlined) at `third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc`
  * code: `for (auto sheet : style_sheets_) { match_request.AddRuleset(&sheet->Contents()->GetRuleSet(), sheet); ... }`
  * provenance:
    * `ForAllStylesheets` is called from `ScopedStyleResolver::CollectMatchingElementScopeRules`, called from `MatchElementScopeRules`'s `element_scope_resolver` non-null arm, directly on the path to the mismatched Assert site.
    * This loop iterates `style_sheets_`, batching rulesets into `match_request` and periodically invoking `func` (which calls `collector.CollectMatchingRules(match_request)`) whenever `match_request.IsFull()`, before ultimately falling through to `collector.SortAndTransferMatchedRules()` and `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site.
    * If recorded and replayed disagree on the number of iterations (i.e. the size/contents of `style_sheets_`), one side could invoke `func`/`CollectMatchingRules` a different number of times (or with different rulesets) than the other, altering the call chain and collected state before reaching `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* ForAllStylesheets match_request.IsFull() inner branch
  * location: `blink::ScopedStyleResolver::ForAllStylesheets` (template, inlined) at `third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc`
  * code: `if (match_request.IsFull()) { func(match_request); match_request.ClearAfterMatching(); }`
  * provenance:
    * `ForAllStylesheets` is called from `ScopedStyleResolver::CollectMatchingElementScopeRules`, called from `MatchElementScopeRules`'s `element_scope_resolver` non-null arm, directly on the path to the mismatched Assert site.
    * Inside the `style_sheets_` loop, this branch decides whether to invoke `func` (i.e. `collector.CollectMatchingRules(match_request)`) immediately once `match_request` is full, versus deferring/batching further rulesets before ultimately falling through to `collector.SortAndTransferMatchedRules()` and `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site.
    * If recorded and replayed disagree on `match_request.IsFull()`, one side would call into `CollectMatchingRules` at a different point (or with different batched rulesets) than the other, altering the call chain and collected state before reaching `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* ForAllStylesheets trailing match_request.IsEmpty() flush branch
  * location: `blink::ScopedStyleResolver::ForAllStylesheets` (template, inlined) at `third_party/blink/renderer/core/css/resolver/scoped_style_resolver.cc`
  * code: `if (!match_request.IsEmpty()) { func(match_request); }`
  * provenance:
    * `ForAllStylesheets` is called from `ScopedStyleResolver::CollectMatchingElementScopeRules`, called from `MatchElementScopeRules`'s `element_scope_resolver` non-null arm, directly on the path to the mismatched Assert site.
    * After the `style_sheets_` loop finishes batching rulesets, this trailing branch decides whether to flush any remaining (not-yet-full) batch via one more `func`/`CollectMatchingRules` call, before falling through to `collector.SortAndTransferMatchedRules()` and `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site.
    * If recorded and replayed disagree on `match_request.IsEmpty()` at this point, one side would make one extra `CollectMatchingRules` call (with the leftover batched rulesets) than the other, altering the call chain and collected state before reaching `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* CollectMatchingRules has_any_attr_rules branch
  * location: `blink::ElementRuleCollector::CollectMatchingRules` at `third_party/blink/renderer/core/css/element_rule_collector.cc:574`
  * code: `if (has_any_attr_rules) {`
  * provenance:
    * `CollectMatchingRules` is called from the `func` callback inside `ScopedStyleResolver::ForAllStylesheets`, which is called from `ScopedStyleResolver::CollectMatchingElementScopeRules`, on the recorded stack's `ElementRuleCollector::CollectMatchingRules(blink::MatchRequest.const&)+3437` frame, directly on the path to the mismatched Assert site.
    * `has_any_attr_rules` is set while scanning the ruleset's attribute-selector buckets (lines 564-568), then gates whether attribute data (`GetAttributes(element, need_style_synchronized)`) is fetched for matching before this call returns and control eventually reaches `collector.SortAndTransferMatchedRules()` and `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site.
    * If recorded and replayed disagree on `has_any_attr_rules`, one side would fetch/synchronize element attributes (potentially triggering `Element::SynchronizeAllAttributes()` → `SynchronizeStyleAttributeInternal()` → `CSSPropertyValueSet::AsText()` → `CSSNumericLiteralValue::CustomCSSText()`, matching the recorded stack) while the other skips this entirely, before both converge back up toward `FinishAddingAuthorRulesForTreeScope`, which would explain the `StackNoCommonFrame` mismatch.

* GetAttributes need_style_synchronized branch
  * location: `GetAttributes(const Element&, bool)` (inlined, anonymous namespace) at `third_party/blink/renderer/core/css/element_rule_collector.cc`
  * code: `if (need_style_synchronized) { ... element.Attributes() ... } else { ... element.AttributesWithoutStyleUpdate() ... }`
  * provenance:
    * `GetAttributes` is called from `ElementRuleCollector::CollectMatchingRules`'s `has_any_attr_rules` arm, directly on the path to the mismatched Assert site.
    * If `need_style_synchronized` is true, `element.Attributes()` calls `Element::SynchronizeAllAttributes()` → `SynchronizeStyleAttributeInternal()` → `CSSPropertyValueSet::AsText()` → `StylePropertySerializer::AsText()` → `CSSNumericLiteralValue::CustomCSSText()`, exactly the recorded stack's leaf chain; the else-arm (`AttributesWithoutStyleUpdate()`) skips synchronization entirely.
    * If recorded and replayed disagree on `need_style_synchronized`, one side would enter the attribute-synchronization/serialization call chain (matching the recorded leaf) while the other would not, before both eventually converge back toward `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site — which would explain the `StackNoCommonFrame` mismatch.

* SynchronizeAllAttributes GetElementData() null-check branch
  * location: `blink::Element::SynchronizeAllAttributes` at `third_party/blink/renderer/core/dom/element.cc` (near `+43` offset)
  * code: `if (!GetElementData()) return;`
  * provenance:
    * `SynchronizeAllAttributes` is called from `Element::Attributes()`, which is called from `GetAttributes`'s `need_style_synchronized` arm, directly on the path to the mismatched Assert site (recorded stack leaf chain).
    * If `!GetElementData()` is true, `SynchronizeAllAttributes` returns immediately, skipping the `style_attribute_is_dirty()` check and `SynchronizeStyleAttributeInternal()` → `CSSPropertyValueSet::AsText()` → `StylePropertySerializer::AsText()` → `CSSNumericLiteralValue::CustomCSSText()` chain (the recorded stack's leaf frames).
    * If recorded and replayed disagree on `!GetElementData()`, one side would enter the style-attribute-synchronization/serialization call chain (matching the recorded leaf) while the other would return early and skip it entirely, before both eventually converge back toward `collector.FinishAddingAuthorRulesForTreeScope(...)`, the mismatched Assert site — which would explain the `StackNoCommonFrame` mismatch.

* CustomCSSText non-integer/out-of-range value branch
  * location: `blink::CSSNumericLiteralValue::CustomCSSText` at `third_party/blink/renderer/core/css/css_numeric_literal_value.cc` (near `+618` offset, `kContainerMax` case)
  * code: `if (value < kMinInteger || value > kMaxInteger || std::trunc(value) != value) {`
  * provenance:
    * `CustomCSSText` is reached via `StylePropertySerializer::AsText()` → `property.Value()->CssText()`, on the path to the recorded stack's leaf chain ending at `recordreplay::RecordReplayString("CSSNumericLiteralValue::CustomCSSText", ...)`.
    * `value` is `To<CSSNumericLiteralValue>(this)->DoubleValue()`; this branch decides whether the non-integer/out-of-range formatting path (`FormatInfinityOrNaN`/`FormatNumber`, guarded further by `!recordreplay::AreEventsDisallowed()`, eventually reaching `RecordReplayString`) is taken, versus the integer-formatting `else`-arm which does not call `RecordReplayString`.
    * If recorded and replayed disagree on `value < kMinInteger || value > kMaxInteger || std::trunc(value) != value`, one side would proceed into the `FormatNumber`/`RecordReplayString` chain (matching the recorded leaf) while the other would take the integer-formatting `else`-arm and skip it entirely, which would explain the `StackNoCommonFrame` mismatch.

* CustomCSSText isinf/isnan vs. finite-number formatting branch
  * location: `blink::CSSNumericLiteralValue::CustomCSSText` at `third_party/blink/renderer/core/css/css_numeric_literal_value.cc` (near `+618` offset, inside the `kContainerMax` non-integer/out-of-range arm)
  * code: `if (std::isinf(value) || std::isnan(value)) { text = FormatInfinityOrNaN(value, UnitTypeToString(GetType())); } else { text = FormatNumber(value, UnitTypeToString(GetType())); ... }`
  * provenance:
    * Reached only after the non-integer/out-of-range branch (`value < kMinInteger || value > kMaxInteger || std::trunc(value) != value`) is taken, still within `CustomCSSText`, strictly before the recorded leaf (`recordreplay::RecordReplayString("CSSNumericLiteralValue::CustomCSSText", ...)`).
    * `value` (`To<CSSNumericLiteralValue>(this)->DoubleValue()`) is already computed earlier in the function; the condition itself is a pure, side-effect-free check on `value`.
    * If recorded and replayed disagree on `std::isinf(value) || std::isnan(value)`, one side takes the `FormatInfinityOrNaN` arm while the other takes the `FormatNumber` arm (which alone leads to the nested `AreEventsDisallowed()` check and `RecordReplayString` call); this would change whether/how the recorded leaf is reached, which would explain the `StackNoCommonFrame` mismatch.

## Suggested Cause of Action

* Add `recordreplay::Assert` calls at each of the following branch conditions, to convert this `ControlFlowMismatch` into a `DataMismatch`:
  * `Element::StyleForLayoutObject`: Assert on `has_custom_style_callbacks`.
  * `StyleResolver::ApplyBaseStyle`: Assert on `state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)`.
  * `StyleResolver::ApplyBaseStyle`: Assert on `!style_recalc_context.parent_forces_recalc && CanApplyInlineStyleIncrementally(element, state, style_request)`.
  * `StyleResolver::ApplyBaseStyleNoCache`: Assert on `style_request.rules_to_include == StyleRequest::kUAOnly || (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())`.
  * `MatchElementScopeRules` (inlined into `StyleResolver::MatchAuthorRules`): Assert on `element_scope_resolver != nullptr`.
  * `MatchElementScopeRules` (inlined into `StyleResolver::MatchAuthorRules`): Assert on `element.IsStyledElement() && element.InlineStyle() && collector.GetPseudoId() == kPseudoIdNone`.
  * `ScopedStyleResolver::ForAllStylesheets`: Assert on `style_sheets_.empty()`.
  * `ScopedStyleResolver::ForAllStylesheets`: Assert on `style_sheets_.size()`.
  * `ScopedStyleResolver::ForAllStylesheets`: Assert on `match_request.IsFull()` at each loop iteration.
  * `ScopedStyleResolver::ForAllStylesheets`: Assert on `!match_request.IsEmpty()` at the trailing flush check.
  * `ElementRuleCollector::CollectMatchingRules`: Assert on `has_any_attr_rules`.
  * `GetAttributes`: Assert on `need_style_synchronized`.
  * `Element::SynchronizeAllAttributes`: Assert on `GetElementData() != nullptr`.
  * `StylePropertySerializer::AsText`: Assert on `size` (property-count loop bound) before the loop.
  * `CSSNumericLiteralValue::CustomCSSText` (`kContainerMax` case): Assert on `value < kMinInteger || value > kMaxInteger || std::trunc(value) != value`.
  * `CSSNumericLiteralValue::CustomCSSText` (`kContainerMax` case, non-integer/out-of-range arm): Assert on `std::isinf(value) || std::isnan(value)`.
* Do not Assert on `element_scope_resolver` or `GetElementData()` pointer values themselves; Assert on the boolean null-check result only.
# Solution

* [Done] `Element::StyleForLayoutObject`
  * Steps: Add assertion checking `has_custom_style_callbacks`.
* [Done] `StyleResolver::ApplyBaseStyle` cache-reuse branch
  * Steps: Add assertion checking `state.CanCacheBaseStyle() && CanReuseBaseComputedStyle(state)`.
* [Done] `StyleResolver::ApplyBaseStyle` inline-style-incremental branch
  * Steps: Add assertion checking `!style_recalc_context.parent_forces_recalc && CanApplyInlineStyleIncrementally(element, state, style_request)`.
* [Done] `StyleResolver::ApplyBaseStyleNoCache`
  * Steps: Add assertion checking `style_request.rules_to_include == StyleRequest::kUAOnly || (style_request.IsPseudoStyleRequest() && element->IsPseudoElement())`.
* [Done] `MatchElementScopeRules` (inlined in `StyleResolver::MatchAuthorRules`) element_scope_resolver branch
  * Steps: Add assertion checking the boolean result of `element_scope_resolver != nullptr` (assert the bool, not the pointer).
* [Done] `MatchElementScopeRules` inline-style AddElementStyleProperties branch
  * Steps: Add assertion checking `element.IsStyledElement() && element.InlineStyle() && collector.GetPseudoId() == kPseudoIdNone`.
* [Done] `ScopedStyleResolver::ForAllStylesheets` empty-check branch
  * Steps: Add assertion checking `style_sheets_.empty()`.
* [Done] `ScopedStyleResolver::ForAllStylesheets` loop iteration count
  * Steps: Add assertion before the loop checking `style_sheets_.size()`.
* [Done] `ScopedStyleResolver::ForAllStylesheets` match_request.IsFull() branch
  * Steps: Add assertion inside the loop, each iteration, checking `match_request.IsFull()`.
* [Done] `ScopedStyleResolver::ForAllStylesheets` trailing flush branch
  * Steps: Add assertion at the trailing flush check, checking `!match_request.IsEmpty()`.
* [Done] `ElementRuleCollector::CollectMatchingRules` has_any_attr_rules branch
  * Steps: Add assertion checking `has_any_attr_rules`.
* [Done] `GetAttributes` need_style_synchronized branch
  * Steps: Add assertion checking `need_style_synchronized`.
* [Done] `Element::SynchronizeAllAttributes` GetElementData() null-check branch
  * Steps: Add assertion checking the boolean result of `GetElementData() != nullptr` (assert the bool, not the pointer).
* [Done] `StylePropertySerializer::AsText` property-count loop bound
  * Steps: Add assertion before the loop checking `size`.
* [Done] `CSSNumericLiteralValue::CustomCSSText` (`kContainerMax` case) non-integer/out-of-range branch
  * Steps: Add assertion checking `value < kMinInteger || value > kMaxInteger || std::trunc(value) != value`.
  * Implementation:
    * Hoisted condition into named bool `is_non_integer_or_out_of_range`, asserted before `if`.
* [Done] `CSSNumericLiteralValue::CustomCSSText` (`kContainerMax` non-integer/out-of-range arm) isinf/isnan branch
  * Steps: Add assertion checking `std::isinf(value) || std::isnan(value)`.
  * Implementation:
    * Hoisted condition into named bool `is_inf_or_nan`, asserted before `if`.
