### PR TITLE
crash-0035-b + crash-0041: Deterministic Instrumentation on Divergent Compiles & SVGImageChromeClient null-guard

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '4b46806952531bcfb173e78883a7d38087f807d1',
+  'v8_revision': '1375e0da50f65cdd79540e8281a2933480d2a8b7',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '003a35d20b2ed488aa13270a76a9828ca0347358',
+  'v8_revision': '3f49dc12a2ec09d0ba471c9076b7769661d09ebd',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1375e0da50f65cdd79540e8281a2933480d2a8b7',
+  'v8_revision': '003a35d20b2ed488aa13270a76a9828ca0347358',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.cc
@@ -67,6 +67,8 @@ void SVGImageChromeClient::InvalidateContainer() {
 }
 
 void SVGImageChromeClient::SuspendAnimation() {
+  if (!image_)
+    return;
   if (image_->MaybeAnimated()) {
     timeline_state_ = kSuspendedWithAnimationPending;
   } else {
@@ -89,7 +91,7 @@ void SVGImageChromeClient::ResumeAnimation() {
 
 void SVGImageChromeClient::RestoreAnimationIfNeeded() {
   // If the timeline is not suspended we needn't attempt to restore.
-  if (!IsSuspended())
+  if (!image_ || !IsSuspended())
     return;
   image_->RestoreAnimation();
 }
@@ -102,6 +104,8 @@ void SVGImageChromeClient::ScheduleAnimation(const LocalFrameView*,
   // run this fake animation timer to trigger layout in SVGImages. The name,
   // "animationTimer", is to match the new requestAnimationFrame-based layout
   // approach.
+  if (!image_)
+    return;
   if (animation_timer_->Value().IsActive())
     return;
   // Schedule the 'animation' ASAP if the image does not contain any

--- a/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image_chrome_client.cc
@@ -67,6 +67,7 @@ void SVGImageChromeClient::InvalidateContainer() {
 }
 
 void SVGImageChromeClient::SuspendAnimation() {
+  // [Replay:LeakMemory]
   if (!image_)
     return;
   if (image_->MaybeAnimated()) {
@@ -90,8 +91,11 @@ void SVGImageChromeClient::ResumeAnimation() {
 }
 
 void SVGImageChromeClient::RestoreAnimationIfNeeded() {
+  // [Replay:LeakMemory]
+  if (!image_)
+    return;
   // If the timeline is not suspended we needn't attempt to restore.
-  if (!image_ || !IsSuspended())
+  if (!IsSuspended())
     return;
   image_->RestoreAnimation();
 }
@@ -104,6 +108,7 @@ void SVGImageChromeClient::ScheduleAnimation(const LocalFrameView*,
   // run this fake animation timer to trigger layout in SVGImages. The name,
   // "animationTimer", is to match the new requestAnimationFrame-based layout
   // approach.
+  // [Replay:LeakMemory]
   if (!image_)
     return;
   if (animation_timer_->Value().IsActive())


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/305

# Summary

* Two independent fixes
  * **G1 (v8):** **StickyEmit** — freeze Progress-opcode emit per script id after first dark compile
  * **G2 (blink):** null-guard `SVGImageChromeClient` consumers after `ChromeDestroyed()` on the `#1368` leaked-Page path

---

# G1: v8 — Deterministic Instrumentation on Divergent Compiles

## Problem

* Criterion: `MicrotaskQueue::PerformCheckpoint` application-data mismatch
  * `recorded: ["3::1:1", "3::2:8"]`
  * `replayed: []`
* Script id `3` is Playwright UtilityScript
  * Tokens: `"3::1:1"` = ToplevelScriptSFI, `"3::2:8"` = IifeArrowSFI
* First compile is pre-`HasDefaultContext` on both sides
  * Progress opcodes correctly omitted
* Later evaluate of the same script id can recompile divergently
  * GC bytecode flush, compilation-cache ageing, and related non-determinism
  * Record: baseline emit checks may now pass → instrumented bytecode → Progress tokens
  * Replay: may keep or rebuild dark bytecode → no Progress tokens
* Compile-path asserts on divergent recompile shape are not the Progress mismatch root

## Solution

* Solution Recipe: allow divergent compiles; freeze emit once a script has been dark
* Implementation
  * `RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)` owns `base_emit_opcodes` + sticky state
  * Emit only when `base_emit_opcodes` and first compile for that id or last emit was instrumented
  * `BytecodeArrayBuilder` only passes script id and ignore flag
  * Remove `BytecodeGenerator::OpcodeEmit` diagnostic `REPLAY_ASSERT`
* Why this works
  * First dark compile stores dark for that script id
  * Later recompile with `base_emit_opcodes` true stays dark on both sides
  * Progress tokens for id `3` match

## Raw Data

* recordingId: `8ef2857f-7663-4fe7-988f-eba2a68c7127`
* buildId: `linux-chromium-20260721-b8d9a62296f4-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* operatorId: `09031f1f-86d6-4a29-9278-b553da746818`
* Warning progress: `43620314`
* EarliestDivergedProgress: `43620315`
* checkpoint: `562`
* sourceId: `3`
* tokens: `"3::1:1"`, `"3::2:8"`

---

# G2: blink/SVGImageChromeClient — null-guard after ChromeDestroyed

## Problem

* RecorderCrash: SIGSEGV, `faultAddress 0x48`, IP `SVGImage::MaybeAnimated+7`
  * Renderer headless shell
  * All-chromium backtrace
* `#1368` leak path (`~SVGImage` under `AreEventsDisallowed("~SVGImage")`)
  * Keeps `Page` in `AllPages()` via `leaked_pages`
  * Calls `ChromeDestroyed()` → `SVGImageChromeClient::image_ = nullptr`
* Later `Page::PlatformColorsChanged` still walks that leaked Page
  * `ScheduleAnimation` → `image_->MaybeAnimated()` with `image_ == nullptr`
  * `MaybeAnimated+7` loads `page_` at `this+0x48` → fault
* Fault is null-`this`, not dangling UAF
* `AnimationTimerFired` / `InvalidateContainer` already null-guard
  * `ScheduleAnimation` did not

## Solution

* Null-guard every `SVGImageChromeClient` consumer still reachable after `ChromeDestroyed()` on a leaked Page
  * `ScheduleAnimation`
  * `SuspendAnimation`
  * `RestoreAnimationIfNeeded`
* Do not drop `ChromeDestroyed()`
  * Reopens crash-0007 UAF
* Do not call `WillBeDestroyed()` on the leak path
  * Reopens `#1368` `AllPages()` divergence

## Raw Data

* recordingId: `a7751658-0e05-4044-a3c2-43e37f87e82d`
* sibling recordingId: `4d4210d1-7889-411e-a12c-3eb294b0fdbd`
* buildId: `linux-chromium-20260722-426dbbb26258-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* crash report id: `f166dc42-8081-4a35-b0f1-b7e7af75855f`
* sibling crash id: `f0aa7f25-85a5-4d2d-92a2-d2357a75b295`
* projectId: `proj-landing-split-proxy-administrator-d6e-workers-dev-ms359ocv`
* task: `run-ms382iyj-sroq`
