### PR TITLE
[crash-0055] Remove diagnostic forEachSession Assert

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'e5ce6830ae951efd0bc20c28e21fec987379a9fc',
+  'v8_revision': '303d9865d17593ac516dd71155c89ff66d4ec553',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '303d9865d17593ac516dd71155c89ff66d4ec553',
+  'v8_revision': '5e20f54aa0a6c06b8cf0263337c6e369b9037b41',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/314

# Summary

* Remove diagnostic `V8InspectorImpl::forEachSession` Assert.
* Session presence is replay-divergent (**ReplayOnlyInspectorSession**).
* Assert caused noisy wMismatch vs `resetContextGroup` (crash-0055).
* Hides real divergence.
* Keep per-visit Mark+Disallow on `replayOwned`.


# Problem

* Problem type: ReplayMismatch.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260730-b5ed877348bd-97130a07511f
* linkerVersion: linker-linux-16068-97130a07511f
* recordingId: cb931db4-9ba8-45ce-8c71-5e9daaa4aca1

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 1355087,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 1439330,
      "checkpoint": 61
    }
  },
  "recorded": "V8InspectorImpl::resetContextGroup 1",
  "replayed": "V8InspectorImpl::forEachSession sessionId=1 hasGroup=1",
  "threadId": 1,
  "backtrace": {
    "progress": 801277,
    "threadId": 1,
    "checkpoint": 56
  },
  "recordedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8_inspector::V8InspectorImpl::resetContextGroup(int)+532",
    "blink::LocalDOMWindow::FrameDestroyed()+170",
    "blink::LocalDOMWindow::Reset()+14",
    "blink::LocalFrame::SetDOMWindow(blink::LocalDOMWindow*)+43",
    "blink::DocumentLoader::InitializeWindow(blink::Document*)+1077",
    "blink::DocumentLoader::CommitNavigation()+158",
    "blink::FrameLoader::CommitDocumentLoader(blink::DocumentLoader*,.blink::HistoryItem*,.blink::CommitReason)+477"
  ],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+1086",
    "v8_inspector::V8ConsoleMessageStorage::~V8ConsoleMessageStorage()+87",
    "unsigned.long.std::Cr::__hash_table<std::Cr::__hash_value_type<int,.std::Cr::unique_ptr<v8_inspector::V8ConsoleMessageStorage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessageStorage>.>.>,.std::Cr::__unordered_map_hasher<int,.std::Cr::__hash_value_type<int,.std::Cr::unique_ptr<v8_inspector::V8ConsoleMessageStorage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessageStorage>.>.>,.std::Cr::hash<int>,.std::Cr::equal_to<int>,.true>,.std::Cr::__unordered_map_equal<int,.std::Cr::__hash_value_type<int,.std::Cr::unique_ptr<v8_inspector::V8ConsoleMessageStorage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessageStorage>.>.>,.std::Cr::equal_to<int>,.std::Cr::hash<int>,.true>,.std::Cr::allocator<std::Cr::__hash_value_type<int,.std::Cr::unique_ptr<v8_inspector::V8ConsoleMessageStorage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessageStorage>.>.>.>.>::__erase_unique<int>(int.const&)+427",
    "v8_inspector::V8InspectorImpl::resetContextGroup(int)+467",
    "blink::LocalDOMWindow::FrameDestroyed()+170",
    "blink::LocalDOMWindow::Reset()+14",
    "blink::LocalFrame::SetDOMWindow(blink::LocalDOMWindow*)+43"
  ]
}
```

# Basic Facts

* **ReplayOnlyInspectorSession**
  * Replay creates a `V8InspectorSession` via `getInspectorSession` → `inspector->connect` under `AutoMarkReplayCode` + `AutoDisallowEvents` (`record_replay_interface.cc`).
  * Session ctor sets `m_replay_owned = AreEventsDisallowed()` (ReplaySession path); DevTools connect does not.
  * That session exists at replay time only.
  * See linker-commands.md (`SendCDPMessage` / inspector session) and determinism-diverged-simulation.md.
  * Asserts / control that observe session presence or `forEachSession` walk vs recording are expected to look divergent.

* **ConsoleStorageMapErase**
  * `resetContextGroup` does `m_consoleStorageMap.erase(contextGroupId)` before its own Assert.
  * `m_consoleStorageMap` is `std::unordered_map` (`v8-inspector-impl.h`).
  * Erase destroys `unique_ptr<V8ConsoleMessageStorage>` → `~V8ConsoleMessageStorage` → `clear()` → `forEachSession` → `releaseObjectGroup("console")`.
  * Unordered map destruction/iteration can reorder side effects (determinism-iteration-ordering.md).
  * This stack is single-key `__erase_unique`, not full-map teardown.
  * Inner `m_sessions[group]` is `std::map<int, Session*>` (sessionId-ordered).

* **MismatchVsFatalDistance**
  * NonFatal mismatch: progress `801277` / checkpoint `56`, thread `1`.
  * Fatal: progress `1875871` / checkpoint `169`, thread `11` (`clock_gettime` vs `pthread_detach` in AVIF decode / `WorkerThread` teardown).
  * Far apart → mismatch may never touch recording streams divergently enough to cause this fatal; causal link unproven.

# Investigation

## Ids

* report: `a12c060b-07d1-4aca-b88b-c23e52118197`
* recordingId: [`cb931db4-9ba8-45ce-8c71-5e9daaa4aca1`](https://app.replay.io/recording/cb931db4-9ba8-45ce-8c71-5e9daaa4aca1)
* projectId: `proj-golf-sapiens-viajes-replit-app-ms7zvv1h`
* task (from recording URL): `run-ms7zz03v-rr49`
* buildId: `linux-chromium-20260730-b5ed877348bd-97130a07511f`
* linkerVersion: `linker-linux-16068-97130a07511f`

## MismatchKind

* ControlFlowMismatch (different Assert strings).
* recorded: `V8InspectorImpl::resetContextGroup 1`
* replayed: `V8InspectorImpl::forEachSession sessionId=1 hasGroup=1`
* Shared ancestor: `V8InspectorImpl::resetContextGroup` ← `LocalDOMWindow::FrameDestroyed` / `Reset` ← navigation commit.

## Assert Sites

* `resetContextGroup` Assert (`v8-inspector-impl.cc`): after `m_consoleStorageMap.erase`, before `m_contexts` erase / `session->reset()` walk.
  * `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::resetContextGroup %d", hasContexts)` with `hasContexts=1` on record.
* `forEachSession` Assert: inside session loop, after `AutoMaybeDisallowEvents(session->replayOwned())`.
  * Macro skips Assert when `AreEventsDisallowed()` (`v8/include/replayio-macros.h`).
  * ReplaySession (`replayOwned`) should suppress this Assert.
  * Replayed string shows it fired → events were allowed → sessionId=1 was not under Disallow at Assert, or was not `replayOwned`.

## Path Split

* Both sides enter `resetContextGroup`.
* Record leaf: Assert in `resetContextGroup` (no prior `forEachSession` Assert at this hitOrder).
  * Implies erase→`clear`→`forEachSession` early-returned or skipped Assert (no session / Disallow).
* Replay leaf: Assert in `forEachSession` during erase→`~V8ConsoleMessageStorage`→`clear`, before `resetContextGroup` Assert.
  * Implies a sessionId=1 existed and Assert was not suppressed.

## Why Assert Looks Wrong

* Observing `forEachSession` / sessionId against the recording stream fights **ReplayOnlyInspectorSession**.
* `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` skips when `AreEventsDisallowed()`.
* Replayed leaf fired ⇒ events were allowed at that Assert ⇒ `session->replayOwned()` was false (or `session` null), so Disallow was not entered.
* Intended ReplaySession path: `getInspectorSession` connect under Disallow → `m_replay_owned=true` → forEachSession Assert suppressed.
* Tension: fired Assert means this was not that suppressed path; still a session-set record vs replay diverge.
* Other connect: `DevToolsSession::ConnectToV8` has no Disallow → not `replayOwned`; if present only on one side, same ControlFlowMismatch shape.
* Either way the Assert is a bad record/replay comparison point for inspector session presence.

## Fatal Relation

* Fatal is different thread, later checkpoint, syscall mismatch in image-decode worker path.
* No stack overlap with inspector mismatch.
* Treat mismatch as likely noise / early diverge signal unless a stream-touching chain is shown.

## Verdict (Assert)

* Yes — this Assert mismatch is the wrong signal.
* Root shape: ControlFlowMismatch from replay-only (or otherwise non-recorded) inspector session presence during `m_consoleStorageMap.erase` → `forEachSession`.
* Not established as cause of the later fatal.

## Assert Provenance (why it exists)

* Added in v8 `#299` / `429e2348635` — `crash-0035/0036/0037: replay-divergence diagnostics`
  * Message then: `V8InspectorImpl::forEachSession %d %d`
  * Purpose: diagnostic for crash-0036 — detect `m_sessions` membership diverge between id snapshot and re-lookup
  * Same commit added `resetContextGroup` / `consoleStorage` Asserts
* crash-0036 `solution.md`: explicitly labeled **diagnostic Assert**
* crash-0039 `#303` / `e390528723a` kept it on purpose:
  * Wrap visit with Mark+Disallow when `session->replayOwned()`
  * Rely on `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` to auto-skip for **ReplaySession**
  * Rejected bare assert-skip without Mark+Disallow (would silence without marking side effects)
  * Renamed string to `sessionId=%d hasGroup=%d`
  * Removed the `consoleStorage` Assert (allowed-to-be-divergent)
* crash-0055 shows that keep-and-suppress strategy failed here: Assert still fired for `sessionId=1`

## Remove?

* Yes for `V8InspectorImpl::forEachSession` Assert.
* It was only a crash-0036 diagnostic.
* Session presence / visit order vs recording is allowed-to-be-divergent (**ReplayOnlyInspectorSession**).
* [InvalidAssertValues] — never Assert on allowed-to-be-divergent control.
* Mark+Disallow ownership wrap can stay; only the Assert line should go.
* `resetContextGroup %d` (hasContexts): separate Assert; crash-0039 kept it; not required for this remove.

# Solution

* Remove `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::forEachSession …")` from `V8InspectorImpl::forEachSession`.
* Keep per-visit `AutoMaybeMarkReplayCode` + `AutoMaybeDisallowEvents` keyed on `session->replayOwned()`.
* Do not touch `resetContextGroup` Assert.
