### PR TITLE
crash-0035/0036/0037: replay-divergence diagnostics

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '06b4126374c30baf62a2cd4e2dce1d48d319010e',
+  'v8_revision': '9549fad2f645b2ff7a73ff6a89d76cc518d6f6ac',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'c6578b17b414c9e2ca5cf37907ba87e88f4664d7',
+  'v8_revision': '06b4126374c30baf62a2cd4e2dce1d48d319010e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -129,12 +129,9 @@ void MainThreadDebugger::SetClientMessageLoop(
 
 void MainThreadDebugger::DidClearContextsForFrame(LocalFrame* frame) {
   DCHECK(IsMainThread());
-  int isRoot = frame->LocalFrameRoot() == frame;
-  ScriptState* main_world_script_state = ToScriptStateForMainWorld(frame);
-  int isMainWorld =
-      main_world_script_state && main_world_script_state->World().IsMainWorld();
   REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-      "MainThreadDebugger::DidClearContextsForFrame %d %d", isRoot, isMainWorld);
+      "MainThreadDebugger::DidClearContextsForFrame %d",
+      frame->LocalFrameRoot() == frame);
   if (frame->LocalFrameRoot() == frame) {
     if (recordreplay::IsRecordingOrReplaying("DidClearContextsForFrame")) {
       RecordReplayClearContexts("MainThreadDebugger::DidClearContextsForFrame", frame);

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -129,6 +129,12 @@ void MainThreadDebugger::SetClientMessageLoop(
 
 void MainThreadDebugger::DidClearContextsForFrame(LocalFrame* frame) {
   DCHECK(IsMainThread());
+  int isRoot = frame->LocalFrameRoot() == frame;
+  ScriptState* main_world_script_state = ToScriptStateForMainWorld(frame);
+  int isMainWorld =
+      main_world_script_state && main_world_script_state->World().IsMainWorld();
+  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
+      "MainThreadDebugger::DidClearContextsForFrame %d %d", isRoot, isMainWorld);
   if (frame->LocalFrameRoot() == frame) {
     if (recordreplay::IsRecordingOrReplaying("DidClearContextsForFrame")) {
       RecordReplayClearContexts("MainThreadDebugger::DidClearContextsForFrame", frame);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/300

# Summary

* Three independent replay-divergence investigations, all shipping **diagnostic Asserts only** (no behavior change).
* All center on `V8InspectorImpl` context/session teardown reached during frame detach, plus one unrelated V8 script-registration gate.
* **G1 — v8 `RecordReplayRegisterScript` (crash-0035, Js mismatch)**
  * Progress opcodes recorded for the Playwright UtilityScript (`sourceId 3`) but absent on replay.
  * Root not proven: investigation stalls at `DivergentCompileEntry`; the recording lacks the data to close it.
  * Adds one `REPLAY_ASSERT` logging `script id` + `HasDefaultContext()` at register time to capture the gate state on the next crash.
* **G2 — v8 `V8InspectorImpl` + blink `MainThreadDebugger` (crash-0036, StackCommonFrame)**
  * `forEachContext` leaf Assert diverges (`recorded 0 0` vs `replayed 1 4`), reached through the shared `resetContextGroup` frame via different callers.
  * Adds Asserts at the three candidate branch points upstream of the leaf (`DidClearContextsForFrame`, `resetContextGroup` hasContexts, `forEachSession`) to bisect which branch first diverges.
  * `DidClearContextsForFrame` also logs `isMainWorld` (frame's main-world context present) alongside `isRoot`.
* **G3 — v8 `V8InspectorImpl::resetContextGroup` (crash-0037, StackNoCommonFrame)**
  * Recorded leaf `Value TryLock` (`InspectorTaskRunner::Dispose`) vs replayed `forEachContext 1 3`, forking inside `m_consoleStorageMap.erase`.
  * The mismatch is in front of the existing `resetContextGroup` hasContexts Assert (which runs after erase).
  * Adds one Assert on `hasConsoleMessageStorage(contextGroupId)` immediately before the erase.

---

# G1: v8 `RecordReplayRegisterScript` — crash-0035 (Js mismatch)

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Js

# Basic Facts

* **EvalSite** — mismatch under recorded CDP `Runtime.evaluate`, not an operator MCP tool.
  * Zero `OperatorToolCall` / `ToolCallStart` before crash.
  * Crash during `CreateAnalysisContext` (`messageKind` `startProcessorServer`); ACX never reached phase `Done`.
  * Sapling `processId` `2`, `manifestIndex` `335`:
    * `{"kind":"runToPoint","endpoint":{"checkpoint":563,"progress":43778079},"emitWarnings":true}`
  * Immediately before Warning: `Application` text
    * `[CommandDiagnostic][RUN-2486-2537] V8InspectorImpl::getContext B 10 1 2 … id=11`
  * Warning at progress `43620314`, checkpoint `562`:
    * `MicrotaskQueue::PerformCheckpoint 1`
    * `recorded: ["3::1:1","3::2:8"]`, `replayed: []`
  * Stack top: `MicrotasksScope::~MicrotasksScope` → `V8RuntimeAgentImpl::evaluate` → `Runtime::DomainDispatcherImpl::evaluate` → `dispatchProtocolMessage`
* `EarliestDivergedProgress`: 43620315
* `checkpoint`: 562
* `sourceId`s at that progress (`recorded`/`replayed`, entry `k=0`):
  * recorded: `3` (`"3::1:1"`)
  * replayed: none (`[]`)
* `applicationDataMismatch` source used: Warning `MicrotaskQueue::PerformCheckpoint 1` at progress 43620314, checkpoint 562
* Playwright `page.evaluate` (pw → in-page code): all 11 identical.
  * Args: `{ maxItems: 500, root: null, baseUrl: null }`.
  * DOM walk (+ shadow roots) for visible interactables; uses `getComputedStyle` / layout reads.
  * Path: `page.evaluate` → UtilityScript `evaluate` → `global.eval(...)` (not the MicrotaskQueue EvalSite).
  * Last before Warning (`lt≈35.3`): `pw-139` (`lt≈32.78`).
* JS stacks at `[P-1, P, P+1, P+2, P+3]` where `P` = 43620314:
  * 43620313: empty
  * 43620314: empty
  * 43620315: empty
  * 43620316: empty
* `jsMismatchProgress` computation: candidates `lastDeterministicProgress` = `{43999999 (Assert), 43620314 (Warning MicrotaskQueue::PerformCheckpoint 1)}` → min = `43620314` → confirms `EarliestDivergedProgress` = `43620315`, `checkpoint` = `562` (Warning's own `checkpoint` field).
  * Warning recorded tokens: `"3::1:1"`, `"3::2:8"` (in that harness).
  * We never see those tokens at replay time.
    * Hence progress stays diverged by 2; checkpoint warns: "got 43778077 expected 43778079"
  * Token shape from `GetScriptLocationString`: `scriptId:name:line:col` → here `name` is empty.
  * Dump emit: linker `OnNewSource` prints only when `IsDetached() && DETACHED_DUMP_SOURCES`, after V8 `RecordReplayOnNewSource`.
  * V8 `RecordReplayRegisterScript` inserts into `gRecordReplayScripts`, then returns before `RecordReplayOnNewSource` when:
    * `!RecordReplayHasDefaultContext()`
    * `recordreplay::AreEventsDisallowed()`
    * `url == "record-replay-internal"` (`[TT-1390]`)

# Record-time divergent JS in Playwright UtilityScript

## Relevant JS Sources

* `sourceId` `3` (`"3::1:1"`, `"3::2:8"`): Playwright UtilityScript top-level IIFE.

```js
// progress: 43620315
      (() => {
        // progress: 43620316
        const module = {};
        // ...
        return new (module.exports.UtilityScript())(globalThis, false);
      })();
```

## Progress opcodes missing at replay

* Verdict: UtilityScript **ran** on replay; it was **not Progress-instrumented**.
  * Not “US only ran on record”.
  * Not CommandCallback Progress scrub ([RUN-1988]).

### Instrumentation decision (compile / register)

* Progress emit gate — `BytecodeArrayBuilder` ctor (`v8/src/interpreter/bytecode-array-builder.cc`):
  * `emit_record_replay_opcodes_` only if `IsRecordingOrReplaying("emit-opcodes") && RecordReplayHasDefaultContext() && !record_replay_ignore`.
  * `RecordReplayOnProgress()` emits `IncExecutionProgressCounter` only when that flag is set.
  * Else at replay: `NotifyActivity` only (no Progress).
* `record_replay_ignore` setters:
  * `SetRecordReplayFlags` (`compiler.cc`): ignore if `!HasDefaultContext || AreEventsDisallowed("CompileFlags") || IsInReplayCode("CompileFlags")`.
  * `SetFlagsForFunctionFromScript` (`parse-info.cc`): ignore if `!RecordReplayHasRegisteredScript(script)`.
* Full register gate — `RecordReplayRegisterScript` (`debug.cc`):
  * Always inserts `gRecordReplayScripts` (so `Debugger.getSourceContents` works).
  * Early-returns **before** `gRegisteredScripts` / `RecordReplayOnNewSource` if `!HasDefaultContext || AreEventsDisallowed || url=="record-replay-internal"`.
  * Does **not** check `IsInReplayCode` (that gate is compile-only).

### Scrub hypothesis — rejected

* CommandCallback scrub (`debug.cc` [RUN-1988]) only resets `*gProgressCounter`; it does **not** clear `gProgressData`.
  * If opcodes had fired then scrubbed: `replayed` would still list `"3::…"`.
  * Observed: `replayed: []`.
* Warning stack is `DevToolsSession::DispatchProtocolCommandImpl` → `V8RuntimeAgentImpl::evaluate` → `MicrotasksScope::~MicrotasksScope`.
  * Not `CommandCallback`.

### Replay evidence (linkerdebug + dumps)

* Recorded assert data: `["3::1:1", "3::2:8"]` → record **did** emit Progress for V8 script id `3`.
* Replayed assert data: `[]` + later checkpoint `got 43778077 expected 43778079` → those two Progress sites never ran on replay.
* Evaluate **did** run: same Warning stack ends in `V8RuntimeAgentImpl::evaluate` (UtilityScript injection expression).
  * `sourceId` `3` never appears as `OnNewSource` on replay.
* Record-time `OnNewSource` Diagnostics: same — first is id `13` (order `49457`); no `OnNewSource 3`.
  * Proves script lives in `gRecordReplayScripts` after the pre-`OnNewSource` insert.
  * Combined with missing `OnNewSource` on **both** sides: `RecordReplayRegisterScript` **early-returned** for id `3` at first compile on record and replay.

### Inference

* **UninstrumentedReplayUS**: replay ran UtilityScript without Progress opcodes at Warning `P=43620314`.
* Divergent observed data: `recorded: ["3::1:1","3::2:8"]` vs `replayed: []`.
* Missing `OnNewSource` for ids `1`–`12` is **shared** by record and replay.
  * Not a replay-only register-skip signal.
  * Cannot alone prove record saw `HasDefaultContext==true` for id `3`.
* First recording `OnNewSource` is also `13`/`14` in `OnRootFrameInitAfterCheckpoint` after `V8RecordReplaySetDefaultContext`.
* **EarlyCDPUtilityScript**: recording allocates id `3` at assert order `31279` via CDP `V8RuntimeAgentImpl::evaluate` → `DebugEvaluate::Global`, before `OnRootFrameInit` (`~49450`) / `ContextCreated` (`~49469`).
  * Immediate next assert (`31280`): `MicrotaskQueue::PerformCheckpoint 1` on that same evaluate.
  * Warning `P=43620314` is a later evaluate of the same script id (cache reuse), not first compile.
* Progress data push does not require `gRegisteredScripts`; opcode emit still gates on `HasDefaultContext` / `!record_replay_ignore` at compile.

## Findings

### Record-time

* No `OnNewSource 3` in record-time `OnNewSource` Diagnostics.
  * First ones are ids `13`–`32`.
* **EarlyCDPUtilityScript** (recording assert order):
  * Id `3` first allocated at order `31279` via CDP `Runtime.evaluate` / `DebugEvaluate::Global`.
  * That is before first `OnRootFrameInit` / `SetDefaultContext` (`~49450`).
* Warning assert data at `P=43620314`: `recorded: ["3::1:1","3::2:8"]`.
  * So **record-time** execution of script `3` emitted Progress.

### Replay-time

* No `OnNewSource 3` in the replay `OnNewSource` dump either.
* Warning assert data at same site: `replayed: []`.
  * So **replay-time** execution of script `3` emitted no Progress.
* rr live sample at id `3` first register (**replay** only):
  * Thread: rr `*3` / tid `1540173` = Replay main thread.
  * `GetNextScriptId` `$esi==3` ⇒ this is first compile of script `3`, not lazy.
  * Register half (`+563`): `$al = 0` ⇒ `HasDefaultContext==false`.
  * Early-return; `AreEventsDisallowed` not reached.
  * Explains replay’s missing `OnNewSource 3` only.

### Relevant Gates

* **FirstCompileFlags** — `SetRecordReplayFlags` (`compiler.cc`), toplevel first compile
  * sets `record_replay_ignore` unless all hold:
    * `IsMainThread()`
    * `RecordReplayHasDefaultContext()`
    * `!AreEventsDisallowed("CompileFlags")`
    * `!IsInReplayCode("CompileFlags")`
* **LazyCompileFlags** — `SetFlagsForFunctionFromScript` (`parse-info.cc`), later function compile
  * sets `record_replay_ignore` unless:
    * `RecordReplayHasRegisteredScript(script)`
* **OpcodeEmit** — `BytecodeArrayBuilder` ctor
  * sets `emit_record_replay_opcodes_` only if all hold:
    * `IsRecordingOrReplaying("emit-opcodes")`
    * `RecordReplayHasDefaultContext()`
    * `!record_replay_ignore`
* **RegisterEntry** — `ProcessCompileEvent` → `RecordReplayRegisterScript`
  * enters only if all hold:
    * `!has_compile_error`
    * `IsRecordingOrReplaying("register-scripts")`
    * `IsMainThread()`
* **OnNewSourcePath** — inside `RecordReplayRegisterScript`, after `gRecordReplayScripts` insert
  * reaches `gRegisteredScripts` + `OnNewSource` only if all hold:
    * first register of this script id
    * `RecordReplayHasDefaultContext()`
    * script type is not WASM
    * `!AreEventsDisallowed()`
    * url is not `record-replay-internal`

### Gating Deduction

#### RawData

* LazyCompileFlags sets ignore unless `RecordReplayHasRegisteredScript(script)`.
* `RecordReplayHasRegisteredScript`: main thread and script id in `gRegisteredScripts`.
* Script id enters `gRegisteredScripts` only when OnNewSourcePath finishes.
* OnNewSourcePath finishes only when all of these hold:
  * first register of this script id
  * `RecordReplayHasDefaultContext()`
  * not WASM
  * `!AreEventsDisallowed()`
  * url is not `record-replay-internal`
* FirstCompileFlags leaves ignore unset only when all of these hold:
  * `IsMainThread()`
  * `RecordReplayHasDefaultContext()`
  * `!AreEventsDisallowed("CompileFlags")`
  * `!IsInReplayCode("CompileFlags")`
* OpcodeEmit emits Progress only when all of these hold:
  * `IsRecordingOrReplaying("emit-opcodes")`
  * `RecordReplayHasDefaultContext()`
  * `!record_replay_ignore`
* Per compile, order is: FirstCompileFlags, then OpcodeEmit, then RegisterEntry, then OnNewSourcePath.
* FirstCompileFlags takes `url` and uses it only for `RecordReplayAssertValues`.
* Second RegisterEntry for the same id returns on the `gRecordReplayScripts` hit. OnNewSourcePath does not run again.

#### RefinedData

* Shared by OnNewSourcePath and FirstCompileFlags:
  * `RecordReplayHasDefaultContext()`
  * `AreEventsDisallowed` check (unqualified vs `"CompileFlags"`)
* On OnNewSourcePath, not on FirstCompileFlags:
  * first register of this script id
  * not WASM
  * url is not `record-replay-internal`
* OpcodeEmit does not add those three. It only sees FirstCompileFlags through `record_replay_ignore`.

#### Conclusions

* FirstCompileFlags and OpcodeEmit omit two OnNewSourcePath checks that LazyCompileFlags gets via `gRegisteredScripts`:
  * not WASM
  * url is not `record-replay-internal`
* UtilityScript (`sourceId` `3`) is not WASM and has empty url. Those two checks do not explain it.

## Findings Part 2–3: compile gates + hypotheses

### Gates (keep)

* **FirstCompileFlags** (`SetRecordReplayFlags`): ignore unless `IsMainThread` ∧ `HasDefaultContext` ∧ `!AreEventsDisallowed("CompileFlags")` ∧ `!IsInReplayCode("CompileFlags")`. No `gRegisteredScripts` check.
* **LazyCompileFlags** (`SetFlagsForFunctionFromScript`): ignore unless `HasRegisteredScript`.
* **OpcodeEmit**: Progress only if `HasDefaultContext` ∧ `!record_replay_ignore`.
* Order per compile: FirstCompileFlags → OpcodeEmit → Register → OnNewSourcePath.
* Eager nested SFIs inherit FirstCompileFlags; lazy later use LazyCompileFlags.

### Replay rr sample (id `3`)

* `CurrentThreadId() = 1` at Register / FirstCompileFlags / OpcodeEmit.
* FirstCompileFlags: `HasDefaultContext == false` → ignore.
* Eager wave: two OpcodeEmits with ignore (token SFIs `"3::1:1"` / `"3::2:8"`). No `ForFunctionCompile` between.
* Lazy for id `3`: `HasRegisteredScript == false` → ignore.
* Both paths dark on replay.

### Anchors

* EarlyCDP: `NextScriptId 3` order `31279` (`DebugEvaluate::Global`) before `SetDefaultContext` / `OnRootFrameInit` `~49450`.
* No `OnNewSource 3` on record or replay.
* Warning: `recorded: ["3::1:1","3::2:8"]` vs `replayed: []`.

### Hypotheses

* **DivergentHasDefaultContext** — rejected.
  * Replay ClosedGate confirmed.
  * Record first compile also pre-`SetDefaultContext` (order `31279` vs `~49450`).
  * Not record-after / replay-before on that compile.
* **DivergentEagerLazy** — rejected.
  * Replay token SFIs were eager.
  * Lazy never instruments unregistered id `3`.
  * Eager first compile ClosedGate both sides.
* **DivergentCompileEntry** — open.
  * Claim: Playwright and its CDP interactions and/or the events downstream from it are somehow missing some ordering.
  * Prior art [RUN-3312](https://linear.app/replay/issue/RUN-3312/investigate-hit-counts-are-missing): Playwright CDP coverage vs first compile ordering → divergent bytecode / breakpoint offsets (`15` vs `17`). Bad = `getPossibleBreakpoints` compile before `startPreciseCoverage`.

### Open

* **DivergentCompileEntry**: record tokens need some OpcodeEmit with `HasDefaultContext`; first EarlyCDP compile cannot supply it on either side.

---

# G2: v8 `V8InspectorImpl` + blink `MainThreadDebugger` — crash-0036 (StackCommonFrame)

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame

# Basic Facts

## FrameCandidates

* `v8_inspector::V8InspectorImpl::forEachContext(int,.std::Cr::function<void.(v8_inspector::InspectedContext*)>.const&)+338`
  * location: `V8InspectorImpl::forEachContext` at `v8/src/inspector/v8-inspector-impl.cc:416-417`
  * code: `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::forEachContext %d %zu", hasGroup, n);`
* `v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+1084`
  * location: `V8InspectorImpl::forEachSession` at `v8/src/inspector/v8-inspector-impl.cc:451`
  * code: `if (sessionIt != it->second.end()) callback(sessionIt->second);`

## DivergentPathSegments

* Recorded root on stack: `LocalDOMWindow::Reset`.
* Replayed root on stack: `V8InspectorImpl::resetContextGroup` (stack truncated; no caller captured).
* Both paths provably share the call to `resetContextGroup` (recorded +783 / replayed +416), which is why this renders as a single tree from that shared frame, with the recorded-only ancestor frames on top.

```cpp
// blink::LocalDOMWindow::Reset()+14
void LocalDOMWindow::Reset() {
  DCHECK(document());
  // blink::LocalDOMWindow::FrameDestroyed()+170
  FrameDestroyed();
  ...
}

// LocalDOMWindow::FrameDestroyed (on recorded stack via Reset())
void LocalDOMWindow::FrameDestroyed() {
  ...
  if (!GetFrame())
    return;
  document()->Shutdown();
  document()->RemoveAllEventListenersRecursively();
  GetAgent()->DetachContext(this);
  NotifyContextDestroyed();
  RemoveAllEventListeners();
  // MainThreadDebugger::DidClearContextsForFrame (not on stack; inlined/elided)
  MainThreadDebugger::Instance()->DidClearContextsForFrame(GetFrame());
  DisconnectFromFrame();
}

// MainThreadDebugger::DidClearContextsForFrame (not itself on stack)
void MainThreadDebugger::DidClearContextsForFrame(LocalFrame* frame) {
  // [Branch] CANDIDATE
  if (frame->LocalFrameRoot() == frame) {
    if (recordreplay::IsRecordingOrReplaying("DidClearContextsForFrame")) {
      RecordReplayClearContexts("MainThreadDebugger::DidClearContextsForFrame", frame);
    }
    // v8_inspector::V8InspectorImpl::resetContextGroup(int)+783 (recorded)
    // v8_inspector::V8InspectorImpl::resetContextGroup(int)+416 (replayed)
    GetV8Inspector()->resetContextGroup(ContextGroupId(frame));
  }
}

// V8InspectorImpl::resetContextGroup — shared frame on both stacks
void V8InspectorImpl::resetContextGroup(int contextGroupId) {
  auto contextsIt = m_contexts.find(contextGroupId);
  // m_consoleStorageMap.erase() destroys the group's V8ConsoleMessageStorage,
  // if present, invoking its own forEachSession/forEachContext walk (replayed path).
  m_consoleStorageMap.erase(contextGroupId);
  m_muteExceptionsMap.erase(contextGroupId);
  // [Branch] CANDIDATE
  if (contextsIt != m_contexts.end()) {
    for (const auto& map_entry : *contextsIt->second)
      m_uniqueIdToContextId.erase(map_entry.second->uniqueId().pair());
    m_contexts.erase(contextsIt);
  }

  // v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<...>.const&)+1084
  forEachSession(contextGroupId,
                 [](V8InspectorSessionImpl* session) { session->reset(); });
}
```

### Recorded path: `resetContextGroup` → `forEachSession` → `session->reset()` → `forEachContext` (leaf Assert)

```cpp
// v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<...>.const&)+1084
void V8InspectorImpl::forEachSession(
    int contextGroupId,
    const std::function<void(V8InspectorSessionImpl*)>& callback) {
  auto it = m_sessions.find(contextGroupId);
  if (it == m_sessions.end()) return;
  std::vector<int> ids;
  ids.reserve(it->second.size());
  for (auto& sessionIt : it->second) ids.push_back(sessionIt.first);

  // [Branch] BOTH: taken (loop entered; both paths iterate m_sessions ids)
  for (auto& sessionId : ids) {
    it = m_sessions.find(contextGroupId);
    // [Branch] CANDIDATE
    if (it == m_sessions.end()) continue;
    auto sessionIt = it->second.find(sessionId);
    // [Branch] BOTH: taken
    if (sessionIt != it->second.end())
      // v8_inspector::V8InspectorSessionImpl::reset()+50
      callback(sessionIt->second);  // callback = [](session){ session->reset(); }
  }
}

// v8_inspector::V8InspectorSessionImpl::reset()+50
void V8InspectorSessionImpl::reset() {
  m_debuggerAgent->reset();
  // v8_inspector::V8RuntimeAgentImpl::reset()+197
  m_runtimeAgent->reset();
  discardInjectedScripts();
}

// v8_inspector::V8RuntimeAgentImpl::reset()+197
void V8RuntimeAgentImpl::reset() {
  v8::replayio::AutoMaybeDisallowEvents disallow(
      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::reset");

  m_compiledScripts.clear();
  // [Branch] RECORDED: taken (leads into forEachContext call below, on recorded stack)
  if (m_enabled) {
    int sessionId = m_session->sessionId();
    // v8_inspector::V8InspectorImpl::forEachContext(int,.std::Cr::function<...>.const&)+338
    m_inspector->forEachContext(m_session->contextGroupId(),
                                [&sessionId](InspectedContext* context) {
                                  context->setReported(sessionId, false);
                                });
    m_frontend.executionContextsCleared();
  }
}

// v8_inspector::V8InspectorImpl::forEachContext(int,.std::Cr::function<...>.const&)+338
void V8InspectorImpl::forEachContext(
    int contextGroupId,
    const std::function<void(InspectedContext*)>& callback) {
  using v8::recordreplay;
  auto it = m_contexts.find(contextGroupId);
  int hasGroup = it != m_contexts.end();
  size_t n = hasGroup ? it->second->size() : 0;
  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
      "V8InspectorImpl::forEachContext %d %zu", hasGroup, n);
  // <<< RECORDED LEAF  (hasGroup=0, n=0)
  if (it == m_contexts.end()) return;
  ...
}
```

### Replayed path: `resetContextGroup` → `m_consoleStorageMap.erase` → `~V8ConsoleMessageStorage` → `clear()` → `forEachSession` → `releaseObjectGroup` → `forEachContext` (leaf Assert)

```cpp
// unsigned long std::Cr::__hash_table<...>::__erase_unique<int>(int const&)+427
// (m_consoleStorageMap.erase(contextGroupId) from resetContextGroup, above)
// -> destroys the mapped std::unique_ptr<V8ConsoleMessageStorage>

// v8_inspector::V8ConsoleMessageStorage::~V8ConsoleMessageStorage()+87
V8ConsoleMessageStorage::~V8ConsoleMessageStorage() { clear(); }

// V8ConsoleMessageStorage::clear (lambda captured on stack as
// __call_impl<...::clear()::$_1...>+44)
void V8ConsoleMessageStorage::clear() {
  m_messages.clear();
  m_estimatedSize = 0;
  // v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<...>.const&)+1084
  m_inspector->forEachSession(m_contextGroupId,
                              [](V8InspectorSessionImpl* session) {
                                session->releaseObjectGroup("console");
                              });
  m_data.clear();
}

// v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<...>.const&)+1084
void V8InspectorImpl::forEachSession(
    int contextGroupId,
    const std::function<void(V8InspectorSessionImpl*)>& callback) {
  auto it = m_sessions.find(contextGroupId);
  if (it == m_sessions.end()) return;
  std::vector<int> ids;
  ids.reserve(it->second.size());
  for (auto& sessionIt : it->second) ids.push_back(sessionIt.first);

  // [Branch] BOTH: taken (loop entered)
  for (auto& sessionId : ids) {
    it = m_sessions.find(contextGroupId);
    // [Branch] CANDIDATE
    if (it == m_sessions.end()) continue;
    auto sessionIt = it->second.find(sessionId);
    // [Branch] BOTH: taken
    if (sessionIt != it->second.end())
      // v8_inspector::V8InspectorSessionImpl::releaseObjectGroup(v8_inspector::String16.const&)+82
      callback(sessionIt->second);  // callback = [](session){ session->releaseObjectGroup("console"); }
  }
}

// v8_inspector::V8InspectorSessionImpl::releaseObjectGroup(v8_inspector::String16.const&)+82
void V8InspectorSessionImpl::releaseObjectGroup(const String16& objectGroup) {
  int sessionId = m_sessionId;
  // v8_inspector::V8InspectorImpl::forEachContext(int,.std::Cr::function<...>.const&)+338
  m_inspector->forEachContext(
      m_contextGroupId, [&objectGroup, &sessionId](InspectedContext* context) {
        InjectedScript* injectedScript = context->getInjectedScript(sessionId);
        if (injectedScript) injectedScript->releaseObjectGroup(objectGroup);
      });
}

// v8_inspector::V8InspectorImpl::forEachContext(int,.std::Cr::function<...>.const&)+338
void V8InspectorImpl::forEachContext(
    int contextGroupId,
    const std::function<void(InspectedContext*)>& callback) {
  using v8::recordreplay;
  auto it = m_contexts.find(contextGroupId);
  int hasGroup = it != m_contexts.end();
  size_t n = hasGroup ? it->second->size() : 0;
  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
      "V8InspectorImpl::forEachContext %d %zu", hasGroup, n);
  // <<< REPLAYED LEAF  (hasGroup=1, n=4)
  if (it == m_contexts.end()) return;
  ...
}
```

## NewCandidates

* `MainThreadDebugger::DidClearContextsForFrame`
  * branches:
    * `third_party/blink/renderer/core/inspector/main_thread_debugger.cc` (approx., see `DidClearContextsForFrame`) — `if (frame->LocalFrameRoot() == frame)` — gates whether `resetContextGroup` runs at all; a divergent outcome here would explain the recorded/replayed `m_contexts`/session state difference seen at the leaf Asserts.
  * provenance: `DidClearContextsForFrame` is the entry point directly ahead of the shared `resetContextGroup` frame that both mismatched leaf Asserts (`forEachContext`) descend from.

* `V8InspectorImpl::resetContextGroup`
  * branches:
    * `v8/src/inspector/v8-inspector-impl.cc` (see `resetContextGroup`) — `if (contextsIt != m_contexts.end())` — gates whether `m_contexts`/`m_uniqueIdToContextId` entries for the group are erased before the `forEachSession`/`forEachContext` walk; a divergent outcome here directly affects the `hasGroup`/`n` values seen at the mismatched leaf Asserts.
  * provenance: `resetContextGroup` is the shared frame both mismatched stacks pass through; this branch executes immediately before the `forEachSession` call that both the recorded and replayed paths fork from.

* `V8InspectorImpl::forEachSession`
  * branches:
    * `v8/src/inspector/v8-inspector-impl.cc` (see `forEachSession`) — `if (it == m_sessions.end()) continue;` (re-lookup of `m_sessions.find(contextGroupId)` per loop iteration) — a divergent outcome (session-group entry vanishing/appearing between the id snapshot and the re-lookup) would change which sessions get their callback invoked, directly affecting downstream `forEachContext`/leaf Assert state.
  * provenance: `forEachSession` is called from both the recorded (`session->reset()`) and replayed (`session->releaseObjectGroup("console")`) paths immediately before their respective walks toward the mismatched `forEachContext` leaf Asserts.

## Suggested Cause of Action

* Add an Assert in `MainThreadDebugger::DidClearContextsForFrame` before `if (frame->LocalFrameRoot() == frame)`.
  * Assert value: `frame->LocalFrameRoot() == frame`.
* Add an Assert in `V8InspectorImpl::resetContextGroup` before `if (contextsIt != m_contexts.end())`.
  * Assert value: `contextsIt != m_contexts.end()`.
* Add an Assert in `V8InspectorImpl::forEachSession` before `if (it == m_sessions.end()) continue;` inside the loop.
  * Assert value: `sessionId` and `it == m_sessions.end()`.
* Wait for another crash with these Asserts in place.
* Use the new Assert data to determine which branch first diverges between recorded and replayed.
# Solution

* [Done] Add diagnostic Assert in `MainThreadDebugger::DidClearContextsForFrame` (blink) [U1].
  * Hints: place before `if (frame->LocalFrameRoot() == frame)` branch.
    * Steps:
    * In `MainThreadDebugger::DidClearContextsForFrame` (third_party/blink/renderer/core/inspector/main_thread_debugger.cc): insert Assert immediately before the `if (frame->LocalFrameRoot() == frame)` statement, asserting `frame->LocalFrameRoot() == frame`.
* [Done] Add diagnostic Assert in `V8InspectorImpl::resetContextGroup` (v8) [U1].
  * Hints: place before `if (contextsIt != m_contexts.end())` branch.
  * Steps:
    * In `V8InspectorImpl::resetContextGroup` (v8/src/inspector/v8-inspector-impl.cc): insert Assert immediately before the `if (contextsIt != m_contexts.end())` statement, asserting `contextsIt != m_contexts.end()`.
* [Done] Add diagnostic Assert in `V8InspectorImpl::forEachSession` (v8) inside loop before `if (it == m_sessions.end()) continue;` [U1].
  * Hints: place before the re-lookup check inside the `for (auto& sessionId : ids)` loop; log `sessionId` and whether the re-lookup found `contextGroupId` still present, to detect divergence in `m_sessions` membership between the id snapshot and re-lookup.
  * Steps:
    * In `V8InspectorImpl::forEachSession` (v8/src/inspector/v8-inspector-impl.cc): inside the loop, insert Assert immediately before the `if (it == m_sessions.end()) continue;` statement, asserting `!(it == m_sessions.end())` and logging `sessionId` as diagnostic context.

---

# G3: v8 `V8InspectorImpl::resetContextGroup` — crash-0037 (StackNoCommonFrame)

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackNoCommonFrame

# Basic Facts

## FrameCandidates

* `content::RenderFrameImpl::SwapOutAndDeleteThis(...)+290`
  * location: `content::RenderFrameImpl::SwapOutAndDeleteThis` at `content/renderer/render_frame_impl.cc:4066`
  * code: `bool success = frame_->Swap(remote_frame, std::move(remote_frame_interfaces->frame_host), std::move(remote_frame_interfaces->frame_receiver), std::move(replicated_frame_state));`
* `v8_inspector::V8InspectorImpl::resetContextGroup(int)+416`
  * location: `v8_inspector::V8InspectorImpl::resetContextGroup` at `v8/src/inspector/v8-inspector-impl.cc:275`
  * code: `m_consoleStorageMap.erase(contextGroupId);`

## NewCandidates

* `V8InspectorImpl::resetContextGroup`
  * branches:
    * `v8/src/inspector/v8-inspector-impl.cc` (`resetContextGroup`) — presence of `contextGroupId` in `m_consoleStorageMap` immediately before `m_consoleStorageMap.erase(contextGroupId)` — erase destroys `V8ConsoleMessageStorage` iff present; that destructor is the replayed path into `forEachContext`, and the existing `resetContextGroup` Assert runs only after erase.
  * provenance: replayed stack is `resetContextGroup` → `erase` → `~V8ConsoleMessageStorage` → `clear` → `forEachContext`; recorded leaf is `DetachImpl` → `Dispose` after `FrameDestroyed()` (which calls `resetContextGroup`) has returned.

## DivergentPathSegments

* Recorded root on stack: `RenderFrameImpl::SwapOutAndDeleteThis`.
* Replayed root on stack: `V8InspectorImpl::resetContextGroup`.
* In `LocalFrame::DetachImpl`, `DomWindow()->FrameDestroyed()` runs before `inspector_task_runner_->Dispose()` and calls `MainThreadDebugger::DidClearContextsForFrame` → `resetContextGroup`. Recorded leaf is after that call returns; replayed leaf is inside that call's `m_consoleStorageMap.erase`.

### Root: content::RenderFrameImpl::SwapOutAndDeleteThis (recorded side)

```cpp
// content::RenderFrameImpl::SwapOutAndDeleteThis(...)+290 (content/renderer/render_frame_impl.cc:4066)
bool success = frame_->Swap(remote_frame,
                            std::move(remote_frame_interfaces->frame_host),
                            std::move(remote_frame_interfaces->frame_receiver),
                            std::move(replicated_frame_state));

  // blink::WebFrame::Swap(WebRemoteFrame*, ...)+157
  bool res = ToCoreFrame(*this)->Swap(frame, std::move(remote_frame_host),
                                      std::move(remote_frame_receiver));

    // blink::Frame::Swap(WebRemoteFrame*, ...)+96
    return SwapImpl(new_web_frame, std::move(remote_frame_host),
                    std::move(remote_frame_receiver));

      // blink::Frame::SwapImpl(WebFrame*, ...)+234
      // [Branch] RECORDED: not-taken
      if (!Detach(FrameDetachType::kSwap)) {
        CHECK(IsDetached());
        return false;
      }

        // blink::Frame::Detach(FrameDetachType)+115
        // [Branch] RECORDED: not-taken
        if (!DetachImpl(type))
          return false;

          // blink::LocalFrame::DetachImpl(FrameDetachType)+936
          // [Branch] UNPROVEN
          if (IsProvisional()) { /* ... */ }

          // [Branch] RECORDED: not-taken
          if (!Client())
            return false;
          // [Branch] RECORDED: not-taken
          if (!DetachChildren())
            return false;

          loader_.Detach();
          // blink::LocalDOMWindow::FrameDestroyed
          DomWindow()->FrameDestroyed();
            // MainThreadDebugger::DidClearContextsForFrame
            // existing: REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
            //   "MainThreadDebugger::DidClearContextsForFrame %d", isRoot);
            // [Branch] UNPROVEN
            if (frame->LocalFrameRoot() == frame) {
              // v8_inspector::V8InspectorImpl::resetContextGroup (replayed root)
              GetV8Inspector()->resetContextGroup(ContextGroupId(frame));
            }

          // [Branch] RECORDED: not-taken
          if (!Client())
            return false;

          // [Branch] UNPROVEN
          if (IsLocalRoot()) { /* ... */ }

          inspector_task_runner_->Dispose();

            // blink::InspectorTaskRunner::Dispose()+36
            recordreplay::AutoLockMaybeEventsDisallowed locker(lock_);
            // recordreplay::AutoLockMaybeEventsDisallowed::AutoLockMaybeEventsDisallowed(base::Lock&)+59
            // RecordReplayValue "Value TryLock"
            disposed_ = true;  // <<< RECORDED LEAF
```

### Root: v8_inspector::V8InspectorImpl::resetContextGroup (replayed side)

```cpp
// v8_inspector::V8InspectorImpl::resetContextGroup(int)+416 (v8/src/inspector/v8-inspector-impl.cc:275)
void V8InspectorImpl::resetContextGroup(int contextGroupId) {
  auto contextsIt = m_contexts.find(contextGroupId);
  // [Branch] CANDIDATE
  // hasConsoleMessageStorage(contextGroupId) before erase
  m_consoleStorageMap.erase(contextGroupId);
  // erasing a present entry destroys V8ConsoleMessageStorage

    // v8_inspector::V8ConsoleMessageStorage::~V8ConsoleMessageStorage()+87
    // (v8/src/inspector/v8-console-message.cc)
    clear();

      // V8ConsoleMessageStorage::clear()
      m_inspector->forEachSession(
          m_contextGroupId,
          [](V8InspectorSessionImpl* session) {
            session->releaseObjectGroup("console");
          });

        // v8_inspector::V8InspectorImpl::forEachSession(int, ...)+1084
        auto it = m_sessions.find(contextGroupId);
        // [Branch] REPLAYED: not-taken
        if (it == m_sessions.end()) return;
        for (auto& sessionIt : it->second) ids.push_back(sessionIt.first);

        // [Branch] REPLAYED: taken
        for (auto& sessionId : ids) {
          it = m_sessions.find(contextGroupId);
          // existing: REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
          //   "V8InspectorImpl::forEachSession %d %d", sessionId, hasGroup);
          // [Branch] REPLAYED: not-taken
          if (it == m_sessions.end()) continue;
          auto sessionIt = it->second.find(sessionId);
          // [Branch] REPLAYED: taken
          if (sessionIt != it->second.end())
            // callback == clear()::$_1 lambda
            // void std::__function::__policy_invoker<...>::__call_impl<...>(...)+44
            callback(sessionIt->second);

              // clear()::$_1 lambda body
              // v8_inspector::V8InspectorSessionImpl::releaseObjectGroup(String16 const&)+82
              session->releaseObjectGroup("console");

                // V8InspectorSessionImpl::releaseObjectGroup(const String16&)
                m_inspector->forEachContext(
                    m_contextGroupId,
                    [&objectGroup, &sessionId](InspectedContext* context) {
                      InjectedScript* injectedScript =
                          context->getInjectedScript(sessionId);
                      if (injectedScript)
                        injectedScript->releaseObjectGroup(objectGroup);
                    });

                  // v8_inspector::V8InspectorImpl::forEachContext(int, ...)+338
                  auto it = m_contexts.find(contextGroupId);
                  int hasGroup = it != m_contexts.end();
                  size_t n = hasGroup ? it->second->size() : 0;
                  // v8::recordreplay::Assert(char const*, ...)+149
                  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
                      "V8InspectorImpl::forEachContext %d %zu", hasGroup, n);
                  // <<< REPLAYED LEAF
```

* After erase returns, `resetContextGroup` already has `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::resetContextGroup %d", hasContexts)` before `if (contextsIt != m_contexts.end())`. That Assert is not in front of this mismatch.

## Suggested Cause of Action

* In `V8InspectorImpl::resetContextGroup` (`v8/src/inspector/v8-inspector-impl.cc`):
  * Add `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` on `hasConsoleMessageStorage(contextGroupId)` immediately before `m_consoleStorageMap.erase(contextGroupId)`.
* Do not add Asserts on `LocalFrame::DetachImpl` `Client()` / `DetachChildren()` / `Frame::SwapImpl` `Detach()`: recorded arms are proven not-taken to reach `Dispose`, and they are not FirstDivergentBranch candidates for this leaf pair.
* Do not add any Assert in `MainThreadDebugger::DidClearContextsForFrame`: it already has `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("MainThreadDebugger::DidClearContextsForFrame %d", isRoot)`.

# Solution

* [Done] `V8InspectorImpl::resetContextGroup` (`v8/src/inspector/v8-inspector-impl.cc`): add Assert on console-storage presence before erase.
  * Hints:
    * Place immediately before `m_consoleStorageMap.erase(contextGroupId)`.
    * Assert `hasConsoleMessageStorage(contextGroupId)`.
    * Existing `resetContextGroup` Assert on `hasContexts` runs after erase and is not in front of this mismatch.
  * Steps:
    * In `V8InspectorImpl::resetContextGroup`, insert `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` immediately before `m_consoleStorageMap.erase(contextGroupId)`, asserting `hasConsoleMessageStorage(contextGroupId)`.

---

# Raw Data

* **crash-0035**
  * buildId: `linux-chromium-20260721-b8d9a62296f4-0814b5e98095`
  * linkerVersion: `linker-linux-16040-0814b5e98095`
  * recordingId: `8ef2857f-7663-4fe7-988f-eba2a68c7127`
* **crash-0036**
  * buildId: `linux-chromium-20260722-f2cb6518dc6b-0814b5e98095`
  * linkerVersion: `linker-linux-16040-0814b5e98095`
  * recordingId: `99d845f0-5a5e-472f-8e64-fc9886c6b154`
* **crash-0037**
  * buildId: `linux-chromium-20260722-f2cb6518dc6b-0814b5e98095`
  * linkerVersion: `linker-linux-16040-0814b5e98095`
  * recordingId: `088bc231-2d1d-40a9-b909-08114ceb4fcc`

