### PR TITLE
DriverBuildCheck: skip build-driver-linker when archive exists on S3

### DIFF
--- a/replay_build_scripts/build-pipeline.py
+++ b/replay_build_scripts/build-pipeline.py
@@ -1,10 +1,45 @@
 import json
+import urllib.error
+import urllib.request
 
 
 def read_commit_hash(file_path):
     """Reads the commit hash from the given file."""
     with open(file_path, "r") as file:
         return file.read().strip()
+
+
+def driver_archive_present(driver_revision):
+    """DriverBuildCheck: True if linux driver archive for this rev is already on S3."""
+    url = f"https://static.replay.io/downloads/linux-recordreplay-{driver_revision}.tgz"
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+        return False
+
+
+def driver_step(backend_commit_hash, driver_revision):
+    """trigger build-driver-linker, or DriverBuildCheck noop if archive already on S3."""
+    if driver_archive_present(driver_revision):
+        return {
+            "label": "DriverBuildCheck (archive present)",
+            "key": "build-driver-linker",
+            "command": (
+                f'echo "DriverBuildCheck: linux-recordreplay-{driver_revision}.tgz already on S3"'
+            ),
+            "agents": ["deploy=true"],
+            "plugins": [{"thedyrt/skip-checkout#v0.1.1": None}],
+        }
+    return {
+        "trigger": "build-driver-linker",
+        "key": "build-driver-linker",
+        "build": {
+            "commit": backend_commit_hash,
+            "message": "Triggered from chromium: ${BUILDKITE_MESSAGE}",
+        },
+    }
 
 
 def generate_buildkite_pipeline(backend_commit_hash):
@@ -14,14 +49,7 @@ def generate_buildkite_pipeline(backend_commit_hash):
     driver_revision = backend_commit_hash.split()[0][:12]
     pipeline = {
         "steps": [
-            {
-                "trigger": "build-driver-linker",
-                "key": "build-driver-linker",
-                "build": {
-                    "commit": backend_commit_hash,
-                    "message": "Triggered from chromium: ${BUILDKITE_MESSAGE}",
-                },
-            },
+            driver_step(backend_commit_hash, driver_revision),
             {
                 "trigger": "chromium-build",
                 "build": {


### PR DESCRIPTION
# Summary

* **DriverBuildCheck** at PipelineUpload: HEAD `linux-recordreplay-<REPLAY_BACKEND_REV[:12]>.tgz` on `static.replay.io`.
* If present: noop step with `key: build-driver-linker` instead of `trigger: build-driver-linker`.
* Avoids rebuilding driver/linker when the archive for that `REPLAY_BACKEND_REV` already exists.

# Problem

* `runtime-build-and-test` always `trigger: build-driver-linker` at `REPLAY_BACKEND_REV`.
* Same revision is rebuilt on every Chromium PR push even when S3 already has the archive.
* Waste of ~10 minutes and a `build-driver-linker` agent each time.

# Solution

* In `replay_build_scripts/build-pipeline.py`, before emitting the trigger:
  * HEAD `https://static.replay.io/downloads/linux-recordreplay-<rev12>.tgz`.
  * On hit: emit a skip-checkout noop with the same `key` so `depends_on` stays valid.
  * On miss or probe failure: keep the existing trigger.
* No agent work inside `build-driver-linker` when the archive is already present.
