### PR TITLE
crash-0019: block C++->JS re-entry during Replay-disallowed events

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '93904356a6b42dc5b32bc7e552c0bff80b3ef594',
+  'v8_revision': '02b7cb54a11c31160cfc639043cca4a82697843c',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '7c2b9c12237345c74dbc412269aa238b7a31414a',
+  'v8_revision': '93904356a6b42dc5b32bc7e552c0bff80b3ef594',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9e1400774f9d54a73f01d19a2898be931533ed18',
+  'v8_revision': '7c2b9c12237345c74dbc412269aa238b7a31414a',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2475,6 +2475,7 @@ static std::string GetStackTrace(v8::Isolate* isolate, v8::TryCatch& try_catch) 
 }
 
 static void RunScript(v8::Isolate* isolate, v8::Local<v8::Context> context, const char* source_raw, const char* filename) {
+  v8::Isolate::AllowJavascriptExecutionScope allow_js(isolate);
   v8::Local<v8::String> filename_string = ToV8String(isolate, filename);
   v8::ScriptOrigin origin(isolate, filename_string);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -778,6 +778,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
                                                         (int)message.length()).ToLocalChecked();
   }
   v8::Local<v8::Function> callback = gCDPMessageCallback->Get(isolate);
+  v8::Isolate::AllowJavascriptExecutionScope allow_js(isolate);
   v8::MaybeLocal<v8::Value> rv = callback->Call(context, v8::Undefined(isolate), 1, &arg);
   CHECK(!rv.IsEmpty());
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/293

# Summary

* Replay diverges: user JS runs during Replay-internal `console.debug` arg preview.
  * `ValueMirror` reads a monkey-patched `stack` getter → user JS executes off-recording.
* Fix: `AutoDisallowEvents`/`AutoMaybeDisallowEvents` also open `DisallowJavascriptExecutionScope(DUMP_ON_FAILURE)`.
  * Blocks C++→JS re-entry without throwing: `Execution::Invoke` returns `undefined`.
  * Under record/replay: `recordreplay::Print` instead of `DumpWithoutCrashing`.
* Nested **ApiAllow** (`v8::Isolate::AllowJavascriptExecutionScope`) at intentional Replay JS entries.
  * Clears `DUMP_ON_FAILURE` so Replay JS can run.
  * Sites: `CommandCallback`, `ClearPauseDataCallback`, `RecordReplayRegisterScript`, `RunScript`, `SendMessageToFrontend`.
* Without **ApiAllow** on `SendMessageToFrontend`:
  * `Runtime.consoleAPICalled` → `onConsoleAPICall` is suppressed.
  * Console messages record as `UnknownMessageError` / `"[RuntimeError] Could not look up message contents"`.
  * E2E waits for real console text → timeouts.

# Solution

* `AutoDisallowEvents` / `AutoMaybeDisallowEvents` open `DisallowJavascriptExecutionScope(DUMP_ON_FAILURE)`.
  * Blocks C++ → JS re-entry: `Execution::Call` returns `undefined`, no throw.
  * While recording/replaying: `recordreplay::Print` (no `DumpWithoutCrashing`).
  * Stops e.g. `reportMessage` → `descriptionForError` → `Get("stack")` → `Error.prepareStackTrace` / `sy`.
* Nested **ApiAllow** at intentional Replay JS entries:
  * `CommandCallback`, `ClearPauseDataCallback`, `gNewScriptHandlers` `Execution::Call`, `RunScript`.
  * `SendMessageToFrontend`: wrap `gCDPMessageCallback->Call` so `onConsoleAPICall` can set `gLastConsoleAPICall`.
* Limit: does not stop JS → JS into user monkey patches once Replay JS is already running.

# Problem

## Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "ScanData",
  "manifest": { "kind": "runToPoint", "endpoint": { "progress": 32000000, "checkpoint": 19 } },
  "recorded": "NewId ScriptWrappable",
  "replayed": "NewProgressCheckpoint 19000000",
  "threadId": 1,
  "backtrace": { "progress": 19000000, "threadId": 1, "checkpoint": 14 }
}
```

## Divergence

* DivergenceStart is `18768650` / `18768651`.
  * `[RUN-1596] V8ConsoleMessageStorage::addMessage`: `lastDeterministicProgress` `18768650`.
  * `[RUN-1919]` ExecutionProgress in non-deterministic user JS at `18768651`.
    * Inside `sy` while `EventsDisallowed:V8RuntimeAgentImpl::reportMessage`.
* Both sides hit the same `console.debug` call, but the JS leading up to it executed differently.

## Causal chain

* Replay-internal wrap/preview of `console.debug` args under `reportMessage`.
  * `V8RuntimeAgentImpl::reportMessage` → `ValueMirror::create` (arg `IsNativeError` → subtype `error`).
  * → `descriptionForError` → `Object::Get("stack")` (value-mirror.cc:273).
  * → monkey-patched `stack` getter (`Error.prepareStackTrace` / minified `sy`) runs **user JS**.
* That user JS advances the progress counter off-recording → Mismatch.

### Verified (rr, `man-divergence-stack.json`)

* Immediate `Object::Get` before progress Warnings:
  * `#0 Object::Get` → `#1 descriptionForError+186`.
  * Disasm: `descriptionForError+181` = that `Object::Get`; first source `Get` is `"stack"`.
  * Forward `cont` from that `Get` → `Warning` via `RecordReplayOnTargetProgressReached` (PC=`18768651`).
* Arg is a native Error:
  * `bt` at `descriptionForError`: `#1 ValueMirror::create+914`, `#17 InjectedScript::wrapObject`.
  * `create` disasm: `+885 IsNativeError` → fallthrough → `+909 descriptionForError`.

## Console contents regression (crash-0019-b)

* Symptom: recorded console text is `"[RuntimeError] Could not look up message contents"`.
* Slice:
  * `SendMessageToFrontend` opens `AutoDisallowEvents` then calls `gCDPMessageCallback` with no **ApiAllow**.
  * `onConsoleAPICall` never runs → `gLastConsoleAPICall` stays null.
  * `Target.getCurrentMessageContents` → `UnknownMessageError`.

# Raw Data

* buildId: `linux-chromium-20260714-9ba9a379cc69-904634a4ff04`
* linkerVersion: `linker-linux-16022-904634a4ff04`
* recordingId: `95608fac-1013-4c98-bd56-52c517618be9`
* E2E fail (missing ApiAllow on crash-0020 tip): https://buildkite.com/replay/runtime-fe-end-to-end-tests/builds/2275
