### PR TITLE
[crash-0035] Diagnostic: BytecodeGenerator OpcodeEmit assert

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1bd43e5791b77f30baa24ef87b366a19d9f27357',
+  'v8_revision': '4b46806952531bcfb173e78883a7d38087f807d1',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9767198bc6c8ec50e2f29d0319c1ca3fef692136',
+  'v8_revision': '1bd43e5791b77f30baa24ef87b366a19d9f27357',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e390528723a5886e51b9fa1c855a61b2b647cc39',
+  'v8_revision': '9767198bc6c8ec50e2f29d0319c1ca3fef692136',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/304
# Summary

* Adds one diagnostic `REPLAY_ASSERT` to the `BytecodeGenerator` ctor.
* Purpose: identify which compile first emits Progress opcodes for a given script on record.
* Targets an unresolved replay JS mismatch where a Playwright `UtilityScript` (`sourceId` 3) ran on replay without Progress instrumentation.
  * Record emitted Progress tokens `["3::1:1","3::2:8"]`; replay emitted `[]`.
* No behavior change: diagnostic-only.

# Problem

* Problem type: ReplayMismatch (Js).
* Symptom: progress counter mismatch at checkpoint (`got 43778077 expected 43778079`) rooted in a missing pair of Progress opcodes.
  * Warning `MicrotaskQueue::PerformCheckpoint 1` at progress `43620314`, checkpoint `562`.
    * `recorded: ["3::1:1","3::2:8"]`, `replayed: []`.
  * Stack: `MicrotasksScope::~MicrotasksScope` → `V8RuntimeAgentImpl::evaluate` → `Runtime::DomainDispatcherImpl::evaluate` → `dispatchProtocolMessage`.

## Divergent JS: Playwright UtilityScript

* `sourceId` 3 is the Playwright `UtilityScript` top-level IIFE, injected via CDP `Runtime.evaluate` → `DebugEvaluate::Global`.
* Verdict: UtilityScript **ran** on replay but was **not Progress-instrumented**.
  * Not "ran only on record".
  * Not a CommandCallback Progress scrub — scrub resets `*gProgressCounter` only, never clears `gProgressData`; a scrub would still leave `"3::…"` in `replayed`.

## Instrumentation gates

* Progress emit gate — `BytecodeArrayBuilder` ctor: `emit_record_replay_opcodes_` set only if `IsRecordingOrReplaying("emit-opcodes")` ∧ `RecordReplayHasDefaultContext()` ∧ `!record_replay_ignore`.
* `record_replay_ignore` setters:
  * `SetRecordReplayFlags` (`compiler.cc`, first compile): ignore unless `IsMainThread` ∧ `HasDefaultContext` ∧ `!AreEventsDisallowed("CompileFlags")` ∧ `!IsInReplayCode("CompileFlags")`.
  * `SetFlagsForFunctionFromScript` (`parse-info.cc`, lazy): ignore unless `RecordReplayHasRegisteredScript(script)`.
* Register gate — `RecordReplayRegisterScript` (`debug.cc`):
  * Always inserts `gRecordReplayScripts` (so `getSourceContents` works).
  * Early-returns before `gRegisteredScripts` / `RecordReplayOnNewSource` if `!HasDefaultContext` ∨ `AreEventsDisallowed` ∨ `url=="record-replay-internal"`.

## Anchors

* `NextScriptId 3` first allocated at assert order `31279` via `DebugEvaluate::Global`, **before** first `OnRootFrameInit` / `SetDefaultContext` (`~49450`).
* No `OnNewSource 3` on record or replay.
* Replay rr sample at id 3 first register: `HasDefaultContext == false` → early-return; explains replay's missing `OnNewSource 3`.

## Hypotheses

* **DivergentHasDefaultContext** — rejected. Record first compile is also pre-`SetDefaultContext` (order `31279` vs `~49450`); not record-after / replay-before.
* **DivergentEagerLazy** — rejected. Replay token SFIs were eager; lazy never instruments unregistered id 3; eager first compile hit the closed gate on both sides.
* **DivergentCompileEntry** — open. Record tokens require some compile with `HasDefaultContext`; the first `EarlyCDP` compile cannot supply it on either side.

# Solution: Diagnostics

Goal: prove or kill **DivergentCompileEntry** — which compile first emits Progress for id 3 on record.

* One `REPLAY_ASSERT` in the `BytecodeGenerator` ctor (`v8/src/interpreter/bytecode-generator.cc`), after `builder_` init:
  * `REPLAY_ASSERT("BytecodeGenerator::OpcodeEmit %d %d %d %d", script_->id(), info_->literal()->start_position(), RecordReplayHasDefaultContext(), info_->flags().record_replay_ignore());`
  * Captures the instrumentation decision: script id + SFI start position (tokens `"3::1:1"` / `"3::2:8"`) + `HasDefaultContext` + `record_replay_ignore`.
  * No new args, no other call sites.

# Raw Data

* buildId: `linux-chromium-20260721-b8d9a62296f4-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* recordingId: `8ef2857f-7663-4fe7-988f-eba2a68c7127`