### PR TITLE
crash-0045/0046: ImageDecodingStore HasInstance + OpcodeEmit freeze vs worker ignore

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '0c678a03f630569293bb73cf6588151a17df9485',
+  'v8_revision': '835005424853967bb39b2bee7bf027cd2a3554f1',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '57a91bfe06140e27f72af3f870d0bb39a69047ad',
+  'v8_revision': '0c678a03f630569293bb73cf6588151a17df9485',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
+++ b/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
@@ -64,6 +64,7 @@ ImageDecodingStore::~ImageDecodingStore() {
 }
 
 ImageDecodingStore& ImageDecodingStore::Instance() {
+  REPLAY_ASSERT("ImageDecodingStore::Instance %d", HasInstance());
   DEFINE_THREAD_SAFE_STATIC_LOCAL(ImageDecodingStore, store, ());
   return store;
 }


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/310

# G1: ImageDecodingStore HasInstance

* ReplayMismatch / StackCommonFrame on `ImageDecodingStore::Instance` first-call ctor.
  * Assert `HasInstance()` before the static-local.

# G2: OpcodeEmit freeze vs worker ignore

* RecorderCrash: frozen opcode-emit ON overruled worker `record_replay_ignore`.
  * In `RecordReplayShouldEmitOpcodes`, frozen ON must not override current ignore when `!IsMainThread()`.

<hr>

# G1: ImageDecodingStore HasInstance

## Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

### Important Context

* buildId: linux-chromium-20260717-94758bf85007-fa9c47bdb8f6
* linkerVersion: linker-linux-16038-fa9c47bdb8f6
* recordingId: 9dcd0d0a-9233-4d4d-a97f-1a30ecce4b97

#### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 248535,
  "category": "SaplingBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 148681,
      "checkpoint": 35
    },
    "getResumeData": [
      "annotations",
      "bookmarks",
      "consoleMessages",
      "events",
      "networkRequestEvents",
      "networkRequests",
      "networkStreamEvents",
      "sources",
      "widgetEvents"
    ]
  },
  "recorded": "Call clock_gettime Arg:0:1 HasOutParam:1:1",
  "replayed": "MemoryPressureObserver::AddObserver B 0",
  "threadId": 12,
  "backtrace": {
    "progress": 126421,
    "threadId": 12,
    "checkpoint": 32
  },
  "recordedStack": [
    "base::subtle::TimeTicksNowIgnoringOverride()+34",
    "base::ElapsedTimer::ElapsedTimer()+14",
    "blink::ImageDecoder::DecodeFrameBufferAtIndex(unsigned.int)+203",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+454",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::ImageDecodingStore::ImageDecodingStore()+180",
    "blink::ImageDecodingStore::Instance()+75",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231"
  ]
}
```

##### Warnings
```json
[
  {
    "text": "Recording assertion with events disallowed: [PRO-2368] ErrorUtils::GetFormattedStack A 0 [EventsDisallowed:recordreplay::ClearPauseData]",
    "count": 13,
    "stack": [
      "v8::recordreplay::Assert(char.const*,....)+149",
      "v8::internal::ErrorUtils::GetFormattedStack(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSObject>)+750",
      "v8::internal::Accessors::ErrorStackGetter(v8::Local<v8::Name>,.v8::PropertyCallbackInfo<v8::Value>.const&)+56",
      "v8::internal::PropertyCallbackArguments::CallAccessorGetter(v8::internal::Handle<v8::internal::AccessorInfo>,.v8::internal::Handle<v8::internal::Name>)+292",
      "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+993",
      "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
      "v8::internal::LoadIC::Load(v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Name>,.bool,.v8::internal::Handle<v8::internal::Object>)+2457",
      "v8::internal::Runtime_LoadNoFeedbackIC_Miss(int,.unsigned.long*,.v8::internal::Isolate*)+238"
    ],
    "progress": 73137,
    "threadId": 1,
    "processId": 41,
    "checkpoint": 31,
    "absoluteTime": 1784459744127.73,
    "wasRecording": false
  },
  {
    "text": "Error: ReplayScript UNALIVE - sendCDPMessage Runtime.releaseObjectGroup\n    at CHECK_ALIVE (record-replay-internal:315:17)\n    at sendCDPMessage (record-replay-internal:201:3)\n    at clearPauseDataCallback (record-replay-internal:852:5) [EventsDisallowed:recordreplay::ClearPauseData]",
    "count": 13,
    "stack": [
      "recordreplay::Warning(char.const*,....)+141",
      "blink::LogWarningCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+200",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+1013",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 73137,
    "threadId": 1,
    "processId": 41,
    "checkpoint": 31,
    "absoluteTime": 1784459744128.1199,
    "wasRecording": false
  },
  {
    "text": "JS clearPauseDataCallback exception: Error: [RUN-2600] No context group available for Isolate. (1001) [EventsDisallowed:recordreplay::ClearPauseData]",
    "count": 13,
    "stack": [
      "recordreplay::Warning(char.const*,....)+141",
      "blink::LogWarningCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+200",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+1013",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 73137,
    "threadId": 1,
    "processId": 41,
    "checkpoint": 31,
    "absoluteTime": 1784459744128.4734,
    "wasRecording": false
  }
]
```

## Basic Facts

### FrameCandidates

* `ImageDecoderWrapper::Decode(...)+454` (recorded)
  * location: `blink::ImageDecoderWrapper::Decode` at `third_party/blink/renderer/platform/graphics/image_decoder_wrapper.cc:133`
  * code: `frame = decoder->DecodeFrameBufferAtIndex(frame_index_);`
* `ImageDecoderWrapper::Decode(...)+46` (replayed)
  * location: `blink::ImageDecoderWrapper::Decode` at `third_party/blink/renderer/platform/graphics/image_decoder_wrapper.cc:102`
  * code: `const bool resume_decoding = ImageDecodingStore::Instance().LockDecoder(`
* `ImageDecodingStore::ImageDecodingStore()+180` (replayed)
  * location: `blink::ImageDecodingStore::ImageDecodingStore` at `third_party/blink/renderer/platform/graphics/image_decoding_store.cc:46-52`
  * code: member-init `memory_pressure_listener_(...)`

### DivergentPathSegments

#### Root: `cc::SoftwareImageDecodeCacheUtils::DoDecodeImage`

```cpp
// cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(...)+231
void DoDecodeImage(const CacheKey& key, const PaintImage& paint_image, ...) {
  // cc::PaintImage::Decode(...)+155
  paint_image.Decode(memory, &info, color_space, frame_index, callback);
  // -> blink::DecodingImageGenerator::GetPixels(...)+943
  //    -> blink::ImageFrameGenerator::DecodeAndScale(...)+619
  //       -> blink::ImageDecoderWrapper::Decode(...)+454 (recorded) / +46 (replayed)
  {
    bool ImageDecoderWrapper::Decode(...) {
      // blink::ImageDecoderWrapper::Decode(...)+46 (replayed)
      // blink::ImageDecodingStore::Instance()+75 (replayed)
      const bool resume_decoding = ImageDecodingStore::Instance().LockDecoder(...);
      // ImageDecodingStore::Instance()
      // [Branch] CANDIDATE — first call constructs; later calls return live store
      DEFINE_THREAD_SAFE_STATIC_LOCAL(ImageDecodingStore, store, ());
      // first call (replayed):
      //   ImageDecodingStore ctor → memory_pressure_listener_ → AddObserver
      //   [Branch] REPLAYED: else-arm
      //   REPLAY_ASSERT("MemoryPressureObserver::AddObserver B %d", sync); // <<< REPLAYED LEAF
      // later call (recorded): store already live → continue
      // blink::ImageDecoderWrapper::Decode(...)+454 (recorded)
      // blink::ImageDecoder::DecodeFrameBufferAtIndex(...)+203 (recorded)
      frame = decoder->DecodeFrameBufferAtIndex(frame_index_);
      // [Branch] RECORDED: taken
      if (frame->GetStatus() != ImageFrame::kFrameComplete) {
        // base::ElapsedTimer::ElapsedTimer()+14 (recorded)
        // base::subtle::TimeTicksNowIgnoringOverride()+34 (recorded)
        begin_ = TimeTicks::Now(); // <<< RECORDED LEAF
      }
    }
  }
}
```

### NewCandidates

* `ImageDecodingStore::Instance`
  * branches:
    * `image_decoding_store.cc:67` — `DEFINE_THREAD_SAFE_STATIC_LOCAL(ImageDecodingStore, store, ())` — first call constructs store
  * provenance: `ImageDecoderWrapper::Decode` → `Instance()` → either leaf

### Suggested Cause of Action

* Assert `gHasInstance` at the top of `ImageDecodingStore::Instance`, before that macro.
* Read the atomic only. Do not call `Instance()` again.
* Turns this ControlFlowMismatch into a DataMismatch on that value.

## Solution

* [Done] Add `REPLAY_ASSERT` on `ImageDecodingStore::HasInstance()` value in `ImageDecodingStore::Instance()`.
  * Hints:
    * Converts current ControlFlowMismatch into DataMismatch reporting recorded vs replayed `gHasInstance` value.
  * Steps:
    * In `third_party/blink/renderer/platform/graphics/image_decoding_store.cc`, `ImageDecodingStore::Instance()` (lines 66-69): insert `REPLAY_ASSERT` on `ImageDecodingStore::HasInstance()` value, before the `DEFINE_THREAD_SAFE_STATIC_LOCAL` line.

# G2: OpcodeEmit freeze vs worker ignore

## Problem

* Problem type: RecorderCrash.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

### Important Context

* buildId: linux-chromium-20260729-b894115c94c5-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: 1c485b30-5f96-4740-8690-bd49016b517f

#### Crash Report Core
```json
{
  "why": "Crash",
  "text": "Check failed: NumRunningBackgroundCompileTasks() != 0.",
  "signal": 5,
  "backtrace": {
    "frames": [
      "V8_Fatal(char.const*,....)+451",
      "v8::internal::interpreter::BytecodeArrayBuilder::BytecodeArrayBuilder(v8::internal::Zone*,.int,.int,.int,.bool,.bool,.v8::internal::FeedbackVectorSpec*,.v8::internal::SourcePositionTableBuilder::RecordingMode)+509",
      "v8::internal::interpreter::BytecodeGenerator::BytecodeGenerator(v8::internal::LocalIsolate*,.v8::internal::Zone*,.v8::internal::UnoptimizedCompilationInfo*,.v8::internal::AstStringConstants.const*,.std::Cr::vector<v8::internal::FunctionLiteral*,.std::Cr::allocator<v8::internal::FunctionLiteral*>.>*,.v8::internal::Handle<v8::internal::Script>)+173",
      "v8::internal::interpreter::Interpreter::NewCompilationJob(v8::internal::ParseInfo*,.v8::internal::FunctionLiteral*,.v8::internal::Handle<v8::internal::Script>,.v8::internal::AccountingAllocator*,.std::Cr::vector<v8::internal::FunctionLiteral*,.std::Cr::allocator<v8::internal::FunctionLiteral*>.>*,.v8::internal::LocalIsolate*)+215",
      "v8::internal::(anonymous.namespace)::ExecuteSingleUnoptimizedCompilationJob(v8::internal::ParseInfo*,.v8::internal::FunctionLiteral*,.v8::internal::Handle<v8::internal::Script>,.v8::internal::AccountingAllocator*,.std::Cr::vector<v8::internal::FunctionLiteral*,.std::Cr::allocator<v8::internal::FunctionLiteral*>.>*,.v8::internal::LocalIsolate*)+298",
      "bool.v8::internal::(anonymous.namespace)::IterativelyExecuteAndFinalizeUnoptimizedCompilationJobs<v8::internal::Isolate>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::SharedFunctionInfo>,.v8::internal::Handle<v8::internal::Script>,.v8::internal::ParseInfo*,.v8::internal::AccountingAllocator*,.v8::internal::IsCompiledScope*,.std::Cr::vector<v8::internal::FinalizeUnoptimizedCompilationData,.std::Cr::allocator<v8::internal::FinalizeUnoptimizedCompilationData>.>*,.std::Cr::vector<v8::internal::DeferredFinalizationJobData,.std::Cr::allocator<v8::internal::DeferredFinalizationJobData>.>*)+271",
      "v8::internal::(anonymous.namespace)::CompileToplevel(v8::internal::ParseInfo*,.v8::internal::Handle<v8::internal::Script>,.v8::internal::MaybeHandle<v8::internal::ScopeInfo>,.v8::internal::Isolate*,.v8::internal::IsCompiledScope*)+1395",
      "v8::internal::Compiler::GetFunctionFromEval(v8::internal::Handle<v8::internal::String>,.v8::internal::Handle<v8::internal::SharedFunctionInfo>,.v8::internal::Handle<v8::internal::Context>,.v8::internal::LanguageMode,.v8::internal::ParseRestriction,.int,.int,.int,.v8::internal::ParsingWhileDebugging)+1943",
      "v8::internal::Runtime_ResolvePossiblyDirectEval(int,.unsigned.long*,.v8::internal::Isolate*)+648",
      "0x55c6bff15c33",
      "0x55c6bffc3d8e",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe8b82c",
      "0x55c6bfe89e5c",
      "0x55c6bfe89b87",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5125",
      "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
      "v8::Script::Run(v8::Local<v8::Context>,.v8::Local<v8::Data>)+1719",
      "blink::V8ScriptRunner::RunCompiledScript(v8::Isolate*,.v8::Local<v8::Script>,.v8::Local<v8::Data>,.blink::ExecutionContext*)+1075",
      "blink::V8ScriptRunner::CompileAndRunScript(blink::ScriptState*,.blink::ClassicScript*,.blink::ExecuteScriptPolicy,.blink::V8ScriptRunner::RethrowErrorsOption)+706",
      "blink::ClassicScript::RunScriptOnScriptStateAndReturnValue(blink::ScriptState*,.blink::ExecuteScriptPolicy,.blink::V8ScriptRunner::RethrowErrorsOption)+61",
      "blink::WorkerGlobalScope::RunWorkerScript()+376",
      "blink::WorkerGlobalScope::EvaluateClassicScript(blink::KURL.const&,.WTF::String,.std::Cr::unique_ptr<WTF::Vector<unsigned.char,.0u,.WTF::PartitionAllocator>,.std::Cr::default_delete<WTF::Vector<unsigned.char,.0u,.WTF::PartitionAllocator>.>.>,.v8_inspector::V8StackTraceId.const&)+232",
      "blink::WorkerThread::EvaluateClassicScriptOnWorkerThread(blink::KURL.const&,.WTF::String,.std::Cr::unique_ptr<WTF::Vector<unsigned.char,.0u,.WTF::PartitionAllocator>,.std::Cr::default_delete<WTF::Vector<unsigned.char,.0u,.WTF::PartitionAllocator>.>.>,.v8_inspector::V8StackTraceId.const&)+104",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
      "base::(anonymous.namespace)::ThreadFunc(void*)+86",
      "linker+784523",
      "linker+21774837"
    ],
    "progress": 8042430,
    "threadId": 13,
    "checkpoint": 19,
    "stackPointerSet": false
  },
  "faultAddress": "(nil)",
  "unknownThread": false,
  "instructionPointer": "v8::base::OS::Abort()+19"
}
```

## Basic Facts

### FrameCandidates

* `BytecodeArrayBuilder::BytecodeArrayBuilder(...)+509`
  * location: `v8::internal::interpreter::BytecodeArrayBuilder::BytecodeArrayBuilder` at `v8/src/interpreter/bytecode-array-builder.cc:86`
  * code: `CHECK(NumRunningBackgroundCompileTasks() != 0);`
* `BytecodeGenerator::BytecodeGenerator(...)+173`
  * location: `v8::internal::interpreter::BytecodeGenerator::BytecodeGenerator` at `v8/src/interpreter/bytecode-generator.cc:1143-1149`
  * code: constructs `builder_(..., script->id(), info->flags().record_replay_ignore(), ...)`
* `Compiler::GetFunctionFromEval(...)+1943`
  * location: `v8::internal::Compiler::GetFunctionFromEval` at `v8/src/codegen/compiler.cc` (eval compile → `CompileToplevel`)
* `blink::WorkerGlobalScope::RunWorkerScript()+376`
  * location: worker classic-script run on worker thread (not browser main, not V8 BackgroundCompileTask)

## Facts

* [F1] No `rr` recording. CrashReportData only. Ignore `onstack`.
* [F2] Abort text: `Check failed: NumRunningBackgroundCompileTasks() != 0.` → `V8_Fatal` / `OS::Abort`. Not a null-deref StaticFaultProof shape.
* [F3] `NumRunningBackgroundCompileTasks` is **Replay-owned**, not upstream.
  * `static std::atomic<size_t> gNumRunningBackgroundCompileTasks` in `v8/src/codegen/compiler.cc` (~1810).
  * Comment: "For use when checking that record/replay opcodes are only emitted for the main thread."
  * Inc/dec only in `BackgroundCompileTask::Run` (~1836 / ~1950).
  * Added with Replay #47 (`ce3081c10ce`): Support background compile tasks when recording/replaying.
* [F4] CHECK site (`bytecode-array-builder.cc:78-87`): if `RecordReplayShouldEmitOpcodes` then emit; if also `!IsMainThread()` then require `NumRunningBackgroundCompileTasks() != 0`.
  * Intent (#47): non-main emit allowed only for V8 **BackgroundCompileTask**.
  * Counter is that proxy. Worker-thread sync compile is not a BackgroundCompileTask → counter stays 0.
* [F5] Trusted backtrace: worker `RunWorkerScript` → `Runtime_ResolvePossiblyDirectEval` → `GetFunctionFromEval` → `BytecodeArrayBuilder` CHECK.
  * Sync unoptimized compile on worker thread while emit is on.
* [F6] `RecordReplayShouldEmitOpcodes` (`v8/src/debug/debug.cc:3707`): process-global `gOpcodeEmitByScript` keyed by `script_id`.
  * `base = IsRecordingOrReplaying("emit-opcodes") && RecordReplayHasDefaultContext() && !record_replay_ignore`.
  * `RecordReplayHasDefaultContext()` = `!!gDefaultContext` (process-global; true once main set it).
* [F7] Sticky history:
  * #305 (`3f49dc12a2e`): introduced map; sticky dark-only: `emit = base && (unseen || prev)`.
  * #307 (`57a91bfe061`, in this build `b894115c94c5`): freeze first decision both ways — later calls return stored value and ignore current `base` / `record_replay_ignore`.
* [F8] Sole CHR-20260729 hit in crash-report overview for this CHECK signature. Build includes #307.

## IgnoreInputs

Default: `record_replay_ignore = false`.

* `SetRecordReplayFlags` (`compiler.cc`) — toplevel, eval, `BackgroundCompileTask` ctor
  * This crash: `GetFunctionFromEval` → `SetRecordReplayFlags(flags, "")`
  * No-op unless `IsRecordingOrReplaying()`
  * Sets ignore if any of:
    * `!IsMainThread()` (`gMainThread == pthread_self()`, set at `SetRecordingOrReplaying`)
    * `!RecordReplayHasDefaultContext()` (`gDefaultContext`)
    * `AreEventsDisallowed("CompileFlags")`
    * `IsInReplayCode("CompileFlags")`
* `SetFlagsForFunctionFromScript` (`parse-info.cc`) — lazy / function compile from existing `Script`
  * Sets ignore if `!RecordReplayHasRegisteredScript(script)`
  * Registered only if `IsMainThread()` and `script.id()` ∈ `gRegisteredScripts`
  * Insert into `gRegisteredScripts` only after `RecordReplayRegisterScript` passes:
    * `HasDefaultContext`
    * not WASM
    * `!AreEventsDisallowed()`
    * `url != "record-replay-internal"`

### FreezeOverride

Given frozen emit ON (`ignore=false` stored), which later IgnoreInputs that flip `ignore` to true may that freeze override?

| IgnoreInput | Freeze-ON overrides? |
|---|---|
| `!IsMainThread()` | never |
| `!RecordReplayHasDefaultContext()` | yes |
| `AreEventsDisallowed("CompileFlags")` | yes |
| `IsInReplayCode("CompileFlags")` | yes |
| `!RecordReplayHasRegisteredScript` (id not in set) | yes |
| `!RecordReplayHasRegisteredScript` because `!IsMainThread()` | never |

## Incidentals

* [F7] #307 freezes first emit decision per `script_id` both ways; later `base` / `record_replay_ignore` ignored.
* [F6] Map and `gDefaultContext` are process-global.
* [F3][F4] Non-main emit allowed only while `NumRunningBackgroundCompileTasks() != 0` (BCT proxy).
* [F5] Crash thread is worker classic-script → sync `GetFunctionFromEval`, not BCT.
* [F8] Sole CHR-20260729 hit; build has #307.

## RootCause

* [F5] Worker sync eval compile reached `BytecodeArrayBuilder` with emit ON → CHECK [F4].
* This path: `SetRecordReplayFlags` on worker ⇒ `!IsMainThread()` ⇒ `record_replay_ignore = true` ⇒ `base` false [F6].
* Emit ON therefore cannot be current `base`; it is frozen ON for that `script_id` overruling current ignore [F7].
* That override is illegal: `!IsMainThread()` is never FreezeOverride-able (table above).

## Fix

* In `RecordReplayShouldEmitOpcodes`: frozen emit ON must not override current `record_replay_ignore` when `!IsMainThread()`.
