### PR TITLE
[crash-0053] Nestable SendCDPMessage context-group override; reject dead groups

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -809,19 +809,21 @@ struct InspectorChannel final : public v8_inspector::V8Inspector::Channel {
   void flushProtocolNotifications() final {}
 };
 
-static absl::optional<int> gContextGroupIdForSendCDPMessage;
+// Nestable override for SendCDPMessage context-group routing.
+// Console → OnConsoleMessage can re-enter via pause evaluate that emits
+// another console API call; a single optional cannot model that.
+static std::vector<int> gContextGroupIdForSendCDPMessageStack;
 
 extern "C" void SetContextGroupIdForSendCDPMessage(int contextGroupId) {
   CHECK(v8::IsMainThread());
   CHECK_GT(contextGroupId, 0);
-  CHECK(!gContextGroupIdForSendCDPMessage.has_value());
-  gContextGroupIdForSendCDPMessage = contextGroupId;
+  gContextGroupIdForSendCDPMessageStack.push_back(contextGroupId);
 }
 
 extern "C" void ClearContextGroupIdForSendCDPMessage() {
   CHECK(v8::IsMainThread());
-  CHECK(gContextGroupIdForSendCDPMessage.has_value());
-  gContextGroupIdForSendCDPMessage.reset();
+  CHECK(!gContextGroupIdForSendCDPMessageStack.empty());
+  gContextGroupIdForSendCDPMessageStack.pop_back();
 }
 
 absl::optional<int> GetCurrentContextGroupIdForIsolate(v8::Isolate* isolate) {
@@ -914,6 +916,33 @@ static int GetPersistentId(v8::Local<v8::Object> object) {
  * However, we might also opt to forego that option entirely, and do it all manually, since many inspectors/agents
  * do not provide too much value if they are not hooked up to a `DevToolsSession` and the `UberDispatcher`.
  */
+static void SendCDPMissingContextError(v8::Isolate* isolate,
+                                       v8::Local<v8::Value> message_arg) {
+  if (gCDPMessageCallback == nullptr) {
+    return;
+  }
+  // Ensure the message has an ID. If not, handle the error in JavaScript.
+  v8::String::Utf8Value inmessage(isolate, message_arg);
+  std::string nmessage(*inmessage);
+  absl::optional<base::Value> jsonMessage = base::JSONReader::Read(nmessage);
+  base::Value::Dict* messageDict = jsonMessage->GetIfDict();
+  CHECK(messageDict != nullptr);
+  CHECK(messageDict->FindInt("id").has_value());
+
+  std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
+  error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
+  error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
+
+  base::DictionaryValue result;
+  result.SetKey("error", base::Value::FromUniquePtrValue(std::move(error)));
+  result.SetIntKey("id", *(messageDict->FindInt("id")));
+
+  std::string json;
+  base::JSONWriter::Write(result, &json);
+  auto message = v8_inspector::StringView((const uint8_t*)json.c_str(), json.length());
+  SendMessageToFrontend(message);
+}
+
 static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
@@ -922,37 +951,18 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
   recordreplay::AutoDisallowEvents disallow("SendCDPMessage");
 
   v8::Isolate* isolate = args.GetIsolate();
-  absl::optional<int> contextGroupId = gContextGroupIdForSendCDPMessage;
-  if (!contextGroupId.has_value()) {
+  absl::optional<int> contextGroupId;
+  if (!gContextGroupIdForSendCDPMessageStack.empty()) {
+    contextGroupId = gContextGroupIdForSendCDPMessageStack.back();
+  } else {
     contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
   }
 
-  // It can be the case that we simply don't have a context group id (a local frame) at this
-  // time; just log it and inform the client.
-  if (!contextGroupId.has_value()) {
-    if (gCDPMessageCallback != nullptr) {
-      // Ensure the message has an ID. If not, handle the error in JavaScript.
-      v8::String::Utf8Value inmessage(args.GetIsolate(), args[0]);
-      std::string nmessage(*inmessage);
-      absl::optional<base::Value> jsonMessage = base::JSONReader::Read(nmessage);
-      base::Value::Dict* messageDict = jsonMessage->GetIfDict();
-      CHECK(messageDict != nullptr);
-      CHECK(messageDict->FindInt("id").has_value());
-
-      // Construct our error result.
-      std::unique_ptr<base::DictionaryValue> error(new base::DictionaryValue);
-      error->SetStringKey("message", "[RUN-2600] No context group available for Isolate.");
-      error->SetIntKey("code", CDPERROR_MISSINGCONTEXT);
-
-      base::DictionaryValue result;
-      result.SetKey("error", base::Value::FromUniquePtrValue(std::move(error)));
-      result.SetIntKey("id", *(messageDict->FindInt("id")));
-
-      std::string json;
-      base::JSONWriter::Write(result, &json);
-      auto message = v8_inspector::StringView((const uint8_t*)json.c_str(), json.length());
-      SendMessageToFrontend(message);
-    }
+  // No group, or the LocalFrame for that group is already gone (post-nav /
+  // teardown). Do not connect a session to a dead context group.
+  if (!contextGroupId.has_value() ||
+      !WeakIdentifierMap<LocalFrame>::Lookup(*contextGroupId)) {
+    SendCDPMissingContextError(isolate, args[0]);
     return;
   }
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -812,18 +812,23 @@ struct InspectorChannel final : public v8_inspector::V8Inspector::Channel {
 // Nestable override for SendCDPMessage context-group routing.
 // Console → OnConsoleMessage can re-enter via pause evaluate that emits
 // another console API call; a single optional cannot model that.
-static std::vector<int> gContextGroupIdForSendCDPMessageStack;
+// POD stack: no global ctor / exit-time dtor (-Werror).
+static constexpr size_t kMaxContextGroupIdOverrideDepth = 16;
+static int gContextGroupIdForSendCDPMessageStack[kMaxContextGroupIdOverrideDepth];
+static size_t gContextGroupIdForSendCDPMessageDepth = 0;
 
 extern "C" void SetContextGroupIdForSendCDPMessage(int contextGroupId) {
   CHECK(v8::IsMainThread());
   CHECK_GT(contextGroupId, 0);
-  gContextGroupIdForSendCDPMessageStack.push_back(contextGroupId);
+  CHECK_LT(gContextGroupIdForSendCDPMessageDepth, kMaxContextGroupIdOverrideDepth);
+  gContextGroupIdForSendCDPMessageStack[gContextGroupIdForSendCDPMessageDepth++] =
+      contextGroupId;
 }
 
 extern "C" void ClearContextGroupIdForSendCDPMessage() {
   CHECK(v8::IsMainThread());
-  CHECK(!gContextGroupIdForSendCDPMessageStack.empty());
-  gContextGroupIdForSendCDPMessageStack.pop_back();
+  CHECK_GT(gContextGroupIdForSendCDPMessageDepth, 0u);
+  gContextGroupIdForSendCDPMessageDepth--;
 }
 
 absl::optional<int> GetCurrentContextGroupIdForIsolate(v8::Isolate* isolate) {
@@ -952,8 +957,9 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Isolate* isolate = args.GetIsolate();
   absl::optional<int> contextGroupId;
-  if (!gContextGroupIdForSendCDPMessageStack.empty()) {
-    contextGroupId = gContextGroupIdForSendCDPMessageStack.back();
+  if (gContextGroupIdForSendCDPMessageDepth > 0) {
+    contextGroupId =
+        gContextGroupIdForSendCDPMessageStack[gContextGroupIdForSendCDPMessageDepth - 1];
   } else {
     contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
   }

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -958,10 +958,14 @@ static void SendCDPMessage(const v8::FunctionCallbackInfo<v8::Value>& args) {
     contextGroupId = GetCurrentContextGroupIdForIsolate(isolate);
   }
 
-  // No group, or the LocalFrame for that group is already gone (post-nav /
-  // teardown). Do not connect a session to a dead context group.
-  if (!contextGroupId.has_value() ||
-      !WeakIdentifierMap<LocalFrame>::Lookup(*contextGroupId)) {
+  // No group, or its main-world V8 Context is already gone (post-nav /
+  // DidClearContextsForFrame). ContextIfInitialized does not create.
+  LocalFrame* frame =
+      contextGroupId.has_value()
+          ? WeakIdentifierMap<LocalFrame>::Lookup(*contextGroupId)
+          : nullptr;
+  if (!frame ||
+      ToV8ContextMaybeEmpty(frame, DOMWrapperWorld::MainWorld()).IsEmpty()) {
     SendCDPMissingContextError(isolate, args[0]);
     return;
   }


### PR DESCRIPTION
# Summary

* Nested console during `OnConsoleMessage` re-entered `SetContextGroupIdForSendCDPMessage`.
* Non-reentrant optional CHECK crashed.
* Fix: nestable override stack.
* Also reject cleared groups at `SendCDPMessage` when main-world Context is empty.

# Problem

* Problem type: ReplayOtherCrash.

## Important Context

* buildId: linux-chromium-20260729-de122dce831e-d5125731e055
* linkerVersion: linker-linux-16050-d5125731e055
* recordingId: d1d226eb-8d46-45d1-bc56-c0c89e3bc28d

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Trace/breakpoint trap",
  "category": "PauseChild",
  "manifest": {
    "kind": "pauseRequest",
    "requestType": "command",
    "requestMethod": "Pause.evaluateInGlobal"
  },
  "threadId": 1,
  "backtrace": {
    "frames": [
      "logging::LogMessage::~LogMessage()+14",
      "SetContextGroupIdForSendCDPMessage+225",
      "v8_inspector::V8ConsoleMessageStorage::addMessage(...)+761",
      "v8_inspector::V8Console::Warn(...)+355",
      "...",
      "v8::debug::EvaluateGlobal(...)+117",
      "blink::SendCDPMessage(...)+416",
      "v8::internal::CommandCallback(...)+943",
      "EvaluateInGlobalCommand::Process(...)+38",
      "recordreplay::OnConsoleMessage(...)+956",
      "v8_inspector::V8ConsoleMessageStorage::addMessage(...)+768",
      "v8_inspector::V8Console::Log(...)+352",
      "..."
    ],
    "progress": 3351,
    "threadId": 1,
    "checkpoint": 5
  },
  "faultAddress": "(nil)",
  "instructionPointer": "logging::LogMessage::~LogMessage()+2769"
}
```

# Facts

* Crash: `CHECK(!gContextGroupIdForSendCDPMessage.has_value())` in `SetContextGroupIdForSendCDPMessage`.
* Stack shape:
  * Outer: `console.log` → `V8ConsoleMessageStorage::addMessage` → Set → `OnConsoleMessage` → Clear.
  * Inside that `OnConsoleMessage`: pause → `Pause.evaluateInGlobal` → `SendCDPMessage`.
  * Evaluated JS: `console.warn` → nested `addMessage` → Set again.
* Override API from [#1354](https://github.com/replayio/chromium/pull/1354):
  * Single global `gContextGroupIdForSendCDPMessage`.
  * Set forbids an already-set value.
  * Clear requires it set.
* Call site in `v8-console-message.cc`:
  * Set → `V8RecordReplayOnConsoleMessage` → Clear around console handling.
  * Purpose: keep CDP object-id resolution on the emitting context group.
* That override can target a torn-down group after navigation.
  * `SendCDPMessage` would still `connect` a session.

# Root Cause

* **NonReentrantOverride**: Set/Clear assume one active console → `OnConsoleMessage` scope.
* Nested console during that scope is legal.
  * Evaluate-from-pause can emit another console API call.
* Second Set hits the CHECK.

# Solution

* Make the override nestable.
  * Replace `absl::optional` with a stack in `Set` / `Clear`.
  * `SendCDPMessage` uses the top entry.
* On consumption in `SendCDPMessage`:
  * Lookup the `LocalFrame` for `contextGroupId`.
  * Require a live main-world Context via `ToV8ContextMaybeEmpty` / `ContextIfInitialized`.
  * Missing frame or empty Context → `CDPERROR_MISSINGCONTEXT`.
  * Do not `connect` a session to a cleared group.
