### PR TITLE
Expose `__RECORD_REPLAY_ARGUMENTS__` to isolated worlds

### DIFF
--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -47,6 +47,7 @@ const {
   CDPERROR_MISSINGCONTEXT,
   CDPERROR_NOTALIVE,
   REPLAY_CDT_PAUSE_OBJECT_GROUP,
+  ownsCommandService,
 
   // for testing
   forTestingSerializeValueToArray
@@ -208,7 +209,10 @@ function sendCDPMessage(method, params) {
   Array_push.call(gCdpRequestStack, cdpRequest);
   const cdpArgs = JSON_stringify({ method, params, id });
   try {
-    sendCDPMessageRaw(cdpArgs);
+    // The root command service receives asynchronous CDP notifications. Pass
+    // this context's callback explicitly so that synchronous responses return
+    // to the handler instance which initiated the request.
+    sendCDPMessageRaw(cdpArgs, messageCallback);
   } catch (err) {
     if (!cdpRequest.result) {
       throw err;
@@ -3308,29 +3312,31 @@ function wrapReplayApiFunction(fn) {
 ///////////////////////////////////////////////////////////////////////////////
 
 patchReplayApi();
-initMessages();
-addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
-addEventListener("Runtime.executionContextCreated", ({ context }) => {
-  gExecutionContexts.set(context.id, context);
-  for (const callback of gContextChangeCallbacks) {
-    callback(context, "add");
-  }
-});
-addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
-  const context = gExecutionContexts.get(executionContextId);
-  for (const callback of gContextChangeCallbacks) {
-    callback(context, "remove");
-  }
-  gExecutionContexts.delete(executionContextId);
-});
-addEventListener("Runtime.executionContextsCleared", () => {
-  for (const context of gExecutionContexts.values()) {
+if (ownsCommandService) {
+  initMessages();
+  addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
+  addEventListener("Runtime.executionContextCreated", ({ context }) => {
+    gExecutionContexts.set(context.id, context);
+    for (const callback of gContextChangeCallbacks) {
+      callback(context, "add");
+    }
+  });
+  addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
+    const context = gExecutionContexts.get(executionContextId);
     for (const callback of gContextChangeCallbacks) {
       callback(context, "remove");
     }
-  }
-  gExecutionContexts.clear();
-});
-sendCDPMessage("Runtime.enable");
+    gExecutionContexts.delete(executionContextId);
+  });
+  addEventListener("Runtime.executionContextsCleared", () => {
+    for (const context of gExecutionContexts.values()) {
+      for (const callback of gContextChangeCallbacks) {
+        callback(context, "remove");
+      }
+    }
+    gExecutionContexts.clear();
+  });
+  sendCDPMessage("Runtime.enable");
+}
 
 })();

--- a/replay-assets/replay_command_handlers.js
+++ b/replay-assets/replay_command_handlers.js
@@ -47,7 +47,6 @@ const {
   CDPERROR_MISSINGCONTEXT,
   CDPERROR_NOTALIVE,
   REPLAY_CDT_PAUSE_OBJECT_GROUP,
-  ownsCommandService,
 
   // for testing
   forTestingSerializeValueToArray
@@ -209,10 +208,7 @@ function sendCDPMessage(method, params) {
   Array_push.call(gCdpRequestStack, cdpRequest);
   const cdpArgs = JSON_stringify({ method, params, id });
   try {
-    // The root command service receives asynchronous CDP notifications. Pass
-    // this context's callback explicitly so that synchronous responses return
-    // to the handler instance which initiated the request.
-    sendCDPMessageRaw(cdpArgs, messageCallback);
+    sendCDPMessageRaw(cdpArgs);
   } catch (err) {
     if (!cdpRequest.result) {
       throw err;
@@ -3312,31 +3308,29 @@ function wrapReplayApiFunction(fn) {
 ///////////////////////////////////////////////////////////////////////////////
 
 patchReplayApi();
-if (ownsCommandService) {
-  initMessages();
-  addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
-  addEventListener("Runtime.executionContextCreated", ({ context }) => {
-    gExecutionContexts.set(context.id, context);
-    for (const callback of gContextChangeCallbacks) {
-      callback(context, "add");
-    }
-  });
-  addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
-    const context = gExecutionContexts.get(executionContextId);
+initMessages();
+addEventListener("Runtime.consoleAPICalled", onConsoleAPICall);
+addEventListener("Runtime.executionContextCreated", ({ context }) => {
+  gExecutionContexts.set(context.id, context);
+  for (const callback of gContextChangeCallbacks) {
+    callback(context, "add");
+  }
+});
+addEventListener("Runtime.executionContextDestroyed", ({ executionContextId }) => {
+  const context = gExecutionContexts.get(executionContextId);
+  for (const callback of gContextChangeCallbacks) {
+    callback(context, "remove");
+  }
+  gExecutionContexts.delete(executionContextId);
+});
+addEventListener("Runtime.executionContextsCleared", () => {
+  for (const context of gExecutionContexts.values()) {
     for (const callback of gContextChangeCallbacks) {
       callback(context, "remove");
     }
-    gExecutionContexts.delete(executionContextId);
-  });
-  addEventListener("Runtime.executionContextsCleared", () => {
-    for (const context of gExecutionContexts.values()) {
-      for (const callback of gContextChangeCallbacks) {
-        callback(context, "remove");
-      }
-    }
-    gExecutionContexts.clear();
-  });
-  sendCDPMessage("Runtime.enable");
-}
+  }
+  gExecutionContexts.clear();
+});
+sendCDPMessage("Runtime.enable");
 
 })();

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -300,7 +300,9 @@ void LocalWindowProxy::Initialize() {
   // debugger-created worlds may be null/hostless.
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       world_->IsIsolatedWorld()) {
-    InstallRecordReplayGlobals(GetIsolate(), context);
+    InstallRecordReplayGlobals(GetIsolate(), context,
+                               /*owns_command_service=*/false);
+    InstallRecordReplayContextApi(GetIsolate(), context);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -297,7 +297,8 @@ void LocalWindowProxy::Initialize() {
 
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       world_->IsIsolatedWorld()) {
-    InstallRecordReplayGlobals(GetIsolate(), GetFrame(), context);
+    InstallRecordReplayGlobals(GetIsolate(), context,
+                               /*is_root_main_world=*/false);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -297,7 +297,7 @@ void LocalWindowProxy::Initialize() {
 
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       world_->IsIsolatedWorld()) {
-    InstallRecordReplayGlobals(GetIsolate(), context);
+    InstallRecordReplayGlobals(GetIsolate(), GetFrame(), context);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -180,7 +180,7 @@ static const char* RecordReplayGetProcessType(
   return "iframe";
 }
 
-// Record/replay state is initialized along with the root main-world
+// Record/replay state is initialized along with the first main-world
 // LocalWindowProxy.
 static bool gRecordReplayStateInitialized;
 
@@ -242,22 +242,31 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  // Whether this is the relative root frame of this process.
-  // IsOrdinary() excludes internal pages like the in-process <select> popup.
-  bool isRootMainWorld = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
-                         GetFrame()->GetPage() &&
-                         GetFrame()->GetPage()->IsOrdinary();
-
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       origin && !origin->Host().empty() && world_->IsMainWorld()) {
-    bool initGlobally = !gRecordReplayStateInitialized && isRootMainWorld;
+    bool initGlobally = !gRecordReplayStateInitialized;
+
+    // Whether this is the relative root frame of this process.
+    // IsOrdinary() excludes internal pages like the in-process <select> popup.
+    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
+                       GetFrame()->GetPage() &&
+                       GetFrame()->GetPage()->IsOrdinary();
 
     if (initGlobally) {
       gRecordReplayStateInitialized = true;
 
-      // After creating the root main-world context for a non-empty origin, we
-      // are ready to set up the state used to process driver commands when
-      // recording/replaying, and to create checkpoints.
+      if (!isMainFrame) {
+        recordreplay::Warning(
+            "LocalWindowProxy::Initialize Called on non-root frame first: %d %d origin=%s url=%s",
+            GetFrame()->IsLocalRoot(),
+            world_->IsMainWorld(),
+            origin->ToRawString().Utf8().c_str(),
+            GetFrame()->GetDocument()->Url().GetString().Utf8().c_str());
+      }
+
+      // After creating the first main-world context that is associated with a
+      // non-empty origin, we are ready to set up the state used to process
+      // driver commands when recording/replaying, and to create checkpoints.
       InitializeRecordReplay(
         RecordReplayGetProcessType(
           GetFrame(),
@@ -267,7 +276,7 @@ void LocalWindowProxy::Initialize() {
       );
     }
 
-    if (isRootMainWorld) {
+    if (isMainFrame) {
       // Root-level navigation event, initially happens before
       // first checkpoint.
       OnRootFrameInit(GetIsolate(), GetFrame(), context);
@@ -280,15 +289,13 @@ void LocalWindowProxy::Initialize() {
       InitializeRecordReplayAfterCheckpoint();
     }
     
-    if (isRootMainWorld) {
+    if (isMainFrame) {
       // Root-level navigation event, after first checkpoint.
       OnRootFrameInitAfterCheckpoint(GetIsolate(), GetFrame(), context);
     }
 
-    if (gRecordReplayStateInitialized) {
-      // Event for all new windows.
-      OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
-    }
+    // Event for all new windows.
+    OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
   }
 
   // Do not require a non-empty host here: for isolated worlds, |origin| comes

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -79,6 +79,17 @@
 
 namespace blink {
 
+// Record/replay state is initialized along with the root main-world
+// LocalWindowProxy.
+static bool gRecordReplayStateInitialized;
+
+// We keep track of recently created local window proxies for ensuring that
+// record/replay state is initialized when the first paint is triggered. FIXME
+// clean up reference.
+static LocalWindowProxy* gLatestLocalWindowProxy;
+
+bool RecordReplayStateEnsureInitialized();
+
 void LocalWindowProxy::Trace(Visitor* visitor) const {
   visitor->Trace(script_state_);
   visitor->Trace(record_replay_listener_);
@@ -91,6 +102,10 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
          next_status == Lifecycle::kGlobalObjectIsDetached ||
          next_status == Lifecycle::kFrameIsDetached ||
          next_status == Lifecycle::kFrameIsDetachedAndV8MemoryIsPurged);
+
+  if (gLatestLocalWindowProxy == this) {
+    gLatestLocalWindowProxy = nullptr;
+  }
 
   // If the current lifecycle is kV8MemoryIsForciblyPurged, next status should
   // be either kFrameIsDetachedAndV8MemoryIsPurged, or kGlobalObjectIsDetached.
@@ -180,9 +195,6 @@ static const char* RecordReplayGetProcessType(
   return "iframe";
 }
 
-// Record/replay state is initialized along with the first LocalWindowProxy.
-static bool gRecordReplayStateInitialized;
-
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
   recordreplay::Assert("LocalWindowProxy::Initialize Start");
@@ -241,29 +253,22 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
-  if (recordreplay::IsRecordingOrReplaying("commands") &&
-      origin && !origin->Host().empty()) {
-    bool initGlobally = !gRecordReplayStateInitialized;
+  // Whether this is the relative root frame of this process.
+  // IsOrdinary() excludes internal pages like the in-process <select> popup.
+  bool isRootMainWorld = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
+                         GetFrame()->GetPage() &&
+                         GetFrame()->GetPage()->IsOrdinary();
 
-    // Whether this is the relative root frame of this process.
-    // IsOrdinary() excludes internal pages like the in-process <select> popup.
-    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
-                       GetFrame()->GetPage() && GetFrame()->GetPage()->IsOrdinary();
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
+      origin && !origin->Host().empty() && world_->IsMainWorld()) {
+    bool initGlobally = !gRecordReplayStateInitialized && isRootMainWorld;
+
     if (initGlobally) {
       gRecordReplayStateInitialized = true;
 
-      if (!isMainFrame) {
-        recordreplay::Warning(
-            "LocalWindowProxy::Initialize Called on non-root frame first: %d %d origin=%s url=%s",
-            GetFrame()->IsLocalRoot(),
-            world_->IsMainWorld(),
-            origin->ToRawString().Utf8().c_str(),
-            GetFrame()->GetDocument()->Url().GetString().Utf8().c_str());
-      }
-
-      // After creating the first context that is associated with a non-empty
-      // origin, we are ready to set up the state used to process driver
-      // commands when recording/replaying, and to create checkpoints.
+      // After creating the root main-world context for a non-empty origin, we
+      // are ready to set up the state used to process driver commands when
+      // recording/replaying, and to create checkpoints.
       InitializeRecordReplay(
         RecordReplayGetProcessType(
           GetFrame(),
@@ -273,7 +278,7 @@ void LocalWindowProxy::Initialize() {
       );
     }
 
-    if (isMainFrame) {
+    if (isRootMainWorld) {
       // Root-level navigation event, initially happens before
       // first checkpoint.
       OnRootFrameInit(GetIsolate(), GetFrame(), context);
@@ -286,13 +291,15 @@ void LocalWindowProxy::Initialize() {
       InitializeRecordReplayAfterCheckpoint();
     }
     
-    if (isMainFrame) {
+    if (isRootMainWorld) {
       // Root-level navigation event, after first checkpoint.
       OnRootFrameInitAfterCheckpoint(GetIsolate(), GetFrame(), context);
     }
 
-    // Event for all new windows.
-    OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
+    if (gRecordReplayStateInitialized) {
+      // Event for all new windows.
+      OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
+    }
   }
 
   // Do not require a non-empty host here: for isolated worlds, |origin| comes
@@ -302,7 +309,6 @@ void LocalWindowProxy::Initialize() {
       world_->IsIsolatedWorld()) {
     InstallRecordReplayGlobals(GetIsolate(), context,
                                /*owns_command_service=*/false);
-    InstallRecordReplayContextApi(GetIsolate(), context);
   }
 
   {
@@ -701,11 +707,6 @@ void LocalWindowProxy::SetAbortScriptExecution(
   InitializeIfNeeded();
   script_state_->GetContext()->SetAbortScriptExecution(callback);
 }
-
-// We keep track of the most recently created local window proxy
-// for ensuring that record/replay state is initialized when
-// the first paint is triggered. FIXME clean up reference.
-static LocalWindowProxy* gLatestLocalWindowProxy;
 
 LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
                                    LocalFrame& frame,

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -242,15 +242,14 @@ void LocalWindowProxy::Initialize() {
     SetSecurityToken(origin.get());
   }
 
+  // IsOrdinary() excludes internal pages like the in-process <select> popup.
   if (recordreplay::IsRecordingOrReplaying("commands") &&
-      origin && !origin->Host().empty() && world_->IsMainWorld()) {
+      origin && !origin->Host().empty() && world_->IsMainWorld() &&
+      GetFrame()->GetPage() && GetFrame()->GetPage()->IsOrdinary()) {
     bool initGlobally = !gRecordReplayStateInitialized;
 
     // Whether this is the relative root frame of this process.
-    // IsOrdinary() excludes internal pages like the in-process <select> popup.
-    bool isMainFrame = GetFrame()->IsLocalRoot() && world_->IsMainWorld() &&
-                       GetFrame()->GetPage() &&
-                       GetFrame()->GetPage()->IsOrdinary();
+    bool isMainFrame = GetFrame()->IsLocalRoot();
 
     if (initGlobally) {
       gRecordReplayStateInitialized = true;

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -299,8 +299,7 @@ void LocalWindowProxy::Initialize() {
     // Isolated worlds need the native bindings used by evaluations, but the
     // __RECORD_REPLAY__ command API is populated only in the root main world
     // so that the renderer-wide command service has a single owner.
-    InstallRecordReplayGlobals(GetIsolate(), context,
-                               /*owns_command_service=*/false);
+    InstallRecordReplayGlobals(GetIsolate(), context);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -295,8 +295,11 @@ void LocalWindowProxy::Initialize() {
     OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
   }
 
-  if (recordreplay::IsRecordingOrReplaying("commands") && origin &&
-      !origin->Host().empty() && world_->IsIsolatedWorld()) {
+  // Do not require a non-empty host here: for isolated worlds, |origin| comes
+  // from IsolatedWorldSecurityOrigin, not the main page's document origin, and
+  // debugger-created worlds may be null/hostless.
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
+      world_->IsIsolatedWorld()) {
     InstallRecordReplayGlobals(GetIsolate(), context,
                                /*is_root_main_world=*/false);
   }

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -79,17 +79,6 @@
 
 namespace blink {
 
-// Record/replay state is initialized along with the root main-world
-// LocalWindowProxy.
-static bool gRecordReplayStateInitialized;
-
-// We keep track of recently created local window proxies for ensuring that
-// record/replay state is initialized when the first paint is triggered. FIXME
-// clean up reference.
-static LocalWindowProxy* gLatestLocalWindowProxy;
-
-bool RecordReplayStateEnsureInitialized();
-
 void LocalWindowProxy::Trace(Visitor* visitor) const {
   visitor->Trace(script_state_);
   visitor->Trace(record_replay_listener_);
@@ -102,10 +91,6 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
          next_status == Lifecycle::kGlobalObjectIsDetached ||
          next_status == Lifecycle::kFrameIsDetached ||
          next_status == Lifecycle::kFrameIsDetachedAndV8MemoryIsPurged);
-
-  if (gLatestLocalWindowProxy == this) {
-    gLatestLocalWindowProxy = nullptr;
-  }
 
   // If the current lifecycle is kV8MemoryIsForciblyPurged, next status should
   // be either kFrameIsDetachedAndV8MemoryIsPurged, or kGlobalObjectIsDetached.
@@ -194,6 +179,10 @@ static const char* RecordReplayGetProcessType(
   }
   return "iframe";
 }
+
+// Record/replay state is initialized along with the root main-world
+// LocalWindowProxy.
+static bool gRecordReplayStateInitialized;
 
 void LocalWindowProxy::Initialize() {
   // https://linear.app/replay/issue/RUN-749
@@ -708,11 +697,22 @@ void LocalWindowProxy::SetAbortScriptExecution(
   script_state_->GetContext()->SetAbortScriptExecution(callback);
 }
 
+// We keep track of the most recently created main-world local window proxy
+// for ensuring that record/replay state is initialized when
+// the first paint is triggered. FIXME clean up reference.
+static LocalWindowProxy* gLatestLocalWindowProxy;
+
 LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
                                    LocalFrame& frame,
                                    scoped_refptr<DOMWrapperWorld> world)
     : WindowProxy(isolate, frame, std::move(world)) {
-  gLatestLocalWindowProxy = this;
+  // RecordReplayStateEnsureInitialized() uses this proxy to force lazy
+  // initialization before the first paint. Isolated worlds cannot initialize
+  // process-wide record/replay state, so they must not replace the main-world
+  // initialization candidate.
+  if (World().IsMainWorld()) {
+    gLatestLocalWindowProxy = this;
+  }
 }
 
 bool RecordReplayStateEnsureInitialized() {

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -295,8 +295,8 @@ void LocalWindowProxy::Initialize() {
     OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
   }
 
-  if (recordreplay::IsRecordingOrReplaying("commands") &&
-      world_->IsIsolatedWorld()) {
+  if (recordreplay::IsRecordingOrReplaying("commands") && origin &&
+      !origin->Host().empty() && world_->IsIsolatedWorld()) {
     InstallRecordReplayGlobals(GetIsolate(), context,
                                /*is_root_main_world=*/false);
   }

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -296,6 +296,9 @@ void LocalWindowProxy::Initialize() {
   // debugger-created worlds may be null/hostless.
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       world_->IsIsolatedWorld()) {
+    // Isolated worlds need the native bindings used by evaluations, but the
+    // __RECORD_REPLAY__ command API is populated only in the root main world
+    // so that the renderer-wide command service has a single owner.
     InstallRecordReplayGlobals(GetIsolate(), context,
                                /*owns_command_service=*/false);
   }

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -295,6 +295,11 @@ void LocalWindowProxy::Initialize() {
     OnNewWindowAfterCheckpoint(GetIsolate(), GetFrame(), context);
   }
 
+  if (recordreplay::IsRecordingOrReplaying("commands") &&
+      world_->IsIsolatedWorld()) {
+    InstallRecordReplayGlobals(GetIsolate(), context);
+  }
+
   {
     TRACE_EVENT2("v8", "ContextCreatedNotification", "IsMainFrame",
                  GetFrame()->IsMainFrame(), "IsOutermostMainFrame",

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -300,8 +300,7 @@ void LocalWindowProxy::Initialize() {
   // debugger-created worlds may be null/hostless.
   if (recordreplay::IsRecordingOrReplaying("commands") &&
       world_->IsIsolatedWorld()) {
-    InstallRecordReplayGlobals(GetIsolate(), context,
-                               /*is_root_main_world=*/false);
+    InstallRecordReplayGlobals(GetIsolate(), context);
   }
 
   {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2543,11 +2543,11 @@ static bool TestEnv(const char* env) {
 }
 
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
-static v8::Global<v8::Object>* gReplayApi;
-static v8::Global<v8::Object>* gReplayArguments;
 
-static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+void InstallRecordReplayGlobals(v8::Isolate* isolate,
+                                LocalFrame* localFrame,
+                                v8::Local<v8::Context> context) {
+  v8::Context::Scope scope(context);
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
@@ -2555,18 +2555,10 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
 
   v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
-  if (gReplayApi == nullptr) {
-    gReplayApi = new v8::Global<v8::Object>();
-  }
-  gReplayApi->Reset(isolate, jsrrApi);
 
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
                  args);
-  if (gReplayArguments == nullptr) {
-    gReplayArguments = new v8::Global<v8::Object>();
-  }
-  gReplayArguments->Reset(isolate, args);
 
   DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
                  ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
@@ -2702,19 +2694,6 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
                  gRecordReplayEternalState->Get(isolate));
 }
 
-void InstallRecordReplayGlobals(v8::Isolate* isolate, v8::Local<v8::Context> target_context) {
-  if (gReplayApi == nullptr || gReplayApi->IsEmpty() ||
-      gReplayArguments == nullptr || gReplayArguments->IsEmpty()) {
-    return;
-  }
-
-  v8::Context::Scope scope(target_context);
-  DefineProperty(isolate, target_context->Global(), "__RECORD_REPLAY__",
-                 gReplayApi->Get(isolate));
-  DefineProperty(isolate, target_context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
-                 gReplayArguments->Get(isolate));
-}
-
 void InitializeRecordReplay(
   const char* processType,
   v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
@@ -2742,7 +2721,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   V8RecordReplaySetDefaultContext(isolate, context);
   
   // Initialize __RECORD_REPLAY__ things.
-  InitializeRecordReplayApiObjects(isolate, localFrame);
+  InstallRecordReplayGlobals(isolate, localFrame, context);
 
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -717,8 +717,6 @@ RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
 // Whether the frame that our globally registered script(s)
 // were run in is alive.
 static bool gReplayScriptsAlive = false;
-static v8::Global<v8::Object>* gReplayApi;
-static bool gReplayApiReady = false;
 
 /**
  * This is called when our local root frame is about to shut down.
@@ -736,10 +734,6 @@ void RecordReplayClearContexts(const char* reason, LocalFrame* frame) {
           .c_str(),
       frame->RecordReplayId());
   gReplayScriptsAlive = false;
-  gReplayApiReady = false;
-  if (gReplayApi) {
-    gReplayApi->Reset();
-  }
 }
 
 static void fromJsIsReplayScriptAlive(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -2550,49 +2544,16 @@ static bool TestEnv(const char* env) {
 
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
-static void GetRecordReplayApi(
-    v8::Local<v8::Name>,
-    const v8::PropertyCallbackInfo<v8::Value>& info) {
-  if (gReplayApiReady && gReplayApi && !gReplayApi->IsEmpty()) {
-    info.GetReturnValue().Set(gReplayApi->Get(info.GetIsolate()));
-  }
-}
-
-static void InstallRecordReplayApiAccessor(v8::Isolate* isolate,
-                                           v8::Local<v8::Context> context) {
-  context->Global()
-      ->SetAccessor(context, ToV8String(isolate, "__RECORD_REPLAY__"),
-                    GetRecordReplayApi, nullptr, v8::MaybeLocal<v8::Value>(),
-                    v8::AccessControl::DEFAULT,
-                    static_cast<v8::PropertyAttribute>(
-                        v8::ReadOnly | v8::DontEnum | v8::DontDelete),
-                    v8::SideEffectType::kHasNoSideEffect)
-      .Check();
-}
-
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> context,
-                                bool is_root_main_world) {
+                                v8::Local<v8::Context> context) {
   v8::Context::Scope scope(context);
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  // The public API closes over command-handler state, so isolated worlds must
-  // use the canonical root object. The native arguments below are recreated so
-  // their callbacks use this context.
-  if (is_root_main_world) {
-    v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
-    DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
-    if (!gReplayApi) {
-      gReplayApi = new v8::Global<v8::Object>();
-    }
-    gReplayApiReady = false;
-    gReplayApi->Reset(isolate, jsrrApi);
-  } else {
-    InstallRecordReplayApiAccessor(isolate, context);
-  }
+  v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
+  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
 
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
@@ -2759,8 +2720,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   V8RecordReplaySetDefaultContext(isolate, context);
   
   // Initialize __RECORD_REPLAY__ things.
-  InstallRecordReplayGlobals(isolate, context,
-                             /*is_root_main_world=*/true);
+  InstallRecordReplayGlobals(isolate, context);
 
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
@@ -2784,10 +2744,6 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
       RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), kInternalScriptURL);
     }
   }
-
-  // Isolated worlds resolve this object lazily. Do not expose it until the
-  // command handler has finished populating the public API.
-  gReplayApiReady = true;
 }
 
 void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -717,6 +717,8 @@ RecordReplayRegisterV8Inspector(v8_inspector::V8Inspector* inspector,
 // Whether the frame that our globally registered script(s)
 // were run in is alive.
 static bool gReplayScriptsAlive = false;
+static v8::Global<v8::Object>* gReplayApi;
+static bool gReplayApiReady = false;
 
 /**
  * This is called when our local root frame is about to shut down.
@@ -734,6 +736,10 @@ void RecordReplayClearContexts(const char* reason, LocalFrame* frame) {
           .c_str(),
       frame->RecordReplayId());
   gReplayScriptsAlive = false;
+  gReplayApiReady = false;
+  if (gReplayApi) {
+    gReplayApi->Reset();
+  }
 }
 
 static void fromJsIsReplayScriptAlive(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -2544,17 +2550,49 @@ static bool TestEnv(const char* env) {
 
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
+static void GetRecordReplayApi(
+    v8::Local<v8::Name>,
+    const v8::PropertyCallbackInfo<v8::Value>& info) {
+  if (gReplayApiReady && gReplayApi && !gReplayApi->IsEmpty()) {
+    info.GetReturnValue().Set(gReplayApi->Get(info.GetIsolate()));
+  }
+}
+
+static void InstallRecordReplayApiAccessor(v8::Isolate* isolate,
+                                           v8::Local<v8::Context> context) {
+  context->Global()
+      ->SetAccessor(context, ToV8String(isolate, "__RECORD_REPLAY__"),
+                    GetRecordReplayApi, nullptr, v8::MaybeLocal<v8::Value>(),
+                    v8::AccessControl::DEFAULT,
+                    static_cast<v8::PropertyAttribute>(
+                        v8::ReadOnly | v8::DontEnum | v8::DontDelete),
+                    v8::SideEffectType::kHasNoSideEffect)
+      .Check();
+}
+
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                LocalFrame* localFrame,
-                                v8::Local<v8::Context> context) {
+                                v8::Local<v8::Context> context,
+                                bool is_root_main_world) {
   v8::Context::Scope scope(context);
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
   SetFunctionProperty(isolate, context->Global(), AnnotationHookJSName,
                       InvokeOnAnnotation);
 
-  v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
-  DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
+  // The public API closes over command-handler state, so isolated worlds must
+  // use the canonical root object. The native arguments below are recreated so
+  // their callbacks use this context.
+  if (is_root_main_world) {
+    v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
+    DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
+    if (!gReplayApi) {
+      gReplayApi = new v8::Global<v8::Object>();
+    }
+    gReplayApiReady = false;
+    gReplayApi->Reset(isolate, jsrrApi);
+  } else {
+    InstallRecordReplayApiAccessor(isolate, context);
+  }
 
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
@@ -2721,7 +2759,8 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   V8RecordReplaySetDefaultContext(isolate, context);
   
   // Initialize __RECORD_REPLAY__ things.
-  InstallRecordReplayGlobals(isolate, localFrame, context);
+  InstallRecordReplayGlobals(isolate, context,
+                             /*is_root_main_world=*/true);
 
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
@@ -2745,6 +2784,10 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
       RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), kInternalScriptURL);
     }
   }
+
+  // Isolated worlds resolve this object lazily. Do not expose it until the
+  // command handler has finished populating the public API.
+  gReplayApiReady = true;
 }
 
 void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -256,10 +256,10 @@ static String ReadReplayCommandAssetFile(const char* fname) {
 
   // Important: Treat as UTF-8.
   String result = String::FromUTF8(
-    !recordreplay::IsReplaying()
-      // Recording.
+    IsCommandHandlingEnabledWhenRecording()
+      // Recording + Replay.
       ? ReadReplayAssetFile(fname, len).c_str()
-      // Replay.
+      // Replay only.
       : V8RecordReplayReadAssetFileContents(fname, &len),
     len
   );
@@ -631,6 +631,9 @@ const char* gOnNewWindowScript = R""""(
   window.__REDUX_DEVTOOLS_EXTENSION__ = window.top.__REDUX_DEVTOOLS_EXTENSION__;
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = window.top.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 
+  // TODO: Feels like this cross-context function usage can cause trouble, especially when
+  //      the user pauses inside the iframe's JS and tries to access something inside the iframe via 
+  //      __RECORD_REPLAY__?
   window.__RECORD_REPLAY__ = window.top.__RECORD_REPLAY__;
   window.__RECORD_REPLAY_ARGUMENTS__ = window.top.__RECORD_REPLAY_ARGUMENTS__;
   window.__RECORD_REPLAY_ETERNAL_STATE__ = window.top.__RECORD_REPLAY_ETERNAL_STATE__;
@@ -746,26 +749,6 @@ static void fromJsHasDiverged(const v8::FunctionCallbackInfo<v8::Value>& args) {
 // Function to invoke on CDP responses and events.
 static v8::Eternal<v8::Function>* gCDPMessageCallback;
 
-// While a context-local Replay API call is dispatching a synchronous CDP
-// message, route its response back to that context's handler. Notifications
-// continue to use the root command service callback.
-static v8::Global<v8::Function>* gScopedCDPMessageCallback;
-
-class ScopedCDPMessageCallback {
- public:
-  ScopedCDPMessageCallback(v8::Isolate* isolate,
-                           v8::Local<v8::Function> callback)
-      : callback_(isolate, callback), previous_(gScopedCDPMessageCallback) {
-    gScopedCDPMessageCallback = &callback_;
-  }
-
-  ~ScopedCDPMessageCallback() { gScopedCDPMessageCallback = previous_; }
-
- private:
-  v8::Global<v8::Function> callback_;
-  v8::Global<v8::Function>* previous_;
-};
-
 static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   CHECK(args[0]->IsFunction());
@@ -777,7 +760,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
   recordreplay::AutoDisallowEvents disallow("RecordReplay_SendMessageToFrontend");
   CHECK(v8::IsMainThread());
 
-  CHECK(gScopedCDPMessageCallback || gCDPMessageCallback);
+  CHECK(gCDPMessageCallback);
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
@@ -798,24 +781,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
                                                         v8::NewStringType::kNormal,
                                                         (int)message.length()).ToLocalChecked();
   }
-  v8::Local<v8::Value> parsed_message =
-      v8::JSON::Parse(context, arg.As<v8::String>()).ToLocalChecked();
-  CHECK(parsed_message->IsObject());
-  bool is_response =
-      parsed_message.As<v8::Object>()
-          ->Has(context, ToV8String(isolate, "id"))
-          .ToChecked();
-  bool use_scoped_callback = gScopedCDPMessageCallback && is_response;
-
-  v8::Local<v8::Function> callback =
-      use_scoped_callback
-          ? gScopedCDPMessageCallback->Get(isolate)
-          : gCDPMessageCallback
-                ? gCDPMessageCallback->Get(isolate)
-                : gScopedCDPMessageCallback->Get(isolate);
-  if (use_scoped_callback) {
-    context = callback->GetCreationContext().ToLocalChecked();
-  }
+  v8::Local<v8::Function> callback = gCDPMessageCallback->Get(isolate);
   v8::Isolate::AllowJavascriptExecutionScope allow_js(isolate);
   v8::MaybeLocal<v8::Value> rv = callback->Call(context, v8::Undefined(isolate), 1, &arg);
   CHECK(!rv.IsEmpty());
@@ -948,19 +914,12 @@ static int GetPersistentId(v8::Local<v8::Object> object) {
  * do not provide too much value if they are not hooked up to a `DevToolsSession` and the `UberDispatcher`.
  */
 static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK((args.Length() == 1 || args.Length() == 2) && args[0]->IsString() &&
-        (args.Length() == 1 || args[1]->IsFunction()) &&
-        "must be called with a string and an optional response callback");
+  CHECK(args.Length() == 1 && args[0]->IsString() &&
+        "must be called with a single string");
 
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();
-  std::unique_ptr<ScopedCDPMessageCallback> scoped_callback;
-  if (args.Length() == 2) {
-    scoped_callback = std::make_unique<ScopedCDPMessageCallback>(
-        isolate, args[1].As<v8::Function>());
-  }
-
   absl::optional<int> contextGroupId = gContextGroupIdForSendCDPMessage;
   if (!contextGroupId.has_value()) {
     contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
@@ -969,7 +928,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   // It can be the case that we simply don't have a context group id (a local frame) at this
   // time; just log it and inform the client.
   if (!contextGroupId.has_value()) {
-    if (gScopedCDPMessageCallback || gCDPMessageCallback != nullptr) {
+    if (gCDPMessageCallback != nullptr) {
       // Ensure the message has an ID. If not, handle the error in JavaScript.
       v8::String::Utf8Value inmessage(args.GetIsolate(), args[0]);
       std::string nmessage(*inmessage);
@@ -2588,8 +2547,7 @@ static bool TestEnv(const char* env) {
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> context,
-                                bool owns_command_service) {
+                                v8::Local<v8::Context> context) {
   // Create the objects and functions below in this context's realm.
   v8::Context::Scope scope(context);
 
@@ -2617,9 +2575,6 @@ void InstallRecordReplayGlobals(v8::Isolate* isolate,
 
   DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
                  v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
-
-  DefineProperty(isolate, args, "ownsCommandService",
-                 v8::Boolean::New(isolate, owns_command_service));
 
   SetFunctionProperty(isolate, args, "log", LogCallback);
   SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
@@ -2743,20 +2698,6 @@ void InstallRecordReplayGlobals(v8::Isolate* isolate,
                  gRecordReplayEternalState->Get(isolate));
 }
 
-void InstallRecordReplayContextApi(v8::Isolate* isolate,
-                                   v8::Local<v8::Context> context) {
-  if (!IsCommandHandlingEnabled()) {
-    return;
-  }
-
-  recordreplay::AutoMarkReplayCode amrc;
-  recordreplay::AutoDisallowEvents disallow(
-      "InstallRecordReplayContextApi");
-  String command_handler_script = ReadReplayCommandHandlerScript();
-  RunScript(isolate, context, command_handler_script.Utf8().c_str(),
-            kInternalScriptURL);
-}
-
 void InitializeRecordReplay(
   const char* processType,
   v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
@@ -2784,8 +2725,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   V8RecordReplaySetDefaultContext(isolate, context);
   
   // Initialize __RECORD_REPLAY__ things.
-  InstallRecordReplayGlobals(isolate, context,
-                             /*owns_command_service=*/true);
+  InstallRecordReplayGlobals(isolate, context);
 
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
@@ -2799,7 +2739,16 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
     localFrame->GetSettings()->SetForceMainWorldInitialization(true);
   }
 
-  InstallRecordReplayContextApi(isolate, context);
+  if (IsCommandHandlingEnabled()) {
+    recordreplay::AutoMarkReplayCode amrc;
+    String commandHandlerScript = ReadReplayCommandHandlerScript();
+    {
+      recordreplay::AutoDisallowEvents disallow("InitializeReplayScripts");
+
+      // Run `commandHandlerScript`.
+      RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), kInternalScriptURL);
+    }
+  }
 }
 
 void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -256,10 +256,10 @@ static String ReadReplayCommandAssetFile(const char* fname) {
 
   // Important: Treat as UTF-8.
   String result = String::FromUTF8(
-    IsCommandHandlingEnabledWhenRecording()
-      // Recording + Replay.
+    !recordreplay::IsReplaying()
+      // Recording.
       ? ReadReplayAssetFile(fname, len).c_str()
-      // Replay only.
+      // Replay.
       : V8RecordReplayReadAssetFileContents(fname, &len),
     len
   );
@@ -631,9 +631,6 @@ const char* gOnNewWindowScript = R""""(
   window.__REDUX_DEVTOOLS_EXTENSION__ = window.top.__REDUX_DEVTOOLS_EXTENSION__;
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = window.top.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 
-  // TODO: Feels like this cross-context function usage can cause trouble, especially when
-  //      the user pauses inside the iframe's JS and tries to access something inside the iframe via 
-  //      __RECORD_REPLAY__?
   window.__RECORD_REPLAY__ = window.top.__RECORD_REPLAY__;
   window.__RECORD_REPLAY_ARGUMENTS__ = window.top.__RECORD_REPLAY_ARGUMENTS__;
   window.__RECORD_REPLAY_ETERNAL_STATE__ = window.top.__RECORD_REPLAY_ETERNAL_STATE__;

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2583,11 +2583,14 @@ static bool TestEnv(const char* env) {
   return v && v[0] && v[0] != '0';
 }
 
+// Share aggregate instrumentation state across realms so that it remains
+// reachable from global evaluations in the main world.
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
                                 v8::Local<v8::Context> context,
                                 bool owns_command_service) {
+  // Create the objects and functions below in this context's realm.
   v8::Context::Scope scope(context);
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
@@ -2731,8 +2734,10 @@ void InstallRecordReplayGlobals(v8::Isolate* isolate,
     ForTestingSerializeValueToArray);
 
   if (gRecordReplayEternalState == nullptr) {
+    v8::Local<v8::Object> eternal_state = v8::Object::New(isolate);
+    eternal_state->SetPrototype(context, v8::Null(isolate)).Check();
     gRecordReplayEternalState =
-        new v8::Eternal<v8::Object>(isolate, v8::Object::New(isolate));
+        new v8::Eternal<v8::Object>(isolate, eternal_state);
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ETERNAL_STATE__",
                  gRecordReplayEternalState->Get(isolate));

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -2543,6 +2543,8 @@ static bool TestEnv(const char* env) {
 }
 
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
+static v8::Global<v8::Object>* gReplayApi;
+static v8::Global<v8::Object>* gReplayArguments;
 
 static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* localFrame) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -2553,10 +2555,18 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
 
   v8::Local<v8::Object> jsrrApi = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY__", jsrrApi);
+  if (gReplayApi == nullptr) {
+    gReplayApi = new v8::Global<v8::Object>();
+  }
+  gReplayApi->Reset(isolate, jsrrApi);
 
   v8::Local<v8::Object> args = v8::Object::New(isolate);
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
                  args);
+  if (gReplayArguments == nullptr) {
+    gReplayArguments = new v8::Global<v8::Object>();
+  }
+  gReplayArguments->Reset(isolate, args);
 
   DefineProperty(isolate, args, "REPLAY_CDT_PAUSE_OBJECT_GROUP",
                  ToV8String(isolate, REPLAY_CDT_PAUSE_OBJECT_GROUP));
@@ -2690,6 +2700,19 @@ static void InitializeRecordReplayApiObjects(v8::Isolate* isolate, LocalFrame* l
   }
   DefineProperty(isolate, context->Global(), "__RECORD_REPLAY_ETERNAL_STATE__",
                  gRecordReplayEternalState->Get(isolate));
+}
+
+void InstallRecordReplayGlobals(v8::Isolate* isolate, v8::Local<v8::Context> target_context) {
+  if (gReplayApi == nullptr || gReplayApi->IsEmpty() ||
+      gReplayArguments == nullptr || gReplayArguments->IsEmpty()) {
+    return;
+  }
+
+  v8::Context::Scope scope(target_context);
+  DefineProperty(isolate, target_context->Global(), "__RECORD_REPLAY__",
+                 gReplayApi->Get(isolate));
+  DefineProperty(isolate, target_context->Global(), "__RECORD_REPLAY_ARGUMENTS__",
+                 gReplayArguments->Get(isolate));
 }
 
 void InitializeRecordReplay(

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -749,6 +749,26 @@ static void fromJsHasDiverged(const v8::FunctionCallbackInfo<v8::Value>& args) {
 // Function to invoke on CDP responses and events.
 static v8::Eternal<v8::Function>* gCDPMessageCallback;
 
+// While a context-local Replay API call is dispatching a synchronous CDP
+// message, route its response back to that context's handler. Notifications
+// continue to use the root command service callback.
+static v8::Global<v8::Function>* gScopedCDPMessageCallback;
+
+class ScopedCDPMessageCallback {
+ public:
+  ScopedCDPMessageCallback(v8::Isolate* isolate,
+                           v8::Local<v8::Function> callback)
+      : callback_(isolate, callback), previous_(gScopedCDPMessageCallback) {
+    gScopedCDPMessageCallback = &callback_;
+  }
+
+  ~ScopedCDPMessageCallback() { gScopedCDPMessageCallback = previous_; }
+
+ private:
+  v8::Global<v8::Function> callback_;
+  v8::Global<v8::Function>* previous_;
+};
+
 static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   CHECK(args[0]->IsFunction());
@@ -760,7 +780,7 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
   recordreplay::AutoDisallowEvents disallow("RecordReplay_SendMessageToFrontend");
   CHECK(v8::IsMainThread());
 
-  CHECK(gCDPMessageCallback);
+  CHECK(gScopedCDPMessageCallback || gCDPMessageCallback);
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   if (!isolate->InContext() || ScriptForbiddenScope::IsScriptForbidden()) {
@@ -781,7 +801,24 @@ static void SendMessageToFrontend(const v8_inspector::StringView& message) {
                                                         v8::NewStringType::kNormal,
                                                         (int)message.length()).ToLocalChecked();
   }
-  v8::Local<v8::Function> callback = gCDPMessageCallback->Get(isolate);
+  v8::Local<v8::Value> parsed_message =
+      v8::JSON::Parse(context, arg.As<v8::String>()).ToLocalChecked();
+  CHECK(parsed_message->IsObject());
+  bool is_response =
+      parsed_message.As<v8::Object>()
+          ->Has(context, ToV8String(isolate, "id"))
+          .ToChecked();
+  bool use_scoped_callback = gScopedCDPMessageCallback && is_response;
+
+  v8::Local<v8::Function> callback =
+      use_scoped_callback
+          ? gScopedCDPMessageCallback->Get(isolate)
+          : gCDPMessageCallback
+                ? gCDPMessageCallback->Get(isolate)
+                : gScopedCDPMessageCallback->Get(isolate);
+  if (use_scoped_callback) {
+    context = callback->GetCreationContext().ToLocalChecked();
+  }
   v8::Isolate::AllowJavascriptExecutionScope allow_js(isolate);
   v8::MaybeLocal<v8::Value> rv = callback->Call(context, v8::Undefined(isolate), 1, &arg);
   CHECK(!rv.IsEmpty());
@@ -914,12 +951,19 @@ static int GetPersistentId(v8::Local<v8::Object> object) {
  * do not provide too much value if they are not hooked up to a `DevToolsSession` and the `UberDispatcher`.
  */
 static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsString() &&
-        "must be called with a single string");
+  CHECK((args.Length() == 1 || args.Length() == 2) && args[0]->IsString() &&
+        (args.Length() == 1 || args[1]->IsFunction()) &&
+        "must be called with a string and an optional response callback");
 
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();
+  std::unique_ptr<ScopedCDPMessageCallback> scoped_callback;
+  if (args.Length() == 2) {
+    scoped_callback = std::make_unique<ScopedCDPMessageCallback>(
+        isolate, args[1].As<v8::Function>());
+  }
+
   absl::optional<int> contextGroupId = gContextGroupIdForSendCDPMessage;
   if (!contextGroupId.has_value()) {
     contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
@@ -928,7 +972,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   // It can be the case that we simply don't have a context group id (a local frame) at this
   // time; just log it and inform the client.
   if (!contextGroupId.has_value()) {
-    if (gCDPMessageCallback != nullptr) {
+    if (gScopedCDPMessageCallback || gCDPMessageCallback != nullptr) {
       // Ensure the message has an ID. If not, handle the error in JavaScript.
       v8::String::Utf8Value inmessage(args.GetIsolate(), args[0]);
       std::string nmessage(*inmessage);
@@ -2545,7 +2589,8 @@ static bool TestEnv(const char* env) {
 static v8::Eternal<v8::Object>* gRecordReplayEternalState;
 
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> context) {
+                                v8::Local<v8::Context> context,
+                                bool owns_command_service) {
   v8::Context::Scope scope(context);
 
   // Add __RECORD_REPLAY_ANNOTATION_HOOK__ as a global.
@@ -2572,6 +2617,9 @@ void InstallRecordReplayGlobals(v8::Isolate* isolate,
 
   DefineProperty(isolate, args, "CDPERROR_NOTALIVE",
                  v8::Number::New(isolate, (double)CDPERROR_NOTALIVE));
+
+  DefineProperty(isolate, args, "ownsCommandService",
+                 v8::Boolean::New(isolate, owns_command_service));
 
   SetFunctionProperty(isolate, args, "log", LogCallback);
   SetFunctionProperty(isolate, args, "logTrace", LogTraceCallback);
@@ -2693,6 +2741,20 @@ void InstallRecordReplayGlobals(v8::Isolate* isolate,
                  gRecordReplayEternalState->Get(isolate));
 }
 
+void InstallRecordReplayContextApi(v8::Isolate* isolate,
+                                   v8::Local<v8::Context> context) {
+  if (!IsCommandHandlingEnabled()) {
+    return;
+  }
+
+  recordreplay::AutoMarkReplayCode amrc;
+  recordreplay::AutoDisallowEvents disallow(
+      "InstallRecordReplayContextApi");
+  String command_handler_script = ReadReplayCommandHandlerScript();
+  RunScript(isolate, context, command_handler_script.Utf8().c_str(),
+            kInternalScriptURL);
+}
+
 void InitializeRecordReplay(
   const char* processType,
   v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {
@@ -2720,7 +2782,8 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
   V8RecordReplaySetDefaultContext(isolate, context);
   
   // Initialize __RECORD_REPLAY__ things.
-  InstallRecordReplayGlobals(isolate, context);
+  InstallRecordReplayGlobals(isolate, context,
+                             /*owns_command_service=*/true);
 
   if (recordreplay::FeatureEnabled("collect-source-maps") &&
       !TestEnv("RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION")) {
@@ -2734,16 +2797,7 @@ static void InitializeReplayScripts(v8::Isolate* isolate, LocalFrame* localFrame
     localFrame->GetSettings()->SetForceMainWorldInitialization(true);
   }
 
-  if (IsCommandHandlingEnabled()) {
-    recordreplay::AutoMarkReplayCode amrc;
-    String commandHandlerScript = ReadReplayCommandHandlerScript();
-    {
-      recordreplay::AutoDisallowEvents disallow("InitializeReplayScripts");
-
-      // Run `commandHandlerScript`.
-      RunScript(isolate, context, commandHandlerScript.Utf8().c_str(), kInternalScriptURL);
-    }
-  }
+  InstallRecordReplayContextApi(isolate, context);
 }
 
 void OnRootFrameInit(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context) {

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -34,11 +34,12 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 // This is the last Replay code that we run for a new Window object.
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
-// Install fresh Record Replay API globals into a V8 context. The eternal state
-// object is shared across contexts.
+// Install Record Replay globals into a V8 context. Native bindings are created
+// in each context. The root main world owns the JS API object, which other
+// worlds resolve lazily.
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                LocalFrame* localFrame,
-                                v8::Local<v8::Context> target_context);
+                                v8::Local<v8::Context> target_context,
+                                bool is_root_main_world);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -34,6 +34,9 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 // This is the last Replay code that we run for a new Window object.
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
+// Install the canonical Record Replay globals into an additional V8 context.
+void InstallRecordReplayGlobals(v8::Isolate* isolate, v8::Local<v8::Context> target_context);
+
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -35,16 +35,9 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Install Record Replay globals into a V8 context. Native bindings and the JS
-// API object are created in each context; eternal state is shared. Only the
-// root main-world context owns renderer-wide command service callbacks.
+// API object are created in each context; eternal state is shared.
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> target_context,
-                                bool owns_command_service);
-
-// Populate the context-local Replay API without changing which context owns
-// renderer-wide command service callbacks.
-void InstallRecordReplayContextApi(v8::Isolate* isolate,
-                                   v8::Local<v8::Context> target_context);
+                                v8::Local<v8::Context> target_context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -34,8 +34,11 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 // This is the last Replay code that we run for a new Window object.
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
-// Install the canonical Record Replay globals into an additional V8 context.
-void InstallRecordReplayGlobals(v8::Isolate* isolate, v8::Local<v8::Context> target_context);
+// Install fresh Record Replay API globals into a V8 context. The eternal state
+// object is shared across contexts.
+void InstallRecordReplayGlobals(v8::Isolate* isolate,
+                                LocalFrame* localFrame,
+                                v8::Local<v8::Context> target_context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -34,12 +34,10 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 // This is the last Replay code that we run for a new Window object.
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
-// Install Record Replay globals into a V8 context. Native bindings are created
-// in each context. The root main world owns the JS API object, which other
-// worlds resolve lazily.
+// Install Record Replay globals into a V8 context. Native bindings and the JS
+// API object are created in each context; eternal state is shared.
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> target_context,
-                                bool is_root_main_world);
+                                v8::Local<v8::Context> target_context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.h
@@ -35,9 +35,16 @@ void OnRootFrameInitAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame
 void OnNewWindowAfterCheckpoint(v8::Isolate* isolate, LocalFrame* localFrame, v8::Local<v8::Context> context);
 
 // Install Record Replay globals into a V8 context. Native bindings and the JS
-// API object are created in each context; eternal state is shared.
+// API object are created in each context; eternal state is shared. Only the
+// root main-world context owns renderer-wide command service callbacks.
 void InstallRecordReplayGlobals(v8::Isolate* isolate,
-                                v8::Local<v8::Context> target_context);
+                                v8::Local<v8::Context> target_context,
+                                bool owns_command_service);
+
+// Populate the context-local Replay API without changing which context owns
+// renderer-wide command service callbacks.
+void InstallRecordReplayContextApi(v8::Isolate* isolate,
+                                   v8::Local<v8::Context> target_context);
 
 // Notify the driver that we're adding an error to the console.
 void RecordReplayOnErrorEvent(ErrorEvent* error_event);


### PR DESCRIPTION
tested with https://github.com/replayio/backend/pull/13104
fixes https://hub.replay.io/issues/issue/1642

Root cause behind the issue - we were just not registering our replay global objects in isolated worlds. This PR implements that