### PR TITLE
inspector: extend replay-owned guard to more inspector call sites

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '6ca754fa1bb9434950b7163a22140da6629f5ae6',
+  'v8_revision': '1165ee60342b15987b34574df32bcbda95c0065c',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '49b3133ceb6c98e0281f9eb6e6eed27ecdc381ac',
+  'v8_revision': '9ed4b4b1433fce9790640c354e05aa27edfe31fd',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9549fad2f645b2ff7a73ff6a89d76cc518d6f6ac',
+  'v8_revision': '49b3133ceb6c98e0281f9eb6e6eed27ecdc381ac',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1cd36a250c575185cda24a8e696c90f74124a163',
+  'v8_revision': '6ca754fa1bb9434950b7163a22140da6629f5ae6',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9ed4b4b1433fce9790640c354e05aa27edfe31fd',
+  'v8_revision': '1cd36a250c575185cda24a8e696c90f74124a163',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -757,6 +757,7 @@ static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& arg
 }
 
 static void SendMessageToFrontend(const v8_inspector::StringView& message) {
+  recordreplay::AutoMarkReplayCode mark;
   recordreplay::AutoDisallowEvents disallow("RecordReplay_SendMessageToFrontend");
   CHECK(v8::IsMainThread());
 
@@ -872,6 +873,7 @@ v8_inspector::V8InspectorSession* getInspectorSession(v8::Isolate* isolate, int 
   InspectorData* data = getInspectorFor(isolate, contextGroupId);
 
   if (!data->inspectorSession) {
+    recordreplay::AutoMarkReplayCode mark;
     recordreplay::AutoDisallowEvents disallow("RecordReplayRegisterV8Inspector");
     data->inspectorSession = inspector->connect(contextGroupId,
                                             new InspectorChannel(),
@@ -917,6 +919,7 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
 
+  recordreplay::AutoMarkReplayCode mark;
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/301
## Summary

* Prevents Replay's own replay-time inspector objects from interacting with the recording.
  * Root cause of `StackCommonFrame` mismatches crash-0036..0038.
* Detects replay-ownership via `IsInReplayCode()`.
  * chromium: marks the Replay-owned inspector entry points with `AutoMarkReplayCode`.
    * `SendMessageToFrontend`, `getInspectorSession` (`connect`), `SendCDPMessage`.
  * v8: `CheckReplayOwned()` = `IsInReplayCode()` replaces the prior feature-flag + `AreEventsDisallowed` heuristic.
* Applies the guard across the divergent inspector call sites.
  * `m_replay_owned` gates both `AutoMaybeMarkReplayCode` + `AutoMaybeDisallowEvents` (independent) on:
    * `V8InspectorImpl::resetContextGroup` / `contextCreated`
    * `V8InspectorSessionImpl::reset` / `releaseObjectGroup`
    * `V8ConsoleMessageStorage::clear`
    * `V8RuntimeAgentImpl` inherits ownership from its session.

---

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame

## Important Context

* buildId: linux-chromium-20260723-615b12e57340-0814b5e98095
* linkerVersion: linker-linux-16040-0814b5e98095
* recordingId: b9e49c0f-d3c0-42d6-87cb-8c9acc5814a7

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 217530,
      "checkpoint": 9
    }
  },
  "recorded": "Value RegisterPointer PageVisibilityObserver",
  "replayed": "V8InspectorImpl::forEachSession 2 1",
  "threadId": 1,
  "backtrace": {
    "progress": 20,
    "threadId": 1,
    "checkpoint": 1
  },
  "recordedStack": [
    "blink::PageVisibilityObserver::PageVisibilityObserver(blink::Page*)+45",
    "blink::PlatformEventController::PlatformEventController(blink::LocalDOMWindow&)+46",
    "blink::DeviceSingleWindowEventController::DeviceSingleWindowEventController(blink::LocalDOMWindow&)+18",
    "blink::DeviceMotionController*.blink::MakeGarbageCollected<blink::DeviceMotionController,.blink::LocalDOMWindow&>(blink::LocalDOMWindow&)+90",
    "blink::DeviceMotionController::From(blink::LocalDOMWindow&)+257",
    "blink::ModulesInitializer::OnClearWindowObjectInMainWorld(blink::Document&,.blink::Settings.const&).const+44",
    "blink::FrameLoader::DispatchDidClearWindowObjectInMainWorld()+127",
    "blink::LocalWindowProxy::Initialize()+2680"
  ],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+1095",
    "v8_inspector::V8InspectorImpl::contextCreated(v8_inspector::V8ContextInfo.const&)+935",
    "blink::MainThreadDebugger::ContextCreated(blink::ScriptState*,.blink::LocalFrame*,.blink::SecurityOrigin.const*)+1217",
    "blink::LocalWindowProxy::Initialize()+2517",
    "blink::LocalWindowProxyManager::UpdateDocument()+35",
    "blink::DocumentLoader::CreateParserPostCommit()+1068",
    "blink::DocumentLoader::StartLoadingResponse()+183"
  ]
}
```

## Root Cause

* This is in all likelihood an allowed divergence on Replay's own installed replay-time inspector object.

## DataCollection

* Pattern (existing): `m_replay_owned` + `v8::replayio::AutoMaybeDisallowEvents` (`v8/src/base/replayio.h`), on `V8RuntimeAgentImpl` only.
* Divergent inspector call trees to guard (crash-0036..0038):
  * `V8InspectorImpl::resetContextGroup` — shared root for crash-0036 + crash-0037 (covers recorded `forEachSession`→`session->reset` and replayed `m_consoleStorageMap.erase`→`~V8ConsoleMessageStorage`→`clear`).
  * `V8ConsoleMessageStorage::clear` — replayed fork under `resetContextGroup` (crash-0036/0037).
  * `V8InspectorSessionImpl::reset` — recorded fork under `resetContextGroup` (crash-0036).
  * `V8InspectorSessionImpl::releaseObjectGroup` — replayed fork from `V8ConsoleMessageStorage::clear` (crash-0036/0037).
  * `V8InspectorImpl::contextCreated` — replayed root for crash-0038 (`MainThreadDebugger::ContextCreated` → `forEachSession` assert).

## Solution

* Detect ownership by replay-code marking rather than the prior heuristic.
  * chromium (`record_replay_interface.cc`): wrap the Replay-owned inspector entry points with `recordreplay::AutoMarkReplayCode`.
    * `SendMessageToFrontend`, `getInspectorSession` (`inspector->connect`), `SendCDPMessage`.
  * v8:
    * `AutoMarkReplayCode` (`include/replayio.h`) wraps `EnterReplayCode`/`ExitReplayCode`, now exposed as `recordreplay::` C++ functions (`src/api/api.cc`, `include/v8.h`).
    * `CheckReplayOwned()` = `IsInReplayCode()` sets `m_replay_owned` at inspector ctors.
    * `AutoMaybeMarkReplayCode` and `AutoMaybeDisallowEvents` are independent RAII guards; divergent replay-owned paths apply both, each gated on `m_replay_owned`.
* Guard applied on:
  * `V8InspectorImpl::resetContextGroup` / `contextCreated` (via `contextGroupIsReplayOwned`).
  * `V8InspectorSessionImpl::reset` / `releaseObjectGroup`.
  * `V8ConsoleMessageStorage::clear`.
  * `V8RuntimeAgentImpl` inherits `m_replay_owned` from its session.