### PR TITLE
[crash-0051 + crash-0050] OrderedAtomic ImageDecodingStore; relocate TT-492 Assert to Serialize

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '30e6f55cba7872a920be2e6e6ba2f437e412d4d4',
+  'v8_revision': 'e3a6ceae0346cc6b6cb7b248d9d168c4356895b0',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e3a6ceae0346cc6b6cb7b248d9d168c4356895b0',
+  'v8_revision': 'e5ce6830ae951efd0bc20c28e21fec987379a9fc',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/third_party/blink/renderer/bindings/core/v8/serialization/v8_script_value_serializer.cc
+++ b/third_party/blink/renderer/bindings/core/v8/serialization/v8_script_value_serializer.cc
@@ -5,6 +5,7 @@
 #include "third_party/blink/renderer/bindings/core/v8/serialization/v8_script_value_serializer.h"
 
 #include "base/auto_reset.h"
+#include "base/record_replay.h"
 #include "third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom-blink.h"
 #include "third_party/blink/public/platform/web_blob_info.h"
 #include "third_party/blink/renderer/bindings/core/v8/native_value_traits_impl.h"
@@ -61,6 +62,20 @@
 #include "third_party/blink/renderer/platform/wtf/text/string_utf8_adaptor.h"
 
 namespace blink {
+
+namespace {
+
+// Same algorithm as v8::internal::HashBytes in value-serializer.cc.
+int HashBytes(const void* aPtr, size_t aSize) {
+  int hash = 0;
+  const uint8_t* ptr = static_cast<const uint8_t*>(aPtr);
+  for (size_t i = 0; i < aSize; i++) {
+    hash = (((hash << 5) - hash) + ptr[i]) | 0;
+  }
+  return hash;
+}
+
+}  // namespace
 
 // The "Blink-side" serialization version, which defines how Blink will behave
 // during the serialization process, is in
@@ -280,6 +295,10 @@ scoped_refptr<SerializedScriptValue> V8ScriptValueSerializer::Serialize(
 
   // Finalize the results.
   std::pair<uint8_t*, size_t> buffer = serializer_.Release();
+  REPLAY_ASSERT(
+      "[TT-492] V8ScriptValueSerializer::Serialize %u %d",
+      static_cast<unsigned>(buffer.second),
+      HashBytes(buffer.first, buffer.second));
   serialized_script_value_->SetData(
       SerializedScriptValue::DataBufferPtr(buffer.first), buffer.second);
   return std::move(serialized_script_value_);

--- a/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
+++ b/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include "base/bind.h"
+#include "base/no_destructor.h"
 #include "base/record_replay_ordered_atomic.h"
 #include "base/synchronization/lock.h"
 #include "third_party/blink/renderer/platform/graphics/image_frame_generator.h"
@@ -40,9 +41,12 @@ namespace {
 
 static const size_t kDefaultMaxTotalSizeOfHeapEntries = 32 * 1024 * 1024;
 
-}  // namespace
+recordreplay::OrderedAtomic<bool>& GetHasInstanceFlag() {
+  static base::NoDestructor<recordreplay::OrderedAtomic<bool>> flag(false);
+  return *flag;
+}
 
-static recordreplay::OrderedAtomic<bool> gHasInstance{false};
+}  // namespace
 
 ImageDecodingStore::ImageDecodingStore()
     : heap_limit_in_bytes_(kDefaultMaxTotalSizeOfHeapEntries),
@@ -52,7 +56,7 @@ ImageDecodingStore::ImageDecodingStore()
           base::BindRepeating(&ImageDecodingStore::OnMemoryPressure,
                               base::Unretained(this))) {
   REPLAY_ASSERT("[TT-1524-1526] ImageDecodingStore::ImageDecodingStore");
-  gHasInstance = true;
+  GetHasInstanceFlag() = true;
 }
 
 ImageDecodingStore::~ImageDecodingStore() {
@@ -71,7 +75,7 @@ ImageDecodingStore& ImageDecodingStore::Instance() {
 }
 
 bool ImageDecodingStore::HasInstance() {
-  return gHasInstance;
+  return GetHasInstanceFlag();
 }
 
 bool ImageDecodingStore::LockDecoder(

--- a/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
+++ b/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include "base/bind.h"
+#include "base/record_replay_ordered_atomic.h"
 #include "base/synchronization/lock.h"
 #include "third_party/blink/renderer/platform/graphics/image_frame_generator.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
@@ -41,7 +42,7 @@ static const size_t kDefaultMaxTotalSizeOfHeapEntries = 32 * 1024 * 1024;
 
 }  // namespace
 
-static std::atomic<bool> gHasInstance{false};
+static recordreplay::OrderedAtomic<bool> gHasInstance{false};
 
 ImageDecodingStore::ImageDecodingStore()
     : heap_limit_in_bytes_(kDefaultMaxTotalSizeOfHeapEntries),

--- a/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
+++ b/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
@@ -28,7 +28,6 @@
 #include <memory>
 
 #include "base/bind.h"
-#include "base/no_destructor.h"
 #include "base/record_replay_ordered_atomic.h"
 #include "base/synchronization/lock.h"
 #include "third_party/blink/renderer/platform/graphics/image_frame_generator.h"
@@ -42,8 +41,8 @@ namespace {
 static const size_t kDefaultMaxTotalSizeOfHeapEntries = 32 * 1024 * 1024;
 
 recordreplay::OrderedAtomic<bool>& GetHasInstanceFlag() {
-  static base::NoDestructor<recordreplay::OrderedAtomic<bool>> flag(false);
-  return *flag;
+  static recordreplay::OrderedAtomic<bool> flag{false};
+  return flag;
 }
 
 }  // namespace


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/313
# [crash-0051] Summary

* Data mismatch: `ImageDecodingStore::Instance` Assert reads `gHasInstance` as recorded `1` / replayed `0`.
* Cause: process-global `std::atomic` written by another thread's first ctor; Replay does not order naked atomics.
* Fix: `recordreplay::OrderedAtomic<bool>` for `gHasInstance`.

# [crash-0051] Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data

## Important Context

* buildId: linux-chromium-20260729-5a2d07b04491-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: fda8b4e6-b0b4-41b8-959e-471c7da11740

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 542285,
  "category": "SaplingBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 1000000,
      "checkpoint": 11
    },
    "getResumeData": [
      "annotations",
      "bookmarks",
      "consoleMessages",
      "events",
      "networkRequestEvents",
      "networkRequests",
      "networkStreamEvents",
      "sources",
      "widgetEvents"
    ]
  },
  "recorded": "ImageDecodingStore::Instance 1",
  "replayed": "ImageDecodingStore::Instance 0",
  "threadId": 11,
  "backtrace": {
    "progress": 611361,
    "threadId": 11,
    "checkpoint": 8
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::ImageDecodingStore::Instance()+42",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
    "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::ImageDecodingStore::Instance()+42",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
    "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640"
  ]
}
```

# [crash-0051] Basic Facts

## FrameCandidates

* `blink::ImageDecodingStore::Instance()+42`
  * location: `blink::ImageDecodingStore::Instance()` at `third_party/blink/renderer/platform/graphics/image_decoding_store.cc`
  * code: `REPLAY_ASSERT("ImageDecodingStore::Instance %d", HasInstance());`

## HitAssertSignal

* Leaf: `REPLAY_ASSERT("ImageDecodingStore::Instance %d", HasInstance());`
* Values: recorded `1` / replayed `0`
* Stacks identical.
* Caller: `ImageDecoderWrapper::Decode` → `ImageDecodingStore::Instance().LockDecoder(...)`
* Leaf thread: CategorizedWorkerPool worker (`SoftwareImageDecodeTaskImpl::RunOnWorkerThread`).

## WhatTheLeafReads

* `HasInstance()` returns process-global `gHasInstance`.
* Assert is before `DEFINE_THREAD_SAFE_STATIC_LOCAL` — no `this`, no object identity.
* Caller's wrapper/`this` cannot explain the leaf.

## HowCanShift

Writers of `gHasInstance`:

* init `false`
* ctor `gHasInstance = true` — only `true` write
* never cleared; at most one `false→true` per process

Only viable mechanism for leaf `1` vs `0`:

* **PriorCtorWrite** — ctor already ran before this leaf on record; not yet on replay.

Ruled out:

* different `ImageDecodingStore` object — leaf is static
* reset after ctor — nothing clears the bit
* caller-owned state — caller does not hold the bit

## MismatchProvenance

* Write: ctor `gHasInstance = true` on **another thread** before this leaf on record.
* Same-thread publisher ruled out from matched per-thread Assert stream:
  * if thread `11` had constructed earlier, it would have hit the ctor Assert on that thread before this leaf
  * both sides would then read `1` here
  * contradicts replayed `0`

```cpp
// third_party/blink/renderer/platform/graphics/image_decoding_store.cc

static std::atomic<bool> gHasInstance{false};

ImageDecodingStore::ImageDecodingStore() {
  REPLAY_ASSERT("[TT-1524-1526] ImageDecodingStore::ImageDecodingStore");
  gHasInstance = true;  // [Write] other-thread publisher on record
}

ImageDecodingStore& ImageDecodingStore::Instance() {
  REPLAY_ASSERT("ImageDecodingStore::Instance %d", HasInstance());
  // recorded: 1  <<< RECORDED LEAF
  // replayed: 0  <<< REPLAYED LEAF
  DEFINE_THREAD_SAFE_STATIC_LOCAL(ImageDecodingStore, store, ());
  return store;
}
```

## NewCandidates

* none — Write site and leaf site are both `gHasInstance` accesses.

# [crash-0051] RootCause

### Proven

* `gHasInstance` is a process-global `std::atomic<bool>` with no OrderedLock on read or write.
* Many CategorizedWorkerPool workers call `Instance()` concurrently.
* Replay does not order `std::atomic` by default.
* recorded `1` / replayed `0` ⇒ ctor Write was visible before this leaf on record and not on replay.
* Publisher was another thread (same-thread publisher ruled out above).

### Unproven

* Which other thread / call site first-constructed on record.
  * Not required for the intervention.

### Intervention

* `determinism-synchronization` — match.
* Bible: replace cross-thread `std::atomic` with `recordreplay::OrderedAtomic<T>` (same load/store API).
* Exact publisher thread not required.

## Suggested Cause of Action

* Replace `std::atomic<bool> gHasInstance` with `recordreplay::OrderedAtomic<bool>`.
* Keep load/store call sites as-is.
* Do not Assert object identity. Do not `RecordReplayValue` the bit.

# [crash-0051] Solution

* [Done] Replace `std::atomic<bool> gHasInstance` with `recordreplay::OrderedAtomic<bool>`.
  * Hints: `determinism-synchronization` — std atomics are unordered; use the in-runtime ordered primitive.
  * Steps: in `image_decoding_store.cc`, swap the type; keep load/store call sites as-is (`= true` / return).

<hr>

# [crash-0050] Summary

* Data mismatch: `ValueDeserializer` Assert — size matches (`492`), `HashBytes` differs (`1590093152` vs `-1035930237`).
* Ground truth stays at deserialize; hot-path Assert is the wrong place to keep digging.
* Fix: write-time Assert (size + `HashBytes`) in `V8ScriptValueSerializer::Serialize` after `Release()`; remove the read-time Asserts in `ValueDeserializer`.

# [crash-0050] Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data

## Important Context

* buildId: linux-chromium-20260729-5a2d07b04491-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: ed745667-9ca9-4e2a-a2ec-4134ab388ac8

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 22595635,
      "checkpoint": 406
    }
  },
  "recorded": "[TT-492] ValueDeserializer::ValueDeserializer A 492 1590093152",
  "replayed": "[TT-492] ValueDeserializer::ValueDeserializer A 492 -1035930237",
  "threadId": 1,
  "backtrace": {
    "progress": 22566825,
    "threadId": 1,
    "checkpoint": 403
  },
  "recordedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::ValueDeserializer::ValueDeserializer(v8::Isolate*,.unsigned.char.const*,.unsigned.long,.v8::ValueDeserializer::Delegate*)+68",
    "blink::V8ScriptValueDeserializer::V8ScriptValueDeserializer(blink::ScriptState*,.blink::UnpackedSerializedScriptValue*,.scoped_refptr<blink::SerializedScriptValue>,.blink::SerializedScriptValue::DeserializeOptions.const&)+93",
    "blink::SerializedScriptValueForModulesFactory::Deserialize(blink::UnpackedSerializedScriptValue*,.v8::Isolate*,.blink::SerializedScriptValue::DeserializeOptions.const&)+152",
    "blink::MessageEvent::data(blink::ScriptState*)+365",
    "blink::(anonymous.namespace)::v8_message_event::DataAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+225"
  ],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::ValueDeserializer::ValueDeserializer(v8::Isolate*,.unsigned.char.const*,.unsigned.long,.v8::ValueDeserializer::Delegate*)+68",
    "blink::V8ScriptValueDeserializer::V8ScriptValueDeserializer(blink::ScriptState*,.blink::UnpackedSerializedScriptValue*,.scoped_refptr<blink::SerializedScriptValue>,.blink::SerializedScriptValue::DeserializeOptions.const&)+93",
    "blink::SerializedScriptValueForModulesFactory::Deserialize(blink::UnpackedSerializedScriptValue*,.v8::Isolate*,.blink::SerializedScriptValue::DeserializeOptions.const&)+152",
    "blink::MessageEvent::data(blink::ScriptState*)+365",
    "blink::(anonymous.namespace)::v8_message_event::DataAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+225"
  ]
}
```

# [crash-0050] Basic Facts

## FrameCandidates

* `v8::ValueDeserializer::ValueDeserializer(...)+68`
  * location: `v8::internal::ValueDeserializer::ValueDeserializer` at `v8/src/objects/value-serializer.cc:1249`
  * code: `REPLAY_ASSERT("[TT-492] ValueDeserializer::ValueDeserializer A %u %d", data.size(), HashBytes(&data[0], data.size()));`
  * recorded: `492 1590093152` / replayed: `492 -1035930237`

## Suggested Cause of Action

* Diagnostics only (not a root-cause claim): avoid piling Asserts on the hot deserialize path.
  * Drop the existing read-time Assert in `ValueDeserializer` once a write-time Assert is in place.
  * Add one write-time Assert (size + `HashBytes`) in `V8ScriptValueSerializer::Serialize` after `serializer_.Release()`, on the buffer passed to `SetData`.
* Re-run for a new mismatch at the write site (or proof that write still matches).

## MismatchProvenance

```cpp
// blink::V8ScriptValueSerializer::Serialize
// third_party/blink/renderer/bindings/core/v8/serialization/v8_script_value_serializer.cc
scoped_refptr<SerializedScriptValue> V8ScriptValueSerializer::Serialize(...) {
  ...
  serialized_script_value_->CloneSharedArrayBuffers(shared_array_buffers_);

  std::pair<uint8_t*, size_t> buffer = serializer_.Release();
  // [Write] CANDIDATE
  // data_buffer_ content is not Asserted today; size later matches at the leaf (492).
  serialized_script_value_->SetData(
      SerializedScriptValue::DataBufferPtr(buffer.first), buffer.second);
  return std::move(serialized_script_value_);
}

// blink::V8ScriptValueDeserializer::V8ScriptValueDeserializer
// third_party/blink/renderer/bindings/core/v8/serialization/v8_script_value_deserializer.cc
// stack: blink::V8ScriptValueDeserializer::V8ScriptValueDeserializer(...)+93
V8ScriptValueDeserializer::V8ScriptValueDeserializer(...)
    : ...,
      deserializer_(script_state_->GetIsolate(),
                    serialized_script_value_->Data(),
                    serialized_script_value_->DataLengthInBytes(),
                    this),
      ... {}

// v8::internal::ValueDeserializer::ValueDeserializer
// v8/src/objects/value-serializer.cc:1249
// stack: v8::ValueDeserializer::ValueDeserializer(...)+68
ValueDeserializer::ValueDeserializer(Isolate* isolate,
                                     base::Vector<const uint8_t> data,
                                     v8::ValueDeserializer::Delegate* delegate)
    : ... {
  REPLAY_ASSERT(
    "[TT-492] ValueDeserializer::ValueDeserializer A %u %d",
    data.size(), HashBytes(&data[0], data.size())
  );
  // recorded: 492 1590093152
  // replayed: 492 -1035930237
  // <<< RECORDED LEAF
  // <<< REPLAYED LEAF
}
```

# [crash-0050] Repro

* Repro'ed successfully.

## Ids

* recordingId: `ed745667-9ca9-4e2a-a2ec-4134ab388ac8`
  * [app.replay.io](https://app.replay.io/recording/ed745667-9ca9-4e2a-a2ec-4134ab388ac8)
* controllerId: `c45a150a-e66d-4502-adc2-2352f53d58c2`
* sessionId: `103b6fb8-961f-4068-afca-413f1d2bec6e`
* crash report id: `15e18ecd-126d-4632-b78f-7752548d8f27`
* processId (fatal leaf): `249`
* No operatorId in Hasura sessions for this recording (controller-only).

# [crash-0050] Solution

* [Open] Diagnostic: relocate Assert from hot read to write
  * Hints:
    * Ground truth remains the DataMismatch at `ValueDeserializer` (`492` / `1590093152` vs `-1035930237`).
    * Add write-time `REPLAY_ASSERT` (size + `HashBytes`) in `blink::V8ScriptValueSerializer::Serialize` after `serializer_.Release()`, on the buffer passed to `SetData`.
    * Then remove the read-time Assert in `v8::internal::ValueDeserializer::ValueDeserializer` so the hot path stays clean.
  * Steps:
    * Insert write-time Assert only.
    * Remove read-time Assert after the write-time Assert is landed.
    * Do not add Asserts on MessageEvent/Deserialize.