### PR TITLE
[crash-0035] Sticky Progress opcode emit per script id

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '4b46806952531bcfb173e78883a7d38087f807d1',
+  'v8_revision': 'b7836869b3cda5863cab2c24461194497db998e2',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/306
# Summary

* **StickyEmit**: per script id, freeze Progress-opcode emit after first dark compile
* Blocks dark → lit on later recompiles when compile timing diverges
* Removes `BytecodeGenerator::OpcodeEmit` diagnostic assert

# Problem

* Criterion: `MicrotaskQueue::PerformCheckpoint` application-data mismatch
  * `recorded: ["3::1:1", "3::2:8"]`
  * `replayed: []`
* Script id `3` is Playwright UtilityScript
* First compile is pre-`HasDefaultContext` on both sides
  * Progress opcodes correctly omitted
* Later evaluate of the same script id can recompile divergently
  * GC bytecode flush, compilation-cache ageing, and related non-determinism
  * Record: checks may now pass → instrumented bytecode → Progress tokens
  * Replay: may keep or rebuild dark bytecode → no Progress tokens

# Solution

* Solution Recipe: allow divergent compiles; freeze emit decision once a script has been dark
* Implementation
  * `RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)` owns baseline emit checks + sticky state
  * `BytecodeArrayBuilder` only passes script id and ignore flag
  * Remove `BytecodeGenerator::OpcodeEmit` `REPLAY_ASSERT`
* Why this works
  * First dark compile stores dark for that script id
  * Later recompile with baseline checks passing stays dark on both sides
  * Progress tokens for id `3` match

# Raw Data

* recordingId: `8ef2857f-7663-4fe7-988f-eba2a68c7127`
* buildId: `linux-chromium-20260721-b8d9a62296f4-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* Warning progress: `43620314`
* checkpoint: `562`
* sourceId: `3`
* tokens: `"3::1:1"` (ToplevelScriptSFI), `"3::2:8"` (IifeArrowSFI)