### PR TITLE
Remove recordreplay::Assert under lock in ParkableStringImpl::MaybeAgeOrParkString

### DIFF
--- a/third_party/blink/renderer/platform/bindings/parkable_string.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string.cc
@@ -400,10 +400,6 @@ ParkableStringImpl::AgeOrParkResult ParkableStringImpl::MaybeAgeOrParkString() {
 
   Status status = CurrentStatus();
   Age age = metadata_->age_;
-  recordreplay::Assert(
-      "ParkableStringImpl::MaybeAgeOrParkString digest=%s status=%d age=%d",
-      base::HexEncode(digest()->data(), digest()->size()).c_str(),
-      static_cast<int>(status), static_cast<int>(age));
   if (age == Age::kYoung) {
     if (status == Status::kUnreferencedExternally)
       metadata_->age_ = MakeOlder(age);


### PR DESCRIPTION
# Summary

* `ParkableStringImpl::MaybeAgeOrParkString` held `metadata_->lock_` then called a diagnostic `recordreplay::Assert(...)`.
  * On replay-mismatch the assert dump path resolved a JS script location.
    * That resolution called `ParkableString::ToString()`, reentering the same `metadata_->lock_`.
* `metadata_->lock_` is non-recursive.
  * Reentrant `pthread_mutex_trylock` failed `Assert(mRecursive)` in `ReplayLock::TryLock()` — crash.
* Fix: remove that diagnostic `Assert(...)` call.
  * Aging/parking control flow unchanged.
* Regression source: this Assert under lock in `ParkableString`.
* Upstream divergences under `AgeStringsAndPark` (ignored for now):
  * Several mismatch types seen, e.g. `digest`/`status`:
    * recorded: `ParkableStringImpl::MaybeAgeOrParkString digest=C154BADFE715AAA3382137A85FEB5ABB01B8D3606B9DDE158D34DECD2B84475C status=0 age=0`
    * replayed: `ParkableStringImpl::MaybeAgeOrParkString digest=0114124A031E835EF2E7442B20533F52171A35022CF7256C563F6E144BBCD543 status=1 age=0`
  * These are hundreds of checkpoints away from the crash — the mismatch merely triggers the dump path, it is not the crash cause.

# Problem

* Problem type: ReplayOtherCrash.

## Important Context

* buildId: linux-chromium-20260714-9ba9a379cc69-904634a4ff04
* linkerVersion: linker-linux-16022-904634a4ff04
* recordingId: e9c84ce8-8737-4cf8-bc09-9b9be8c9d374

### Crash Report Core
```json
{
  "why": "LinkerFatalError",
  "file": "linker/ReplayLock.cpp",
  "line": 103,
  "text": "Assertion failed!",
  "category": "SaplingPaints",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 1185663,
      "checkpoint": 15
    },
    "getResumeData": [
      "paints"
    ]
  },
  "threadId": 1,
  "backtrace": {
    "frames": [
      "recordreplay::ReplayLock::TryLock()+189",
      "new_pthread_mutex_trylock(void*)+21",
      "0x100050cde04c",
      "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
      "0x100050cdd060",
      "blink::ParkableString::ToString().const+32",
      "non-virtual.thunk.to.blink::ParkableStringResource16::data().const+13",
      "unsigned.short.v8::internal::StringShape::DispatchToSpecificTypeWithoutCast<unsigned.short.v8::internal::StringShape::DispatchToSpecificType<v8::internal::String::GetImpl(int,.v8::internal::PtrComprCageBase,.v8::internal::SharedStringAccessGuardIfNeeded.const&).const::StringGetDispatcher,.unsigned.short,.int&,.v8::internal::PtrComprCageBase&,.v8::internal::SharedStringAccessGuardIfNeeded.const&>(v8::internal::String,.int&,.v8::internal::PtrComprCageBase&,.v8::internal::SharedStringAccessGuardIfNeeded.const&)::CastingDispatcher,.unsigned.short,.v8::internal::String&,.int&,.v8::internal::PtrComprCageBase&,.v8::internal::SharedStringAccessGuardIfNeeded.const&>(int&,.v8::internal::PtrComprCageBase&,.v8::internal::SharedStringAccessGuardIfNeeded.const&)+401",
      "v8::internal::Script::GetPositionInfo(int,.v8::internal::Script::PositionInfo*,.v8::internal::Script::OffsetFlag).const+1284",
      "v8::internal::Script::GetPositionInfo(v8::internal::Handle<v8::internal::Script>,.int,.v8::internal::Script::PositionInfo*,.v8::internal::Script::OffsetFlag)+90",
      "v8::internal::GetScriptLocationString(int,.int)+372",
      "v8::internal::RecordReplayCallbackAssertDescribeData(void*,.unsigned.long)+86",
      "std::_Function_handler<void.(Assertion.const&),.recordreplay::CreateAssertDumpFile()::'lambda'(Assertion.const&)>::_M_invoke(std::_Any_data.const&,.Assertion.const&)+67",
      "recordreplay::CreateAssertDumpFile()+732",
      "recordreplay::RecordReplayAssertWithStackVA(void*,.char.const*,.__va_list_tag*)+4623",
      "BindingRecordReplayAssert(char.const*,.__va_list_tag*)+32",
      "recordreplay::Assert(char.const*,....)+141",
      "blink::ParkableStringImpl::MaybeAgeOrParkString()+244",
      "blink::ParkableStringManager::AgeStringsAndPark()+169",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 1160598,
    "threadId": 1,
    "checkpoint": 14
  }
}
```

# Facts

* [F1] `backend/src/cpp/linker/ReplayLock.cpp:103` (`ReplayLock::TryLock()`, lines 98-120) is `Assert(mRecursive);`.
  * Reached only when `mOwner == thread->GetId()` (current thread already owns this lock).
  * Fails iff the lock was initialized non-recursive (`mRecursive == false`).

* [F2] `pthread_mutex_trylock` binding resolves the target `ReplayLock` per-mutex-pointer via `EnsureReplayLock(aPtr)` (`backend/src/cpp/linker/BindingLocks.cpp`).
  * Recursiveness fixed once at `pthread_mutex_init` time, from `PTHREAD_MUTEX_RECURSIVE` attr type.
  * `base::Lock`/`base::AutoLock` (Chromium) wraps a plain non-recursive `pthread_mutex_t` by default.

* [F3] `blink::ParkableStringImpl::MaybeAgeOrParkString()` (`parkable_string.cc`) takes `base::AutoLock locker(metadata_->lock_)` first, then calls `recordreplay::Assert("ParkableStringImpl::MaybeAgeOrParkString digest=... status=... age=...")`.
  * This `Assert(fmt, ...)` call is an unconditional diagnostic/progress marker — always fires, not itself a failure.

* [F4] `recordreplay::RecordReplayAssertWithStackVA` (`backend/src/cpp/recording/Assert.cpp`) only invokes `gDescribeData`/mismatch handling (`OnMismatch`, `CreateAssertDumpFile`) when the current assert's text/stack/app-data **mismatches** the recorded assertion.
  * `gDescribeData` is set via `SetAssertDataCallbacks` to `RecordReplayCallbackAssertDescribeData`.

* [F5] `RecordReplayCallbackAssertDescribeData` (`v8/src/runtime/runtime-debug.cc`) interprets the assert's associated buffer as script-progress entries, calling `GetScriptProgressEntryString` → `GetScriptLocationString` → `v8::internal::Script::GetPositionInfo`, which needs the script's source string.
  * Confirms backtrace frames `RecordReplayCallbackAssertDescribeData` → `GetScriptLocationString` → `Script::GetPositionInfo`.

* [F6] `blink::ParkableStringImpl::ToString()` (same file as F3) also does `base::AutoLock locker(metadata_->lock_)` — same lock field/type as in `MaybeAgeOrParkString` (F3).
  * If `Script::GetPositionInfo` resolves source text backed by the very `ParkableStringImpl` whose lock is already held (plausible since `AgeStringsAndPark` iterates all parkable strings and the mismatching assert can reference a JS location in one of those same strings), `ToString()` reenters `metadata_->lock_` on the same thread.

* [F7] Because `metadata_->lock_` is non-recursive (F2), the reentrant `pthread_mutex_trylock` call in `ToString()` hits `ReplayLock::TryLock()` with `mOwner == thread->GetId()` and fails `Assert(mRecursive)` at `ReplayLock.cpp:103` (F1) — matches crash file/line and full backtrace order:
  * `ParkableStringImpl::MaybeAgeOrParkString` (via `Assert`) → `CreateAssertDumpFile`/`RecordReplayCallbackAssertDescribeData` → `Script::GetPositionInfo` → `ParkableString::ToString` → intercepted `pthread_mutex_trylock` → `ReplayLock::TryLock` → `Assert(mRecursive)`.
  * Occurs on main/renderer thread (`threadId 1`), consistent with `AssertOnValidThread()` in both `ParkableStringImpl` methods and `IsMainThread()` gating in `Assertion::DumpSafe`.

## Root Cause

* `blink::ParkableStringImpl::MaybeAgeOrParkString()`'s diagnostic `Assert()` call transitively triggers `ParkableString::ToString()` while `metadata_->lock_` is already held by the same thread, causing a non-recursive-mutex reentrant `pthread_mutex_trylock` that fails `Assert(mRecursive)` in `ReplayLock::TryLock()` [F1][F2][F3][F6][F7]. Root cause confirmed via full call-chain match (F5,F7); not reproduced/executed, but backtrace order + code inspection fully explain the crash.

## Slice

* `ParkableStringManager::AgeStringsAndPark()` → `ParkableStringImpl::MaybeAgeOrParkString()` takes `base::AutoLock locker(metadata_->lock_)` [F3].
* Same function calls `recordreplay::Assert(...)` diagnostic marker (always fires) [F3].
* `Assert` → `BindingRecordReplayAssert` → `RecordReplayAssertWithStackVA` → `CreateAssertDumpFile` invokes `gDescribeData` on mismatch [F4].
* `gDescribeData` = `RecordReplayCallbackAssertDescribeData` → `GetScriptLocationString` → `Script::GetPositionInfo`, resolving script source string [F5].
* `Script::GetPositionInfo` resolves source backed by a `ParkableStringImpl`, calling `ParkableString::ToString()`, which takes `base::AutoLock locker(metadata_->lock_)` on the same lock field/object already held [F6].
* `ToString()`'s lock acquisition intercepted as `pthread_mutex_trylock`, routed to `ReplayLock::TryLock()` via `EnsureReplayLock` binding [F2].
* `TryLock()` sees `mOwner == thread->GetId()` (same thread reentry) and lock initialized non-recursive (`mRecursive == false`) [F1][F2].
* `Assert(mRecursive)` at `ReplayLock.cpp:103` fails — crash [F1][F7].

# Solution

* In `ParkableStringImpl::MaybeAgeOrParkString` (`parkable_string.cc`): remove the `recordreplay::Assert(...)` call.
* That Assert was a diagnostic marker under `metadata_->lock_`; on mismatch its dump path reentered the same non-recursive lock via `ToString`.
* Removing it avoids the reentry; aging/parking control flow unchanged.
