### PR TITLE
[crash-0042] Disable replay-owned console preview; rewind divergent Progress

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e8036cb6e7f5b50a89cf4ced0eb38dfba575d84e',
+  'v8_revision': 'b871c2706bf027ce9b153ddec10c682ff6ac3c46',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'b871c2706bf027ce9b153ddec10c682ff6ac3c46',
+  'v8_revision': '565776a1cde90c61f3d3ed4e2e24dce330b9cbd7',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9bc9ef776ce47a235cab77bc440421952ada3da8',
+  'v8_revision': '7bfe6b2464fe98ec26dd2dd71dab4dc49550aca5',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '57a91bfe06140e27f72af3f870d0bb39a69047ad',
+  'v8_revision': 'e8036cb6e7f5b50a89cf4ced0eb38dfba575d84e',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '565776a1cde90c61f3d3ed4e2e24dce330b9cbd7',
+  'v8_revision': '7ca6a591f41a2522406c3e5ba4cb26863892e750',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '7ca6a591f41a2522406c3e5ba4cb26863892e750',
+  'v8_revision': '9bc9ef776ce47a235cab77bc440421952ada3da8',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/308

# Summary

* Lead: `Window.crypto` **ApiGetterStub** under `EventsDisallowed` ran monkey-patched Turnstile user JS → `[RUN-1919]` / Progress mismatch / SaplingPaints **ReplayMismatch**.
* Path: replay-owned `console.debug` `generatePreview=true` → ValueMirror auto-`Get` of `kNoScriptId` → `InvokeApiFunction` → **ApiGetterStub** (**GateSkip** vs `Execution::Invoke` user-JS gate).
* Fixes:
  * G1: `generatePreview=false` when `m_replay_owned` in `V8RuntimeAgentImpl::messageAdded`.
  * G2: **ProgressRewind** (`[RUN-1988]`) — after divergent `Invoke` / API entry under `EventsDisallowed`, restore Progress counter + `gProgressData` if instrumented user JS advanced them.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Js

## Important Context

* buildId: linux-chromium-20260728-8416f525d9b8-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: 5b1326b7-5360-4ee3-9903-0be6bdf927bd

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "SaplingPaints",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 20396887,
      "checkpoint": 15
    },
    "getResumeData": [
      "paints"
    ]
  },
  "recorded": "NewProgressCheckpoint 20000000",
  "replayed": "[RUN-1675-1826] JSDate::CurrentTimeValue",
  "threadId": 1,
  "backtrace": {
    "progress": 20279716,
    "threadId": 1,
    "checkpoint": 14
  },
  "recordedStack": [],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::JSDate::CurrentTimeValue(v8::internal::Isolate*)+81",
    "v8::internal::Builtin_Impl_DateNow(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+43"
  ],
  "applicationDataMismatch": "{ \"lastDeterministicProgress\": 19999999, \"recorded\": [], \"replayed\": [\"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:163817\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:163893\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:163252\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:164043\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"...truncated 279707 more\"] }"
}
```

#### Warnings
```json
[
  {
    "text": "[RUN-1919] JS ExecutionProgress in non-deterministic user JS PC=19719136 scriptId=11 @11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:227533 stack=DR (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:227533)console.debug (<anonymous>)DV.DL (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:179921)DV.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:64450)DR (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:228521)Object.lwFCV (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:170501)DV.DK (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:171295)DV.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:64311)DR (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:228521)Object.lwFCV (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:170501)DV.DK (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:171295)DV.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-pla [EventsDisallowed:V8InspectorImpl::forEachSession]",
    "count": 1,
    "stack": [
      "v8::recordreplay::Warning(char.const*,....)+140",
      "v8::internal::Runtime_RecordReplayAssertExecutionProgress(int,.unsigned.long*,.v8::internal::Isolate*)+1055"
    ],
    "progress": 19719136,
    "threadId": 1,
    "processId": 5,
    "checkpoint": 13,
    "absoluteTime": 1785274335924.5706,
    "wasRecording": false
  },
  {
    "text": "Assertion application data mismatch: [RUN-1596] V8ConsoleMessageStorage::addMessage #2 { \"lastDeterministicProgress\": 19719135, \"recorded\": [], \"replayed\": [\"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:227533\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:213784\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/lqpe7/0x4AAAAAACVBlf5qH-41ZUTk/dark/fbE/new/normal?lang=auto:1:168711\", \"...truncated 343 more\"] }",
    "count": 7,
    "stack": [
      "v8::recordreplay::Assert(char.const*,....)+149",
      "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+735",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185",
      "v8_inspector::V8Console::Debug(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+355",
      "v8::internal::(anonymous.namespace)::ConsoleCall(v8::internal::Isolate*,.v8::internal::BuiltinArguments.const&,.void.(v8::debug::ConsoleDelegate::*)(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&))+800",
      "v8::internal::Builtin_ConsoleDebug(int,.unsigned.long*,.v8::internal::Isolate*)+74"
    ],
    "progress": 19719488,
    "threadId": 1,
    "processId": 5,
    "checkpoint": 13,
    "absoluteTime": 1785274335927.8022,
    "wasRecording": false
  },
  {
    "text": "Progress counter mismatch at checkpoint: got 19837866 expected 19834951 (lastCheckPoint 13)",
    "count": 1,
    "stack": [
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+848",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 19837866,
    "threadId": 1,
    "processId": 5,
    "checkpoint": 13,
    "absoluteTime": 1785274336391.7668,
    "wasRecording": false
  },
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 30,
    "stack": [
      "WTF::RecursiveMutex::unlock()+135",
      "blink::AudioNode::Dispose()+228",
      "blink::AudioNode::InvokePreFinalizer(cppgc::LivenessBroker.const&,.void*)+44",
      "cppgc::internal::PreFinalizerHandler::InvokePreFinalizers()+214",
      "cppgc::internal::HeapBase::ExecutePreFinalizers()+39",
      "v8::internal::CppHeap::TraceEpilogue()+210",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+3404",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::Heap::HandleGCRequest()+223",
      "v8::internal::StackGuard::HandleInterrupts()+626",
      "v8::internal::Runtime_StackGuard(int,.unsigned.long*,.v8::internal::Isolate*)+314"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1785274330956.1895,
    "wasRecording": true
  }
]
```

# Basic Facts

* `EarliestDivergedProgress`: 19719136, checkpoint 13.
  * Derived from smallest `lastDeterministicProgress` (19719135) among all `applicationDataMismatch` signals (Assert: 19999999; Warning: 19719135).
* `sourceId` at `EarliestDivergedProgress`: 11 (recorded: none/`[]`; replayed: scriptId 11, Cloudflare Turnstile script).
* Source: Warning `[RUN-1596] V8ConsoleMessageStorage::addMessage #2` (`applicationDataMismatch` embedded in warning text), stack rooted at `v8_inspector::V8ConsoleMessageStorage::addMessage`.
* Sources file (raw dump, `DETACHED_DUMP_SOURCES=1` via `runToPoint` at checkpoint 13, progress 19719136): ``.
* Extracted source: `` (scriptId 11, Cloudflare Turnstile script).
* `ReplayOnlyUserJsCall`: yes.
  * `[RUN-1919]` Warning at progress 19719136, checkpoint 13: `JS ExecutionProgress in non-deterministic user JS ... scriptId=11 ... console.debug (<anonymous>) ... [EventsDisallowed:V8InspectorImpl::forEachSession]`.
  * Earliest `applicationDataMismatch` (Warning `[RUN-1596]`) has `recorded: []` and `replayed` entries all pointing to scriptId 11 (Turnstile) user-script locations.
  * Both signals sit on a replay-only, `EventsDisallowed` C++ path (`V8InspectorImpl::forEachSession` → `V8ConsoleMessageStorage::addMessage`/`console.debug`), indicating replay-only code called into instrumented user JS.
* JS path evidence: crash-report only (per `ReplayOnlyUserJsCall: yes`, neighborhood evaluate skipped); see `[RUN-1919]` Warning and `[RUN-1596]` `applicationDataMismatch` in `### Crash Report Core` / `#### Warnings` above.
* `EarliestDivergedProgress` recomputed per `crash-divergence-js.md`: `jsMismatchProgress` (smallest `lastDeterministicProgress` = 19719135, from Warning `[RUN-1596]`) `+ 1` = 19719136, checkpoint 13 (from that same Warning).
  * Primary target signal = Warning `[RUN-1596] V8ConsoleMessageStorage::addMessage #2`; its C++ stack is rendered below (not the later `[RUN-1919]` reporting-site stack).
* CANDIDATE marks on `## DivergentPathSegments`: `V8InspectorImpl::forEachSession` call (`[Branch] CANDIDATE`) and its `session->runtimeAgent()->messageAdded(...)` callback (`[Write] CANDIDATE`) in `V8ConsoleMessageStorage::addMessage`, matching `ReplayOnlyUserJsCall` evidence (`[RUN-1919]` `EventsDisallowed:V8InspectorImpl::forEachSession`).

## DivergentPathSegments

### Root: `V8ConsoleMessageStorage::addMessage`

```cpp
// v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+735
void V8ConsoleMessageStorage::addMessage(
    std::unique_ptr<V8ConsoleMessage> message) {
  int contextGroupId = m_contextGroupId;
  V8InspectorImpl* inspector = m_inspector;
  if (message->type() == ConsoleAPIType::kClear) clear();
  // [Branch] UNPROVEN

  TraceV8ConsoleMessageEvent(message->origin(), message->type());

  v8::recordreplay::Assert("[RUN-1596] V8ConsoleMessageStorage::addMessage #1");

  // v8_inspector::V8InspectorImpl::forEachSession(...)
  // [Branch] CANDIDATE -- EventsDisallowed replay-only path re-enters instrumented user JS (see [RUN-1919])
  inspector->forEachSession(
      contextGroupId, [&message](V8InspectorSessionImpl* session) {
        if (message->origin() == V8MessageOrigin::kConsole)
          session->consoleAgent()->messageAdded(message.get());
        // [Write] CANDIDATE -- notifies session/front-end synchronously, only source of divergent replayed-side JS re-entry
        session->runtimeAgent()->messageAdded(message.get());
      });

  // v8::recordreplay::Assert(char.const*,....)+149
  v8::recordreplay::Assert("[RUN-1596] V8ConsoleMessageStorage::addMessage #2");  // <<< REPLAYED LEAF

  // ... (rest omitted: not on path to hit Assert)
}
```

### Root: `V8Console::Debug`

```cpp
// v8::internal::Builtin_ConsoleDebug(int,.unsigned.long*,.v8::internal::Isolate*)+74
BUILTIN(ConsoleDebug) {
  // v8::internal::(anonymous.namespace)::ConsoleCall(...)+800
  ConsoleCall(isolate, args, &debug::ConsoleDelegate::Debug);
  RETURN_FAILURE_IF_SCHEDULED_EXCEPTION(isolate);
  return ReadOnlyRoots(isolate).undefined_value();
}

void ConsoleCall(
    Isolate* isolate, const internal::BuiltinArguments& args,
    void (debug::ConsoleDelegate::*func)(const v8::debug::ConsoleCallArguments&,
                                         const v8::debug::ConsoleContext&)) {
  CHECK(!isolate->has_pending_exception());
  CHECK(!isolate->has_scheduled_exception());
  if (!isolate->console_delegate()) return;
  // [Branch] UNPROVEN
  HandleScope scope(isolate);
  debug::ConsoleCallArguments wrapper(args);
  // v8::debug::ConsoleDelegate::Debug -> v8_inspector::V8Console::Debug(...)+355
  (isolate->console_delegate()->*func)(
      wrapper,
      v8::debug::ConsoleContext(context_id, Utils::ToLocal(context_name)));
}

// v8_inspector::V8Console::Debug(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+355
void V8Console::Debug(const v8::debug::ConsoleCallArguments& info,
                      const v8::debug::ConsoleContext& consoleContext) {
  // v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185
  ConsoleHelper(info, consoleContext, m_inspector)
      .reportCall(ConsoleAPIType::kDebug);
}

// v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187
void reportCall(ConsoleAPIType type,
                const std::vector<v8::Local<v8::Value>>& arguments) {
  if (!m_groupId) return;
  // [Branch] UNPROVEN
  std::unique_ptr<V8ConsoleMessage> message =
      V8ConsoleMessage::createForConsoleAPI(
          m_context, m_contextId, m_groupId, m_inspector,
          m_inspector->client()->currentTimeMS(), type, arguments,
          consoleContextToString(m_isolate, m_consoleContext),
          m_inspector->debugger()->captureStackTrace(false));
  // v8_inspector::V8ConsoleMessageStorage::addMessage(...)+735
  consoleMessageStorage()->addMessage(std::move(message));  // <<< REPLAYED LEAF (continues in Root: `V8ConsoleMessageStorage::addMessage` above)
}
```

## Possible CPP Candidates

* `V8InspectorSessionImpl::wrapObject(..., WrapMode::kWithPreview)` (`v8/src/inspector/injected-script.cc` / `v8-inspector-session-impl.cc`).
  * Thin slice: `V8ConsoleMessageStorage::addMessage` → `forEachSession` (replay-owned session, `EventsDisallowed`) → `session->runtimeAgent()->messageAdded(message)` → `V8RuntimeAgentImpl::reportMessage(message, /*generatePreview=*/true)` → `message->reportToFrontend(&m_frontend, m_session, true)` → `V8ConsoleMessage::wrapArguments` → `session->wrapObject(context, arg, "console", /*generatePreview=*/true)` → `InjectedScript::wrapObject(..., WrapMode::kWithPreview)`.
  * Causal chain: `console.debug` arguments are object values; generating an RDP preview walks their properties/iterators, which can invoke user-defined getters, `Symbol.iterator`, or `toString`/`Symbol.toPrimitive`. This runs live, further, script-visible JS as a *side effect of replay-only inspector bookkeeping* (the replay-owned session's message reporting), not as part of the page's own recorded control flow.
  * Why it matches the evidence: `[RUN-1919]` fires with stack `... console.debug (<anonymous>) ...` tagged `[EventsDisallowed:V8InspectorImpl::forEachSession]`, i.e. exactly the `forEachSession` call above, for the replay-owned session (`m_replay_owned` seeded at connect from `AreEventsDisallowed()`, see `v8-inspector-session-impl.cc`). The `applicationDataMismatch` shows `recorded: []` / `replayed:` scriptId 11 (Turnstile) locations — the recording never re-entered this script here, but replay does, consistent with a replay-only preview-generation call reaching into instrumented user code.

* `V8InspectorImpl::forEachSession` iteration itself (`v8/src/inspector/v8-inspector-impl.cc`) as the branch that enables the above.
  * Thin slice: `addMessage` calls `inspector->forEachSession(contextGroupId, callback)`; for each session, `AutoMaybeDisallowEvents disallow(replay_owned, isolate, "V8InspectorImpl::forEachSession")` is entered only when `session->replayOwned()`, then `callback(session)` runs (which drives `consoleAgent()/runtimeAgent()->messageAdded`).
  * Causal chain: whether a given `console.debug` call re-enters user JS during replay depends on which sessions are currently registered on the inspector (replay's own session vs. real DevTools session) at the moment `addMessage` runs — a replay/record asymmetry in *session population*, not in the page script itself, is a plausible root divergence trigger for whether the preview-generation call (above) happens at all.
  * Why it matches the evidence: the exact `[EventsDisallowed:V8InspectorImpl::forEachSession]` tag in `[RUN-1919]` names this call frame directly as the site where non-deterministic user JS execution was flagged.

## Hypothesis A: User JS was called from Replay-side JS (e.g. replay_command_handlers.js)

* Unlikely.
* It looks like the User JS code is directly called from the ValueMirror code.

## Hypothesis B: User JS was called from CPP

* We have a gate on direct C++→user JS in `Execution::Invoke` (`RecordReplayIsDivergentUserJSWithoutPause`); it would warn `JS Invoke: Non-deterministic user JS` and return `undefined` without running the user function.
* BUT that gate is not sufficient here: native/API getters take the early `InvokeApiFunction` path and skip the check; ValueMirror only auto-`Get`s getters with `ScriptId == kNoScriptId`; such a native getter stub can then call into monkey-patched user JS. Evidence: `[RUN-1919]` (user JS bytecode actually ran under `EventsDisallowed`) with no `JS Invoke` warning — so the Invoke target was not registered user JS.

### Verified: Window `crypto` API getter is the stub on the path to `[RUN-1919]`

* **ApiGetterStub**: `blink::(anonymous namespace)::v8_window::CryptoAttributeGetCallback`
  * Mangling: `_ZN5blink12_GLOBAL__N_19v8_window26CryptoAttributeGetCallbackERKN2v820FunctionCallbackInfoINS2_5ValueEEE`
* **ObservedCallChain** (rr reverse from `[RUN-1919]` site, then step into callback):
  * `Object::GetPropertyWithAccessor+727`
  * → `Builtins::InvokeApiFunction`
  * → `FunctionCallbackArguments::Call+342` (`call *%r15`)
  * → **ApiGetterStub** (`CryptoAttributeGetCallback`)
* **CausalForwardCheck**: from inside **ApiGetterStub**, `cont` hit `[RUN-1919]` Warning at progress `19719136` (`EventsDisallowed:V8InspectorImpl::forEachSession`, scriptId 11).
* **GateSkip**: this path never enters `Execution::Invoke`’s divergent-user-JS Warning at `Invoke+818` (`JS Invoke: Non-deterministic user JS`). `GetPropertyWithAccessor` calls `InvokeApiFunction` directly for `FunctionTemplateInfo` getters (`objects.cc`).
* Not the inspector helper `nativeGetterCallback` (`value-mirror.cc`); that BP was not on the reverse path from `[RUN-1919]` before **ApiGetterStub**.

#### Rediscover + double-verify (linkerdebug / rr)

Recording: `5b1326b7-5360-4ee3-9903-0be6bdf927bd`. Session tool: `` = ``.

1. `session start <recordingId>` → `send rrnew` → wait for `(rr)` / `>`.
2. End stop (keep inferior alive):
   * `rr handle SIGINT stop print pass` then `cont`.
   * Expect stop at recorded `SIGINT` (`0x70000005`), not `exited normally`.
   * If you previously set `SIGINT nostop`, reverse hits that SIGINT forever until nostop again for `rcont`.
   * If inferior fully exits (`No registers` / `The program is not being run`): `rr run`, then repeat step 2. Session is still alive.
3. Land on `[RUN-1919]` (cold site, no conditionals):
   * `break _ZN2v88internal43Runtime_RecordReplayAssertExecutionProgressEiPmPNS0_7IsolateE+1055`
   * `rr handle SIGINT nostop noprint pass` then `rcont`.
   * Hit = EventsDisallowed ExecutionProgress path (`cmpb` / `gHasPrintedStack` neighborhood). Crash-report PC for the Warning is this `+1055` frame.
4. Reverse to API entry:
   * `delete` the `+1055` BP.
   * `break _ZN2v88internal8Builtins17InvokeApiFunctionEPNS0_7IsolateEbNS0_6HandleINS0_20FunctionTemplateInfoEEENS4_INS0_6ObjectEEEiPS8_NS4_INS0_10HeapObjectEEE`
   * `rcont` → expect `GetPropertyWithAccessor+727` as caller (`backtrace`).
5. Identify stub (double-check #1 — symbol at call target):
   * `break _ZN2v88internal25FunctionCallbackArguments4CallENS0_15CallHandlerInfoE+342` (`call *%r15`).
   * `cont` from `InvokeApiFunction` entry (or from that Call).
   * `registers` → `$r15`; `stepi` into target.
   * Expect: `...v8_window26CryptoAttributeGetCallback...+0`.
6. Prove it feeds `[RUN-1919]` (double-check #2 — forward causality):
   * `break` the same `...AssertExecutionProgress...+1055` again.
   * From inside **ApiGetterStub**, `cont`.
   * Expect: RecordingWarning text `[RUN-1919] JS ExecutionProgress in non-deterministic user JS PC=19719136 ... [EventsDisallowed:V8InspectorImpl::forEachSession]` and/or hit BP `+1055`.
7. Optional neighborhood (do **not** set hot `Invoke` from cold start):
   * From end: `V8Console::Debug` → `forEachSession` → `InjectedScript::wrapObject` → `ValueMirror::getProperties` → accessor Get → chain above.
   * Do not set unconditional `Execution::Invoke` until already inside that Debug/`getProperties` neighborhood.

#### Source anchors

* Gate skipped: `v8/src/objects/objects.cc` — `Object::GetPropertyWithAccessor`, `FunctionTemplateInfo` branch → `Builtins::InvokeApiFunction`.
* Gate location (not taken): `v8/src/execution/execution.cc` — `RecordReplayIsDivergentUserJSWithoutPause` / Warning `JS Invoke: Non-deterministic user JS`.
* `[RUN-1919]` emit: `v8/src/runtime/runtime-debug.cc` — `Runtime_RecordReplayAssertExecutionProgress`.
* ValueMirror auto-Get of `kNoScriptId` getters: `v8/src/inspector/value-mirror.cc` (preview property walk); inspector `nativeGetterCallback` is a different helper and was not this stub.

# Solution

## G1: `generatePreview=false` on replay-owned console reporting

* Replay console-message collection (`addMessage` → `messageAdded` → `consoleAPICalled` → `V8RecordReplayOnConsoleMessage` → `Target_getCurrentMessageContents`) does not need CDP `generatePreview`: collection only needs wrapped `RemoteObject` `type`/`value`/`objectId`; RRP previews are built later via `ProtocolObjectPreview`.
* `V8RuntimeAgentImpl::messageAdded` always called `reportMessage(message, true)`.
* That drove `wrapArguments` → `wrapObject(..., generatePreview=true)` → ValueMirror auto-`Get` of `kNoScriptId` getters under `EventsDisallowed:V8InspectorImpl::forEachSession`.
* Fix: when `m_replay_owned`, pass `generatePreview=false`.
* Stops the preview property walk that reaches **ApiGetterStub**.

## G2: Rewind Progress after divergent C++→JS / API entry (`[RUN-1988]`)

* **ProgressRewind**: if instrumented user JS runs under `EventsDisallowed` without a pause, Progress advances on the replay-only path; on exit from the entry, restore `*gProgressCounter` and truncate `gProgressData` to their pre-entry values so the checkpoint Progress stays matched.
* Only real C++→JS entry is `Execution::Invoke` → `JSEntry`.
* `InvokeApiFunction` is C++ `FunctionCallback` dispatch.
  * Also reached direct from `GetPropertyWithAccessor` without entering `Invoke`.
  * `Invoke`'s API early-out calls it before the divergent-user-JS gate.
* Prior **ProgressRewind** lived only in `CommandCallback`.
  * Missed this path → Progress advanced under `EventsDisallowed` → checkpoint Progress mismatch.
* Move **ProgressRewind** to:
  * `Invoke`
  * `InvokeApiFunction`
  * `HandleApiCallHelper` / `HandleApiCallAsFunctionOrConstructor`
* `RecordReplayScrubDivergentProgressScope` implements **ProgressRewind**:
  * Active only when recording/replaying, main thread, `AreEventsDisallowed`, `!HasDivergedFromRecording`.
  * On exit: if Progress advanced, restore counter + `gProgressData`.
