### PR TITLE
RECO-7: Deterministic StackOverflows + network stream eager callbacks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0eefa5fca191b061bb6a4276c594375b6a7e521d',
+  'v8_revision': '2dd7b4717213beb600f22a87861bcca819971d74',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'ac4038d0b601f438a0dd6d94527bd0b27bdf2fdf',
+  'v8_revision': '0eefa5fca191b061bb6a4276c594375b6a7e521d',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'b1d890af12debbb42f46086891b5a5f39aeda11c',
+  'v8_revision': 'ac4038d0b601f438a0dd6d94527bd0b27bdf2fdf',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '2dd7b4717213beb600f22a87861bcca819971d74',
+  'v8_revision': '7df26641ee5cd9d2293e0278e983629d2fc7bed4',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1672,7 +1672,7 @@ static void GetCurrentNetworkStreamData(const v8::FunctionCallbackInfo<v8::Value
     return;
   }
 
-  uint8_t* bytes = &(*gCurrentNetworkStreamData)[index];
+  const uint8_t* bytes = gCurrentNetworkStreamData->data() + index;
   std::string encoded = base::Base64Encode(
     base::span<const uint8_t>(bytes, length)
   );

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_network.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_network.cc
@@ -262,6 +262,7 @@ void OnNetworkResourceRedirect(uint64_t inspector_id, const blink::KURL& new_url
     return;
   }
 
+  blink::ScriptForbiddenScope::AllowUserAgentScript allow_script;
   base::DictionaryValue dict;
   dict.SetString("requestId", RecordReplayNetworkRequestId(inspector_id));
   dict.SetString("requestUrl", new_url.GetString().Utf8());
@@ -287,6 +288,7 @@ void OnNetworkReceiveResponse(uint64_t inspector_id,
     return;
   }
 
+  blink::ScriptForbiddenScope::AllowUserAgentScript allow_script;
   base::DictionaryValue dict;
   dict.SetString("requestId", RecordReplayNetworkRequestId(inspector_id));
   const char* http_version = HttpVersionToString(response.HttpVersion());
@@ -311,6 +313,7 @@ void OnNetworkReceiveData(uint64_t inspector_id, const char* data, int length) {
     return;
   }
 
+  blink::ScriptForbiddenScope::AllowUserAgentScript allow_script;
   std::string requestId = RecordReplayNetworkRequestId(inspector_id);
 
   if (recordreplay::DependencyGraphEnabled()) {
@@ -345,6 +348,7 @@ void OnNetworkFinishLoading(uint64_t inspector_id,
     return;
   }
 
+  blink::ScriptForbiddenScope::AllowUserAgentScript allow_script;
   std::string requestId = RecordReplayNetworkRequestId(inspector_id);
 
   if (recordreplay::DependencyGraphEnabled()) {
@@ -368,6 +372,7 @@ void OnNetworkFail(uint64_t inspector_id, const blink::WebURLError& error) {
     return;
   }
 
+  blink::ScriptForbiddenScope::AllowUserAgentScript allow_script;
   std::string requestId = RecordReplayNetworkRequestId(inspector_id);
 
   if (recordreplay::DependencyGraphEnabled()) {


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/296
# Summary

* Hub: https://hub.replay.io/issues/issue/1610
* **G1 Deterministic StackOverflows**: replace SP SoftSO with JS-frame-depth truncation.
  * TurboFan emits SoftSO at graph-build time so catch attaches to `ThrowStackOverflow`.
* **G2 Network**: allow eager stream callbacks under `ScriptForbiddenScope`, and fix empty-body slice access.
* **G3 Hot diag**: drop `ISOLATE_CONTEXT_CHANGE` print and `[RUN-2042-2109]` traces.

---

# G1: Deterministic StackOverflows

## Problem

* Repro: `replayio record https://app.numolabs.ai/`
* Symptom: `Recording invalidated: Stack overflow` from `Isolate::StackOverflow`.
* Chrome / `RECORD_REPLAY_DONT_RECORD=1`: same recursion yields catchable SoftSO `RangeError`.
* SoftSO trigger is absolute SP vs `StackGuard` limit.
  * Limit depends on C++ depth at init and at JS entry.
  * Per-frame stack bytes differ by tier.
  * Same JS recursion SoftSOs at different depths across record vs replay → invalidation required.

## Solution

### DepthTruncate

* New TLS counter `ThreadLocalTop::replay_js_frame_depth_`.
* Bytecodes `ReplayIncJsFrameDepth` / `ReplayDecJsFrameDepth` on frame enter/exit.
  * Gated on `emit_record_replay_opcodes_`, not the instrument gate.
* After Inc, if depth ≥ `kReplayMaxJsFrameDepth` (1024) → `Runtime::kThrowStackOverflow`.
  * Same catchable `RangeError` as SoftSO, before the real SP limit.
* Lowering: Ignition / Baseline / Maglev keep inline TLS ±1 + SoftSO throw.
* Unwind: `FoundHandler` resyncs the counter to the live JS frame count.
* Drop `InvalidateRecording("Stack overflow")` from `Isolate::StackOverflow`.
  * Keep it on Wasm SoftSO (`Runtime_ThrowWasmStackOverflow`).

### GraphBuildSplit (TurboFan)

* TurboFan must not keep a throwable simplified Inc that lowers after `TempSchedule`.
  * Catch `IfException` is wired at graph-build when inside a handler.
  * ECL re-threads `IfException` effect/control from the pre-lowering `TempSchedule`.
  * Any post-schedule reparent of `IfException` onto `ThrowCall` is overwritten.
* `VisitReplayIncJsFrameDepth` emits SoftSO directly in `bytecode-graph-builder`:
  * Shared path: load / +1 / store `replay_js_frame_depth_` via simplified field ops.
  * Branch on SoftSO limit (`BranchHint` overflow unlikely).
  * **FastPath**: resume bytecode env.
  * **OverflowArm**: JS `CallRuntime(kThrowStackOverflow)` → `Throw` / leave.
    * Inside a handler, BGB auto-wires `IfException` onto that call at birth.
* No TF `kReplayIncrementAndCheckJsFrameDepth` node.
  * Removed op + ECL lower + related typer/verifier/memory-optimizer cases.
* Maglev keeps its own Inc IR + SoftSO codegen.
* `kReplayDecrementJsFrameDepth` stays simplified + ECL (`kNoThrow`, no catch rewire).

### Why this shape

* SoftSO throw is on a separate `ThrowCall`, not on the depth mutate itself.
  * Projections must attach to `ThrowCall` when the graph is built.
* Expanding before any schedule matches the timing of `LowerJSStackCheck`.
  * That helper keeps the same node as the throwing call; our OverflowArm cannot.

---

# G2: Network Stream Eager Callbacks

## StreamDataUnderScriptForbidden

* Style/layout forbids script (`ScriptForbiddenScope`).
* Memory-cache load → `OnNetworkReceiveData` → eager `getCurrentNetworkStreamData` → `v8::Object::Set`.
  * Hits `BeforeCallEnteredCallback` CHECK.
* `OnNetworkPrepareRequest` already wraps `AllowUserAgentScript`.
  * Redirect / ReceiveResponse / ReceiveData / FinishLoading / Fail did not.
* Fix: same `AllowUserAgentScript` on those paths in `record_replay_network.cc`.

## EmptySliceIndex

* Eager `getCurrentNetworkStreamData` with `index:0`, `length:0` on empty bodies.
* `&(*vec)[0]` aborts under hardened libc++ when `size==0`.
* Fix: `vec->data() + index` in `record_replay_interface.cc`.
  * Valid at `index==size` for `length==0`.

---

# G3: Hot Context Diagnostics

* `Isolate::set_context` printed `ISOLATE_CONTEXT_CHANGE` on every switch.
  * Dominated verbose logs (~273k / ~295k lines on numolabs).
* Drop that print; restore plain `set_context` assignment.
* Drop `[RUN-2042-2109]` `Trace` sites in `V8InspectorImpl`
  * `contextCreated` / `resetContextGroup` / `discardInspectedContext`.
* Keep CommandCallback `COMMAND_CONTEXT_*` prints.