### PR TITLE
Add TaskQueueThrottler ctor diagnostic REPLAY_ASSERT

### DIFF
--- a/third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc
+++ b/third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc
@@ -32,6 +32,8 @@ TaskQueueThrottler::TaskQueueThrottler(
     : task_queue_(task_queue), tick_clock_(tick_clock) {
   // Pointer registration is needed for sorting in BudgetPool::UpdateThrottlingStateForAllQueues
   recordreplay::RegisterPointer("TaskQueueThrottler", this);
+  REPLAY_ASSERT("TaskQueueThrottler::TaskQueueThrottler %d",
+                recordreplay::PointerId(this));
 }
 
 TaskQueueThrottler::~TaskQueueThrottler() {


### PR DESCRIPTION
# Summary

* Diagnostic-only change for a Data ReplayMismatch.
  * The `PointerId(throttler)` asserted in `BudgetPool::RemoveThrottler` diverged (recorded 16378 / replayed 9349).
  * Root cause is unprovable from the current recording, so we only add a diagnostic to bisect the divergence.
* Adds one `REPLAY_ASSERT` at `TaskQueueThrottler` construction, right after `RegisterPointer`, capturing `PointerId(this)`.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data

## Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 23153077,
      "checkpoint": 456
    }
  },
  "recorded": "[TT-1465-1466] BudgetPool::RemoveThrottler 16378",
  "replayed": "[TT-1465-1466] BudgetPool::RemoveThrottler 9349",
  "threadId": 1,
  "backtrace": {
    "progress": 23153077,
    "threadId": 1,
    "checkpoint": 454
  }
}
```

The mismatched Assert input is `recordreplay::PointerId(throttler)` (recorded 16378 / replayed 9349), asserted at:

```cpp
// blink::scheduler::BudgetPool::RemoveThrottler(...)+173
// third_party/blink/renderer/platform/scheduler/common/throttling/budget_pool.cc
REPLAY_ASSERT("[TT-1465-1466] BudgetPool::RemoveThrottler %d",
              recordreplay::PointerId(throttler));  // <<< RECORDED LEAF / <<< REPLAYED LEAF
```

The `PointerId` is assigned at `TaskQueueThrottler` construction:

```cpp
// TaskQueueThrottler::TaskQueueThrottler(...)
// third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc
recordreplay::RegisterPointer("TaskQueueThrottler", this);
```

## NewCandidates

* `RegisterPointer` of `TaskQueueThrottler`
  * location: `third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc`
  * provenance:
    * `RegisterPointer` writes `PointerId(this)`.
    * Hit Assert reads `PointerId(throttler)` for that object.

# Solution

* Add diagnostic `REPLAY_ASSERT` at `TaskQueueThrottler` construction.
  * Target: `TaskQueueThrottler::TaskQueueThrottler(MainThreadTaskQueue*, const base::TickClock*)` in `third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc`, directly after `recordreplay::RegisterPointer("TaskQueueThrottler", this);`.
  * Insert `REPLAY_ASSERT("TaskQueueThrottler::TaskQueueThrottler %d", recordreplay::PointerId(this));`.

# Raw Data

* buildId: linux-chromium-20260721-b8d9a62296f4-0814b5e98095
* linkerVersion: linker-linux-16040-0814b5e98095
* recordingId: 48933e2a-0d1e-47b4-b4af-6fcb5e7058db
