### PR TITLE
Avoid sync IPC calls when pause-evaluating cookies

### DIFF
--- a/third_party/blink/renderer/core/loader/cookie_jar.cc
+++ b/third_party/blink/renderer/core/loader/cookie_jar.cc
@@ -8,6 +8,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/record_replay.h"
 #include "base/strings/strcat.h"
 #include "net/base/features.h"
 #include "net/cookies/parsed_cookie.h"
@@ -93,6 +94,9 @@ void CookieJar::SetCookie(const String& value) {
   if (cookie_url.IsEmpty())
     return;
 
+  if (recordreplay::AreEventsUnavailable("CookieJar::SetCookie"))
+    return;
+
   base::ElapsedTimer timer;
   bool requested = RequestRestrictedCookieManagerIfNeeded();
   bool site_for_cookies_ok = true;
@@ -148,6 +152,9 @@ void CookieJar::SetCookie(const String& value) {
 String CookieJar::Cookies() {
   KURL cookie_url = document_->CookieURL();
   if (cookie_url.IsEmpty())
+    return String();
+
+  if (recordreplay::AreEventsUnavailable("CookieJar::Cookies"))
     return String();
 
   base::ElapsedTimer timer;


### PR DESCRIPTION
Sync IPC calls can't be fulfilled when the recording diverges during a pause. This is *similar* to what we have to do with `localStorage`: 
https://github.com/replayio/chromium/blob/9ee31c8a6276e1f36bec2d0e7a83817a29dd3bb8/third_party/blink/renderer/modules/storage/storage_area.cc#L268-L271

It's worth noting that storage is protected by `recordreplay::HasDivergedFromRecording()`. I'm not 100% sure which one is better and I'm going back and forth on that.

I have WIP tests for this here: https://github.com/replayio/backend/pull/13084 . But it's worth noting that... they don't currently have working assertions in them. The problem is that this patch returns an empty string and not the resolved value.

This is different from the storage code because storage values are backed by the in-memory cache (that activated after the first access!). Cookies are not implemented like that and they always require a roundtrip to IPC. I think this can be improved but it would require more complicated work and I'm not sure if we want to commit to it right now.

It's also worth noting that `localStorage` evaluations won't return correct values if evaluated before the first access in the recording because the in-memory cache won't be populated/activated in such a scenario.

Crash report:
```json
{
  "why": "ServerProcessCrash",
  "controlId": "6303bd22-a3c4-4453-9d44-faed5d14681c",
  "sessionIds": [
    "7176d9bf-1fa6-44d7-a613-fae85e1c936d"
  ],
  "recordingId": "3be1f309-d16e-46f4-9200-a5f587cd6b18",
  "buildId": "linux-chromium-20260715-5fda1dec160a-904634a4ff04",
  "architecture": "x64",
  "linkerVersion": "linker-linux-16022-904634a4ff04",
  "forTest": false,
  "description": "{\"operatorId\":\"fdf69998-34c2-4db6-a836-6dd16abfc727\",\"requestId\":\"\"}",
  "recordingAssertionsDisabled": false,
  "recordingFeaturesDisabled": [],
  "manualLinkerVersionOverride": "",
  "process": {
    "why": "Hanged",
    "threadId": 0,
    "hangedThreads": [
      {
        "state": {
          "threadId": 1,
          "waitingOnCvar": {
            "lock": true,
            "ptr": true,
            "waiters": [
              1
            ]
          }
        },
        "backtrace": {
          "threadId": 1,
          "frames": [
            "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+826",
            "new_pthread_cond_wait(void*,.void*)+50",
            "0x1000505ae04c",
            "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
            "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
            "0x1000505ad060",
            "base::ConditionVariable::Wait()+146",
            "base::WaitableEvent::WaitMany(base::WaitableEvent**,.unsigned.long)+1064",
            "mojo::WaitSet::State::Wait(base::WaitableEvent**,.unsigned.long*,.mojo::Handle*,.unsigned.int*,.MojoHandleSignalsState*)+1814",
            "mojo::SyncHandleRegistry::Wait(bool.const**,.unsigned.long)+275",
            "mojo::SyncEventWatcher::SyncWatch(bool.const**,.unsigned.long)+601",
            "mojo::SequenceLocalSyncEventWatcher::SyncWatch(bool.const*)+153",
            "mojo::InterfaceEndpointClient::SendMessageWithResponder(mojo::Message*,.bool,.mojo::InterfaceEndpointClient::SyncSendMode,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+680",
            "mojo::internal::SendMojoMessage(mojo::MessageReceiverWithResponder&,.mojo::Message&,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+94",
            "network::mojom::blink::RestrictedCookieManagerProxy::GetCookiesString(blink::KURL.const&,.net::SiteForCookies.const&,.scoped_refptr<blink::SecurityOrigin.const>.const&,.bool,.WTF::String*)+556",
            "blink::CookieJar::Cookies()+343",
            "blink::(anonymous.namespace)::v8_document::CookieAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+301",
            "v8::internal::DebugEvaluate::Local(v8::internal::Isolate*,.v8::internal::StackFrameId,.int,.v8::internal::Handle<v8::internal::String>,.bool)+1050",
            "v8_inspector::V8DebuggerAgentImpl::evaluateOnCallFrame(...)",
            "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+403",
            "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
            "EvaluateInFrameCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,...>&)+132",
            "CommandRequest::Process(Json::Value.const&)+596",
            "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
            "PauseRequestHandler::Start(Json::Value.const&)+210",
            "ManifestFinished(Json::Value*)+816",
            "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
            "recordreplay::OnScanTargetHit()+36",
            "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671"
          ],
          "progress": 90,
          "checkpoint": 1
        }
      }
    ],
    "category": "PauseChild"
  },
  "processNonFatal": {
    "why": "MissingReport",
    "threadId": 0,
    "category": "PauseChild"
  },
  "warnings": [
    {
      "wasRecording": false,
      "threadId": 2,
      "text": "Thread::WaitForeverForRecordedCall epoll_wait",
      "progress": 90,
      "checkpoint": 1,
      "processId": 53,
      "absoluteTime": 1784204728302.6619,
      "stack": [
        "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
      ],
      "count": 2
    }
  ],
  "processId": 53
}
```