### PR TITLE
Revert recent Replay-only inspector path modifications

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1165ee60342b15987b34574df32bcbda95c0065c',
+  'v8_revision': '4158967a207c3733bd637f9e6e9986094421b541',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -757,7 +757,6 @@ static void SetCDPMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& arg
 }
 
 static void SendMessageToFrontend(const v8_inspector::StringView& message) {
-  recordreplay::AutoMarkReplayCode mark;
   recordreplay::AutoDisallowEvents disallow("RecordReplay_SendMessageToFrontend");
   CHECK(v8::IsMainThread());
 
@@ -873,7 +872,6 @@ v8_inspector::V8InspectorSession* getInspectorSession(v8::Isolate* isolate, int 
   InspectorData* data = getInspectorFor(isolate, contextGroupId);
 
   if (!data->inspectorSession) {
-    recordreplay::AutoMarkReplayCode mark;
     recordreplay::AutoDisallowEvents disallow("RecordReplayRegisterV8Inspector");
     data->inspectorSession = inspector->connect(contextGroupId,
                                             new InspectorChannel(),
@@ -919,7 +917,6 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
 
-  recordreplay::AutoMarkReplayCode mark;
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();

--- a/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
+++ b/third_party/blink/renderer/core/inspector/main_thread_debugger.cc
@@ -129,9 +129,6 @@ void MainThreadDebugger::SetClientMessageLoop(
 
 void MainThreadDebugger::DidClearContextsForFrame(LocalFrame* frame) {
   DCHECK(IsMainThread());
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-      "MainThreadDebugger::DidClearContextsForFrame %d",
-      frame->LocalFrameRoot() == frame);
   if (frame->LocalFrameRoot() == frame) {
     if (recordreplay::IsRecordingOrReplaying("DidClearContextsForFrame")) {
       RecordReplayClearContexts("MainThreadDebugger::DidClearContextsForFrame", frame);


### PR DESCRIPTION
Resets the tree to `426dbbb` by reverting the recent Replay-only inspector path modifications and associated diagnostics.

Undoes:
- #1401 (https://github.com/replayio/chromium/pull/1401)
- #1399 (https://github.com/replayio/chromium/pull/1399)
- #1396 (https://github.com/replayio/chromium/pull/1396)
