### PR TITLE
[crash-0043] Guard V8RuntimeAgentImpl::addBinding against empty context

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '5e20f54aa0a6c06b8cf0263337c6e369b9037b41',
+  'v8_revision': '5b6376afa14133f5c17b7cb3b9be3715aa6e74b0',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '5b6376afa14133f5c17b7cb3b9be3715aa6e74b0',
+  'v8_revision': '25df1350fffc28b46c2a8138364e35f5528205b9',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/309

# Summary

* RecorderCrash: SIGSEGV in `Context::Global()` from `V8RuntimeAgentImpl::addBinding`.
* Cause: `InspectedContext::context()` returned empty `Local<Context>`; caller unchecked.
* Fix: `IsEmpty()` early-return + `Warning` with context id before `->Global()`.
* Does not clear **BadInspectedContext** from `m_contexts` — only prevents the null deref.

# Problem

* Problem type: RecorderCrash.

## Important Context

* buildId: linux-chromium-20260720-e0654e7a6b22-fa9c47bdb8f6
* linkerVersion: linker-linux-16038-fa9c47bdb8f6
* recordingId: 7c900e21-db6d-47f1-a1c2-f7e819120748

### Crash Report Core
```json
{
 "why": "Crash",
 "signal": 11,
 "backtrace": {
 "frames": [
 "_ZN12v8_inspector18V8RuntimeAgentImpl10addBindingEPNS_16InspectedContextERKNS_8String16E+484",
 "_ZNSt2Cr10__function16__policy_invokerIFvPN12v8_inspector16InspectedContextEEE11__call_implINS0_20__default_alloc_funcIZNS2_18V8RuntimeAgentImpl10addBindingERKNS2_8String16EN8v8_crdtp6detail10ValueMaybeIiEENSF_ISA_EEE3$_0S5_EEEEvPKNS0_16__policy_storageES4_+259",
 "_ZN12v8_inspector15V8InspectorImpl14forEachContextEiRKNSt2Cr8functionIFvPNS_16InspectedContextEEEE+1239",
 "_ZN12v8_inspector18V8RuntimeAgentImpl10addBindingERKNS_8String16EN8v8_crdtp6detail10ValueMaybeIiEENS6_IS1_EE+1053",
 "_ZN12v8_inspector8protocol7Runtime20DomainDispatcherImpl10addBindingERKN8v8_crdtp12DispatchableE+275",
 "_ZN8v8_crdtp14UberDispatcher14DispatchResult3RunEv+36",
 "_ZN12v8_inspector22V8InspectorSessionImpl23dispatchProtocolMessageENS_10StringViewE+611",
 "_ZN5blink15DevToolsSession27DispatchProtocolCommandImplEiRKN3WTF6StringEN4base4spanIKhLm18446744073709551615EEE+310",
 "_ZN5blink5mojom5blink27DevToolsSessionStubDispatch6AcceptEPNS1_15DevToolsSessionEPN4mojo7MessageE+233",
 "_ZN4mojo23InterfaceEndpointClient22HandleValidatedMessageEPNS_7MessageE+820",
 "_ZN4mojo17MessageDispatcher6AcceptEPNS_7MessageE+298",
 "_ZN4mojo23InterfaceEndpointClient21HandleIncomingMessageEPNS_7MessageE+87",
 "_ZN3IPC12_GLOBAL__N_132ChannelAssociatedGroupController22AcceptOnEndpointThreadEN4mojo7MessageE+312",
 "_ZN4base8internal7InvokerINS0_9BindStateIMN4mojo12_GLOBAL__N_138ThreadSafeInterfaceEndpointClientProxyEFvNS3_7MessageEEJ13scoped_refptrIS5_ES6_EEEFvvEE7RunOnceEPNS0_13BindStateBaseE+70",
 "_ZN4base13TaskAnnotator11RunTaskImplERNS_11PendingTaskE+257",
 "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl10DoWorkImplEPNS_7LazyNowE+1001",
 "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl6DoWorkEv+127",
 "_ZThn200_N4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl6DoWorkEv+21",
 "_ZN4base18MessagePumpDefault3RunEPNS_11MessagePump8DelegateE+154",
 "_ZN4base16sequence_manager8internal35ThreadControllerWithMessagePumpImpl3RunEbNS_9TimeDeltaE+355",
 "_ZN4base7RunLoop3RunERKNS_8LocationE+461",
 "_ZN7content12RendererMainENS_18MainFunctionParamsE+1434",
 "_ZN7content28RunOtherNamedProcessTypeMainERKNSt2Cr12basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEENS_18MainFunctionParamsEPNS_19ContentMainDelegateE+686",
 "_ZN7content21ContentMainRunnerImpl3RunEv+673",
 "_ZN7content17RunContentProcessENS_17ContentMainParamsEPNS_17ContentMainRunnerE+294",
 "_ZN7content11ContentMainENS_17ContentMainParamsE+95",
 "_ZN8headless12_GLOBAL__N_114RunContentMainENS_15HeadlessBrowser7OptionsEN4base12OnceCallbackIFvPS1_EEE+313",
 "_ZN8headless23RunChildProcessIfNeededEiPPKc+373",
 "_ZN8headless17HeadlessShellMainEiPPKc+55",
 "ChromeMain+629",
 "linker+21373514"
 ],
 "progress": 35274924,
 "threadId": 1,
 "checkpoint": 49,
 "stackPointerSet": false
 },
 "faultAddress": "(nil)",
 "unknownThread": false,
 "instructionPointer": "_ZN2v87Context6GlobalEv+33"
}
```

# Facts

* [F1] No `rr` recording available (only report.json; no trace path) → used StaticFaultProof.
* [F2] `why: "Recorder"` in report.json → crash is in the recorder (Chromium renderer), not the replay backend/ProcessorServer.
* [F3] Prepared crash raw data (build+linker, resolved symbols). Key output:
 * `crashAddress` = `0x4ad5890` (`v8::Context::Global()`), `crashIpAddress` = `0x4ad58b1` (offset +0x21 = +33, matches `instructionPointer`).
 * `callerAddress` = `0x5414b00` (`V8RuntimeAgentImpl::addBinding`).
* Disasm: `Global.disasm.txt`, `addBinding.disasm.txt`.
* [F4] `Global.disasm.txt`: faulting instr `4ad58b1: mov (%rdi),%rax` — first instruction after prologue, dereferences `this` (`%rdi`) with no offset.
 * `faultAddress: (nil)` ⇒ `%rdi` (`this` for `Context::Global()`) was null.
* [F5] `addBinding.disasm.txt`, call site `5414cdf: call 4ad5890 <Context::Global()>`, preceded by:
 * `5414cd4: call 53d1400 <InspectedContext::context() const>` (on `%r15`, the `InspectedContext*`).
 * `5414cd9/5414cdc: mov %rax,%r14 / mov %rax,%rdi` — `context()`'s return value passed directly as `this` to `Global()`, unchecked.
 * Proves: `InspectedContext::context()` returned a null/empty `Local<Context>`, then `Context::Global()` dereferenced it without a null-check.
* [F6] `V8RuntimeAgentImpl::addBinding` confirms binary evidence:
 * ```cpp
 v8::Local<v8::Context> localContext = context->context();
 v8::Local<v8::Object> global = localContext->Global();
 ```
 * No `IsEmpty()`/null check between `context()` and `->Global()`.
* [F7] `InspectedContext::context()` returns `m_context.Get(isolate())`.
 * `m_context` is `SetWeak` to `WeakCallbackData::resetContext`.
* [F8] `forEachContext` re-looks-up by id mid-loop.
 * Guards freed `InspectedContext*`.
 * Does not skip empty `m_context`.
* [F9] Backtrace: page DevTools mojo → `Runtime.addBinding` → `forEachContext` → `Global()`.
 * Not Replay `SendCDPMessage`.
* [F10] **ReplaySession**: `getInspectorSession` `connect` under Mark+Disallow → `m_replay_owned=true`.
 * Shares `m_contexts` with DevTools.
* [F11] Weak first-pass `Reset()`s `m_context`. Second-pass `contextCollected` → `discardInspectedContext`.
 * That gap is **BadInspectedContext**.
* [F12] crash-0020-b NativeContext switch does not fix this path.
 * Already in this build. Different fault site.

# Root Cause Hypothesis

* Why: page CDP walked a **BadInspectedContext** — mapped `InspectedContext*` with empty `m_context` — and `addBinding` called `->Global()` unchecked → SIGSEGV.
* **ReplaySession** shares that `m_contexts` map. Only non-stock pressure that makes this reachable.
* Unproven: which Replay path left **BadInspectedContext** mapped.
 * Not: missing `contextCreated`, session leak vs context cleanup, crash-0020 NativeContext switch.
 * Not: **MemoryCacheEntry** leak (Hypothesis A).

## Who unmaps `InspectedContext`

* Sole per-id eraser: `V8InspectorImpl::discardInspectedContext` → `m_contexts[group]->erase(contextId)`.
* Only reached via `V8InspectorImpl::contextCollected` (also whole-group wipe: `resetContextGroup`).

### Likely-missing unmap slice

* Fault shape: `m_context` already empty, entry still in `m_contexts` ⇒ weak first-pass `resetContext` ran; second-pass unmap did not.
* Required continuation after first-pass:

```
InspectedContext::WeakCallbackData::callContextCollected // second-pass
 → V8InspectorImpl::contextCollected(groupId, contextId)
 → discardInspectedContext(groupId, contextId) // erase from m_contexts
```

* Earlier sync unmap (avoids **BadInspectedContext** entirely) — often skipped by stock:

```
LocalWindowProxy::DisposeContext
 // skipped when next_status ∈ {kFrameIsDetached, kFrameIsDetachedAndV8MemoryIsPurged}
 // (stock: defer to GC contextCollected; see comment at `local_window_proxy.cc`)
 → MainThreadDebugger::ContextWillBeDestroyed
 → V8InspectorImpl::contextDestroyed
 → contextCollected → discardInspectedContext
```

* For that skip, GC second-pass above is the only unmap. That is the slice that failed to clear the map before page CDP `forEachContext` → `addBinding`.

### Implicit assertion: mapped ⇒ live context

* Stock may skip `ContextWillBeDestroyed` (frame-detach statuses above).
 * Comment asserts GC will later call `contextCollected` (`local_window_proxy.cc`).
* No code asserts that skip was compensated yet.
* `V8RuntimeAgentImpl::addBinding` implicitly asserts it:
 * `localContext = context->context();` then `localContext->Global()` with no `IsEmpty()` check ([F5][F6]).
 * `forEachContext` only re-looks-up by id; does not skip empty `m_context` ([F8]).
* So: mapped entry ⇒ treated as live. False after weak first-pass `Reset` and before second-pass `discardInspectedContext`.

# Possible Related Interventions

* Recipe family: `determinism-leak-memory` (`leak-references` / `AreEventsDisallowed` retain-or-skip).

* Unlikely:
 * **MemoryCacheEntry** — rejected under Hypothesis A.
 * **SVG `leaked_pages`** (`svg_image.cc` `~SVGImage`) — SVG Pages are not instrumented.
 * `Page::WillBeDestroyed` — leaks `PageScheduler` only.
 * `~ExecutionContext` — leaks `policy_container_` only.
 * `DevToolsSession::sendNotification` — skips notify during GC.
 * `IntersectionObserver::ProcessCustomWeakness` — skips weak clear.

## Hypothesis A: Bad MemoryCacheEntry leak.

* Rejected — no causal path from this leak to **BadInspectedContext**.
* Claim under test: `leak-references`/`MemoryCacheEntry` retains a Document-adjacent graph after `ScriptState`/context is gone, leaving mapped `InspectedContext` with empty `m_context`.
* Claim rested on shape metaphor only ("shell alive / content empty").
* Intervention (`memory_cache.h` / `.cc`):
 * Stock: `UntracedMember<Resource>` + `RegisterWeakCallbackMethod` → `ClearResourceWeak` → `MemoryCache::Remove` when Resource dies.
 * Replay: ctor/`GetResource`/`Trace` gated on `IsRecordingOrReplaying("leak-references", "MemoryCacheEntry")`.
 * Uses `Member<Resource> strong_resource_` and `visitor->Trace(strong_resource_)`.
 * Effect: pins `Resource` while entry stays in `resource_maps_`. Nothing else.
* `Resource::Trace` (`resource.cc`): traces `loader_`, `clients_`, `clients_awaiting_callback_`, `finished_clients_`, `finish_observers_`, `replay_clients_strong_`, `replay_finish_observers_strong_`.
 * No `Document`, `ExecutionContext`, `ScriptState`, `InspectedContext`, or `m_contexts`.
* Ownership trees are disjoint:
 * Blink: `MemoryCache` → `MemoryCacheEntry` → `Resource`.
* Inspector: `V8InspectorImpl::m_contexts` → `InspectedContext` → weak `m_context`.
 * No edge either direction.
* How `m_context` becomes empty while `InspectedContext*` still mapped ([F11]):
 * Only writer: weak first-pass `WeakCallbackData::resetContext` → `m_context.Reset()`, then `SetSecondPassCallback(callContextCollected)`.
 * Second-pass: `contextCollected` → `discardInspectedContext` erases from `m_contexts`.
 * Sync discard: `LocalWindowProxy` → `MainThreadDebugger::ContextWillBeDestroyed` → `contextDestroyed` → same `contextCollected`, while `ScriptState` still holds the strong context.
 * `MemoryCacheEntry` is on neither path.
* What the leak cannot do:
 * Keep/drop entries in `m_contexts`.
 * `Reset` `m_context`.
 * Skip or delay `discardInspectedContext`.
 * Open or widen the weak first-/second-pass gap.
* Opposite polarity if clients are retained:
 * Separate intervention: `Resource::replay_clients_strong_` (RUN-1724) can keep `ResourceClient` → Document graph alive.
 * That retains `ScriptState`/context — opposite of empty `m_context`.
* Conclusion: metaphor is not a causal link. Reject.

# Solution

* Guard `V8RuntimeAgentImpl::addBinding` against empty context ([F5][F6][F8]).
 * After `localContext = context->context()`, `if (localContext.IsEmpty()) return;` before `->Global()`.
 * Log `Warning` with context id on the empty path.
 * Does not fix why **BadInspectedContext** stays mapped — only prevents the SIGSEGV.