### PR TITLE
Disable parkable string parking under no-park-strings

### DIFF
--- a/third_party/blink/renderer/platform/bindings/parkable_string.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string.cc
@@ -12,7 +12,6 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/process/memory.h"
-#include "base/record_replay.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/synchronization/lock.h"
 #include "base/task/single_thread_task_runner.h"
@@ -533,11 +532,7 @@ ParkableStringImpl::CaptureAgeStateSnapshot() {
 
 bool ParkableStringImpl::CanParkNow() const {
   return CurrentStatus() == Status::kUnreferencedExternally &&
-         metadata_->age_ != Age::kYoung &&
-         // Never park strings when recording/replaying, as they can be unparked
-         // at non-deterministic points (e.g. during script compilation) and
-         // perform file accesses.
-         !recordreplay::IsRecordingOrReplaying("no-park-strings");
+         metadata_->age_ != Age::kYoung;
 }
 
 void ParkableStringImpl::Unpark() {

--- a/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
@@ -44,7 +44,8 @@ struct ParkableStringManager::Statistics {
 namespace {
 
 bool CompressionEnabled() {
-  return base::FeatureList::IsEnabled(features::kCompressParkableStrings);
+  return base::FeatureList::IsEnabled(features::kCompressParkableStrings) &&
+         !recordreplay::IsRecordingOrReplaying("no-park-strings");
 }
 
 class OnPurgeMemoryListener : public GarbageCollected<OnPurgeMemoryListener>,


### PR DESCRIPTION
# ParkableStringManager: disable parking under `no-park-strings`

## Summary

* Follow-up to crash-0025 / crash-0013.
* Symptom: replay mismatch at `ParkableStringManager::AgeStringsAndPark` Assert.
  * Diverging `status` / `hasOneRef` from non-deterministic `StringImpl::ref_count_`.
* Root cause: parkable strings still register for aging while recording/replaying.
  * Aging posts delayed tasks and reads ref counts that diverge.
* Fix: force `CompressionEnabled()` false under `no-park-strings`.
  * No parkable registration → no aging / `PostDelayedTask` → no divergent Assert.
  * Existing callers (`ShouldPark`, `ScheduleAgingTaskIfNeeded`, purge) already early-return when compression is off.
  * Drops the now-unreachable `no-park-strings` check in `CanParkNow()`.

# Solution

* Closest intervention: `determinism-leak-memory.md`.
* Force `CompressionEnabled()` false under `no-park-strings`.
  * Existing callers already early-return: `ShouldPark`, `ScheduleAgingTaskIfNeeded`, purge.
  * No parkable registration → no aging/`PostDelayedTask` → crash-0013 gone.
  * Drop `CanParkNow()`'s `no-park-strings` check: unreachable once `ShouldPark` is false.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data

## Investigation

* Same Assert site on both stacks: `ParkableStringManager::AgeStringsAndPark`
* Assert values:
  * recorded: `status=0 age=0 hasOneRef=1`
  * replayed: `status=1 age=0 hasOneRef=0`
* Ordinals:
  * `Age`: `kYoung=0`, `kOld=1`, `kVeryOld=2`
  * `Status`: `kUnreferencedExternally=0`, `kTooManyReferences=1`, `kLocked=2`
* This hit: `age` matched (`kYoung`). `status`/`hasOneRef` diverged.
* Snapshot fields:
  * `age` ← `metadata_->age_`
  * `hasOneRef` ← `string_.Impl()->HasOneRef()` ← `StringImpl::ref_count_ == 1`
  * `status` ← `CurrentStatus()`:
    * `lock_depth_ != 0` → `kLocked`
    * else `!HasOneRef()` → `kTooManyReferences`
    * else `kUnreferencedExternally`
* This hit's `status` 0→1 matches `hasOneRef` 1→0. Not `kLocked`.

## Root Cause

* **DivergentRefCount**: `StringImpl::ref_count_` differs at the Assert.
* Slice:
  * Assert reads `hasOneRef` / derived `status`
  * ← `HasOneRef()` / `CurrentStatus()`
  * ← `ref_count_.load`
  * ← concurrent `AddRef` / `Release` with no record/replay order
* `age_` matched here. Separate channel when it diverges: `MakeYoung` via `Lock` / `ToString`.

# Raw Data

* buildId: linux-chromium-20260719-c6cc495dd583-fa9c47bdb8f6
* linkerVersion: linker-linux-16038-fa9c47bdb8f6
* recordingId: 4efdfade-e66a-4ed8-b367-7e5663275c35
