### PR TITLE
crash-0020-b: extend Context-identity diagnostics for CommandCallback fault

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'fa6829500b6b4e26872d233bd6e5b5c8400119d6',
+  'v8_revision': '07dc20943e513b463b10742f7e5913286e0c6acc',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e18e7530acf44edadc460248e297f67767b69477',
+  'v8_revision': 'b1d890af12debbb42f46086891b5a5f39aeda11c',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '5d8af221b80765b71258438977f6942a55ca1907',
+  'v8_revision': 'fa6829500b6b4e26872d233bd6e5b5c8400119d6',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '07dc20943e513b463b10742f7e5913286e0c6acc',
+  'v8_revision': 'e18e7530acf44edadc460248e297f67767b69477',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/295

# Summary

* Follow-up to #1385 (v8 #294).
* Two change groups:
  * **RegressionFix**: crash-0020 diagnostics dereferenced `debug_context_id` unsafely → this SEGFAULT.
  * **DiagnosticsImprovement**: more Context trail logs so the next hit can name the bad SlotContext.
* Still unknown: which Context is corrupted, and why.

# Solution

V8: `api.cc`, `debug.cc`, `isolate-inl.h`.

* **RegressionFix**
  * `RecordReplayContextAddressToken`: never read `debug_context_id` unless `includeId=true` and the address is a `NativeContext`.
  * `EnsureIsolateContext`: emit `COMMAND_CONTEXT_CHANGE` with `includeId=false` before any Context field access; `CHECK` before `raw_native_context()`; if slot ≠ native, switch to native.
* **DiagnosticsImprovement**
  * `EnsureIsolateContext`: drop `gLastCommandContext` dedup — log every call.
  * `Isolate::set_context`: log `ISOLATE_CONTEXT_CHANGE from=… to=…` on every pointer change.


# Problem

* IMPORTANT: This is a follow-up to the diagnostics we landed in:
  * [](../crash-0020/problem.md)
  * [](../crash-0017/problem.md)
* Problem type: ReplayOtherCrash.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-other-crashes.md
* Consider the operator logs for `operatorId`.
* Noisy dumps
  * $WORKSPACE/crash-report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
  * You can read /home/domi/replay/determinator/workspaces/issues/crash-0020-b/problem-introduction.md to see the raw context if needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/node
* $REPLAY_DIR/chromium/src

## Important Context

* operatorId: 73d85ce2-9402-4bfe-a970-c5012748e680
* buildId: linux-chromium-20260716-9ee31c8a6276-904634a4ff04
* linkerVersion: linker-linux-16022-904634a4ff04
* recordingId: f66b85a9-d961-4037-a817-12dae442bf65

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Segmentation fault",
  "category": "PauseChild",
  "manifest": {
    "kind": "pauseRequest",
    "requestType": "command",
    "requestMethod": "Pause.evaluateInGlobal"
  },
  "threadId": 1,
  "backtrace": {
    "frames": [
      "v8::internal::EnsureIsolateContext(v8::internal::Isolate*,.v8::base::Optional<v8::internal::SaveAndSwitchContext>&)+240",
      "v8::internal::CommandCallback(char.const*,.char.const*)+193",
      "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
      "GetObjectJSON(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+292",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+241",
      "PauseData::AddObject(std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>.const&,.PropertyLevel)+925",
      "ProcessResult(Json::Value&)+1378",
      "EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+49",
      "CommandRequest::Process(Json::Value.const&)+596",
      "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
      "PauseRequestHandler::Start(Json::Value.const&)+210",
      "ManifestFinished(Json::Value*)+816",
      "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
      "recordreplay::OnScanTargetHit()+36",
      "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671",
      "v8::internal::OnInstrumentation(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.int)+208",
      "v8::internal::Runtime_RecordReplayInstrumentation(int,.unsigned.long*,.v8::internal::Isolate*)+270",
      "0x100a3ff15a38",
      "0x100a3fffaed1",
      "0x100a3fe8b82c",
      "0x100a3fe8b82c",
      "0x100a3fe89e5c",
      "0x100a3fe89b87",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3583",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::debug::CallFunctionOn(v8::Local<v8::Context>,.v8::Local<v8::Function>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.bool)+259",
      "v8_inspector::(anonymous.namespace)::innerCallFunctionOn(v8_inspector::V8InspectorSessionImpl*,.v8_inspector::InjectedScript::Scope&,.v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.bool,.v8_inspector::WrapMode,.bool,.bool,.v8_inspector::String16.const&,.bool,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+1172",
      "v8_inspector::V8RuntimeAgentImpl::callFunctionOn(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::PtrMaybe<std::Cr::vector<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>,.std::Cr::allocator<std::Cr::unique_ptr<v8_inspector::protocol::Runtime::CallArgument,.std::Cr::default_delete<v8_inspector::protocol::Runtime::CallArgument>.>.>.>.>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::CallFunctionOnCallback>.>)+651",
      "v8_inspector::protocol::Runtime::DomainDispatcherImpl::callFunctionOn(v8_crdtp::Dispatchable.const&)+701",
      "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
      "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+611",
      "blink::DevToolsSession::DispatchProtocolCommandImpl(int,.WTF::String.const&,.base::span<unsigned.char.const,.18446744073709551615ul>)+310",
      "blink::mojom::blink::DevToolsSessionStubDispatch::Accept(blink::mojom::blink::DevToolsSession*,.mojo::Message*)+233",
      "mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*)+820",
      "mojo::MessageDispatcher::Accept(mojo::Message*)+298",
      "mojo::InterfaceEndpointClient::HandleIncomingMessage(mojo::Message*)+87",
      "IPC::(anonymous.namespace)::ChannelAssociatedGroupController::AcceptOnEndpointThread(mojo::Message)+312",
      "base::internal::Invoker<base::internal::BindState<void.(mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy::*)(mojo::Message),.scoped_refptr<mojo::(anonymous.namespace)::ThreadSafeInterfaceEndpointClientProxy>,.mojo::Message>,.void.()>::RunOnce(base::internal::BindStateBase*)+70",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 45514,
    "threadId": 1,
    "checkpoint": 34
  },
  "faultAddress": "0x101800700050",
  "instructionPointer": "v8::internal::RecordReplayContextAddressToken(v8::Isolate*,.unsigned.long,.bool)+60"
}
```

#### Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 45514,
    "threadId": 2,
    "processId": 529,
    "checkpoint": 34,
    "absoluteTime": 1784253491710.6074,
    "wasRecording": false
  },
  {
    "text": "Thread::WaitForeverForRecordedCall pthread_detach",
    "count": 1,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 45514,
    "threadId": 6,
    "processId": 529,
    "checkpoint": 34,
    "absoluteTime": 1784253491710.724,
    "wasRecording": false
  }
]
```

# Context Diagnostics

```
+0     processId=5   V8InspectorImpl::getContext A 1 1 0 iso=100a00082300 ctx=0
+0     processId=5   V8InspectorImpl::getContext A 2 1 0 iso=100a00082300 ctx=0
+16ms  processId=5   STATUS_CHANGE_ALIVE iso=100a00082300 ctx=101800211755 id=0 group=0 win=349 frame=81
+460ms processId=7   COMMAND_CONTEXT_CHANGE default iso=100a00082300 ctx=101800211755 group=0 win=? frame=?
+0     processId=7   COMMAND_CONTEXT_ID iso=100a00082300 ctx=101800211755 id=3
+340ms processId=5   WeakIdentifierMap<LocalFrame>::Put 1
+1ms   processId=5   V8InspectorSessionImpl 1 1
+20ms  processId=5   V8InspectorImpl::resetContextGroup 1 1 0
+1ms   processId=5   V8InspectorImpl::resetContextGroup 1 1 2
+1ms   processId=5   V8InspectorImpl::resetContextGroup.entry 2 1 iso=100a00082300 ctx=1018001eb33d id=2
+0     processId=5   V8InspectorImpl::resetContextGroup.entry 1 1 iso=100a00082300 ctx=1018001c3fad id=1
+2ms   processId=5   V8InspectorImpl::contextCreated 1 1 1 0 iso=100a00082300 ctx=1018001c3fad id=1
+2ms   processId=5   V8InspectorImpl::contextCreated 2 1 1 1 iso=100a00082300 ctx=1018001eb33d id=2
+5ms   processId=7   V8InspectorImpl::contextCreated 3 1 1 0 iso=100a00082300 ctx=101800211755 id=3
+1ms   processId=7   V8InspectorImpl::contextCreated 4 1 1 1 iso=100a00082300 ctx=101800298139 id=4
+1ms   processId=5   V8InspectorSessionImpl 1 2
+76s   processId=529 COMMAND_CONTEXT_CHANGE slot iso=100a00082300 ctx=101800735b39 group=0 win=? frame=?
+0     processId=529 COMMAND_CONTEXT_ID iso=100a00082300 ctx=101800735b39 id=0
+63ms  processId=529 COMMAND_CONTEXT_CHANGE slot iso=100a00082300 ctx=101800735ad5 group=0 win=? frame=?
+1ms   processId=529 COMMAND_CONTEXT_ID iso=100a00082300 ctx=101800735ad5 id=0
+34s   processId=529 COMMAND_CONTEXT_CHANGE slot iso=100a00082300 ctx=101800442349 group=1 win=? frame=?
+0     processId=529 COMMAND_CONTEXT_ID iso=100a00082300 ctx=101800442349 id=0
+33ms  processId=529 COMMAND_CONTEXT_CHANGE slot iso=100a00082300 ctx=1018006fff65 group=1 win=? frame=?
<CRASH when trying to access bad ctx for COMMAND_CONTEXT_ID message.>
```
