### PR TITLE
crash-0020: extend Context-identity diagnostics with inspector contextId

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'ccd7d769917c59145382ae17a8000e96483b178f',
+  'v8_revision': '5d8af221b80765b71258438977f6942a55ca1907',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'f79ae7fdaf3198582d5b6b7fac8228a9b877a36e',
+  'v8_revision': 'ccd7d769917c59145382ae17a8000e96483b178f',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9e1400774f9d54a73f01d19a2898be931533ed18',
+  'v8_revision': 'f79ae7fdaf3198582d5b6b7fac8228a9b877a36e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -400,7 +400,7 @@ function Target_getCurrentMessageContents() {
     return {
       source: "UnknownMessageError",
       level: "error",
-      text: "Could not look up message contents"
+      text: "[RuntimeError] Could not look up message contents"
     };
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -780,6 +780,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
                                                         (int)message.length()).ToLocalChecked();
   }
   v8::Local<v8::Function> callback = gCDPMessageCallback->Get(isolate);
+  v8::Isolate::AllowJavascriptExecutionScope allow_js(isolate);
   v8::MaybeLocal<v8::Value> rv = callback->Call(context, v8::Undefined(isolate), 1, &arg);
   CHECK(!rv.IsEmpty());
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -80,7 +80,8 @@ extern v8::Local<v8::Object> RecordReplayGetBytecode(
     v8::Local<v8::Object> paramsObj);
 
 extern int gPauseContextGroupId;
-std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate,
+                                            uintptr_t ctxAddr, bool includeId);
 
 } // namespace internal
 } // namespace v8
@@ -725,10 +726,11 @@ void RecordReplayClearContexts(const char* reason, LocalFrame* frame) {
   }
   v8::Isolate* isolate = V8PerIsolateData::MainThreadIsolate();
   recordreplay::Print(
-      "ReplayScript STATUS_CHANGE_UNALIVE - %s iso=%" PRIxPTR
-      " new-default-ctx=%" PRIxPTR " frame=%d",
-      reason, reinterpret_cast<uintptr_t>(isolate),
-      V8RecordReplayGetDefaultContextAddress(isolate), frame->RecordReplayId());
+      "ReplayScript STATUS_CHANGE_UNALIVE - %s %s frame=%d", reason,
+      v8::internal::RecordReplayContextAddressToken(
+          isolate, V8RecordReplayGetDefaultContextAddress(isolate), true)
+          .c_str(),
+      frame->RecordReplayId());
   gReplayScriptsAlive = false;
 }
 
@@ -2733,7 +2735,8 @@ void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8:
   gReplayScriptsAlive = true;
   recordreplay::Print("ReplayScript STATUS_CHANGE_ALIVE %s group=%d win=%d frame=%d",
       v8::internal::RecordReplayContextAddressToken(
-          isolate, *reinterpret_cast<v8::internal::Address*>(*context)).c_str(),
+          isolate, *reinterpret_cast<v8::internal::Address*>(*context), true)
+          .c_str(),
       v8::internal::gPauseContextGroupId,
       localFrame->DomWindow()->RecordReplayId(),
       localFrame->RecordReplayId());


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/294

# Summary

* Nested `Pause.getObjectPreview` crashes in `CommandCallback` while reading a dead Context.
* Existing CHECKs in `EnsureIsolateContext` did not stop it.
* This PR adds Context-identity logging so we can see which Context was live.
* The new `id=` logging also crashed CI during SaveExamples.
  * Cause: creating a `v8::Local` with no HandleScope.
  * Fix: add HandleScopes around those Gets.

# Solution

## S1: Identify Context by heap address

* Log `ctx=` as the tagged heap pointer from `isolate->context()`.
* Matches the fault: `faultAddress = ctx + 0x93`.
* Safe to print without reading Context fields.

## S2: ContextAddress token

* Shared token shape: `iso=.. ctx=..`.
* Emitted on Context switch as `COMMAND_CONTEXT_CHANGE`.
* Also used for `STATUS_CHANGE_ALIVE` / `UNALIVE` and inspector `getContext` misses.

## S3: Optional inspector `id=`

* When requested, also print `debug_context_id`.
* That read touches Context memory, so it can fault on garbage.
* Keep it off for `COMMAND_CONTEXT_CHANGE`.
* Keep it on for `COMMAND_CONTEXT_ID`, inspector traces, and `STATUS_CHANGE_*`.

## S4: HandleScope for Local Gets

* `Eternal/Persistent::Get` needs a HandleScope.
* Added in `V8RecordReplayGetDefaultContextAddress`, `resetContextGroup`, and `discardInspectedContext`.

## Remaining work

* [TODO] Who wrote SlotContext `ctx=1018006fffd1` on `processId` 362.
* [TODO] Correlate that `ctx` with `COMMAND_CONTEXT_ID` / inspector bindings.


# Problem

* Problem type: ReplayOtherCrash.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-other-crashes.md
* $WORKSPACE/crash-report.json (= $DETERMINATOR_DIR/issues/crash-0020/crash-report.json) - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* You can read $DETERMINATOR_DIR/issues/crash-0020/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR (= /home/domi/replay) /backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* operatorId: e215fedf-7598-416e-88ac-c53e851b39b1
* buildId: linux-chromium-20260715-5fda1dec160a-904634a4ff04
* linkerVersion: linker-linux-16022-904634a4ff04
* recordingId: d0f06ada-85d7-4e93-b358-a7104217a7db

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Segmentation fault",
  "category": "PauseChild",
  "manifest": {
    "kind": "pauseRequest",
    "requestType": "command",
    "requestMethod": "Pause.getObjectPreview"
  },
  "threadId": 1,
  "backtrace": {
    "frames": [
      "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
      "GetObjectJSON(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+292",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+241",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+3135",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+678",
      "GetObjectPreviewCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+381",
      "CommandRequest::Process(Json::Value.const&)+596",
      "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
      "PauseRequestHandler::Start(Json::Value.const&)+210",
      "ManifestFinished(Json::Value*)+816",
      "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
      "recordreplay::OnScanTargetHit()+36",
      "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671",
      "v8::internal::OnInstrumentation(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.int)+208",
      "v8::internal::Runtime_RecordReplayInstrumentation(int,.unsigned.long*,.v8::internal::Isolate*)+270",
      "0x100a3ff15a38",
      "0x100a3fffaed1",
      "0x100a3fe8b82c",
      "0x100a3fe8b82c",
      "0x100a3fe89e5c",
      "0x100a3fe89b87",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3544",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::debug::CallFunctionOn(v8::Local<v8::Context>,.v8::Local<v8::Function>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.bool)+259",
      "v8_inspector::(anonymous.namespace)::innerCallFunctionOn(v8_inspector::V8InspectorSessionImpl*,.v8_inspector::InjectedScript::Scope&,.v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.bool,.v8_inspector::WrapMode,.bool,.bool,.v8_inspector::String16.const&,.bool,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+1172",
      "v8_inspector::V8RuntimeAgentImpl::callFunctionOn(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+651",
      "v8_inspector::protocol::Runtime::DomainDispatcherImpl::callFunctionOn(v8_crdtp::Dispatchable.const&)+701",
      "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
      "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+611",
      "blink::DevToolsSession::DispatchProtocolCommandImpl(int,.WTF::String.const&,.base::span<unsigned.char.const,.18446744073709551615ul>)+310",
      "blink::mojom::blink::DevToolsSessionStubDispatch::Accept(blink::mojom::blink::DevToolsSession*,.mojo::Message*)+233",
      "mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*)+820",
      "mojo::MessageDispatcher::Accept(mojo::Message*)+298",
      "mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*)+87",
      "IPC::(anonymous.namespace)::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message)+312",
      "base::internal::Invoker<base::internal::BindState<void.(mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy::*)(mojo::Message),.scoped_refptr<mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy>,.mojo::Message>,.void.()>::RunOnce(base::internal::BindStateBase*)+70",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 53362,
    "threadId": 1,
    "checkpoint": 55
  },
  "faultAddress": "0x101800700064",
  "instructionPointer": "v8::internal::CommandCallback(char.const*,.char.const*)+233"
}
```

#### Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 53362,
    "threadId": 2,
    "processId": 362,
    "checkpoint": 55,
    "absoluteTime": 1784169037903.723,
    "wasRecording": false
  },
  {
    "text": "Thread::WaitForeverForRecordedCall pthread_detach",
    "count": 1,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 53362,
    "threadId": 6,
    "processId": 362,
    "checkpoint": 55,
    "absoluteTime": 1784169037903.8267,
    "wasRecording": false
  }
]
```

# Basic Facts

## Repro

* [MUST-READ] $RUNTIME_BIBLE/crashes/crash-repro.md
* Source: `$WORKSPACE/operator.log/741779456.log`
* Spec for `call-mcp.ts` (`$WORKSPACE/mcp-spec.json`):
* Notes:
  * `CreateAnalysisContext` phase `Done` before tools.
  * Crashing MCP tool: `InspectElement` (`point: Point:13`, `element: .uc-overlay`)
    * No `OperatorToolCallEnd` before `CrashReport`

```json
[
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "ReadSource", "path": "https://bug-playground-app.netlify.app/assets/index-DL2Wn_LQ.js", "line": 22585 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "ReadSource", "path": "https://bug-playground-app.netlify.app/assets/index-DL2Wn_LQ.js", "line": 22640 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "ReadSource", "path": "https://bug-playground-app.netlify.app/assets/index-DL2Wn_LQ.js", "line": 22685 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "ReadSource", "path": "https://bug-playground-app.netlify.app/assets/index-DL2Wn_LQ.js", "line": 22690 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "SearchSources", "pattern": "uc-next", "includeGenerated": true },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "ReadSource", "path": "https://bug-playground-app.netlify.app/assets/index-DL2Wn_LQ.js", "line": 22695 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "Screenshot", "timestamp": 624 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "Screenshot", "timestamp": 4225 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "Screenshot", "timestamp": 13225 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "Screenshot", "timestamp": 10523 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "Screenshot", "timestamp": 22225 },
  { "recordingId": "d0f06ada-85d7-4e93-b358-a7104217a7db", "tool": "InspectElement", "point": "Point:13", "element": ".uc-overlay" }
]
```

# Facts

* [F1] Same pattern as `$DETERMINATOR_DIR/workspaces/issues/crash-0017/problem.md`:
  * `instructionPointer` = `CommandCallback+233`
  * `faultAddress` = `0x101800700064`
  * Nested under `Pause.getObjectPreview` → `SendCommand` → `CommandCallback`
* [F2] Disasm of `_ZN2v88internal15CommandCallbackEPKcS2_` (linkerdebug, no-manifest `rrnew`):
  * `+233` = `mov 0x93(%r15),%ecx`
  * `%r15` = `*(Isolate+0x4848)` = `isolate->context()`, loaded at `+139` after `EnsureIsolateContext` at `+114`
  * Single-frame field load, not stack overflow
  * Fault = deref of garbage/unmapped `Context`
* [F3] crash-0017 already put CHECKs in `EnsureIsolateContext` (`debug.cc`):
  * `CHECK(!ctx.is_null())`
  * `CHECK(ctx.IsHeapObject())`
  * `CHECK(IsValidHeapObject(...))`
  * `CHECK(ctx.IsContext())`
  * This crash is still a raw SIGSEGV at the post-CHECK field load, not a CHECK death
* [F4] `IsValidHeapObject` is page-membership only:
  * Dangling ptr into a still-mapped heap page can pass
  * `ctx.IsContext()` does deref the map word
  * Unmapped Context should die in that CHECK, not at `+233`
  * Path through `EnsureIsolateContext` is proven in F7
* [F5] Crash-report `manifest` lacks `objectId`, but operator log has MCP repro params (see Repro)
  * Prior no-manifest `rrnew` never hit this fault for that reason
* [F6] Warm PauseChild idle-reuse does not explain this crash (`operator.log/741779456.log`).
  * Tool gap: last `Screenshot` `02:25:13` → `InspectElement` `02:30:37` (~5m24s ACX idle).
  * Crashing PauseChild is new at that call:
    * `pauseId` `fc155db8` / `processId` `362` created `02:30:37.718–722`.
    * First `Pause.getObjectPreview` `02:30:37.928` (~200ms later).
  * Parent `processId` `70` is older (~9m, ACX `newBranch`); fault is on the fresh PauseChild fork, not a reused warm PauseChild.
  * Local `call-mcp` (`tmp.log`): same shape — new Pause for `Point:13`, then `getObjectPreview` succeeds.
  * crash-0017 **WarmPauseChild** means a busy PauseChild with prior manifests, not long idle then reuse.
* [F7] Oplog proves **SlotContext** path and faulting Context identity (`operator.log/741779456.log`, `processId` 362).
  * Last `COMMAND_CONTEXT_CHANGE` before `LinkerFault`:
    * `slot iso=100a000758e0 ctx=1018006fffd1 group=1`
    * During `Pause.evaluateInGlobal` (manifest index 12)
  * Not DefaultContext: that iso's `STATUS_CHANGE_ALIVE` is `ctx=101800211755`
  * Fault matches that SlotContext:
    * `faultAddress` `0x101800700064` = `0x1018006fffd1 + 0x93`
  * Crashing `Pause.getObjectPreview` (index 16) emits no new `COMMAND_CONTEXT_CHANGE`
    * Change-gated
    * Slot still held `1018006fffd1`
