### PR TITLE
[crash-0054] Discardable local alloc before lock_ when events unavailable

### DIFF
--- a/components/discardable_memory/client/client_discardable_shared_memory_manager.cc
+++ b/components/discardable_memory/client/client_discardable_shared_memory_manager.cc
@@ -262,6 +262,15 @@ void ClientDiscardableSharedMemoryManager::OnBackgrounded() {
 std::unique_ptr<base::DiscardableMemory>
 ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
     size_t size) {
+  // When events unavailable, local alloc before lock_ (avoid waiting on Mojo holders).
+#if BUILDFLAG(IS_POSIX)
+  if (recordreplay::AreEventsUnavailable()) {
+    static std::atomic<size_t> diverge_bytes_allocated{0};
+    return std::make_unique<base::MadvFreeDiscardableMemoryPosix>(
+        size, &diverge_bytes_allocated);
+  }
+#endif
+
   base::AutoLock lock(lock_);
 
   if (!is_purge_scheduled_) {
@@ -358,15 +367,6 @@ ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(
   // Make sure crash keys are up to date in case allocation fails.
   if (heap_->GetSize() != heap_size_prior_to_releasing_purged_memory)
     MemoryUsageChanged(heap_->GetSize(), heap_->GetFreelistSize());
-
-  // After diverging use simple local allocation to avoid IPC.
-#if BUILDFLAG(IS_POSIX)
-  if (recordreplay::AreEventsUnavailable()) {
-    static std::atomic<size_t> diverge_bytes_allocated{0};
-    return std::make_unique<base::MadvFreeDiscardableMemoryPosix>(
-        size, &diverge_bytes_allocated);
-  }
-#endif
 
   size_t pages_to_allocate =
       std::max(allocation_size / base::GetPageSize(), pages);


### PR DESCRIPTION
# Summary

* Pause hang: tid1 waits on `ClientDiscardableSharedMemoryManager::lock_` held by tid3 in Mojo `Wait`.
* `#1391` already local-allocs on `AreEventsUnavailable()`, but under the lock.
* Move that early-out *before* `AutoLock` so pause never waits on other threads.


# Problem

* Problem type: ReplayPauseCrash.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] 
*  - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in  when needed.

### RepoSrc

* 
* 

## Important Context

* buildId: linux-chromium-20260722-426dbbb26258-0814b5e98095
* linkerVersion: linker-linux-16040-0814b5e98095
* recordingId: b7d14c78-0f15-4d6e-8e19-f734ad942e8e

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "PauseChild",
  "manifest": "pauseRequest",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingToAcquireLock": {
          "ptr": "0x1000001ebe18",
          "owner": 3
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayLock::Lock()+264",
          "new_pthread_mutex_lock(void*)+21",
          "0x10005054504c",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "0x100050544060",
          "base::internal::LockImpl::LockInternalWithTracking()+70",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(unsigned.long)+1508",
          "base::DiscardableMemoryAllocator::AllocateLockedDiscardableMemoryWithRetryOrDie(unsigned.long,.base::OnceCallback<void.()>)+40",
          "cc::(anonymous.namespace)::AllocateDiscardable(SkImageInfo.const&,.base::OnceCallback<void.()>)+141",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+115",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "cc::SoftwareImageDecodeCache::GetDecodedImageForDrawInternal(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&)+146",
          "cc::SoftwareImageDecodeCache::GetDecodedImageForDraw(cc::DrawImage.const&)+133",
          "cc::PlaybackImageProvider::GetRasterContent(cc::DrawImage.const&)+455",
          "blink::CanvasResourceProvider::CanvasImageProvider::GetRasterContent(cc::DrawImage.const&)+174",
          "cc::DrawImageRectOp::RasterWithFlags(cc::DrawImageRectOp.const*,.cc::PaintFlags.const*,.SkCanvas*,.cc::PlaybackParams.const&)+1054",
          "cc::PaintOpBuffer::Playback(SkCanvas*,.cc::PlaybackParams.const&,.std::Cr::vector<unsigned.long,.std::Cr::allocator<unsigned.long>.>.const*).const+904",
          "cc::SkiaPaintCanvas::drawPicture(sk_sp<cc::PaintOpBuffer.const>,.base::RepeatingCallback<void.(SkCanvas*,.unsigned.int)>)+323",
          "cc::SkiaPaintCanvas::drawPicture(sk_sp<cc::PaintOpBuffer.const>)+43",
          "blink::CanvasResourceProvider::RasterRecord(sk_sp<cc::PaintOpBuffer>,.bool)+33",
          "blink::CanvasResourceProvider::FlushCanvasInternal(bool)+102",
          "blink::Canvas2DLayerBridge::FlushRecording(bool)+616",
          "blink::Canvas2DLayerBridge::FinalizeFrame(bool)+94",
          "non-virtual.thunk.to.blink::CanvasRenderingContext2D::FinalizeFrame(bool)+96",
          "blink::BaseRenderingContext2D::getImageDataInternal(int,.int,.int,.int,.blink::ImageDataSettings*,.blink::ExceptionState&)+555",
          "content::BrowsingDataRemoverImpl::RemoveAndReply(base::Time.const&,.base::Time.const&,.unsigned.long,.unsigned.long,.content::BrowsingDataRemover::Observer*)+21",
          "blink::(anonymous.namespace)::v8_canvas_rendering_context_2d::GetImageDataOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+1341",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+1013",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "0x100a3ff15b38",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5010",
          "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+459",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::String>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+237",
          "v8::debug::EvaluateGlobal(v8::Isolate*,.v8::Local<v8::String>,.v8::debug::EvaluateGlobalMode,.bool)+117",
          "v8_inspector::V8RuntimeAgentImpl::evaluate(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<double>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::EvaluateCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::EvaluateCallback>.>)+1092",
          "v8_inspector::protocol::Runtime::DomainDispatcherImpl::evaluate(v8_crdtp::Dispatchable.const&)+846",
          "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
          "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+611",
          "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+403",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+1013",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "0x100a3ff15b38",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5010",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::internal::CommandCallback(char.const*,.char.const*)+1061",
          "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
          "EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+38",
          "CommandRequest::Process(Json::Value.const&)+596",
          "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
          "PauseRequestHandler::Start(Json::Value.const&)+210",
          "ManifestFinished(Json::Value*)+912",
          "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
          "recordreplay::OnScanTargetHit()+36",
          "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671",
          "v8::internal::OnInstrumentation(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.int)+208",
          "v8::internal::Runtime_RecordReplayInstrumentation(int,.unsigned.long*,.v8::internal::Isolate*)+270",
          "0x100a3ff15a38",
          "0x100a3fffafd1",
          "0x100a3fe8b82c",
          "0x100a3fe8c1c0",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5010",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::Function::Call(v8::Local<v8::Context>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*)+763",
          "blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>,.blink::ExecutionContext*,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.v8::Isolate*)+931",
          "blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase,.(blink::bindings::CallbackInvokeHelperMode)2,.(blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int,.v8::Local<v8::Value>*)+91",
          "blink::V8Function::Invoke(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::HeapVector<blink::ScriptValue,.0u>.const&)+401",
          "blink::V8Function::InvokeAndReportException(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::HeapVector<blink::ScriptValue,.0u>.const&)+127",
          "blink::ScheduledAction::Execute(blink::ExecutionContext*)+231",
          "blink::DOMTimer::Fired()+623",
          "blink::TimerBase::RunInternal()+408",
          "base::DefaultDelayedTaskHandleDelegate::RunTask(base::OnceCallback<void.()>)+35",
          "base::internal::Invoker<base::internal::BindState<void.(base::DefaultDelayedTaskHandleDelegate::*)(base::OnceCallback<void.()>),.base::WeakPtr<base::DefaultDelayedTaskHandleDelegate>,.base::OnceCallback<void.()>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+159",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "content::ContentMainRunnerImpl::Run()+673"
        ],
        "onstack": [
          "recordreplay::ReplayLock::Lock()+264",
          "linker+1936128",
          "std::_Function_base::_Base_manager<EnsureReplayLock(void*,.bool,.bool)::'lambda'(recordreplay::ReplayLock*)>::_M_manager(std::_Any_data&,.std::_Any_data.const&,.std::_Manager_operation)",
          "_fini+30669",
          "new_pthread_mutex_lock(void*)+21",
          "new_pthread_mutex_trylock(void*)+37",
          "SkBlitter::Choose(SkPixmap.const&,.SkMatrixProvider.const&,.SkPaint.const&,.SkArenaAlloc*,.bool,.sk_sp<SkShader>,.SkSurfaceProps.const&)::$_1::operator()().const+121",
          "SkBlitter::Choose(SkPixmap.const&,.SkMatrixProvider.const&,.SkPaint.const&,.SkArenaAlloc*,.bool,.sk_sp<SkShader>,.SkSurfaceProps.const&)+1207",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "recordreplay::GetOrderedResourceId(void*)+18",
          "recordreplay::LoadOrderedResourceId(recordreplay::CallContext&,.unsigned.long)+71",
          "Op_pthread_mutex_lock(recordreplay::CallContext&)+21",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "Op_pthread_mutex_trylock(recordreplay::CallContext&)+21",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+273",
          "xsltStrxfrm",
          "base::internal::LockImpl::LockInternalWithTracking()+44",
          "linker+1144051",
          "recordreplay::ptmalloc::free(void*)+71",
          "recordreplay::ReplaySpaceFree(void*)+312",
          "recordreplay::RecordReplayAssertWithStackVA(void*,.char.const*,.__va_list_tag*)+698",
          "linker+1936248",
          "_fini+30688",
          "recordreplay::ReplayLock::TryLock()+143",
          "std::_Function_base::_Base_manager<EnsureReplayLock(void*,.bool,.bool)::'lambda'(recordreplay::ReplayLock*)>::_M_manager(std::_Any_data&,.std::_Any_data.const&,.std::_Manager_operation)",
          "std::_Function_handler<void.(recordreplay::ReplayLock*),.EnsureReplayLock(void*,.bool,.bool)::'lambda'(recordreplay::ReplayLock*)>::_M_invoke(std::_Any_data.const&,.recordreplay::ReplayLock*&&)",
          "new_pthread_mutex_trylock(void*)+21",
          "base::internal::LockImpl::LockInternalWithTracking()+70",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(unsigned.long)+1508",
          "base::DiscardableMemoryAllocator::AllocateLockedDiscardableMemoryWithRetryOrDie(unsigned.long,.base::OnceCallback<void.()>)+40",
          "cc::(anonymous.namespace)::AllocateDiscardable(SkImageInfo.const&,.base::OnceCallback<void.()>)+141",
          "recordreplay::Assert(char.const*,....)+141",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+115",
          "recordreplay::ReplaySpaceMalloc(unsigned.long)+55",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "linker+2466944",
          "linker+2467432",
          "linker+2466912",
          "linker+2466912",
          "recordreplay::ptmalloc::malloc(unsigned.long)+240",
          "linker+2466912",
          "recordreplay::ReplaySpaceMalloc(unsigned.long)+55",
          "operator.new(unsigned.long)+40",
          "void.std::Cr::__hash_table<unsigned.short,.std::Cr::hash<unsigned.short>,.std::Cr::equal_to<unsigned.short>,.std::Cr::allocator<unsigned.short>.>::__do_rehash<true>(unsigned.long)+44",
          "std::Cr::pair<std::Cr::__hash_iterator<std::Cr::__hash_node<std::Cr::__hash_value_type<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>,.void*>*>,.bool>.std::Cr::__hash_table<std::Cr::__hash_value_type<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>,.std::Cr::__unordered_map_hasher<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__hash_value_type<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>,.cc::SoftwareImageDecodeCacheUtils::CacheKeyHash,.std::Cr::equal_to<cc::SoftwareImageDecodeCacheUtils::CacheKey>,.true>,.std::Cr::__unordered_map_equal<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__hash_value_type<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>,.std::Cr::equal_to<cc::SoftwareImageDecodeCacheUtils::CacheKey>,.cc::SoftwareImageDecodeCacheUtils::CacheKeyHash,.true>,.std::Cr::allocator<std::Cr::__hash_value_type<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>.>.>::__emplace_unique_key_args<cc::SoftwareImageDecodeCacheUtils::CacheKey,.cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>.>(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::SoftwareImageDecodeCacheUtils::CacheKey&&,.std::Cr::__list_iterator<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.void*>&&)+656",
          "recordreplay::ReplaySpaceMalloc(unsigned.long)+55",
          "linker+2467272",
          "base::internal::LRUCacheBase<std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>,.base::internal::GetKeyFromKVPair,.base::internal::HashingLRUCacheKeyIndex<cc::SoftwareImageDecodeCacheUtils::CacheKey,.cc::SoftwareImageDecodeCacheUtils::CacheKeyHash,.std::Cr::equal_to<cc::SoftwareImageDecodeCacheUtils::CacheKey>.>.>::Put(std::Cr::pair<cc::SoftwareImageDecodeCacheUtils::CacheKey,.std::Cr::unique_ptr<cc::SoftwareImageDecodeCacheUtils::CacheEntry,.std::Cr::default_delete<cc::SoftwareImageDecodeCacheUtils::CacheEntry>.>.>&&)+595",
          "linker+2467272",
          "recordreplay::ReplaySpaceMalloc(unsigned.long)+55",
          "cc::SoftwareImageDecodeCache::AddCacheEntry(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&)+180",
          "std::_Function_base::_Base_manager<EnsureReplayLock(void*,.bool,.bool)::'lambda'(recordreplay::ReplayLock*)>::_M_manager(std::_Any_data&,.std::_Any_data.const&,.std::_Manager_operation)",
          "cc::SoftwareImageDecodeCache::GetDecodedImageForDrawInternal(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&)+146",
          "cc::SoftwareImageDecodeCache::GetDecodedImageForDraw(cc::DrawImage.const&)+133",
          "cc::PlaybackImageProvider::GetRasterContent(cc::DrawImage.const&)+455",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "Op_pthread_mutex_trylock(recordreplay::CallContext&)+21",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+273",
          "blink::CanvasResourceProvider::CanvasImageProvider::GetRasterContent(cc::DrawImage.const&)+174",
          "linker+2466944",
          "linker+2466944",
          "mspace_free(void*,.void*)+967",
          "linker+2467112",
          "linker+2467080",
          "recordreplay::Stream::LoadNextChunk(bool,.bool)+448",
          "linker+2466912",
          "cc::DrawImageRectOp::RasterWithFlags(cc::DrawImageRectOp.const*,.cc::PaintFlags.const*,.SkCanvas*,.cc::PlaybackParams.const&)+1054",
          "SkPaint::setColor(SkRGBA4f<(SkAlphaType)3>.const&,.SkColorSpace*)+196",
          "linker+2466912",
          "recordreplay::ptmalloc::malloc(unsigned.long)+240",
          "SkPaint::setColor(SkRGBA4f<(SkAlphaType)3>.const&,.SkColorSpace*)+196",
          "SkPaint::setColor(SkRGBA4f<(SkAlphaType)3>.const&,.SkColorSpace*)+196",
          "cc::ScopedRasterFlags::ScopedRasterFlags<float,.void>(cc::PaintFlags.const*,.cc::ImageProvider*,.SkMatrix.const&,.int,.float)+205",
          "cc::PaintOpBuffer::Playback(SkCanvas*,.cc::PlaybackParams.const&,.std::Cr::vector<unsigned.long,.std::Cr::allocator<unsigned.long>.>.const*).const+904",
          "chrome+224243992",
          "cc::SkiaPaintCanvas::drawPicture(sk_sp<cc::PaintOpBuffer.const>,.base::RepeatingCallback<void.(SkCanvas*,.unsigned.int)>)+323",
          "cc::SkiaPaintCanvas::drawPicture(sk_sp<cc::PaintOpBuffer.const>)+43",
          "blink::CanvasResourceProvider::RasterRecord(sk_sp<cc::PaintOpBuffer>,.bool)+33",
          "blink::CanvasResourceProvider::FlushCanvasInternal(bool)+102",
          "linker+2467080",
          "blink::Canvas2DLayerBridge::FlushRecording(bool)+616",
          "blink::Canvas2DLayerBridge::FinalizeFrame(bool)+94",
          "linker+2466944",
          "non-virtual.thunk.to.blink::CanvasRenderingContext2D::FinalizeFrame(bool)+96",
          "linker+2466912",
          "blink::BaseRenderingContext2D::getImageDataInternal(int,.int,.int,.int,.blink::ImageDataSettings*,.blink::ExceptionState&)+555",
          "recordreplay::ReplaySpaceFree(void*)+312",
          "base::SampleVectorBase::Accumulate(int,.int)+58",
          "chrome+223726832",
          "base::Histogram::AddCount(int,.int)+53",
          "non-virtual.thunk.to.blink::CanvasRenderingContext2D::getImageDataInternal(int,.int,.int,.int,.blink::ImageDataSettings*,.blink::ExceptionState&)+81",
          "chrome+225930720",
          "content::BrowsingDataRemoverImpl::RemoveAndReply(base::Time.const&,.base::Time.const&,.unsigned.long,.unsigned.long,.content::BrowsingDataRemover::Observer*)+21",
          "blink::(anonymous.namespace)::v8_canvas_rendering_context_2d::GetImageDataOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+1341",
          "chrome+225930720",
          "chrome+23028161",
          "chrome+22429847",
          "blink::(anonymous.namespace)::v8_canvas_rendering_context_2d::GetImageDataOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "blink::(anonymous.namespace)::v8_canvas_rendering_context_2d::GetImageDataOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)"
        ],
        "progress": 11420055,
        "threadId": 1,
        "checkpoint": 932
      }
    },
    {
      "state": {
        "ownsLock": [
          "0x1000001ebe18"
        ],
        "threadId": 3,
        "waitingOnCvar": {
          "ptr": true,
          "lock": true,
          "waiters": [
            3
          ]
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941",
          "new_pthread_cond_wait(void*,.void*)+50",
          "0x10005053504c",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "0x100050534060",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+961",
          "base::WaitableEvent::Wait()+31",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableSharedMemory(unsigned.long,.int)+423",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(unsigned.long)+1026",
          "base::DiscardableMemoryAllocator::AllocateLockedDiscardableMemoryWithRetryOrDie(unsigned.long,.base::OnceCallback<void.()>)+40",
          "cc::(anonymous.namespace)::AllocateDiscardable(SkImageInfo.const&,.base::OnceCallback<void.()>)+141",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+115",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "cc::SoftwareImageDecodeCache::DecodeImageInTask(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCache::DecodeTaskType)+491",
          "cc::(anonymous.namespace)::SoftwareImageDecodeTaskImpl::RunOnWorkerThread()+328",
          "cc::ImageController::ProcessNextImageDecodeOnWorkerThread(cc::ImageController::WorkerState*)+541",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::internal::TaskTracker::RunTaskImpl(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+72",
          "base::internal::TaskTracker::RunContinueOnShutdown(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+65",
          "base::internal::TaskTracker::RunTask(base::internal::Task,.base::internal::TaskSource*,.base::TaskTraits.const&)+334",
          "base::internal::TaskTracker::RunAndPopNextTask(base::internal::RegisteredTaskSource)+502",
          "base::internal::WorkerThread::RunWorker()+503",
          "base::internal::WorkerThread::RunPooledWorker()+13",
          "base::internal::WorkerThread::ThreadMain()+119",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "onstack": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941",
          "_fini+30547",
          "EnsureReplayCvar(void*,.bool)+560",
          "recordreplay::RecordReplayAssertWithStackVA(void*,.char.const*,.__va_list_tag*)+1267",
          "std::_Function_base::_Base_manager<EnsureReplayCvar(void*,.bool)::'lambda'(recordreplay::ReplayCvar*)>::_M_manager(std::_Any_data&,.std::_Any_data.const&,.std::_Manager_operation)",
          "_fini+30547",
          "new_pthread_cond_wait(void*,.void*)+50",
          "base::internal::UncheckedScopedBlockingCall::UncheckedScopedBlockingCall(base::Location.const&,.base::BlockingType,.base::internal::UncheckedScopedBlockingCall::BlockingCallType)+638",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+961",
          "base::WaitableEvent::Wait()+31",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableSharedMemory(unsigned.long,.int)+423",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(unsigned.long)+1026",
          "base::DiscardableMemoryAllocator::AllocateLockedDiscardableMemoryWithRetryOrDie(unsigned.long,.base::OnceCallback<void.()>)+40",
          "mspace_malloc(void*,.unsigned.long)+624",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+113",
          "recordreplay::ReplayLock::Lock()+121",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "recordreplay::ReplayLock::NotifyWaiter()+148",
          "recordreplay::ReplayLock::Unlock()+145",
          "recordreplay::GetOrderedResourceId(void*)+18",
          "recordreplay::LoadOrderedResourceId(recordreplay::CallContext&,.unsigned.long)+71",
          "Op_pthread_cond_anywait(recordreplay::CallContext&)+24",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "recordreplay::ReplayLock::NotifyWaiter()+148",
          "recordreplay::ReplayLock::Unlock()+145",
          "Op_pthread_mutex_trylock(recordreplay::CallContext&)+162",
          "Op_fopen(recordreplay::CallContext&)+64",
          "_fini+47321",
          "_fini+11007",
          "mspace_malloc(void*,.unsigned.long)+624",
          "recordreplay::Thread::Current()+53",
          "new_pthread_getspecific(unsigned.int)+26",
          "chrome+251008904",
          "base::ThreadLocalStorage::Slot::Get().const+20",
          "chrome+251008904",
          "base::internal::GetTaskPriorityForCurrentThread()+103",
          "base::internal::UncheckedScopedBlockingCall::UncheckedScopedBlockingCall(base::Location.const&,.base::BlockingType,.base::internal::UncheckedScopedBlockingCall::BlockingCallType)+646",
          "chrome+19670209",
          "chrome+22037610",
          "base::ConditionVariable::Wait()+117",
          "base::ThreadLocalStorage::Slot::Set(void*)+24",
          "base::internal::ScopedBlockingCallWithBaseSyncPrimitives::ScopedBlockingCallWithBaseSyncPrimitives(base::Location.const&,.base::BlockingType)+19",
          "base::ConditionVariable::Wait()+146",
          "chrome+19670209",
          "chrome+22037610",
          "base::ConditionVariable::Wait()+117",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+961",
          "chrome+223734440",
          "base::WaitableEvent::Wait()+31",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableSharedMemory(unsigned.long,.int)+423",
          "chrome+221485864",
          "chrome+221485864",
          "chrome+19301248",
          "chrome+22187527",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableSharedMemory(unsigned.long,.int)+288",
          "chrome+19466990",
          "discardable_memory::ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory(unsigned.long)+1026",
          "base::DiscardableMemoryAllocator::AllocateLockedDiscardableMemoryWithRetryOrDie(unsigned.long,.base::OnceCallback<void.()>)+40",
          "mspace_malloc(void*,.unsigned.long)+624",
          "cc::(anonymous.namespace)::AllocateDiscardable(SkImageInfo.const&,.base::OnceCallback<void.()>)+141",
          "recordreplay::Assert(char.const*,....)+49",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+115",
          "recordreplay::ReplaySpaceMalloc(unsigned.long)+55",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "recordreplay::RecordReplayAssertWithStackVA(void*,.char.const*,.__va_list_tag*)+1735",
          "mspace_malloc(void*,.unsigned.long)+1432",
          "std::Cr::basic_streambuf<char,.std::Cr::char_traits<char>.>::xsputn(char.const*,.long)+97",
          "chrome+223450520",
          "recordreplay::ptmalloc::malloc(unsigned.long)+240",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::internal::TaskTracker::RunTaskImpl(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+72",
          "base::internal::TaskTracker::RunContinueOnShutdown(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+65",
          "base::internal::TaskTracker::RunTask(base::internal::Task,.base::internal::TaskSource*,.base::TaskTraits.const&)+334",
          "base::internal::TaskTracker::RunAndPopNextTask(base::internal::RegisteredTaskSource)+502",
          "chrome+223449944",
          "chrome+20128464",
          "mspace_free(void*,.void*)+339",
          "cc::SoftwareImageDecodeCache::DecodeImageInTask(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCache::DecodeTaskType)+491",
          "recordreplay::ptmalloc::free(void*)+71",
          "cc::(anonymous.namespace)::SoftwareImageDecodeTaskImpl::RunOnWorkerThread()+328",
          "linker+2014288",
          "cc::ImageController::ProcessNextImageDecodeOnWorkerThread(cc::ImageController::WorkerState*)+541",
          "recordreplay::RecordReplayAssertWithStackVA(void*,.char.const*,.__va_list_tag*)+1735",
          "chrome+250266208",
          "chrome+250266208",
          "chrome+251008840",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "cc::ImageController::ScheduleImageDecodeOnWorkerIfNeeded()+85",
          "cc::UniqueNotifier::Schedule()+82",
          "cc::(anonymous.namespace)::TaskSetFinishedTaskImpl::RunOnWorkerThread()+105",
          "recordreplay::LoadOrderedResourceId(recordreplay::CallContext&,.unsigned.long)+71",
          "base::internal::TaskTracker::RunTaskImpl(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+72",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+79",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+79",
          "base::internal::ThreadGroupImpl::EnsureEnoughWorkersLockRequired(base::internal::ThreadGroup::BaseScopedCommandsExecutor*)+652",
          "base::internal::ThreadGroupImpl::IncrementTasksRunningLockRequired(base::TaskPriority)+116",
          "base::internal::ThreadGroupImpl::WorkerThreadDelegateImpl::GetWork(base::internal::WorkerThread*)+470",
          "base::internal::WorkerThread::RunWorker()+428",
          "base::internal::WorkerThread::RunPooledWorker()+13"
        ],
        "progress": 11420055,
        "threadId": 3,
        "checkpoint": 932
      }
    }
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 11420055,
    "threadId": 2,
    "processId": 569,
    "checkpoint": 932,
    "absoluteTime": 1785167457856.5205,
    "wasRecording": false
  }
]
```

# Facts

* Hang (not mismatch): tid1 waits on `ClientDiscardableSharedMemoryManager::lock_` owned by tid3.
* tid3: holds that lock → `AllocateLockedDiscardableSharedMemory` → `WaitableEvent::Wait` (IPC).
* `lock_` is already named → already OrderedPthreadMutex.
  * ctor: `lock_("ClientDiscardableSharedMemoryManager.lock_")`.
  * Missing OrderedLock is not the gap.
* Per divergences bible: do not Assert on sync code (ordered or should-be-ordered).
* `AllocateLockedDiscardableMemory`: `AutoLock` at entry.
  * Asserts and `AreEventsUnavailable` → local alloc (skip IPC) run only under the lock.
* After diverge: `GetOrderedResourceId` returns 0 → acquire skips `AutoOrderedLock`, falls to unordered `ReplayLock`.

# Slice

* Pause: `OnScanTargetHit` → `PauseRequestHandler` → `EvaluateInGlobal` / CDP `getImageData`.
* Prior (still live): tid3 worker decode holds **LockX** = `ClientDiscardableSharedMemoryManager::lock_`.
  * `DecodeImageInTask` → `AllocateLockedDiscardableMemory` → `AutoLock(LockX)`.
  * Under LockX: `AllocateLockedDiscardableSharedMemory` → `WaitableEvent::Wait` (Mojo IPC).
* tid1 (pause request): same alloc path → `AutoLock(LockX)` → waits; owner = tid3.
* Hang: tid3 never leaves IPC wait; tid1 never gets LockX.

# Related Work

* crash-0026 / chromium `#1391`
  (`f36861a1c9734`, in this build):
  * In `AllocateLockedDiscardableMemory`, after freelist miss:
    if `AreEventsUnavailable()` → local `MadvFreeDiscardableMemoryPosix`
    instead of Mojo/`event.Wait()`.
  * Check sits under `AutoLock(lock_)`.
  * Gap: tid1 blocks on `lock_` before the local-alloc check.
  * tid3 stuck in Mojo `Wait` post-diverge is expected collateral, not a
    separate bug to unstick.

# Solution

* Move the existing `AreEventsUnavailable()` → `MadvFreeDiscardableMemoryPosix`
  early-out to *before* `AutoLock(lock_)` in
  `ClientDiscardableSharedMemoryManager::AllocateLockedDiscardableMemory`.
* Keep `AreEventsUnavailable()` (Disallowed or Diverged), not only
  `HasDivergedFromRecording()`.
* Risk check (no real blockers):
  * Local path: `mmap` + static byte counter only; no `heap_` / freelist /
    `allocated_memory_` → safe without `lock_`.
  * Starts locked (`is_locked_ = true`) → matches `AllocateLocked*` contract.
  * Skipping freelist: perf / different backing only; fine on Unavailable.
  * SHM vs process-local semantics: already accepted by `#1391`.
  * After diverge OrderedLock is already off (`GetOrderedResourceId` → 0);
    “not paused” does not restore it.
  * POSIX-only guard unchanged (`#if BUILDFLAG(IS_POSIX)`).
