### PR TITLE
Add Context-identity diagnostics to pin down garbage-Context crash in CommandCallback

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'ffe66fe960a17f5c44b9ef9f3d313e42c1121d04',
+  'v8_revision': 'afdd89a9bb0d6e6005985601156eca0bb4fd7d55',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'afdd89a9bb0d6e6005985601156eca0bb4fd7d55',
+  'v8_revision': '94caae5b0fe3e8ac9d59634a8897f2f342c497be',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '94caae5b0fe3e8ac9d59634a8897f2f342c497be',
+  'v8_revision': '9e1400774f9d54a73f01d19a2898be931533ed18',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -80,6 +80,7 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
     v8::Local<v8::Object> paramsObj);
 
 extern int gPauseContextGroupId;
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
 
 } // namespace internal
 } // namespace v8
@@ -101,9 +102,6 @@ using RemoteObjectIdType = WTF::String;
 
 extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
 extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate);
-namespace v8 { namespace internal {
-std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
-} }
 extern "C" void V8RecordReplayFinishRecording();
 extern "C" void V8RecordReplaySetCrashReason(const char* reason);
 extern "C" char* V8RecordReplayReadAssetFileContents(const char* aPath, size_t* aLength);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -79,6 +79,8 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
     v8::Isolate* isolate_,
     v8::Local<v8::Object> paramsObj);
 
+extern int gPauseContextGroupId;
+
 } // namespace internal
 } // namespace v8
 
@@ -98,6 +100,10 @@ using RemoteObjectIdTypeRaw = std::u16string;
 using RemoteObjectIdType = WTF::String;
 
 extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx);
+extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate);
+namespace v8 { namespace internal {
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
+} }
 extern "C" void V8RecordReplayFinishRecording();
 extern "C" void V8RecordReplaySetCrashReason(const char* reason);
 extern "C" char* V8RecordReplayReadAssetFileContents(const char* aPath, size_t* aLength);
@@ -719,10 +725,12 @@ void RecordReplayClearContexts(const char* reason, LocalFrame* frame) {
   if (!gReplayScriptsAlive || frame != gRootLocalFrame) {
     return;
   }
-  recordreplay::Print("ReplayScript STATUS_CHANGE_UNALIVE - %s iso=%" PRIxPTR " frame=%d",
-      reason,
-      reinterpret_cast<uintptr_t>(V8PerIsolateData::MainThreadIsolate()),
-      frame->RecordReplayId());
+  v8::Isolate* isolate = V8PerIsolateData::MainThreadIsolate();
+  recordreplay::Print(
+      "ReplayScript STATUS_CHANGE_UNALIVE - %s iso=%" PRIxPTR
+      " new-default-ctx=%" PRIxPTR " frame=%d",
+      reason, reinterpret_cast<uintptr_t>(isolate),
+      V8RecordReplayGetDefaultContextAddress(isolate), frame->RecordReplayId());
   gReplayScriptsAlive = false;
 }
 
@@ -2725,9 +2733,10 @@ void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8:
   
   // 2. Initialize sourcemap worker, command handlers etc.
   gReplayScriptsAlive = true;
-  recordreplay::Print("ReplayScript STATUS_CHANGE_ALIVE iso=%" PRIxPTR " ctx=%" PRIxPTR " win=%d frame=%d",
-      reinterpret_cast<uintptr_t>(isolate),
-      *reinterpret_cast<v8::internal::Address*>(*context),
+  recordreplay::Print("ReplayScript STATUS_CHANGE_ALIVE %s group=%d win=%d frame=%d",
+      v8::internal::RecordReplayContextAddressToken(
+          isolate, *reinterpret_cast<v8::internal::Address*>(*context)).c_str(),
+      v8::internal::gPauseContextGroupId,
       localFrame->DomWindow()->RecordReplayId(),
       localFrame->RecordReplayId());
   InitializeReplayScripts(isolate, localFrame, context);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -41,10 +41,12 @@
 #include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
 #include "third_party/blink/renderer/platform/bindings/v8_binding.h"
 #include "third_party/blink/renderer/platform/bindings/v8_dom_wrapper.h"
+#include "third_party/blink/renderer/platform/bindings/v8_per_isolate_data.h"
 #include "third_party/inspector_protocol/crdtp/maybe.h"
 #include "v8/include/v8-inspector.h"
 
 #include <array>
+#include <cinttypes>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -717,7 +719,10 @@ void RecordReplayClearContexts(const char* reason, LocalFrame* frame) {
   if (!gReplayScriptsAlive || frame != gRootLocalFrame) {
     return;
   }
-  recordreplay::Print("ReplayScript STATUS_CHANGE_UNALIVE - %s", reason);
+  recordreplay::Print("ReplayScript STATUS_CHANGE_UNALIVE - %s iso=%" PRIxPTR " frame=%d",
+      reason,
+      reinterpret_cast<uintptr_t>(V8PerIsolateData::MainThreadIsolate()),
+      frame->RecordReplayId());
   gReplayScriptsAlive = false;
 }
 
@@ -2720,7 +2725,11 @@ void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8:
   
   // 2. Initialize sourcemap worker, command handlers etc.
   gReplayScriptsAlive = true;
-  recordreplay::Print("ReplayScript STATUS_CHANGE_ALIVE");
+  recordreplay::Print("ReplayScript STATUS_CHANGE_ALIVE iso=%" PRIxPTR " ctx=%" PRIxPTR " win=%d frame=%d",
+      reinterpret_cast<uintptr_t>(isolate),
+      *reinterpret_cast<v8::internal::Address*>(*context),
+      localFrame->DomWindow()->RecordReplayId(),
+      localFrame->RecordReplayId());
   InitializeReplayScripts(isolate, localFrame, context);
 }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/292
# Summary

* Diagnostics-only change for a `PauseChild` `LinkerFault` SIGSEGV in `Pause.evaluateInGlobal`.
  * Fault is a deref of a garbage V8 `Context` (`IsolateContext`/`gDefaultContext`) inside `CommandCallback`.
  * Crash report alone cannot prove which `Context` source ran, nor whether it was the installed or a stale one.
* Adds a shared, dereference-free `iso ctx` token on every `Context` boundary so the faulting `Context` can be correlated post-hoc.
  * Single source of truth: `RecordReplayContextAddressToken(isolate, ctxAddr)` (`v8/src/api/api.cc`) formats `iso=.. ctx=..`; all sites call it (no inline duplication).
  * New deref-free export `V8RecordReplayGetDefaultContextAddress(isolate)` (`v8/src/api/api.cc`): the `gDefaultContext` tagged pointer, safe under a garbage current `Context`.
  * `record_replay_interface.cc`: `STATUS_CHANGE_ALIVE` emits the token + `group win frame` for the just-installed `DefaultContext`; `STATUS_CHANGE_UNALIVE` emits `new-default-ctx` (via the new export) + `frame`.
  * `v8/src/debug/debug.cc` `EnsureIsolateContext`: change-gated `COMMAND_CONTEXT_CHANGE` log with the token and `source=slot|default` branch proof.
  * `v8/src/inspector/v8-inspector-impl.cc` `getContext` A/B miss logs append the token (with the safe `DefaultContext` address) so a missing context group/id lines up against the last `ALIVE`/`UNALIVE`.
* Adds early cheapest-first `CHECK`s in `EnsureIsolateContext` so the invariant is named before the field load faults.
* Repos: `chromium/src` + `v8` submodule.


# Problem

* Problem type: ReplayOtherCrash.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-other-crashes.md
* $WORKSPACE/crash-report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* You can read $DETERMINATOR_DIR/issues/crash-0017/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* operatorId: 369f5af7-4221-491d-b0b3-8045965e68e2
* buildId: linux-chromium-20260714-9ba9a379cc69-904634a4ff04
* linkerVersion: linker-linux-16022-904634a4ff04
* recordingId: 40263241-d216-432f-ab53-77edf8e9352a

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Segmentation fault",
  "category": "PauseChild",
  "manifest": {
    "kind": "pauseRequest",
    "requestType": "command",
    "requestMethod": "Pause.evaluateInGlobal"
  },
  "threadId": 1,
  "backtrace": {
    "frames": [
      "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
      "GetObjectJSON(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+292",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+241",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+798",
      "ProcessResult(Json::Value&)+1378",
      "EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+49",
      "CommandRequest::Process(Json::Value.const&)+596",
      "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
      "PauseRequestHandler::Start(Json::Value.const&)+210",
      "ManifestFinished(Json::Value*)+816",
      "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
      "recordreplay::OnScanTargetHit()+36",
      "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671",
      "v8::internal::OnInstrumentation(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.int)+208",
      "v8::internal::Runtime_RecordReplayInstrumentation(int,.unsigned.long*,.v8::internal::Isolate*)+270",
      "0x10027ff15a38",
      "0x10027fffaed1",
      "0x10027fe8b82c",
      "0x10027fe8b82c",
      "0x10027fe89e5c",
      "0x10027fe89b87",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3544",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::debug::CallFunctionOn(v8::Local<v8::Context>,.v8::Local<v8::Function>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.bool)+259",
      "v8_inspector::(anonymous.namespace)::innerCallFunctionOn(v8_inspector::V8InspectorSessionImpl*,.v8_inspector::InjectedScript::Scope&,.v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.bool,.v8_inspector::WrapMode,.bool,.bool,.v8_inspector::String16.const&,.bool,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+1172",
      "v8_inspector::V8RuntimeAgentImpl::callFunctionOn(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+651",
      "v8_inspector::protocol::Runtime::DomainDispatcherImpl::callFunctionOn(v8_crdtp::Dispatchable.const&)+701",
      "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
      "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+611",
      "blink::DevToolsSession::DispatchProtocolCommandImpl(int,.WTF::String.const&,.base::span<unsigned.char.const,.18446744073709551615ul>)+310",
      "blink::mojom::blink::DevToolsSessionStubDispatch::Accept(blink::mojom::blink::DevToolsSession*,.mojo::Message*)+233",
      "mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*)+820",
      "mojo::MessageDispatcher::Accept(mojo::Message*)+298",
      "mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*)+87",
      "IPC::(anonymous.namespace)::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message)+312",
      "base::internal::Invoker<base::internal::BindState<void.(mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy::*)(mojo::Message),.scoped_refptr<mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy>,.mojo::Message>,.void.()>::RunOnce(base::internal::BindStateBase*)+70",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 16345,
    "threadId": 1,
    "checkpoint": 4
  },
  "faultAddress": "0x10180044005c",
  "instructionPointer": "v8::internal::CommandCallback(char.const*,.char.const*)+310"
}
```

# Basic Facts

* Repro: [MUST-READ] `$RUNTIME_BIBLE/crashes/crash-repro.md`
* Manifests: `$WORKSPACE/repro-man.json`

## Possibly Relevant Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 16345,
    "threadId": 2,
    "processId": 1281,
    "checkpoint": 4,
    "absoluteTime": 1784062739249.8582,
    "wasRecording": false
  },
  {
    "text": "Thread::WaitForeverForRecordedCall pthread_detach",
    "count": 1,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 16345,
    "threadId": 6,
    "processId": 1281,
    "checkpoint": 4,
    "absoluteTime": 1784062739249.982,
    "wasRecording": false
  }
]
```


# Facts

* [F1] Crash code lives in `$REPLAY_DIR/backend/src/cpp/linker/PauseData.cpp` (`PauseData::AddObject`, `GetObjectJSON`) and `$REPLAY_DIR/backend/src/cpp/shared/Command.cpp` (`SendCommand`/`SendCommandRaw`) — NOT chromium/node src.
* [F2] **Corrupted object = the current V8 `Context` (`IsolateContext` = `*(Isolate+0x4848)`).** Its tagged pointer in `%r12` is `0x10180043FFC9` (HeapObject base `0x10180043FFC8`) but points to unmapped/garbage memory, so the first field read on it faults. This is a garbage-Context deref, not stack overflow.
  * `instructionPointer` = `v8::internal::CommandCallback(char const*, char const*)+310`, the real native command trampoline (`$REPLAY_DIR/node/deps/v8/src/debug/debug.cc`), invoked via `gDefaultCallback` from `SendCommandRaw`.
  * Symbol is only resolvable mangled: break on `_ZN2v88internal15CommandCallbackEPKcS2_` (plain `symbols CommandCallback` returns unrelated `recordreplay::*` matches).
  * Build disasm (`$WORKSPACE/CommandCallback.disasm.txt`, chrome `linux-chromium-20260714-9ba9a379cc69-904634a4ff04`): `+310` = `mov 0x93(%r12),%ecx` at VA `0x4c123f6`.
    * `%r12` at fault = Context tagged `0x10180043FFC9`.
    * Provenance of that value (see F6): post-`EnsureIsolateContext` converge, optionally rewritten by `CanonicalHandleScope::Lookup` (`4c123c2`).
    * Crash load `mov 0x93(%r12),%ecx` (+ surrounding `and`/`or` with `0xffffffff00000000`) decompresses the tagged field at Context offset `0x92` (`0x93` = offset `0x92` + tag `1`). `faultAddress` = `%r12+0x93` = `0x10180043FFC9 + 0x93` = `0x10180044005c` ⇒ the Context's own memory is unreadable.
    * Crash is before `params` parse / `gCommandCallback` / `Execution::Call` (those start at `+0x21f` / later), so the corruption is in the Context itself, not in the command payload or callback.
* [F3] Operator log (`operator.log/994190861.log`):
  * `CreateAnalysisContext` phase `Done` before the crash.
  * Crashing MCP tool: `InspectElement` (`point: Point:5` → `973555660994125835263707157889037`, `element: h1`).
  * No `OperatorToolCallEnd` for that call.
  * **WarmPauseChild**: `processId` 1281 / `childId` `4de5255e-8b4f-4381-b0c6-8097e44b94d5` / `pauseId` `9c02bd62-fee1-49a3-9a54-c6ef4c03e419`.
    * Spawned ~20:58:59.
    * Ran manifests 1–24 on that PauseChild.
    * `LinkerFault` on `manifestIndex` 25 (~20:59:18), ~37ms after `SendManifest`.
  * Crashing `Pause.evaluateInGlobal` expression returns a DOM Element via `findSelectorParentElementChain` for `{"css":"#root > div > main > header > h1"}`.
  * `CrashReport` ~30s later is aggregation delay, not hang.
* [F4] `RecordReplayClearContexts` marks root-frame script teardown.
  * Call site: `LocalDOMWindow` teardown → `MainThreadDebugger::DidClearContextsForFrame` → `RecordReplayClearContexts`.
  * Only if `gReplayScriptsAlive` and `frame == gRootLocalFrame`.
  * Logs `ReplayScript STATUS_CHANGE_UNALIVE`.
  * Sets `gReplayScriptsAlive = false`.
  * JS command handlers read that via `fromJsIsReplayScriptAlive` / `CHECK_ALIVE`.
  * Leaves `IsolateContext` and `gDefaultContext` unchanged.
  * `EnsureIsolateContext` only replaces a **null** `IsolateContext` via `gDefaultContext`.
  * Stale non-null is kept.
  * `LocalWindowProxy::DisposeContext` leaves `IsolateContext` unchanged.
* [F5] Operator log: no `STATUS_CHANGE_UNALIVE` on the crash fork chain.
  * PauseChild `1281` / `4de5255e`: none.
  * Parent `processId` 7 / branch `0a905a5c`: none.
  * Grandparent `processId` 5: only `STATUS_CHANGE_ALIVE`.
  * Session `UNALIVE` lines are other processes.
* [F6] Two Context sources can reach FaultLoad; only one is null-checked; which source ran is unknown.
  * **Sources** (only these two object identities):
    * **SlotContext** — `*(Isolate+0x4848)` kept on non-null branch (`4c12333` → `jne 4c1238e`).
    * **DefaultContext** — `gDefaultContext` via `V8RecordReplayGetDefaultContext` + `SaveAndSwitchContext` on null branch (`4c1234e`/`4c1237b`/`4c12387`).
    * `CanonicalHandleScope::Lookup` (`handles.cc:228-246` / `4c123c2`) may rewrite the handle location; it does **not** change the tagged object identity.
  * **Null checks** (`debug.cc:3857-3863`, `api.cc:11222-11224`):
    * **SlotContext** at entry: yes — `isolate->context().is_null()` / disasm `test %r12d`.
    * **DefaultContext** after `Get`: **no** — no `Local::IsEmpty`, no `Context::is_null` before `OpenHandle` / `ssc.emplace`.
    * Post-converge `isolate->context()` before field deref: **no**.
    * `is_null` = `ptr() == kNullAddress` only (`heap-object.h:29-31`) — not “heap gone.”
  * **`gDefaultContext` lifetime** — see F7. Never cleared by `RecordReplayClearContexts`. `Eternal` roots each install.
  * **Observed at fault:** `CommandCallback+310` = `4c123f6` `mov 0x93(%r12),%ecx`, `%r12 = 0x10180043FFC9`.
    * Source map: first field read in `AutoAllowCodeGenerationFromStrings` ctor — not a separate observed fault site.
  * **Claim checks:**
    * Claim1 “did not null-check all possible Contexts” → **verified** (DefaultContext unchecked).
    * Claim2 “don’t know which Context it is” → **verified** (SlotContext vs DefaultContext; crash report has no branch proof).
  * **Unrecoverable from this crash report:** no rr; no stack-at-fault Optional `-0xa8(%rbp)` (null-path-only).
  * Recoverable only with: rr, or a branch/source diagnostic + repro.
* [F7] **`V8RecordReplaySetDefaultContext` call surface** — which Isolate/Context can become `gDefaultContext`.
  * **Call chain** (only path):
    * `LocalWindowProxy::Initialize` (`local_window_proxy.cc:186-279`)
    * → gate: `IsRecordingOrReplaying("commands")` && `origin` with non-empty `Host`
    * → gate **RootProxy**: `IsLocalRoot() && world_->IsMainWorld() && Page::IsOrdinary()`
    * → `OnRootFrameInit` → `InitializeReplayScripts` → `V8RecordReplaySetDefaultContext(isolate, context)` (`record_replay_interface.cc:2663-2724`)
  * **Isolate:** always `V8PerIsolateData::MainThreadIsolate()` (`window_proxy_manager.cc:90-97`).
    * `Set` no-ops unless `IsMainThread()` (`api.cc:11216-11219`).
    * Worker / off-main-thread isolates never install here.
  * **Context installed:** that `LocalWindowProxy`'s just-created main-world `script_state_` Context for the process **LocalRoot** frame.
    * `IsLocalRoot` = no parent, or parent is `RemoteFrame` (`local_frame.cc:432-437`) — so tab main frame **or** OOPIF local-root in this renderer.
    * Comment assumes one tab per process (`record_replay_interface.cc:2666-2667`).
  * **Not installed from:** non-`LocalRoot` frames, isolated worlds, non-ordinary pages, empty-host origins, non-`commands` recordings.
  * **Re-install:** every later **RootProxy** `Initialize` (incl. navigation `DisposeContext` → `UpdateDocument` → `Initialize`) calls `Set` again.
    * `gRootLocalFrame` updated each time (`OnRootFrameInit`).
  * **vs SlotContext surface:** `isolate->context()` can be any currently entered Context on that same MainThreadIsolate (any frame/world), not only **RootProxy**.
  * Corrects F6 “set once”.
* [F8] **StaleSlotContext** retention — only path that can leave a non-rooted Context pointer in `IsolateContext`.
  * Entered Context (any frame/world) is stored in `IsolateContext` (`Isolate+0x4848`).
  * `LocalWindowProxy::DisposeContext` does not clear `IsolateContext` (`local_window_proxy.cc:88-161`).
  * `RecordReplayClearContexts` does not clear `IsolateContext` (`record_replay_interface.cc:715-721`).
  * `EnsureIsolateContext` replaces `IsolateContext` only when null (`debug.cc:3857-3863`).
  * Non-null stale pointer is reused on the SlotContext branch (F6).
  * That Context is Eternal-rooted only if it is also the current `gDefaultContext` install (F7 / `api.cc:11216-11219`); otherwise no Replay root keeps it alive.
  * But `IsolateContext` itself is a V8 GC root (`isolate.cc:606-607`): while non-null there, V8 cannot collect it — unmapped SlotContext needs a clear+GC window then a stale non-root rewrite, not collection under a live slot.
* [F9] `DisposeContext` writes `IsolateContext` to the Context it is tearing down.
  * First act: `ScriptState::Scope scope(script_state_)` (`local_window_proxy.cc:112`) — enters that Context.
  * Then detaches / disposes it; never clears `IsolateContext` (F8).
* [F10] Managed-dtor Page teardown hits F9.
  * `Page::WillBeDestroyed` always starts with `main_frame->Detach(...)` (`page.cc:989-999`) → frame teardown → `DisposeContext` (F9).
  * Under `AreEventsDisallowed("Page::WillBeDestroyed")`, only the scheduler is leaked afterward (`page.cc:1032-1042`); `Detach` already ran.
* [F11] `#1368` `f2bffb892368a` (in build `9ba9a379cc69`) changes that Managed-dtor path for SVGImage Pages.
  * `SVGImage::~SVGImage` when `AreEventsDisallowed("~SVGImage")`: insert `page_` into static `leaked_pages`, call `ChromeDestroyed`, **skip** `WillBeDestroyed` (`svg_image.cc:228-233`).
  * Else: still `WillBeDestroyed()` (`svg_image.cc:248-250`).
  * Pre-`#1368`: `~SVGImage` always called `WillBeDestroyed` (including under Managed dtor) → F10 → F9.
  * SVG Pages are `CreateNonOrdinary` (`svg_image.cc:847`) — not F7 **RootProxy** after `#1374`; can still be F9 SlotContext.
* [F12] Tab inactivity / backgrounding does not explain the garbage-Context crash.
  * Visibility → `NotifyPageVisibilityStateChanged` only (paint bookkeeping).
  * Freeze → `DidFreeze` (event + defer loads); no `DisposeContext` / no `IsolateContext` clear.
  * Background `MemoryPurgeManager` → memory-pressure only; not `ForciblyPurgeV8Memory`.
  * Freeze handlers that detach root would log `STATUS_CHANGE_UNALIVE`; F5 has none on the crash fork.
* [F13] This crash path is already diverged before `CommandCallback`.
  * `PauseRequestHandler::Start` always calls `DivergeFromRecording()` before `PerformPauseDataRequest` (`Manifest.cpp:1199-1209`).
  * Crash report + repro manifests are `kind: pauseRequest` / `Pause.evaluateInGlobal`.
  * Local linkerdebug (`$WORKSPACE/.debug_session.linkerdebug.log`): every `pauseRequest` `ManifestResult` has `"divergedFromRecording": true` (23 true / 0 false), including index 25.
  * So nested `SendCommand` → `CommandCallback` under that pause would take the `HasDivergedFromRecording()` branch (`debug.cc:3908`, disasm `4c12474`).
  * This fault never reaches that branch: `+310` / `AutoAllowCodeGenerationFromStrings` is before the `HasDiverged` check at `+0x1b4`.
* [F14] v8 `#291` / chromium `#1378` (in this build) cannot produce the unmapped Context at `CommandCallback+310`.
  * What `#291` does (`v8/src/objects/managed.cc`):
    * V8 `Managed` is a heap object that owns a C++ object via `shared_ptr` (Wasm/ICU/etc.).
    * When GC collects a `Managed`, pass 2 of the finalizer normally deletes that C++ object.
    * `#291`: if `AreEventsDisallowed()`, pass 2 returns without deleting. The C++ object stays on the isolate list `managed_ptr_destructors_head_`.
    * Those C++ objects are deleted only from `Isolate::ReleaseSharedPtrs`, whose only call site is `Isolate::Deinit` (`isolate.cc:3755`).
  * Why that cannot feed this crash:
    * Fault site reads only `IsolateContext` / `gDefaultContext` (F2/F6). It does not read `managed_ptr_destructors_head_`.
    * `#291` retains a `shared_ptr` to the C++ payload (Wasm/ICU/etc.) on that list. That retained ref is not a `Context` and is not stored in `IsolateContext` / `gDefaultContext`.
    * Blink has no `v8::Managed` users. `#291` pass 2 does not call `DisposeContext`, does not write `IsolateContext`, does not write `gDefaultContext`.
    * If GC collects some `Context` C while a raw pointer to C lived inside a leaked C++ payload: that dangling pointer stays inside that payload. Reaching `CommandCallback+310` would still require a later write of C into `IsolateContext` / `gDefaultContext`. `#291` does not perform that write.
    * While C is in `IsolateContext` or current `gDefaultContext`, it is rooted (F7/F8). GC cannot unmap that C and leave those slots holding it.
    * This crash runs `CommandCallback` on the main thread via `Isolate::Current()` (`debug.cc:3896-3903`) = `MainThreadIsolate`, on a live WarmPauseChild (F3).
    * Worker isolate destroy: only Blink production `V8PerIsolateData::Destroy` call site is `WorkerBackingThread::ShutdownOnBackingThread` (`worker_backing_thread.cc:105-115`). That runs `ReleaseSharedPtrs` on the **worker** isolate. Worker cannot install `gDefaultContext` (F7). Worker `IsolateContext` is not main's.
    * Main isolate destroy: `V8PerIsolateData::Destroy` calls `isolate->Exit()` and nulls `g_main_thread_per_isolate_data` before `Dispose` (`v8_per_isolate_data.cc:176-193`). After that there is no main `Isolate::Current()` left to run this `CommandCallback`.
  * Exclusion: `#291`'s retained ref is the wrong object and the wrong slot. GC can kill other Contexts; it cannot turn the `#291` list into the faulting `IsolateContext` / `gDefaultContext` value without a separate write into those slots, which `#291` does not do.

# Solution

* Goal: correlate the crashing Context (F6 SlotContext vs DefaultContext, unknown tagged ptr) against the installed/torn-down Context via one shared id set on every boundary.
* Canonical `ContextAddress`, dereference-free so it survives the garbage Context (F2): token `iso=%" PRIxPTR " ctx=%" PRIxPTR` (`iso` = the `MainThreadIsolate` `v8::Isolate*`; `ctx` = Context tagged `ptr()`).
  * Only identity reachable on every surface without a deref. Higher-level ids are Blink-only (`win`/`frame`); V8 ids (`debug_context_id`, `InspectedContext::contextId`) need a Context deref → would fault (F2). So Blink-only ids ride along only where free.
  * Emitted through one shared formatter `RecordReplayContextAddressToken(isolate, ctxAddr)` (`v8/src/api/api.cc`) so all sites share the exact same token layout (no inline duplication).
  * New export `V8RecordReplayGetDefaultContextAddress(isolate)` (`v8/src/api/api.cc`): returns the `gDefaultContext` tagged pointer, or `0`, without dereferencing it. Safe from teardown / command diagnostics where the current Context may be garbage. Used to supply `ctx` where only the isolate is in scope.
* `record_replay_interface.cc`:
  * `STATUS_CHANGE_ALIVE` (`OnRootFrameInit`, where `context` is in scope): emit the token + `group win frame` — `ctx` = the just-installed `DefaultContext` (F7); `group` = `gPauseContextGroupId`; `win`/`frame` = `localFrame->DomWindow()->RecordReplayId()` / `localFrame->RecordReplayId()`.
  * `STATUS_CHANGE_UNALIVE` (715-721): add `new-default-ctx` (via `V8RecordReplayGetDefaultContextAddress`) + `frame`, keep `reason` and `iso`. No current-Context `ctx`: site has only `LocalFrame*` and teardown never clears the slot (F8) — the asymmetry is the point; the `DefaultContext` address is what is still reachable.
* `EnsureIsolateContext` (`v8/src/debug/debug.cc`): change-gated diagnostic, static `Address gLastCommandContext = kNullAddress`, logs on `ptr()` change (first call always), then updates it:
  * `recordreplay::Print("ReplayScript COMMAND_CONTEXT_CHANGE %s %s group=%d win=? frame=?", source, RecordReplayContextAddressToken(isolate, ctx.ptr()).c_str(), gPauseContextGroupId)`.
  * `source` = `"slot"`/`"default"` — the F6 branch proof.
  * `ctx` = `isolate->context()`: slot branch as-is; default branch re-read after `ssc.emplace`.
  * `gPauseContextGroupId` = `0` if unset (only assigned under `HasDivergedFromRecording()`); log as-is. Made non-`static`/`extern` so Blink can log the same value on `STATUS_CHANGE_ALIVE`.
  * `win=? frame=?` placeholders keep one log shape across surfaces (this site has no frame in scope).
  * Correlate `iso`+`ctx` here vs the last `ALIVE`/Set: identifies faulting Context as installed `DefaultContext`, stale `SlotContext` (F8), or neither.
* `V8InspectorImpl::getContext` (`v8/src/inspector/v8-inspector-impl.cc`): the two miss logs (A: missing context group; B: missing context id) append the same token, with `ctx` = the safe `DefaultContext` address (`m_isolate` + `V8RecordReplayGetDefaultContextAddress`). Lets a miss line up against the last `ALIVE`/`UNALIVE`/`COMMAND_CONTEXT_CHANGE` — A often follows `STATUS_CHANGE_UNALIVE` once `resetContextGroup` cleared the map.
* Asserts after the `Print` (diagnostic on the wire first), cheapest-first, so the invariant is named not a raw SIGSEGV. Use `CHECK` not `DCHECK` (always-on in these builds):
  * `CHECK(isolate)`, `CHECK(isolate->heap())` — validate isolate (healthy per F2/F8, don't assume).
  * `CHECK(!ctx.is_null())` — DefaultContext-empty case (F6 Claim1); integer compare.
  * `CHECK(ctx.IsHeapObject())` — tag-bit check, no deref.
  * `CHECK(IsValidHeapObject(isolate->heap(), HeapObject::cast(ctx)))` — validate tagged ptr against heap page metadata (address math, no field read); catches garbage/unmapped before `mov 0x93(%r12)`.
  * `CHECK(ctx.IsContext())` — map-word read (offset 0, far earlier than `+0x93`); "wrong type" vs "unmapped".
* Scope: `record_replay_interface.cc` + `v8/src/api/api.cc` + `v8/src/debug/debug.cc` + `v8/src/inspector/v8-inspector-impl.cc`.