### PR TITLE
crash-0031/0032: sensor reading diagnostics + divergent-user-JS guard fix

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '7df26641ee5cd9d2293e0278e983629d2fc7bed4',
+  'v8_revision': '8780b325c54f1ae8fc7cd4b9295b9dd7daa1d7df',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '8780b325c54f1ae8fc7cd4b9295b9dd7daa1d7df',
+  'v8_revision': '4158967a207c3733bd637f9e6e9986094421b541',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/services/device/public/cpp/generic_sensor/sensor_reading_shared_buffer_reader.cc
+++ b/services/device/public/cpp/generic_sensor/sensor_reading_shared_buffer_reader.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "base/memory/ptr_util.h"
+#include "base/record_replay.h"
 #include "device/base/synchronization/shared_memory_seqlock_buffer.h"
 #include "services/device/public/cpp/generic_sensor/sensor_reading.h"
 
@@ -69,7 +70,18 @@ bool SensorReadingSharedBufferReader::GetReading(
            ++retries < kMaxReadAttemptsCount);
 
   // Consider the number of retries less than kMaxRetries as success.
-  return retries < kMaxReadAttemptsCount;
+  bool ok = retries < kMaxReadAttemptsCount;
+  ok = recordreplay::RecordReplayValue(
+      "SensorReadingSharedBufferReader::GetReading ok", ok);
+  if (ok) {
+    recordreplay::RecordReplayBytes(
+        "SensorReadingSharedBufferReader::GetReading", result,
+        sizeof(*result));
+  }
+  recordreplay::Assert(
+      "SensorReadingSharedBufferReader::GetReading ok %d ts %f", ok,
+      ok ? result->timestamp() : -1.0);
+  return ok;
 }
 
 }  // namespace device

--- a/third_party/blink/renderer/modules/device_orientation/device_motion_event_pump.cc
+++ b/third_party/blink/renderer/modules/device_orientation/device_motion_event_pump.cc
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include "base/record_replay.h"
 #include "services/device/public/cpp/generic_sensor/sensor_reading.h"
 #include "services/device/public/mojom/sensor.mojom-blink.h"
 #include "third_party/blink/public/common/browser_interface_broker_proxy.h"
@@ -130,7 +131,14 @@ DeviceMotionData* DeviceMotionEventPump::GetDataFromSharedMemory() {
   DeviceMotionEventRotationRate* rotation_rate = nullptr;
 
   device::SensorReading accelerometer_reading;
-  if (accelerometer_->GetReading(&accelerometer_reading)) {
+  bool has_accelerometer_reading =
+      accelerometer_->GetReading(&accelerometer_reading);
+  recordreplay::Assert(
+      "DeviceMotionEventPump::GetDataFromSharedMemory accelerometer %d "
+      "ts_zero %d",
+      has_accelerometer_reading,
+      has_accelerometer_reading && accelerometer_reading.timestamp() == 0.0);
+  if (has_accelerometer_reading) {
     if (accelerometer_reading.timestamp() == 0.0)
       return nullptr;
 
@@ -143,8 +151,16 @@ DeviceMotionData* DeviceMotionEventPump::GetDataFromSharedMemory() {
   }
 
   device::SensorReading linear_acceleration_sensor_reading;
-  if (linear_acceleration_sensor_->GetReading(
-          &linear_acceleration_sensor_reading)) {
+  bool has_linear_acceleration_reading =
+      linear_acceleration_sensor_->GetReading(
+          &linear_acceleration_sensor_reading);
+  recordreplay::Assert(
+      "DeviceMotionEventPump::GetDataFromSharedMemory linear_acceleration %d "
+      "ts_zero %d",
+      has_linear_acceleration_reading,
+      has_linear_acceleration_reading &&
+          linear_acceleration_sensor_reading.timestamp() == 0.0);
+  if (has_linear_acceleration_reading) {
     if (linear_acceleration_sensor_reading.timestamp() == 0.0)
       return nullptr;
 
@@ -157,7 +173,12 @@ DeviceMotionData* DeviceMotionEventPump::GetDataFromSharedMemory() {
   }
 
   device::SensorReading gyroscope_reading;
-  if (gyroscope_->GetReading(&gyroscope_reading)) {
+  bool has_gyroscope_reading = gyroscope_->GetReading(&gyroscope_reading);
+  recordreplay::Assert(
+      "DeviceMotionEventPump::GetDataFromSharedMemory gyroscope %d ts_zero %d",
+      has_gyroscope_reading,
+      has_gyroscope_reading && gyroscope_reading.timestamp() == 0.0);
+  if (has_gyroscope_reading) {
     if (gyroscope_reading.timestamp() == 0.0)
       return nullptr;
 

--- a/third_party/blink/renderer/modules/device_orientation/device_sensor_entry.cc
+++ b/third_party/blink/renderer/modules/device_orientation/device_sensor_entry.cc
@@ -4,6 +4,7 @@
 
 #include "third_party/blink/renderer/modules/device_orientation/device_sensor_entry.h"
 
+#include "base/record_replay.h"
 #include "services/device/public/cpp/generic_sensor/sensor_reading.h"
 #include "services/device/public/cpp/generic_sensor/sensor_reading_shared_buffer_reader.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
@@ -86,10 +87,16 @@ bool DeviceSensorEntry::GetReading(device::SensorReading* reading) {
   DCHECK(shared_buffer_reader_);
 
   if (!shared_buffer_reader_->GetReading(reading)) {
+    recordreplay::Assert(
+        "DeviceSensorEntry::GetReading type %d ok 0 ts_zero 0",
+        static_cast<int>(type_));
     HandleSensorError();
     return false;
   }
 
+  recordreplay::Assert(
+      "DeviceSensorEntry::GetReading type %d ok 1 ts_zero %d",
+      static_cast<int>(type_), reading->timestamp() == 0.0);
   return true;
 }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/297
# G1: v8 Invoke — divergent user JS on API-callback fast path (crash-0032)

## Problem

* `Js` ReplayMismatch: progress-counter divergence during a `runToPoint`.
* Warnings show non-deterministic user JS running via `Error.stack` → `prepareStackTrace`, reached under `console.debug`.
* The `RecordReplayIsDivergentUserJSWithoutPause` guard sat inside the API-callback branch of `Invoke`, so it never covered the general invoke path that actually reaches user JS.

## Solution

* `execution.cc`
  * Move the guard out of the API-callback fast path to after it.
  * Re-check `params.target->IsJSFunction()` and cast locally, so it only runs for real JS functions.
* `debug.cc`
  * Remove noisy `ReplayScript COMMAND_CONTEXT_CHANGE` / `COMMAND_CONTEXT_ID` prints and the now-unused `source` variable.
* `messages.cc`
  * Remove the stale `[PRO-2368]` `REPLAY_ASSERT` in `GetFormattedStack`.

# G2: DeviceMotionEventPump — sensor reading SHM divergence

## Problem

* `Js` ReplayMismatch at `DeviceMotionEventPump::GetDataFromSharedMemory`.
* Recorded `gyroscope 1 ts_zero 0` vs replayed `gyroscope 1 ts_zero 1`: a sensor reading present on both sides but with a divergent zero-timestamp.

## Solution

* Record/Replay relevant SHM.

# Raw Data

```json
{
  "backtrace": {
    "threadId": 1,
    "progress": 3381832,
    "checkpoint": 13
  },
  "why": "Mismatch",
  "threadId": 1,
  "order": 629669,
  "recorded": "DeviceMotionEventPump::GetDataFromSharedMemory gyroscope 1 ts_zero 0",
  "replayed": "DeviceMotionEventPump::GetDataFromSharedMemory gyroscope 1 ts_zero 1",
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::DeviceMotionEventPump::GetDataFromSharedMemory()+556",
    "blink::DeviceMotionEventPump::FireEvent(blink::TimerBase*)+14",
    "blink::TimerBase::RunInternal()+408",
    "base::DefaultDelayedTaskHandleDelegate::RunTask(base::OnceCallback<void.()>)+35",
    "base::internal::Invoker<base::internal::BindState<void.(base::DefaultDelayedTaskHandleDelegate::*)(base::OnceCallback<void.()>),.base::WeakPtr<base::DefaultDelayedTaskHandleDelegate>,.base::OnceCallback<void.()>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+159",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::DeviceMotionEventPump::GetDataFromSharedMemory()+556",
    "blink::DeviceMotionEventPump::FireEvent(blink::TimerBase*)+14",
    "blink::TimerBase::RunInternal()+408",
    "base::DefaultDelayedTaskHandleDelegate::RunTask(base::OnceCallback<void.()>)+35",
    "base::internal::Invoker<base::internal::BindState<void.(base::DefaultDelayedTaskHandleDelegate::*)(base::OnceCallback<void.()>),.base::WeakPtr<base::DefaultDelayedTaskHandleDelegate>,.base::OnceCallback<void.()>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+159",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001"
  ],
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "checkpoint": 14,
      "progress": 3689760
    }
  },
  "category": "newBranch"
}
```