### PR TITLE
[crash-0049 + crash-0048] Scrub null gProgressData; RecordReplayValue Mojo PlatformHandle fd

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '835005424853967bb39b2bee7bf027cd2a3554f1',
+  'v8_revision': 'c235a0da3a4031ab348423955a4337d6ceeacfb0',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'c235a0da3a4031ab348423955a4337d6ceeacfb0',
+  'v8_revision': 'dd578b1fee2a40c8224b6ddde46670d444004ddf',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/mojo/public/cpp/base/file_mojom_traits.cc
+++ b/mojo/public/cpp/base/file_mojom_traits.cc
@@ -48,8 +48,9 @@ StructTraits<mojo_base::mojom::FileDataView, base::File>::fd(base::File& file) {
 bool StructTraits<mojo_base::mojom::FileDataView, base::File>::Read(
     mojo_base::mojom::FileDataView data,
     base::File* file) {
-  *file = base::File(RecordReplayPlatformFile(data.TakeFd().TakePlatformFile()),
-                     data.async());
+  *file = base::File(
+      RecordReplayPlatformFile(data.TakeFd().ReleasePlatformFile()),
+      data.async());
   return true;
 }
 

--- a/mojo/public/cpp/base/file_mojom_traits.cc
+++ b/mojo/public/cpp/base/file_mojom_traits.cc
@@ -3,9 +3,39 @@
 // found in the LICENSE file.
 
 #include "mojo/public/cpp/base/file_mojom_traits.h"
+
 #include "base/files/file.h"
+#include "base/files/platform_file.h"
+#include "base/record_replay.h"
+#include "build/build_config.h"
 
 namespace mojo {
+namespace {
+
+base::PlatformFile RecordReplayPlatformFile(base::PlatformFile platform_file) {
+#if BUILDFLAG(IS_WIN)
+  uintptr_t as_value = reinterpret_cast<uintptr_t>(platform_file);
+#else
+  uintptr_t as_value = static_cast<uintptr_t>(platform_file);
+#endif
+  uintptr_t recorded = recordreplay::RecordReplayValue(
+      "Traits<FileDataView>::Read", as_value);
+#if BUILDFLAG(IS_WIN)
+  base::PlatformFile recorded_file =
+      reinterpret_cast<base::PlatformFile>(recorded);
+#else
+  base::PlatformFile recorded_file =
+      static_cast<base::PlatformFile>(recorded);
+#endif
+  // Opaque syscall identity only; discard live fd when substituting.
+  if (recorded_file != platform_file &&
+      platform_file != base::kInvalidPlatformFile) {
+    base::ScopedPlatformFile discard(platform_file);
+  }
+  return recorded_file;
+}
+
+}  // namespace
 
 mojo::PlatformHandle
 StructTraits<mojo_base::mojom::FileDataView, base::File>::fd(base::File& file) {
@@ -18,7 +48,8 @@ StructTraits<mojo_base::mojom::FileDataView, base::File>::fd(base::File& file) {
 bool StructTraits<mojo_base::mojom::FileDataView, base::File>::Read(
     mojo_base::mojom::FileDataView data,
     base::File* file) {
-  *file = base::File(data.TakeFd().TakePlatformFile(), data.async());
+  *file = base::File(RecordReplayPlatformFile(data.TakeFd().TakePlatformFile()),
+                     data.async());
   return true;
 }
 

--- a/mojo/public/cpp/base/file_mojom_traits.cc
+++ b/mojo/public/cpp/base/file_mojom_traits.cc
@@ -3,39 +3,9 @@
 // found in the LICENSE file.
 
 #include "mojo/public/cpp/base/file_mojom_traits.h"
-
 #include "base/files/file.h"
-#include "base/files/platform_file.h"
-#include "base/record_replay.h"
-#include "build/build_config.h"
 
 namespace mojo {
-namespace {
-
-base::PlatformFile RecordReplayPlatformFile(base::PlatformFile platform_file) {
-#if BUILDFLAG(IS_WIN)
-  uintptr_t as_value = reinterpret_cast<uintptr_t>(platform_file);
-#else
-  uintptr_t as_value = static_cast<uintptr_t>(platform_file);
-#endif
-  uintptr_t recorded = recordreplay::RecordReplayValue(
-      "Traits<FileDataView>::Read", as_value);
-#if BUILDFLAG(IS_WIN)
-  base::PlatformFile recorded_file =
-      reinterpret_cast<base::PlatformFile>(recorded);
-#else
-  base::PlatformFile recorded_file =
-      static_cast<base::PlatformFile>(recorded);
-#endif
-  // Opaque syscall identity only; discard live fd when substituting.
-  if (recorded_file != platform_file &&
-      platform_file != base::kInvalidPlatformFile) {
-    base::ScopedPlatformFile discard(platform_file);
-  }
-  return recorded_file;
-}
-
-}  // namespace
 
 mojo::PlatformHandle
 StructTraits<mojo_base::mojom::FileDataView, base::File>::fd(base::File& file) {
@@ -48,9 +18,7 @@ StructTraits<mojo_base::mojom::FileDataView, base::File>::fd(base::File& file) {
 bool StructTraits<mojo_base::mojom::FileDataView, base::File>::Read(
     mojo_base::mojom::FileDataView data,
     base::File* file) {
-  *file = base::File(
-      RecordReplayPlatformFile(data.TakeFd().ReleasePlatformFile()),
-      data.async());
+  *file = base::File(data.TakeFd().TakePlatformFile(), data.async());
   return true;
 }
 

--- a/mojo/public/cpp/bindings/lib/handle_serialization.cc
+++ b/mojo/public/cpp/bindings/lib/handle_serialization.cc
@@ -4,12 +4,34 @@
 
 #include "mojo/public/cpp/bindings/lib/handle_serialization.h"
 
+#include "base/files/scoped_file.h"
 #include "base/numerics/safe_conversions.h"
+#include "base/record_replay.h"
+#include "build/build_config.h"
 #include "mojo/public/cpp/bindings/lib/bindings_internal.h"
 #include "mojo/public/cpp/bindings/lib/pending_receiver_state.h"
 
 namespace mojo {
 namespace internal {
+
+PlatformHandle RecordReplayIncomingPlatformHandle(PlatformHandle handle) {
+#if BUILDFLAG(IS_POSIX) || BUILDFLAG(IS_FUCHSIA)
+  if (!handle.is_valid_fd()) {
+    return handle;
+  }
+  int fd = handle.ReleaseFD();
+  int recorded_fd = static_cast<int>(recordreplay::RecordReplayValue(
+      "Serializer<PlatformHandle>::Deserialize",
+      static_cast<uintptr_t>(fd)));
+  // Opaque syscall identity only; discard live fd when substituting.
+  if (recorded_fd != fd) {
+    base::ScopedFD discard(fd);
+  }
+  return PlatformHandle(base::ScopedFD(recorded_fd));
+#else
+  return handle;
+#endif
+}
 
 void SerializeHandle(ScopedHandle handle, Message& message, Handle_Data& data) {
   if (!handle.is_valid()) {

--- a/mojo/public/cpp/bindings/lib/handle_serialization.h
+++ b/mojo/public/cpp/bindings/lib/handle_serialization.h
@@ -57,6 +57,10 @@ ScopedInterfaceEndpointHandle DeserializeAssociatedEndpointHandle(
     const AssociatedEndpointHandle_Data& data,
     Message& message);
 
+// Forces recorded POSIX fd identity for Mojo-transferred PlatformHandles.
+COMPONENT_EXPORT(MOJO_CPP_BINDINGS_BASE)
+PlatformHandle RecordReplayIncomingPlatformHandle(PlatformHandle handle);
+
 template <typename T>
 ScopedHandleBase<T> DeserializeHandleAs(const Handle_Data& data,
                                         Message& message) {
@@ -92,8 +96,8 @@ struct Serializer<PlatformHandle, PlatformHandle> {
   static bool Deserialize(Handle_Data* input,
                           PlatformHandle* output,
                           Message* message) {
-    *output =
-        UnwrapPlatformHandle(DeserializeHandleAs<Handle>(*input, *message));
+    *output = RecordReplayIncomingPlatformHandle(
+        UnwrapPlatformHandle(DeserializeHandleAs<Handle>(*input, *message)));
     return true;
   }
 };


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/311

# crash-0049 Summary

* RecorderCrash: `RecordReplayCallbackAssertGetData` aborts on libc++ `vector[]` of empty non-null `gProgressData`.
* Cause: `RecordReplayScrubDivergentProgressScope` dtor `resize(0)` when pre-entry was null.
  * Leaves resident empty vector.
  * Later SequenceManager `[RUN-1916]` Assert → `gGetData` → `[0]`.
* Fix
  * Scrub dtor
    * `delete` + `gProgressData = nullptr` when `start_data_size_ == 0`.
    * Else `resize(start_data_size_)`.
  * `gGetData`: treat `empty()` like null.

# crash-0048 Summary

* Data mismatch: `__close` `Arg:0` fd `188` vs `170` on WebSQL `SandboxedClose` (thread 20).
* Cause: Mojo-transferred POSIX fd is a SharedSyscallResource.
  * Produced on Mojo IO thread via `recvmsg` SCM_RIGHTS.
  * Consumed on another thread at mojom `PlatformHandle` deserialize — unordered read.
* Fix: `RecordReplayValue` at `Serializer<PlatformHandle>::Deserialize` for valid POSIX fds.
  * Discard live fd when substituting.
  * Skip non-fd platform types.
  * Not IO-thread `incoming_fds_`; not `FileDataView`-only.

# crash-0049

## Problem

* Problem type: RecorderCrash.

### RepoSrc

* backend
* chromium/src

### Important Context

* buildId: linux-chromium-20260729-5a2d07b04491-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId (CrashA / MoveReadyDelayedTasksToWorkQueues): 762f7f0c-31a5-4b05-b652-ed2cff92e7d4
  * report:  (also )
* recordingId (CrashB / TakeImmediateIncomingQueueTasks): 6a2f888c-5fdf-48aa-90f6-d122f9866ca4
  * report: 
  * overview:  bucket `Recorder/...TakeImmediateIncomingQueueTasks`

#### Crash Report Core (CrashA)
```json
{
  "why": "Crash",
  "signal": 5,
  "backtrace": {
    "frames": [
      "v8::internal::RecordReplayCallbackAssertGetData(void**,.unsigned.long*)+174",
      "linker+395947",
      "linker+419476",
      "linker+482566",
      "linker+768012",
      "base::sequence_manager::internal::SequenceManagerImpl::MoveReadyDelayedTasksToWorkQueues(base::LazyNow*)+141",
      "base::sequence_manager::internal::SequenceManagerImpl::SelectNextTaskImpl(base::LazyNow&,.base::sequence_manager::internal::SequencedTaskSource::SelectTaskOption)+136",
      "non-virtual.thunk.to.base::sequence_manager::internal::SequenceManagerImpl::SelectNextTask(base::LazyNow&,.base::sequence_manager::internal::SequencedTaskSource::SelectTaskOption)+32",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+639",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "linker+21373514"
    ],
    "progress": 13254138,
    "threadId": 1,
    "checkpoint": 634,
    "stackPointerSet": false
  },
  "faultAddress": "(nil)",
  "unknownThread": false,
  "instructionPointer": "std::Cr::__libcpp_verbose_abort(char.const*,....)+5"
}
```

#### Crash Report Core (CrashB)
```json
{
  "why": "Crash",
  "signal": 5,
  "backtrace": {
    "frames": [
      "v8::internal::RecordReplayCallbackAssertGetData(void**,.unsigned.long*)+174",
      "linker+395947",
      "linker+766992",
      "recordreplay::Assert(char.const*,....)+141",
      "base::sequence_manager::internal::TaskQueueImpl::TakeImmediateIncomingQueueTasks(...)+57",
      "base::sequence_manager::internal::WorkQueue::TakeImmediateIncomingQueueTasks()+67",
      "base::sequence_manager::internal::TaskQueueImpl::ReloadEmptyImmediateWorkQueue()+21",
      "base::sequence_manager::internal::AtomicFlagSet::RunActiveCallbacks().const+129",
      "base::sequence_manager::internal::SequenceManagerImpl::SelectNextTaskImpl(...)+125"
    ],
    "progress": 12687395,
    "threadId": 1,
    "checkpoint": 114
  },
  "instructionPointer": "std::Cr::__libcpp_verbose_abort(char.const*,....)+5"
}
```

## Facts

* [F1] Tool call: `rg` + JSON-parsed  for a trace-path field → none found → no `rr` recording, only CrashReportData → per `crashes/recorder-crashes.md` must use StaticFaultProof, not dynamic `rr`.
  * `report.json`: `kind: "recorder"`, `buildid`/`recording_id` match Important Context; `crash_report.why: "Recorder"`, `crash_report.process.why: "Crash"` → crash occurred in a RECORDING process, not replaying.
* [F2] Precedent:  and  (same `why: "Recorder"` shape, no trace path) both resolved via StaticFaultProof.
* [F3] Signal 5 (SIGTRAP) + `instructionPointer: std::Cr::__libcpp_verbose_abort(char const*,...)+5` → abort-style fault, not a raw null-deref segfault.
* [F4] Top backtrace frame `v8::internal::RecordReplayCallbackAssertGetData(void**,unsigned long*)+174` (defined `v8/src/runtime/runtime-debug.cc`) is a Replay-owned assert-data callback, not upstream V8 code. Registered via `gRecordReplaySetAssertDataCallbacks` from `v8/src/api/api.cc` when `i::gRecordReplayAssertProgress` is true ([F47]).
* [F5] Frames 2-5 were unsymbolized `linker+N` offsets (linker binary `linker-linux-16050-d5125731e055`, nearest-symbol resolutions in [F8], interpreted in [F9]).
* [F6] Frames 6+ are normal Chromium renderer message-loop machinery (`SequenceManagerImpl` → `ThreadControllerWithMessagePumpImpl` → `RunLoop::Run` → `RendererMain` → ... → `ChromeMain`) → abort happened on renderer main thread during normal task execution, not startup/shutdown.
* [F7] Tool call: `tsx backend/scripts/prepare-crash-raw-data.ts report.json --out ` (run directly via `tsx`, not `mcp__determinator__run_program`, which rejects paths outside `$TOOLS_DIR`) → failed: `PrepareCrashRawData:CrashSymbolNotFound` for symbol `std::Cr::__libcpp_verbose_abort(char.const*,....)` (the `ip`); buildId matched fine. Cause is mangled-vs-demangled lookup mismatch ([F29]), not a missing symbol ([F15]-[F16]).
* [F8] Tool call: ad-hoc script  calling `makeArraySymbolifier()` (`backend/src/processing/analyzeCrash.ts`) against local symbols (`chromium/standalone-symbols/linux-chromium-20260729-5a2d07b04491-d5125731e055.symbols.{tgz,json}` + `backend/out/linker.symbols.json`) resolved the 4 `linker+N` frames (raw output ):
  * `linker+395947` → `std::vector<recordreplay::RecordedFunctionSpecifierFull,...>::_M_realloc_insert<...>` (libstdc++ symbol; linker binary itself is built with libstdc++, distinct from chrome's libc++, no inconsistency).
  * `linker+419476` → `GetStableHashTableInfo(void const*)` (`backend/src/cpp/recording/StableHashTable.cpp`).
  * `linker+482566` → `LZ4_compress_fast_force(char const*, char*, int, int, int)`.
  * `linker+768012` → `recordreplay::EndDependencyExecution()` (`backend/src/cpp/linker/DependencyGraph.cpp`).
  * Also used `RecordReplayCallbackAssertGetData`'s symbols.json entry to compute its address/length (start `0x507eaa0`, length 176 bytes, next symbol at `0x507eb50`) via ad-hoc Python parse of the same symbols.json — reused in [F30].
* [F9] Tool call: `rg` for `EndDependencyExecution` in `backend/src/cpp/linker/DependencyGraph.cpp` → body calls `Assert(IsMainThread())` only when `IsScanningExecution(*ProgressCounter())`, a linker-internal recording-time assert unrelated to F8's neighboring frames. No source links `SequenceManagerImpl`/`MoveReadyDelayedTasksToWorkQueues` to `EndDependencyExecution` → F8's `linker+N` resolutions are nearest-preceding-symbol artifacts, not a real call chain (naive nearest-symbol resolution ≠ proof; also explains F31's mis-symbolized call target).
* [F10] Tool call: `rg` for `EndDependencyExecution`/`RecordReplayCallbackAssertGetData`/`gRecordReplayAssert*` across `v8/src/api/api.cc`, `base/record_replay.cc`, `base/record_replay.h` reconstructed one Assert call site (not proven as this crash's caller):
  * `base::EndDependencyExecution()` (`base/record_replay.cc`) → `V8RecordReplayEndDependencyExecution()` (`v8/src/api/api.cc`).
  * Latter: if `V8RecordReplayUpdateDependencyGraph()` → pops dependency-graph exec stack ([F17]), calls linker callback `gRecordReplayEndDependencyExecution()`, then if `i::gRecordReplayAssertDependencyGraph` → `recordreplay::Assert("EndDependencyExecution")`.
  * `recordreplay::Assert(format,...)` (`base/record_replay.cc`) → `V8RecordReplayAssertVA` (`v8/src/api/api.cc`) → if `recordreplay::HasAsserts()` → linker function pointer `gRecordReplayAssert(format,args)` → `backend/src/cpp/recording/Assert.cpp` `RecordReplayAssertWithStackVA`, which calls `gGetData` ([F20]).
* [F11] `i::gRecordReplayAssertDependencyGraph` (`v8/src/api/api.cc`) set once at startup: `= !!getenv("RECORD_REPLAY_DEPENDENCY_GRAPH_ASSERTS")` → opt-in, not default-on. Gates the `EndDependencyExecution` Assert text in [F10]; does not by itself prove that Assert ran in this crash.
* [F12] Tool call: `rg "standalone-symbols"` across `backend` → generator is `backend/scripts/chromium/symbols-build.ts` (also referenced by `backend/scripts/prepare-crash-raw-data.ts`, `backend/scripts/symbolify-crash-log.ts`, `backend/scripts/runtime/crashReaders.ts`, dev-env defaults). Reads `buildId` from `base/record_replay_driver.cc` (`gBuildId[]`), calls `buildSymbolsArchive(buildId, "out/Release", ["chrome"])` (`backend/src/shared/instanceUtils.ts`) → only the `chrome` binary is symbolized (Linux); output `<buildId>.symbols.json` written to `$REPLAY_SYMBOLS_DIR` (default `chromium/standalone-symbols`), same path `prepare-crash-raw-data.ts` reads (confirms F7's lookup path; no alternate symbol-generation path exists).
* [F13] `generateSymbolFiles` (`backend/src/shared/symbols.ts`): on non-Windows, runs `spawnSync("/usr/bin/nm", [file])` (static symtab, not `nm -D`), keeps only lines matching `^(.*?) [t|T|W] (.*)` → local/global-text (`t`/`T`) + weak (`W`) symtab entries only, written as raw (mangled) address→name map into `.symbols.json`.
* [F14] `std::__libcpp_verbose_abort` is Chromium's own override, defined in `base/nodebug_assertion.cc`, marked `BASE_EXPORT`, wrapping `IMMEDIATE_CRASH()` (`base/immediate_crash.h`) → compiled directly into `chrome` as a normal global function symbol, in scope of the `nm`-based symbolifier [F13].
* [F15] Tool call: parsed `chromium/standalone-symbols/linux-chromium-20260729-5a2d07b04491-d5125731e055.symbols.json` (`chrome` key, 501655-entry addr→name map) with Python → found `('58710480', '_ZNSt2Cr22__libcpp_verbose_abortEPKcz')`; `c++filt` demangles to `std::Cr::__libcpp_verbose_abort(char const*, ...)`, exact match (mod cosmetic `.`/`+5` offset) to `instructionPointer`.
* [F16] [F15] confirms the symbol is NOT stripped, correctly nm-resolvable → F7's `CrashSymbolNotFound` was not caused by a stripped/missing symbol; lookup-logic bug identified in [F29].
* [F17] Tool call: `rg "V8RecordReplayEndDependencyExecution|DependencyGraph"` in `v8/src/api/api.cc` → `V8RecordReplayEndDependencyExecution()` unconditionally calls `gDependencyGraphExecutionStack->pop_back()` with no null-check, unlike sibling `V8RecordReplayDependencyGraphExecutionNode()` (checks `!gDependencyGraphExecutionStack` first). Separate code defect candidate; not linked to the observed abort frame ([F32]).
* [F18] Tool call: read `backend/src/cpp/recording/Assert.cpp` (`RecordReplayAssertWithStackVA`) → `#ifdef RECORDING` branch (active per [F1]) only serializes assertion text/stack and returns; never calls abort/CHECK → a recording-side `recordreplay::Assert(...)` is not itself the abort.
* [F20] Tool call: same file, `RecordReplayAssertWithStackVA` → before serializing, calls `gGetData((void**)&applicationData, &applicationDataSize)` (registered via `SetAssertDataCallbacks`); for V8 = `RecordReplayCallbackAssertGetData`, i.e. the top backtrace frame (F4) → abort happened inside this get-data callback, not in Assert's own bookkeeping.
* [F21] Tool call: read `RecordReplayCallbackAssertGetData` body (`v8/src/runtime/runtime-debug.cc`) → guards `!IsMainThread() || !gProgressData` (early return `*psize=0`), else: `gReportedProgressData = gProgressData; gProgressData = nullptr; *pbuf = &(*gReportedProgressData)[0]; *psize = gReportedProgressData->size() * sizeof(uint64_t);` → indexes `[0]` with no `size()==0` guard. With always-on libc++ assertions ([F26]-[F28]), empty vector → `_LIBCPP_ASSERT` → `__libcpp_verbose_abort`.
* [F22] Tool call: read `base/nodebug_assertion.cc` → `std::__libcpp_verbose_abort` is a thin wrapper around `IMMEDIATE_CRASH()`, the abort target of libc++ container assertions (e.g. `operator[]` bounds checks). No manual `CHECK`/`DCHECK` exists in `RecordReplayCallbackAssertGetData`'s source.
* [F23] Tool call: `rg "libcxx_hardening_mode"` / `_LIBCPP_HARDENING_MODE` across `chromium/src` → no matches. Relevant always-on flag is `_LIBCPP_ENABLE_ASSERTIONS_DEFAULT` ([F26]).
* [F24] Tool call: read `gProgressData`/`gReportedProgressData` decl + push site in `v8/src/runtime/runtime-debug.cc` → `gProgressData` is `static std::vector<uint64_t>*`, lazily `new`'d and `push_back`'d only when `gRecordReplayAssertProgress` is set. Size at crash proven empty by disasm ([F32]), not by this source alone.
* [F25] Tool call: `rg "use_custom_libcxx ="` across `chromium/src` → `build/config/c++/c++.gni`: `use_custom_libcxx = is_fuchsia || is_android || is_apple || is_linux || ...` → in-tree/custom libc++ (not system libstdc++) governs assertion behavior for this Linux buildId.
* [F26] Tool call: `rg "_LIBCPP_ENABLE_ASSERTIONS|_LIBCPP_HARDENING_MODE"` across `chromium/src` → `buildtools/third_party/libc++/__config_site`: `#define _LIBCPP_ENABLE_ASSERTIONS_DEFAULT 1`, unconditional (not gated on `is_debug`/`enable_iterator_debugging`) → libc++ bounds-check assertions are ALWAYS enabled in this build config, incl. this Release buildId. Confirmed by comment in `build/config/c++/BUILD.gn`: "we always enable this in `__config_site`, in all build configurations" (distinct from `_LIBCPP_ENABLE_DEBUG_MODE`/iterator-debugging, gated on `enable_iterator_debugging`, not relevant here).
* [F27] Tool call: read `buildtools/third_party/libc++/trunk/include/__assert` → `_LIBCPP_ASSERT(expr, msg)` macro: if `_LIBCPP_ENABLE_ASSERTIONS` (always 1, F26) and `expr` false → calls `std::__libcpp_verbose_abort(...)` directly (exact function from `instructionPointer`, F3/F14).
* [F28] Tool call: `rg "_LIBCPP_ASSERT"` in `buildtools/third_party/libc++/trunk/include/vector` → `operator[]` body: `_LIBCPP_ASSERT(__n < size(), "vector[] index out of bounds")` → exact match to `(*gReportedProgressData)[0]` (F21) when `size()==0`.
* [F29] Tool call: read `findSymbol` in `backend/scripts/prepare-crash-raw-data.ts` → does exact string equality (`name !== symbolName`) between CrashReportData's demangled backtrace text (e.g. `v8::internal::RecordReplayCallbackAssertGetData(void**,.unsigned.long*)`) and symbols.json entries, which store **mangled** `nm` output (e.g. `_ZN2v88internal33RecordReplayCallbackAssertGetDataEPPvPm`, F13) → guaranteed mismatch for any C++ symbol, not just `__libcpp_verbose_abort` → root cause of F7/F16's `CrashSymbolNotFound`. `rg "demangle|c++filt"` in the same file → no matches: no demangling step exists anywhere in the lookup path. Tooling bug, orthogonal to the runtime crash mechanism.
* [F30] Tool call: wrote ad-hoc script `backend/scripts/fetch-and-disasm.ts` (removed after use) calling `ensureReplayRuntime`/`resolveLibraryBinaryPath` (`backend/src/build/install.ts`) with `downloadBuildFileFromS3` (`AWS_PROFILE=ReplayProdDev` S3 access confirmed working) to fetch the exact-buildId `chrome` binary + matching linker, bypassing F29's broken `findSymbol`, then ran `objdump -d --start-address=0x507eaa0 --stop-address=0x507eba0` (address/length from F8: `RecordReplayCallbackAssertGetData` at `0x507eaa0`, length 176 bytes) → full disasm saved to .
* [F31] From F30's disasm: function loads `gProgressData` (`0xef34248`), null-checks it, loads `gReportedProgressData` (`0xef34250`), frees any prior value, does `gReportedProgressData = gProgressData; gProgressData = nullptr;`, then `mov (%rax),%rcx` / `cmp %rcx,0x8(%rax)` / `je 0x507eb26` — classic libc++ `std::vector` layout (`+0x0`=begin, `+0x8`=end), i.e. `begin==end` ⇔ `size()==0`. The `je`-taken (empty-vector) branch loads 4 static args + `edx=0x587` (line 1415) and calls a target mis-symbolized (nearest-symbol artifact, [F9]) as `GetDebugPolicyProviderNameEv` — actual target is the `_LIBCPP_ASSERT`/`__libcpp_verbose_abort` trampoline — immediately followed by `int3;int3` padding (`0x507eb4e`/`0x507eb4f`), the standard "unreachable after `[[noreturn]]` abort" pattern.
* [F32] Crash `instructionPointer` offset `+174` from `RecordReplayCallbackAssertGetData`'s start (`0x507eaa0`) = `0x507eb4e` → lands exactly on the `int3` after the abort call in the `begin==end` (empty-vector) branch ([F31]) → **direct static proof** (per StaticFaultProof requirements, `crashes/recorder-crashes.md`) that execution took the `size()==0` branch.
* [F33] Tool call: `rg` for `gProgressData|gReportedProgressData` (and re-confirmed via `ProgressData`, [F38]) in `v8/src/runtime/runtime-debug.cc` → exhaustive list of all reference sites: (1) declaration (`static std::vector<uint64_t>* gProgressData;`, file-scope `static`), (2) `RecordReplayCallbackAssertGetData` (reads/nulls only, F21/F31), (3) `Runtime_RecordReplayAssertExecutionProgress` (~line 1152-1164): `if (gRecordReplayAssertProgress) { if (!gProgressData) { gProgressData = new std::vector<uint64_t>(); } gProgressData->push_back(BuildScriptProgressEntry(function)); }` → allocation and `push_back` occur back-to-back in the same synchronous main-thread call, with no intervening path that could observe/leave the vector non-null-but-empty via this function alone.
* [F34] Tool call: `rg -l "gProgressData"` across `chromium/src` (whole tree) → zero results outside `runtime-debug.cc` (F33 already enumerated all in-file matches) → `gProgressData` is file-scope `static`, no external linkage, no other writer/clearer exists anywhere → only writers are F33's alloc+push_back pair and F21's null-out → source-level static analysis is exhausted: no reviewed code path produces a non-null empty `gProgressData`, leaving the mechanism behind the observed `size()==0` (F32) unexplained by static source review alone.
* [F35] Tool call: `rg` for `-fno-exceptions`/`-fexceptions` in `build/config/compiler/BUILD.gn` + `build/config/BUILDCONFIG.gn` → default config includes `//build/config/compiler:no_exceptions`; on non-Windows that is `-fno-exceptions` → `std::vector::push_back`'s internal `bad_alloc`/etc. cannot throw out of `Runtime_RecordReplayAssertExecutionProgress` in this build, ruling out "exception mid-`push_back` leaves `gProgressData` non-null-but-empty" as a mechanism.
* [F36] Tool call: read `recordreplay::RecordReplayAssertWithStackVA` (`backend/src/cpp/recording/Assert.cpp`) → calls `gGetData(...)` (= `RecordReplayCallbackAssertGetData`, F20) synchronously on the same call stack, using `CurrentThreadId()` for its own thread-id bookkeeping (no thread hop/dispatch before the `gGetData` call) → the crashing thread reads `gProgressData` on the same thread that would be the sole writer, ruling out a cross-thread race/torn-read on the raw pointer as the empty-vector mechanism.
* [F37] Tool call: `rg "V8RecordReplayEndDependencyExecution"` in `v8/src/api/api.cc` → full body confirms F10's source reconstruction: `pop_back()` (unguarded, F17) → `gRecordReplayEndDependencyExecution()` → if `gRecordReplayAssertDependencyGraph` → `recordreplay::Assert("EndDependencyExecution")` (plain literal, no format specifiers/varargs). One of several Assert call sites that can reach `gGetData` ([F44]/[F54]); not proven as this crash's caller.
* [F38] Re-confirmed via `rg "ProgressData"` in `v8/src/runtime/runtime-debug.cc` → exactly the 9 lines already enumerated in F33/F34 (declarations, the two `gGetData`-callback statements, the alloc+push_back pair) → no additional read/write site exists; static analysis of this TU is fully exhausted, no further code-level candidate mechanism found for a non-null-but-empty `gProgressData` beyond what F33/F34 already established.
* [F39] Tool call: `rg` full body of `Runtime_RecordReplayAssertExecutionProgress` (`v8/src/runtime/runtime-debug.cc`) → refines F33: `if (++*gProgressCounter == gTargetProgress) { RecordReplayOnTargetProgressReached(); }` runs FIRST, unconditionally, BEFORE the `gRecordReplayAssertProgress`-gated `gProgressData` alloc+push_back block → a synchronous nested call can occur inside the same invocation, prior to that call's own push_back.
* [F40] Tool call: `rg` for `RecordReplayOnTargetProgressReached` def in `v8/src/api/api.cc` → body: `CHECK(IsMainThread())`; if `recordreplay::AreEventsDisallowed()` → diagnostic-only path (`Warning`) and return; else calls linker function pointer `gRecordReplayProgressReached()` (F41) → potential same-thread reentry into linker code from within the V8 runtime function.
* [F41] Tool call: `rg` for `Macro(RecordReplayProgressReached` in `v8/src/api/api.cc` → confirms it's one of the `gRecordReplay*` linker-callback-pointer macros (same family as F10's `gRecordReplayEndDependencyExecution`/`gRecordReplayAssert`), opaque to Chromium-source-only review; implementation lives in `backend`.
* [F42] Tool call: `rg "RecordReplayProgressReached"` in `backend/src/cpp` → resolves to `EXPORT void RecordReplayProgressReached()` (`backend/src/cpp/driver/Driver.cpp`) → thin wrapper calling `recordreplay::OnProgressReached()` (`backend/src/cpp/recording/ProgressCounter.cpp`).
* [F43] Tool call: read `recordreplay::OnProgressReached()` (`backend/src/cpp/recording/ProgressCounter.cpp`) → when `gProgressCounter == gNextCheckpointProgress` (and not `gPreventCheckpointProgress`) it calls `RecordReplayAssert("NewProgressCheckpoint %zu", ...)` then `NewCheckpoint(...)` → a second, independent Assert call site, distinct from `EndDependencyExecution`'s (F10/F37), reachable synchronously from inside `Runtime_RecordReplayAssertExecutionProgress` via F39-F40's chain, before that invocation's own `gProgressData` push_back executes.
* [F44] Tool call: re-read `recordreplay::RecordReplayAssertWithStackVA` (`backend/src/cpp/recording/Assert.cpp`, lines ~286-322) → `gGetData(...)` (= `RecordReplayCallbackAssertGetData`, F20) is invoked unconditionally for EVERY `Assert(...)` call regardless of asserted text/site → every Assert path that reaches `gGetData` can observe whatever `gProgressData`/`gReportedProgressData` state exists at that moment.
* [F45] Tool call: read `recordreplay::NewCheckpoint()` (`backend/src/cpp/recording/Navigate.cpp`) → body performs linker-internal record/replay bookkeeping only (recording bytes/values, ordered-lock checkpoint creation), no calls back into V8/JS execution visible → bounds F43's reentrancy scope to the `Assert("NewProgressCheckpoint")` call itself, no further nested JS-side reentry evidenced in this function.
* [F47] Tool call: `rg "gRecordReplaySetAssertDataCallbacks"` in `v8/src/api/api.cc` → callback registration itself gated `if (i::gRecordReplayAssertProgress)`, SAME flag gating F33/F39's `gProgressData` alloc+push_back block → `RecordReplayCallbackAssertGetData` only ever installed as `gGetData` when that flag is true (distinct from F11's `gRecordReplayAssertDependencyGraph`, which only gates the `EndDependencyExecution` Assert text, not callback registration). `gRecordReplayAssertProgress = gRecordReplayAssertValues || getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS")`.
* [F48]-[F49] Tool calls: `rg` for `gTargetProgress`/`RecordReplaySetTargetProgress` (`v8/src/api/api.cc`) + `SetProgressCallback`/`gProgressCallback` (`backend/src/cpp/recording/ProgressCounter.cpp`, `backend/src/cpp/driver/Driver.cpp`, `backend/src/cpp/linker/BindingInternal.cpp`) → `RecordReplaySetTargetProgress(progress)` (`CHECK(IsMainThread()); gTargetProgress = progress;`) is registered at init as the linker's `ProgressCallback` via `gRecordReplaySetProgressCallback(i::RecordReplaySetTargetProgress)`/`AddBinding("RecordReplaySetProgressCallback", SetProgressCallback)`; `UpdateTargetProgress()` (static in `ProgressCounter.cpp`) computes the earliest of `gNextCheckpointProgress`/interrupt/(replay-only)`gDestinationProgress` and invokes it → proves F39-F45's reentrant chain is one unified progress mechanism (linker-driven), not two independently-timed counters.
* [F50] Tool call: `rg "gProgressCounter\b"`/`"gTargetProgress"` across `v8/src` → `i::gProgressCounter` (api.cc) initialized as `gRecordReplayProgressCounter()` (`backend/src/cpp/driver/Driver.cpp`: `EXPORT uint64_t* RecordReplayProgressCounter() { return ProgressCounter(); }`) → V8's and linker's (`ProgressCounter.cpp`) `gProgressCounter` are the SAME memory location, not separate counters.
* [F51] Tool call: `rg "IncrementProgressCounter\("` across `chromium/src` → zero call sites → linker's generic `recordreplay::IncrementProgressCounter()` (which itself does a preceding `RecordReplayAssertWithStack(..., "IncrementProgressCounter")` before incrementing, `backend/src/cpp/recording/ProgressCounter.cpp`) is NOT used by V8 → `Runtime_RecordReplayAssertExecutionProgress`'s `++*gProgressCounter` bumps the shared counter directly, bypassing that wrapper/assert.
* [F52] Tool call: read full body of `recordreplay::OnProgressReached()` (`backend/src/cpp/recording/ProgressCounter.cpp`) → ordered checks: (1) early-return if `!gProgressCallback`; (2) replay-only: `gProgressCounter==gDestinationProgress` → `OnDestinationProgressReached()`; (3) `gProgressCounter==gInterruptProgressValues[0]` → `ExecuteProgressInterrupt` (itself `RecordReplayAssert("ProgressInterrupt %zu",...)`, a 3rd independent Assert call-site, not previously listed in F43); (4) `gProgressCounter==gNextCheckpointProgress` → advance it, then (if not prevented) `RecordReplayAssert("NewProgressCheckpoint %zu",...)` + `NewCheckpoint(...)` (F43); (5) `UpdateTargetProgress()`. Steps 2-4 can each independently trigger a reentrant `Assert→gGetData` call before the enclosing `Runtime_RecordReplayAssertExecutionProgress` invocation's own push_back executes.
* [F53] Sanity check: raw crash data (`progress: 13254138`, `checkpoint: 634`) vs. `DefaultCheckpointProgressInterval` (1000000, F43-adjacent): `13254138 mod 1000000 = 254138`, not a multiple → crash progress isn't exactly at a default-interval checkpoint boundary; inconclusive alone (interval may be overridden via `RECORD_REPLAY_CHECKPOINT_PROGRESS_INTERVAL`, or the reached target may be an interrupt/destination value) — does not confirm/rule out which F52 branch fired.
* [F54] Tool call: `rg "gGetData\("` in `backend/src/cpp/recording/Assert.cpp` → re-confirms F44 for all 4 known Assert call-sites (`EndDependencyExecution`, `NewProgressCheckpoint`, `ProgressInterrupt`, `IncrementProgressCounter`): `gGetData` fires unconditionally per call (after an `AreEventsDisallowed() && !HasDivergedFromRecording()` guard unrelated to progress-data state) → all reach the same crashing callback.
* [F55] Tool call: whole-tree `rg "gProgressData"` re-verification across `chromium/src` (superset of F34, post F47-F54) → still zero writer/clearer sites outside `runtime-debug.cc`'s 3 known ones (alloc+push_back pair, null-out in the callback) → static source review is fully exhausted; no code path (reentrant or not) statically produces a non-null-but-empty `gProgressData`.
* [F56] Tool call: parsed overview sibling recorder bucket  (CrashB) vs CrashA . Same `buildid`, `linkerVersion`, `kind: recorder`, `signal: 5`, `instructionPointer: std::Cr::__libcpp_verbose_abort(...)+5`, top frame `RecordReplayCallbackAssertGetData(...)+174` (same offset as CrashA / [F32]). Different `recording_id` / progress / checkpoint (`CrashB`: progress `12687395`, checkpoint `114`). Copies under .
* [F57] CrashB backtrace (better symbolized than CrashA): `RecordReplayCallbackAssertGetData+174` → `linker+395947` → `linker+766992` → `recordreplay::Assert(...)+141` → `TaskQueueImpl::TakeImmediateIncomingQueueTasks(...)+57` → `WorkQueue::TakeImmediateIncomingQueueTasks` → `TaskQueueImpl::ReloadEmptyImmediateWorkQueue` → `AtomicFlagSet::RunActiveCallbacks` → `SequenceManagerImpl::SelectNextTaskImpl` → same message-loop tail as CrashA. Proves CrashB's path is chrome `recordreplay::Assert` → linker Assert machinery → `gGetData` callback (same fault mode as [F20]/[F32]).
* [F58] Tool call: `rg` / read `base/task/sequence_manager/task_queue_impl.cc` → `TaskQueueImpl::TakeImmediateIncomingQueueTasks` first statement is `recordreplay::Assert("[RUN-1916] TaskQueueImpl::TakeImmediateIncomingQueueTasks %zu", queue->size());` → CrashB's chrome caller + `Assert+141` / `TakeImmediateIncomingQueueTasks+57` identifies that Assert text as CrashB's invocation (not `EndDependencyExecution` / `NewProgressCheckpoint` / `ProgressInterrupt`).
* [F59] Tool call: `rg` for Asserts under delayed-task move path → `SequenceManagerImpl::MoveReadyDelayedTasksToWorkQueues` itself has no Assert; nested `TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue` has `recordreplay::Assert("[RUN-1916] TaskQueueImpl::MoveReadyDelayedTasksToWorkQueue #2 %d %d", ...)` (`task_queue_impl.cc`). CrashA's first chrome frame is `SequenceManagerImpl::MoveReadyDelayedTasksToWorkQueues+141` with no symbolized `recordreplay::Assert` frame ([F5]/[F9] linker nearest-symbol gap) → consistent with a nested `[RUN-1916]` Assert under that call, not proven to the same degree as CrashB ([F58]).
* [F60] Both CrashA and CrashB enter via `SequenceManagerImpl::SelectNextTaskImpl` (CrashA: `MoveReadyDelayedTasksToWorkQueues` call site inside it; CrashB: `ReloadEmptyWorkQueues` → `RunActiveCallbacks` → `TakeImmediateIncomingQueueTasks`). Same empty-`gProgressData` abort ([F56]/[F32]) from two distinct `[RUN-1916]` SequenceManager Assert sites. Does not explain how `gProgressData` became non-null-but-empty ([F55]).
* [F61] Tool call: `objdump -d` of exact-buildId `chrome` (`backend/scripts/storage/builds/linux-chromium-20260729-5a2d07b04491-d5125731e055/chrome`) for `Runtime_RecordReplayAssertExecutionProgress` at `0x507ef00` → . When `gProgressData` is null: `_Znwm(0x18)` → zero-init vector (`begin=end=cap=0`) → **store pointer to `gProgressData` at `0x507ef9d`** → then `SharedFunctionInfo::StartPosition` → `vector::push_back`. Refines [F33]: EmptyPublish is globally visible before `push_back`.
* [F62] Tool call: whole-`.text` scan for RIP-relative xrefs to `gProgressData` (`0xef34248`) / `gReportedProgressData` (`0xef34250`) → sites beyond [F33]/[F55]'s source list: `RecordReplayScrubDivergentProgressScope` ctor `0x507e5b0` / dtor `0x507e630`, plus the stats-wrapper clone of `Runtime_RecordReplayAssertExecutionProgress`. Symbol present in this buildId binary; **absent from current `chromium/src` tree** (`rg` zero hits) → [F34]/[F55] source-only review was incomplete for this buildId.
* [F63] Tool call: disasm :
  * Ctor arms only when `IsRecordingOrReplaying && IsMainThread && AreEventsDisallowed && !HasDivergedFromRecording`; saves `*gProgressCounter` and `gProgressData ? gProgressData->size() : 0`.
  * Dtor (if armed, still `!HasDivergedFromRecording`, counter advanced): restores `*gProgressCounter`; if `gProgressData` non-null and `size() > saved_size`, sets `end = begin + saved_size` (truncate in place, pointer kept).
  * When ctor saved `size==0` and the scope's JS path later EmptyPublish+`push_back`'d, dtor truncate → **non-null empty `gProgressData`**. Matches [F32].
* [F64] Tool call: E8-rel32 call-site scan → `RecordReplayScrubDivergentProgressScope` constructed in: `Builtins::InvokeApiFunction`, `HandleApiCallHelper<true>`, `HandleApiCallHelper<false>`, `HandleApiCallAsFunctionOrConstructor`, `(anonymous namespace)::Invoke`. Matches crash-0042 G2 / `[RUN-1988]` ProgressRewind placement.
* [F65] CrashB stack has no `Runtime_RecordReplayAssertExecutionProgress` and a single `RunLoop::Run` → empty state was already resident when the `[RUN-1916]` Assert ran, not an in-window EmptyPublish observation. [F63]'s truncate-to-zero is the write that can leave that resident state after the scrub scope returns to the message loop.
* [F66] `gGetData` contract ([F21]): `gProgressData == nullptr` means “no assert application data” (early return `*psize=0`). Non-null always indexes `[0]`. Null and empty are not equivalent.
* [F67] crash-0042 G2 / `[RUN-1988]` intent for `RecordReplayScrubDivergentProgressScope`: on exit, restore `*gProgressCounter` **and** `gProgressData` to pre-entry values. Counter restore matches intent ([F63]). Vector path only restores **length** via in-place truncate; it does **not** restore **null** when pre-entry was null (`saved_size==0` but pointer now live). Truncate-to-zero ≠ restore-null → violates [F66].

## Unknowns

* [U1] ~~By what mechanism `gProgressData` became non-null-but-empty~~ → resolved ([F63], [F65], [F67]).
* [U2] Which [F64] scrub call site armed before CrashA / CrashB — not pinned without `rr` ([F1]). Not required for the defect class.

## Root Cause

Verdict: `RecordReplayScrubDivergentProgressScope` dtor leaves non-null empty `gProgressData` when pre-entry was null; later `gGetData` aborts on `[0]`.

* Abort site ([F18], [F20]-[F21], [F25]-[F28], [F32], [F56]): `RecordReplayCallbackAssertGetData` → `vector::operator[]` `_LIBCPP_ASSERT` on `begin==end`. Same `+174` on CrashA and CrashB.
* Contract ([F66]): null = no data. Empty non-null is illegal for `gGetData`.
* Writer ([F62]-[F65], [F67]): scrub dtor (buildId binary; missing from current tree) truncates to `saved_size` and keeps the pointer. Pre-entry null → `saved_size==0` → non-null empty after rewind.
* Intent vs implementation ([F67]): ProgressRewind should restore pre-entry state. Counter: yes. `gProgressData` nullness: no.
* Crash entry ([F57]-[F60]): SequenceManager `[RUN-1916]` Assert after the scrub scope already returned (CrashB stack proves resident empty, not in-`Runtime_` EmptyPublish).
* Orthogonal: [F17] unguarded dependency-graph `pop_back` — not on this path.

### Crucial data points

* `gProgressData` / `gReportedProgressData`: `0xef34248` / `0xef34250` in this buildId `chrome`.
* EmptyPublish store: `Runtime_RecordReplayAssertExecutionProgress+0x9d` (`0x507ef9d`)
* Scrub ctor/dtor: `0x507e5b0` / `0x507e630`
* Scrub call sites: `InvokeApiFunction`, `HandleApiCallHelper<true|false>`, `HandleApiCallAsFunctionOrConstructor`, `Invoke` ([F64]).
* `gGetData` empty abort: `RecordReplayCallbackAssertGetData+174` = `0x507eb4e` (`int3` after `__libcpp_verbose_abort`)
* Precedent/intent:  G2 / `[RUN-1988]`.

### Solution items vs remaining unknown

Verdict: No — `solution.md` lines 9–23 are not the right move.

* Right fix: scrub dtor must restore pre-entry null (e.g. `delete` + `gProgressData = nullptr` when `saved_size==0`), not truncate-to-zero. Optional belt: `gGetData` treat `size()==0` like null.
* Local tree lacks scrub source ([F62]) — restore/patch against buildId-present code first.
* Items 1–3: wrong/orthogonal ([F58], [F17], [F29]).

### Slice

* `EventsDisallowed` + not diverged → scrub arms, `saved_size==0` because `gProgressData` was null ([F63]-[F64], [F67]).
* Scoped JS: `Runtime_RecordReplayAssertExecutionProgress` → EmptyPublish + `push_back` ([F61]).
* Scrub dtor: restore counter; truncate vector to size 0; pointer kept ([F63], [F67]).
* Message loop: `SelectNextTaskImpl` → `[RUN-1916]` Assert (CrashB: `TakeImmediateIncomingQueueTasks` [F58]; CrashA: under `MoveReadyDelayedTasksToWorkQueues` [F59]).
* `RecordReplayAssertWithStackVA` → `gGetData` ([F20]).
* Non-null empty ([F32], [F65]) → `[0]` → `_LIBCPP_ASSERT` → `__libcpp_verbose_abort` → SIGTRAP ([F3], [F66]).

## Solution

* Recipe: restore pre-entry nullness of `gProgressData` in the scrub dtor.
  * Length truncate only when pre-entry size was non-zero.
* Implementation
  * `RecordReplayScrubDivergentProgressScope` dtor:
    * If `start_data_size_ == 0`: `delete` + `nullptr`.
    * Else: existing `resize(start_data_size_)`.
  * `RecordReplayCallbackAssertGetData`: early-return when `gProgressData->empty()`.
* Why
  * `gGetData` contract: null means no assert application data.
  * Non-null always indexes `[0]`.
  * Truncate-to-zero after EmptyPublish violated that contract.
  * Null restore matches crash-0042 ProgressRewind intent.

# crash-0048

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260729-5a2d07b04491-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: 20d74025-f946-4994-b9a8-c067bdde0637

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2595226,
      "checkpoint": 130
    }
  },
  "recorded": "Call __close Arg:0:188",
  "replayed": "Call __close Arg:0:170",
  "threadId": 20,
  "backtrace": {
    "progress": 2531065,
    "threadId": 20,
    "checkpoint": 128
  },
  "recordedStack": [
    "base::internal::ScopedFDCloseTraits::Free(int)+11",
    "base::File::Close()+191",
    "sql::(anonymous.namespace)::SandboxedClose(sqlite3_file*)+18",
    "sqlite3PagerClose+393",
    "sqlite3BtreeClose+37",
    "sqlite3LeaveMutexAndCloseZombie+220",
    "sqlite3Close+296",
    "blink::SQLiteDatabase::Close()+60"
  ],
  "replayedStack": [
    "base::internal::ScopedFDCloseTraits::Free(int)+11",
    "base::File::Close()+191",
    "sql::(anonymous.namespace)::SandboxedClose(sqlite3_file*)+18",
    "sqlite3PagerClose+393",
    "sqlite3BtreeClose+37",
    "sqlite3LeaveMutexAndCloseZombie+220",
    "sqlite3Close+296",
    "blink::SQLiteDatabase::Close()+60"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "JS Invoke: Non-deterministic user JS PC=620961 scriptId=-1 @https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:117315 stack=console.debug (<anonymous>)https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:117351https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:117404_I0Pa (https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:177227)https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:177232https://banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247969:1:177270 [EventsDisallowed:V8InspectorImpl::forEachSession]",
    "count": 1,
    "stack": [
      "v8::recordreplay::Warning(char.const*,....)+140",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3070",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+852",
      "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
      "v8::internal::Runtime::GetObjectProperty(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.bool*)+174",
      "v8::Object::Get(v8::Local<v8::Context>,.v8::Local<v8::Value>)+260",
      "v8_inspector::(anonymous.namespace)::descriptionForError(v8::Local<v8::Context>,.v8::Local<v8::Object>,.v8_inspector::(anonymous.namespace)::ErrorType)+186",
      "v8_inspector::ValueMirror::create(v8::Local<v8::Context>,.v8::Local<v8::Value>)+914",
      "v8_inspector::InjectedScript::wrapObject(v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_inspector::WrapMode,.v8::MaybeLocal<v8::Value>,.int,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::RemoteObject,.std::Cr::default_delete<v8_inspector::protocol::Runtime::RemoteObject>.>*)+104",
      "v8_inspector::InjectedScript::wrapObject(v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_inspector::WrapMode,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::RemoteObject,.std::Cr::default_delete<v8_inspector::protocol::Runtime::RemoteObject>.>*)+23",
      "v8_inspector::V8InspectorSessionImpl::wrapObject(v8::Local<v8::Context>,.v8::Local<v8::Value>,.v8_inspector::String16.const&,.bool)+138",
      "v8_inspector::V8ConsoleMessage::wrapArguments(v8_inspector::V8InspectorSessionImpl*,.bool).const+518",
      "v8_inspector::V8ConsoleMessage::reportToFrontend(v8_inspector::protocol::Runtime::Frontend*,.v8_inspector::V8InspectorSessionImpl*,.bool).const+565",
      "v8_inspector::V8RuntimeAgentImpl::messageAdded(v8_inspector::V8ConsoleMessage*)+44",
      "v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+1101",
      "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+702",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185",
      "v8_inspector::V8Console::Debug(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+355",
      "v8::internal::(anonymous.namespace)::ConsoleCall(v8::internal::Isolate*,.v8::internal::BuiltinArguments.const&,.void.(v8::debug::ConsoleDelegate::*)(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&))+800",
      "v8::internal::Builtin_ConsoleDebug(int,.unsigned.long*,.v8::internal::Isolate*)+74"
    ],
    "progress": 620961,
    "threadId": 1,
    "processId": 3,
    "checkpoint": 74,
    "absoluteTime": 1785378380753.4568,
    "wasRecording": false
  },
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 44,
    "stack": [
      "WTF::RecursiveMutex::unlock()+135",
      "blink::AudioNode::Dispose()+228",
      "blink::AudioNode::InvokePreFinalizer(cppgc::LivenessBroker.const&,.void*)+44",
      "cppgc::internal::PreFinalizerHandler::InvokePreFinalizers()+214",
      "cppgc::internal::HeapBase::ExecutePreFinalizers()+39",
      "v8::internal::CppHeap::TraceEpilogue()+210",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+3404",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::Heap::HandleGCRequest()+223",
      "v8::internal::StackGuard::HandleInterrupts()+626",
      "v8::internal::Runtime_StackGuard(int,.unsigned.long*,.v8::internal::Isolate*)+314"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1785378371799.8958,
    "wasRecording": true
  },
  {
    "text": "Recording assertion with events disallowed: [TT-1465] FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed 13565 [EventsDisallowed:Heap::CollectGarbage]",
    "count": 24,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "blink::scheduler::FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed(blink::scheduler::MainThreadTaskQueue*)+46",
      "blink::scheduler::MainThreadWebSchedulingTaskQueueImpl::~MainThreadWebSchedulingTaskQueueImpl()+119",
      "blink::scheduler::MainThreadWebSchedulingTaskQueueImpl::~MainThreadWebSchedulingTaskQueueImpl()+14",
      "cppgc::internal::(anonymous.namespace)::MutatorThreadSweeper::SweepWithDeadline(v8::base::TimeDelta,.cppgc::internal::(anonymous.namespace)::MutatorThreadSweepingMode)+555",
      "cppgc::internal::Sweeper::SweeperImpl::FinishIfOutOfWork()+256",
      "v8::internal::Heap::CompleteSweepingYoung(v8::internal::GarbageCollector)+1146",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+198",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int,.v8::internal::AllocationType,.v8::internal::AllocationOrigin,.v8::internal::AllocationAlignment)+1998",
      "v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int,.v8::internal::AllocationType,.v8::internal::AllocationOrigin,.v8::internal::AllocationAlignment)+36",
      "v8::internal::Factory::NewFillerObject(int,.v8::internal::AllocationAlignment,.v8::internal::AllocationType,.v8::internal::AllocationOrigin)+1037",
      "v8::internal::Runtime_AllocateInYoungGeneration(int,.unsigned.long*,.v8::internal::Isolate*)+253"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1785378372977.444,
    "wasRecording": true
  },
  {
    "text": "Recorded value with events disallowed TryLock [EventsDisallowed:Heap::CollectGarbage]",
    "count": 32,
    "stack": [
      "WTF::RecursiveMutex::lock()+59",
      "blink::BaseAudioContext::~BaseAudioContext()+83",
      "cppgc::internal::(anonymous.namespace)::MutatorThreadSweeper::SweepWithDeadline(v8::base::TimeDelta,.cppgc::internal::(anonymous.namespace)::MutatorThreadSweepingMode)+555",
      "cppgc::internal::Sweeper::SweeperImpl::FinishIfOutOfWork()+256",
      "v8::internal::Heap::CompleteSweepingYoung(v8::internal::GarbageCollector)+1146",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+198",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int,.v8::internal::AllocationType,.v8::internal::AllocationOrigin,.v8::internal::AllocationAlignment)+1998",
      "v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int,.v8::internal::AllocationType,.v8::internal::AllocationOrigin,.v8::internal::AllocationAlignment)+36",
      "v8::internal::Factory::NewFillerObject(int,.v8::internal::AllocationAlignment,.v8::internal::AllocationType,.v8::internal::AllocationOrigin)+1037",
      "v8::internal::Runtime_AllocateInYoungGeneration(int,.unsigned.long*,.v8::internal::Isolate*)+253"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1785378372977.8423,
    "wasRecording": true
  }
]
```

## DivergentPathSegments

* Anchor (hit Assert, `FrameCandidates`): the record/replay syscall-argument check on `__close(fd)`, hit inside `base::internal::ScopedFDCloseTraits::Free(int)+11` — `recorded`="Call __close Arg:0:188", `replayed`="Call __close Arg:0:170".

```cpp
// sql/sandboxed_vfs.h — SandboxedVfs::Delegate::OpenFile
class Delegate {
  // [Write] NOT-ASSERTABLE
  // WebSQL: Mojo-transferred PlatformFile (SharedSyscallResource), not a
  // renderer-local open() ScalarRval. Opaque syscall identity only.
  virtual base::File OpenFile(const base::FilePath& file_path,
                              int sqlite_requested_flags) = 0;
};

// sql/sandboxed_vfs.cc
int SandboxedVfs::Open(const char* full_path,
                       sqlite3_file& result_file,
                       int requested_flags,
                       int* granted_flags) {
  // [Write] NOT-ASSERTABLE
  // fd identity entered this process via Mojo message handles → TakePlatformFile
  // on the calling DB thread (unordered read of SharedSyscallResource).
  base::File file = delegate_->OpenFile(file_path, requested_flags);
  // sql::SandboxedVfsFile::Create(base::File file, base::FilePath file_path, SandboxedVfs* vfs, sqlite3_file& buffer)
  SandboxedVfsFile::Create(std::move(file), std::move(file_path),
                           this, result_file);
}

// sql/sandboxed_vfs_file.cc — SandboxedVfsFile::Create
void SandboxedVfsFile::Create(base::File file, base::FilePath file_path,
                              SandboxedVfs* vfs, sqlite3_file& buffer) {
  // [Write] NOT-ASSERTABLE
  // file_ member-initialized from the same fd; no recomputation.
  bridge.sandboxed_vfs_file =
      new SandboxedVfsFile(std::move(file), std::move(file_path), vfs);
}

// base/files/file_posix.cc
void File::Close() {
  // [Write] NOT-ASSERTABLE
  // file_ (ScopedFD) still holds the same never-recomputed fd value.
  file_.reset();
}

// base/files/scoped_file.cc
void ScopedFDCloseTraits::Free(int fd) {
  int ret = IGNORE_EINTR(close(fd));  // <<< RECORDED LEAF (fd=188) / <<< REPLAYED LEAF (fd=170)
  PCHECK(0 == ret);
}
```

# Investigation

* Mismatch: `__close` `Arg:0` fd recorded `188` / replayed `170`. Same stacks. `threadId: 20`. `processId: 3`.
* Recording: [20d74025-f946-4994-b9a8-c067bdde0637](https://app.replay.io/recording/20d74025-f946-4994-b9a8-c067bdde0637)
* Hit Assert site: `base::internal::ScopedFDCloseTraits::Free(int)+11` — `Call __close Arg:0`.
* HitAssert order: `2943100` (linkerdebug).

## LinkerdebugFd

Raw dumps: dump/.

* **HitAssert**
  * `order:2943100` `thread:20` `Call __close Arg:0:188`
  * Stack: `ScopedFDCloseTraits::Free` → `File::Close` → `SandboxedClose` → `sqlite3*` → `blink::SQLiteDatabase::Close`
  * dump/hit-assert.json
* **HasInfoBeforeHit**
  * `order:2943099` `Value CloseFileDescriptor hasInfo` — same close stack, immediately before HitAssert.
  * This Value matched on replay (mismatch is the next Assert).
  * No `CloseFileDescriptor 188 N` anywhere in the recording ⇒ `hasInfo` was false (unmarked fd).
  * Driver (`FileDescriptor.cpp`): unmarked closes still `ScalarArg`-check the fd; only `hasInfo` triggers ordered `CloseFileDescriptor`.
* **Unmarked188**
  * `MarkFileDescriptor 188 …`: 0 matches (full assert scan).
  * `CloseFileDescriptor 188 …`: 0 matches.
  * Consistent with Mojo SCM_RIGHTS PlatformFile (not renderer `open()` → `MarkFileDescriptor`).
* **HitCloseBurst** (thread 20, identical SQLite close stack, orders ascending):
  * `2943100` fd **188** ← HIT (recorded Arg)
  * `2943119` fd **200**
  * `2943173` fd **169**
  * `2943237` fd **170** ← equals **replayed** Arg at HIT
  * `2943300` fd **189**
  * `2943354` fd **186**
  * dump/hit-close-burst.json, dump/t20-closes.jsonl
* **Thread20CloseUniverse**
  * Only 12 `Call __close` asserts on thread 20 in the whole recording.
  * Pre-burst (orders ~1.82M–1.86M): fds `190/189/169/191` on a different sqlite stack (not `SQLiteDatabase::Close`).
  * Burst above is the only `SQLiteDatabase::Close` close cluster on this thread.
* **Fd170Elsewhere** (number reuse, not the Hit File)
  * Many `Call __close Arg:0:170` on threads 1 and 9; also `MarkFileDescriptor 170 /tmp/.org.chromium.Chromium.*` + `CloseFileDescriptor 170 0` on those threads.
  * Those are separate lifetime cycles of the same integer after free/reuse.
  * dump/fd-lifecycle-188-170.jsonl
* **AssertContext** around HitAssert: dump/assert-context-hit-close.jsonl
  * Before: `WaitableEvent` / `SyncWaiter` unlock → task select → `UncheckedScopedBlockingCall` → HasInfoBeforeHit → HitAssert.
  * After HitAssert: Mojo `WebDatabaseHostProxy::Closed` / `Message::SerializeHandles`, then next SandboxedClose fds `200`, `169`, …

## DataWriteProvenance

* Divergent datum: `__close` `Arg:0` on **thread 20**.
* Thin slice by thread (write → leaf):
  * **Mojo IO thread**: `ChannelPosix` → `SocketRecvmsg` → `recvmsg` (Call stream) → SCM_RIGHTS → `incoming_fds_` → `GetReadPlatformHandlesForIpcz` → handles on Mojo message.
  * **SharedRemote sequenced runner**: forwards sync `WebDatabaseHost.OpenFile`.
  * **Calling DB thread** (Hit File: thread 20): `StructTraits<FileDataView, base::File>::Read` → `TakeFd().TakePlatformFile()` → `base::File` → `WebDatabaseHost::OpenFile` / `SandboxedVfs` / `SandboxedVfsFile`.
  * **Thread 20** (later): `SQLiteDatabase::Close` → `SandboxedClose` → `File::Close` → `close(fd)` ← HitAssert.
* **Unordered read**: thread 20’s `TakePlatformFile()` reads the fd from the Mojo message’s `PlatformHandle`s.
  * Not from thread 20’s Call stream.
  * Those handles were filled on the Mojo IO thread from the IO-thread `recvmsg` Call stream.
* Data source class: **SharedSyscallResource** (IPC `PlatformFile`). `[InvalidAssertValues]` — `NOT-ASSERTABLE` on DivergentPathSegments writes.

## Evidence / data points

* WebDatabaseHost wiring:
  * `SharedRemote` on `base::ThreadPool::CreateSequencedTaskRunner({base::WithBaseSyncPrimitives()})`.
  * Sync OpenFile from DB threads; Remote send/recv on that one sequence.
  * Sync wait uses `WaitableEvent` / `SyncEventWatcher`; POSIX `WaitableEventKernel.lock_` is ordered (`"WaitableEventKernel.lock_"`).
  * Sync replies correlate by `request_id`.
* Channel / recvmsg:
  * `Op_recvmsg` `RecordReplayOutput`: `ReadOrWriteBytes` on `flags`, `namelen`, `name`, `controllen`, `control`, then iov payload.
  * Matched replay: library function not invoked; outputs restored from call stream (recording.md).
  * `ChannelPosix::incoming_fds_` is IO-thread-local; popped only in `GetReadPlatformHandlesForIpcz`.
  * `kMissingHandles`: message stays in read buffer until more fds arrive from a later `recvmsg`; then pop resumes.
  * `num_handles` taken from message header in the same restored payload as the bytes being dispatched.
  * `Channel::ReadBuffer::Claim` `RecordReplayBytes` is `#if BUILDFLAG(IS_WIN)` only — not on this Linux mismatch.
* File consume site (exact) — **unordered read**:
  * Calling DB thread: `TakeFd().TakePlatformFile()` from Mojo message handles (not that thread’s Call stream).
* Fork-side (diffOursAll.diff):
  * `base/files/scoped_file_linux.cc` `EnableFDOwnershipEnforcement`: left disabled — “when replaying the ordering of calls across threads isn't preserved exactly and a fd can be closed on one thread before it is opened on another thread.”
  * `ChannelPosix` ctor: `write_lock_("ChannelPosix.write_lock_")` (ordered).
  * `ChannelPosix::Write`: Asserts `ChannelPosix::Write Start` / `#1` (`RUN-618`).
  * No File-traits / `incoming_fds_` / WebSQL `OpenFile` intervention in fork diff.
* BigBuffer contrast:
  * `Traits<BigBufferDataView>::Read` `kSharedMemory` tag uses `RecordReplayBytes` (RUN-1618).
  * File path is PlatformHandle / SCM_RIGHTS, not shm — `determinism-shared-memory` does not apply.
* Driver note (`FileDescriptor.cpp`): when replaying, multiple descriptors can share the same number; many fds are closed non-deterministically; only descriptors with associated info are ordered on open/close.
* Mojo PassThrough sites only:
  * `MultiplexRouter::DetachEndpointClient` and `Node::SetUserData` wrap `BeginPassThroughEvents` when `AreEventsDisallowed()`.
  * Not the WebSQL OpenFile receive path.
* Warnings (not DominantWarning):
  * All `threadId: 1`, `processId: 3`: JS Invoke non-deterministic user JS / V8Inspector `console.debug`; Ordered lock `AudioNode::Dispose` GC; `[TT-1465] FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed` GC; TryLock `BaseAudioContext` destructor GC.
  * Mismatch `threadId: 20`, WebSQL/`SandboxedClose`/`__close` only.
  * No shared lock/object identity with the mismatch.
* Seeded `solution.md` (rejected): `determinism-passthrough` / `RecordReplayValue` after `delegate_->OpenFile` in `SandboxedVfs::Open`.

## Mechanism Implementation

### SharedSyscallResourceUnorderedRead (the defect)

* `PlatformFile` is a **SharedSyscallResource**: opaque syscall Arg identity only.
  * Not used for in-process logic.
  * Redirected syscalls ignore the live value on replay.
* **Produce** (Mojo IO thread): `recvmsg` Call stream restores SCM_RIGHTS → `incoming_fds_` → message `PlatformHandle`s.
  * That Call stream is per IO thread. Other threads cannot reorder it.
* **Unordered read** (calling DB thread / Hit File: thread 20): `TakeFd().TakePlatformFile()` loads the fd from the Mojo message’s handles.
  * Not from thread 20’s Call stream.
* **Detect** (thread 20): `__close` Call-stream AssertInput on `Arg:0` from the held `base::File` fd.
* Held identity among sibling closes diverged (`188` vs `170` in HitCloseBurst).

### RecvmsgRedirection (not the broken edge)

* `recvmsg` is a Library Call redirection on the Mojo IO thread.
* Outputs (including SCM_RIGHTS) are restored from **that** thread’s Call FIFO.
* Intra-recvmsg attach is fixed for one restored payload.
* Ordering `recvmsg` further does not order thread 20’s later `TakePlatformFile` read.

### HitAssertSite (linker)

* Thread 20: `__close` → `ScalarArg` → AssertInput `Arg:0`.
* First mismatch: recorded `188`, replayed `170`.
* File already held the wrong int; written earlier at `TakePlatformFile`.

## Surviving leads

### S2 — PlatformHandleConsumeScalar (chosen)

* Claim: force-record the opaque POSIX fd at the unordered read.
* Site: `Serializer<PlatformHandle>::Deserialize` after `UnwrapPlatformHandle` (every mojom `handle<platform>` take).
* Recipe: `determinism-shared-syscall-resource` / `RecordReplayValue`.
* Why not OrderedLock on `recvmsg`: produce-side Call stream is already ordered; the unordered edge is the consumer-thread handle take.
* Why not `incoming_fds_` / IO-thread queue pop: wrong thread; produce already restored there.
* Why not `FileDataView` only: too narrow (`ReadOnlyFile`, sockets, …).
* Caveat: discard live fd if it differs from the recorded value before substituting; skip non-fd platform types.

## Refuted

* **S1 WrongHandle (intra-queue association)**
  * `recvmsg` restore is atomic (payload `num_handles` + SCM_RIGHTS control).
  * Matched calls cannot attach fd `170` to a message that recorded fd `188` within one receive.
* **CrossThreadFdReorder → File.fd** (was L1)
  * Fork `scoped_file_linux.cc` disables FD ownership enforcement because “a fd can be closed on one thread before it is opened on another.”
  * That comment is about the **ownership tracker**, not about rewriting `base::File`’s held fd.
  * Matched `recvmsg` does not consult the live fd table on replay.
  * `SharedRemote` / `WaitableEventKernel` ordering do not fix cross-thread fd table lifetime; fork already admits that gap — but that gap is not a direct File.fd write mechanism under matched restore.
* **CloseOrdinalSkew**
  * First mismatched Assert is this `Call __close Arg:0` ⇒ prior Call asserts matched.
  * Same close slot, different Arg ⇒ held fd diverged; not “wrong close count.”
  * LinkerdebugFd: replayed `170` is a later sibling close in HitCloseBurst, not an off-by-N walk of the close stream.
* **Linux Channel Claim desync**
  * `Channel::ReadBuffer::Claim` `RecordReplayBytes` is `#if BUILDFLAG(IS_WIN)` only.
* **Mojo PassThrough / LiveFd on normal OpenFile**
  * `BeginPassThroughEvents` in Mojo only wraps DisallowEvents paths (`MultiplexRouter::DetachEndpointClient`, `Node::SetUserData`).
  * Report has no `Call with events disallowed recvmsg` warning.
* **SHM / `determinism-shared-memory`**
  * `mojo_base.mojom.File` = `handle<platform> fd` + `async` — PlatformHandle / SCM_RIGHTS, not `BigBuffer`/`SharedBuffer` shm.
* **PassThrough / seeded `SandboxedVfs::Open` RRV**
  * Not a PassThrough region.
  * Wrong layer; correct site is `PlatformHandle` deserialize (S2).
* **FileDataView-only RRV**
  * Same edge for one consumer; misses `ReadOnlyFile` / other `handle<platform>`.
* **IO-thread `incoming_fds_` RRV**
  * Produce-side; does not order consumer-thread unordered read.
* **OrderedLock on `recvmsg`**
  * IO-thread Call stream already orders `recvmsg`.
  * Does not order consumer-thread `PlatformHandle` take from message handles.
* **Call-stream reorder / cross-thread Call steal**
  * Per-thread Call FIFOs cannot deliver another thread’s `recvmsg` outputs to thread 20.
* **DominantWarning**
  * Warnings are `threadId: 1` (GC / `AudioNode` / `BaseAudioContext` / V8Inspector `console.debug`).
  * Mismatch is `threadId: 20`, stacks only WebSQL/`SandboxedClose`/`__close`.
  * No shared lock/object identity; warnings do not predict the fd Arg mismatch.

## Recipes

* `determinism-shared-memory`: no.
* `determinism-passthrough`: no.
* `determinism-synchronization`: no (OrderedLock on `recvmsg` wrong edge).
* `determinism-shared-syscall-resource` / `RecordReplayValue` at `Serializer<PlatformHandle>::Deserialize`: **S2** (implemented).

# Problems

## P1: Unordered SharedSyscallResource read at Mojo PlatformHandle take

* HitAssert: `__close` `Arg:0` recorded `188` / replayed `170` on thread 20.
* Produce (Mojo IO thread): `recvmsg` Call stream → SCM_RIGHTS → message `PlatformHandle`s.
* Unordered read (consumer thread): mojom `Serializer<PlatformHandle>::Deserialize` after `UnwrapPlatformHandle`.
  * Not from that thread’s Call stream.
* `PlatformFile` / POSIX fd is opaque syscall identity only.
  * Redirected syscalls ignore it on replay.
* OrderedLock on `recvmsg` is the wrong edge.
* `FileDataView` alone is too narrow (`ReadOnlyFile`, sockets, …).

# Solution

## P1: Unordered SharedSyscallResource read at Mojo PlatformHandle take

* [Done] `determinism-shared-syscall-resource`: `RecordReplayValue` in `RecordReplayIncomingPlatformHandle` from `Serializer<PlatformHandle>::Deserialize`.
  * Hints:
    * Common consume site for every mojom `handle<platform>` POSIX fd.
    * Not PassThrough. Not `SandboxedVfs::Open`. Not OrderedLock on `recvmsg`.
    * Not `incoming_fds_` / IO-thread queue pop.
    * Not `FileDataView` traits only.
  * Steps:
    * In `mojo/public/cpp/bindings/lib/handle_serialization.cc`, `RecordReplayValue("Serializer<PlatformHandle>::Deserialize", ...)` on valid POSIX fds.
    * Discard the live fd via `ScopedFD` when it differs from the recorded value.
    * Skip non-fd platform types (Mach / zx / Win).
