### PR TITLE
crash-0035-c: freeze opcode emit decision lit and dark

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd052f25983e18d98e2c7ddc407eb59ffb45e9af4',
+  'v8_revision': '57a91bfe06140e27f72af3f870d0bb39a69047ad',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '3f49dc12a2ec09d0ba471c9076b7769661d09ebd',
+  'v8_revision': 'd052f25983e18d98e2c7ddc407eb59ffb45e9af4',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/307

# Summary

* #305 still left `NewProgressCheckpoint` mismatches.
* `RecordReplayShouldEmitOpcodes` froze disabled, but not enabled → disabled on one side.
* Fix: freeze the first decision per `script_id`.

# Problem

* ReplayMismatch after v8 #305: recorded `NewProgressCheckpoint`, replayed `CSSNumericLiteralValue::CustomCSSText`.
* DominantWarning earlier: Assert at `GetSharedFunctionInfoForScriptImpl` for `record-replay-react-devtools`.
  * 28/46: record has Progress at `1:1`/`3:2`. Replay has none.
  * 9/46: record has none. Replay has Progress at `50:6`.
* That script compiles under `OnRootFrameInitAfterCheckpoint` → `RunScript` with emit allowed on both sides.
  * Default context set. No `AutoMarkReplayCode`. No `AutoDisallowEvents`.
* Progress tokens come from runtime `RecordReplayAssertExecutionProgress`, not from compile.
* #305 computed `emit = base && (unseen || previous)` keyed by `script_id`.
  * Stored `false` stayed `false`.
  * Stored `true` could still become `false` when a later compile had `base == false`.
  * One side alone can disable opcodes on recompile. The other keeps the earlier enabled bytecode.
  * Explains Progress missing in both directions.

# Solution

* `RecordReplayShouldEmitOpcodes` (`v8/src/debug/debug.cc`):
  * First call: store and return `base_emit_opcodes`.
  * Later calls: return the stored value.
* Record/replay can no longer diverge by disabling emit on only one side after first compile.

# Raw Data

* buildId: `linux-chromium-20260728-8416f525d9b8-d5125731e055`
* linkerVersion: `linker-linux-16050-d5125731e055`
* recordingId: [`cc66c64a-622f-497f-99b4-f4289d385b68`](https://app.replay.io/recording/cc66c64a-622f-497f-99b4-f4289d385b68)
* sessionId: `ce4ea798-c0d2-400d-87a7-8d6680ab43b3`
* Prior: chromium #1408 / v8 #305
