### PR TITLE
[crash-0057 + crash-0056] DOMScheduler fixed_priority leak-memory & NotifyError path Asserts & "leak-memory" canonical label

### DIFF
--- a/mojo/public/cpp/bindings/lib/control_message_proxy.cc
+++ b/mojo/public/cpp/bindings/lib/control_message_proxy.cc
@@ -10,6 +10,7 @@
 
 #include "base/bind.h"
 #include "base/callback_helpers.h"
+#include "base/record_replay.h"
 #include "base/run_loop.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "base/time/time.h"
@@ -207,6 +208,8 @@ void ControlMessageProxy::NotifyIdle() {
 
 void ControlMessageProxy::OnConnectionError() {
   encountered_error_ = true;
+  recordreplay::Assert("ControlMessageProxy::OnConnectionError %d",
+                       !pending_flush_callback_.is_null());
   if (!pending_flush_callback_.is_null())
     RunFlushForTestingClosure();
 }

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -747,7 +747,11 @@ void InterfaceEndpointClient::NotifyError(
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   // https://linear.app/replay/issue/RUN-965
-  recordreplay::Assert("InterfaceEndpointClient::NotifyError %d", encountered_error_);
+  recordreplay::Assert(
+      "InterfaceEndpointClient::NotifyError %d %d %s %d %d",
+      encountered_error_, recordreplay::PointerId(this),
+      interface_name_ ? interface_name_ : "", !!error_handler_,
+      !!error_with_reason_handler_);
 
   if (encountered_error_)
     return;

--- a/third_party/blink/renderer/core/animation/animation_timeline.cc
+++ b/third_party/blink/renderer/core/animation/animation_timeline.cc
@@ -25,13 +25,13 @@ void AnimationTimeline::AnimationAttached(Animation* animation) {
   DCHECK(!animations_.Contains(animation));
   animations_.insert(animation);
 
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "AnimationTimeline"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "AnimationTimeline"))
     record_replay_animations_strong_.insert(animation);
 }
 
 void AnimationTimeline::AnimationDetached(Animation* animation) {
   animations_.erase(animation);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "AnimationTimeline"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "AnimationTimeline"))
     record_replay_animations_strong_.erase(animation);
 
   animations_needing_update_.erase(animation);

--- a/third_party/blink/renderer/core/css/css_font_selector.cc
+++ b/third_party/blink/renderer/core/css/css_font_selector.cc
@@ -70,7 +70,7 @@ void CSSFontSelector::RegisterForInvalidationCallbacks(
     FontSelectorClient* client) {
   CHECK(client);
   clients_.insert(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "CSSFontSelector")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "CSSFontSelector")) {
     record_replay_strong_clients_.insert(client);
   }
 }
@@ -78,7 +78,7 @@ void CSSFontSelector::RegisterForInvalidationCallbacks(
 void CSSFontSelector::UnregisterForInvalidationCallbacks(
     FontSelectorClient* client) {
   clients_.erase(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "CSSFontSelector")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "CSSFontSelector")) {
     record_replay_strong_clients_.erase(client);
   }
 }

--- a/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
+++ b/third_party/blink/renderer/core/css/resolver/matched_properties_cache.cc
@@ -52,7 +52,7 @@ void CachedMatchedProperties::Set(const ComputedStyle& style,
     matched_properties.push_back(new_matched_properties.properties);
     matched_properties_types.push_back(new_matched_properties.types_);
 
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                              "CachedMatchedProperties"))
       replay_matched_properties_strong_.push_back(
           new_matched_properties.properties);

--- a/third_party/blink/renderer/core/css/style_engine.cc
+++ b/third_party/blink/renderer/core/css/style_engine.cc
@@ -820,7 +820,7 @@ CSSStyleSheet* StyleEngine::CreateSheet(
       result.stored_value->value = style_sheet->Contents();
       sheet_to_text_cache_.insert(style_sheet->Contents(), text_content);
 
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "StyleEngine")) {
+      if (recordreplay::IsRecordingOrReplaying("leak-references", "StyleEngine")) {
         style_sheet_contents_strong_.insert(style_sheet->Contents());
       }
     }

--- a/third_party/blink/renderer/core/css/style_image_cache.cc
+++ b/third_party/blink/renderer/core/css/style_image_cache.cc
@@ -23,7 +23,7 @@ StyleFetchedImage* StyleImageCache::CacheStyleImage(Document& document,
             FetchParameters::ImageRequestBehavior::kDeferImageLoad,
         origin_clean == OriginClean::kTrue, is_ad_related, params.Url());
 
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "StyleImageCache")) {
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "StyleImageCache")) {
       fetched_image_map_strong_.insert(result.stored_value->value);
     }
   }

--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
@@ -82,7 +82,7 @@ class IdleRequestCallbackWrapper
   IdleRequestCallbackWrapper(ScriptedIdleTaskController::CallbackId id,
                              ScriptedIdleTaskController* controller)
       : id_(id), controller_(controller) {
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                              "IdleRequestCallbackWrapper"))
       replay_strong_controller_ = controller;
   }

--- a/third_party/blink/renderer/core/fetch/body_stream_buffer.cc
+++ b/third_party/blink/renderer/core/fetch/body_stream_buffer.cc
@@ -153,7 +153,7 @@ void BodyStreamBuffer::Init() {
     if (signal_->aborted()) {
       Abort();
     } else {
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "BodyStreamBuffer")) {
+      if (recordreplay::IsRecordingOrReplaying("leak-references", "BodyStreamBuffer")) {
         // Abort() interacts with the recording so we need it to run consistently.
         signal_->AddAlgorithm(WTF::BindOnce(&BodyStreamBuffer::Abort, WrapPersistent(this)));
       } else {
@@ -241,7 +241,7 @@ void BodyStreamBuffer::StartLoading(FetchDataLoader* loader,
       client->Abort();
       return;
     }
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "BodyStreamBuffer")) {
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "BodyStreamBuffer")) {
       // Client aborts can interact with the recording, so we want them to run consistently.
       signal_->AddAlgorithm(WTF::BindOnce(&FetchDataLoader::Client::Abort, WrapPersistent(client)));
     } else {

--- a/third_party/blink/renderer/core/frame/event_handler_registry.cc
+++ b/third_party/blink/renderer/core/frame/event_handler_registry.cc
@@ -113,7 +113,7 @@ void EventHandlerRegistry::UpdateEventHandlerTargets(
   switch (op) {
     case kAdd:
       targets->insert(target);
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+      if (recordreplay::IsRecordingOrReplaying("leak-references",
                                                "EventHandlerRegistry")) {
         replay_strong_targets_.insert(target);
       }
@@ -121,14 +121,14 @@ void EventHandlerRegistry::UpdateEventHandlerTargets(
     case kRemove:
       DCHECK(targets->Contains(target));
       targets->erase(target);
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+      if (recordreplay::IsRecordingOrReplaying("leak-references",
                                                "EventHandlerRegistry")) {
         replay_strong_targets_.erase(target);
       }
       return;
     case kRemoveAll:
       targets->RemoveAll(target);
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+      if (recordreplay::IsRecordingOrReplaying("leak-references",
                                                "EventHandlerRegistry")) {
         replay_strong_targets_.RemoveAll(target);
       }

--- a/third_party/blink/renderer/core/inspector/network_resources_data.cc
+++ b/third_party/blink/renderer/core/inspector/network_resources_data.cc
@@ -130,7 +130,7 @@ size_t NetworkResourcesData::ResourceData::EvictContent() {
 void NetworkResourcesData::ResourceData::SetResource(
     const Resource* cached_resource) {
   cached_resource_ = cached_resource;
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  if (recordreplay::IsRecordingOrReplaying("leak-references",
                                            "NetworkResourcesData"))
     replay_cached_resource_strong_ = cached_resource;
   if (const auto* font_resource = DynamicTo<FontResource>(cached_resource))
@@ -176,7 +176,7 @@ void NetworkResourcesData::ResourceData::FontResourceDataWillBeCleared() {
   }
   // There is no point tracking the resource anymore.
   cached_resource_ = nullptr;
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  if (recordreplay::IsRecordingOrReplaying("leak-references",
                                            "NetworkResourcesData"))
     replay_cached_resource_strong_ = nullptr;
   network_resources_data_->MaybeDecodeDataToContent(RequestId());

--- a/third_party/blink/renderer/core/intersection_observer/intersection_observer.cc
+++ b/third_party/blink/renderer/core/intersection_observer/intersection_observer.cc
@@ -352,7 +352,7 @@ void IntersectionObserver::observe(Element* target,
       MakeGarbageCollected<IntersectionObservation>(*this, *target);
   target->EnsureIntersectionObserverData().AddObservation(*observation);
   observations_.insert(observation);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserver")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserver")) {
     replay_strong_observations_.insert(observation);
   }
   if (root() && root()->isConnected()) {
@@ -398,7 +398,7 @@ void IntersectionObserver::unobserve(Element* target,
 
   observation->Disconnect();
   observations_.erase(observation);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserver")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserver")) {
     replay_strong_observations_.erase(observation);
   }
   active_observations_.erase(observation);
@@ -414,7 +414,7 @@ void IntersectionObserver::disconnect(ExceptionState& exception_state) {
   for (auto& observation : observations_)
     observation->Disconnect();
   observations_.clear();
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserver")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserver")) {
     replay_strong_observations_.clear();
   }
   active_observations_.clear();

--- a/third_party/blink/renderer/core/intersection_observer/intersection_observer_controller.cc
+++ b/third_party/blink/renderer/core/intersection_observer/intersection_observer_controller.cc
@@ -94,7 +94,7 @@ bool IntersectionObserverController::ComputeIntersections(
         needs_occlusion_tracking_ |= observer->trackVisibility();
       } else {
         tracked_explicit_root_observers_.erase(observer);
-        if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserverController")) {
+        if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserverController")) {
           replay_strong_tracked_explicit_root_observers_.erase(observer);
         }
       }
@@ -126,7 +126,7 @@ void IntersectionObserverController::AddTrackedObserver(
   if (observer.RootIsImplicit() || !observer.HasObservations())
     return;
   tracked_explicit_root_observers_.insert(&observer);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserverController")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserverController")) {
     replay_strong_tracked_explicit_root_observers_.insert(&observer);
   }
   if (observer.trackVisibility()) {
@@ -151,7 +151,7 @@ void IntersectionObserverController::RemoveTrackedObserver(
   // compelling reason to do it here, so we avoid the iteration through
   // observers and observations here.
   tracked_explicit_root_observers_.erase(&observer);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserverController")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserverController")) {
     replay_strong_tracked_explicit_root_observers_.erase(&observer);
   }
 }
@@ -163,7 +163,7 @@ void IntersectionObserverController::AddTrackedObservation(
   if (!observer->RootIsImplicit())
     return;
   tracked_implicit_root_observations_.insert(&observation);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserverController")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserverController")) {
     replay_strong_tracked_implicit_root_observations_.insert(&observation);
   }
   if (observer->trackVisibility()) {
@@ -184,7 +184,7 @@ void IntersectionObserverController::RemoveTrackedObservation(
   if (!observer->RootIsImplicit())
     return;
   tracked_implicit_root_observations_.erase(&observation);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "IntersectionObserverController")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "IntersectionObserverController")) {
     replay_strong_tracked_implicit_root_observations_.erase(&observation);
   }
 }

--- a/third_party/blink/renderer/core/loader/resource/font_resource.cc
+++ b/third_party/blink/renderer/core/loader/resource/font_resource.cc
@@ -113,7 +113,7 @@ void FontResource::StartLoadLimitTimersIfNecessary(
                     self), \
       kFontLoadWaitLong);
 
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "FontResource")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "FontResource")) {
     POST_TIMER_TASKS(WrapPersistent(this))
   } else {
     POST_TIMER_TASKS(WrapWeakPersistent(this))

--- a/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
+++ b/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
@@ -130,7 +130,7 @@ void ImageResourceContent::HandleObserverFinished(
     if (it != observers_.end()) {
       observers_.erase(it);
       finished_observers_.insert(observer);
-      if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+      if (recordreplay::IsRecordingOrReplaying("leak-references",
                                                "ImageResourceContent")) {
         replay_strong_observers_.erase(replay_strong_observers_.find(observer));
         replay_strong_finished_observers_.insert(observer);
@@ -151,7 +151,7 @@ void ImageResourceContent::AddObserver(ImageResourceObserver* observer) {
         this);
     observers_.insert(observer);
     
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                               "ImageResourceContent")) {
       replay_strong_observers_.insert(observer);
     }
@@ -179,7 +179,7 @@ void ImageResourceContent::RemoveObserver(ImageResourceObserver* observer) {
     fully_erased = observers_.erase(it) && finished_observers_.find(observer) ==
                                                finished_observers_.end();
     
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                               "ImageResourceContent")) {
       replay_strong_observers_.erase(replay_strong_observers_.find(observer));
     }
@@ -188,7 +188,7 @@ void ImageResourceContent::RemoveObserver(ImageResourceObserver* observer) {
     DCHECK(it != finished_observers_.end());
     fully_erased = finished_observers_.erase(it);
     
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                               "ImageResourceContent")) {
       replay_strong_finished_observers_.erase(replay_strong_finished_observers_.find(observer));
     }

--- a/third_party/blink/renderer/core/svg/svg_element.cc
+++ b/third_party/blink/renderer/core/svg/svg_element.cc
@@ -597,7 +597,7 @@ void SVGElement::AddInstance(SVGElement* instance) {
   DCHECK(!instances.Contains(instance));
 
   instances.insert(instance);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  if (recordreplay::IsRecordingOrReplaying("leak-references",
                                            "SVGElement"))
     EnsureSVGRareData()->ReplayStrongElementInstances().insert(instance);
 }
@@ -615,7 +615,7 @@ void SVGElement::RemoveInstance(SVGElement* instance) {
 
   instances.erase(instance);
 
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "SVGElement"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "SVGElement"))
     EnsureSVGRareData()->ReplayStrongElementInstances().erase(instance);
 }
 
@@ -1128,7 +1128,7 @@ void SVGElement::InvalidateInstances() {
 
   SvgRareData()->ElementInstances().clear();
 
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "SVGElement"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "SVGElement"))
     EnsureSVGRareData()->ReplayStrongElementInstances().clear();
 }
 

--- a/third_party/blink/renderer/core/url/dom_url.cc
+++ b/third_party/blink/renderer/core/url/dom_url.cc
@@ -102,7 +102,7 @@ URLSearchParams* DOMURL::searchParams() {
     }
 
     search_params_ = URLSearchParams::Create(Url().Query(), this);
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "DOMURL::searchParams_")) {
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "DOMURL::searchParams_")) {
       replay_strong_search_params_ = search_params_;
     }
   }

--- a/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
+++ b/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
@@ -51,7 +51,7 @@ void DOMScheduler::ContextDestroyed() {
     signal_to_task_queue_map_.size());
 
   // Keep queues alive until DOMScheduler itself is GC-collected.
-  if (!recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  if (!recordreplay::IsRecordingOrReplaying("leak-references",
                                             "DOMScheduler")) {
     fixed_priority_task_queues_.clear();
     signal_to_task_queue_map_.clear();
@@ -180,7 +180,7 @@ void DOMScheduler::CreateTaskQueueFor(DOMTaskSignal* signal) {
   signal_to_task_queue_map_.insert(
       signal,
       MakeGarbageCollected<DOMTaskQueue>(std::move(task_queue), priority));
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+  if (recordreplay::IsRecordingOrReplaying("leak-references",
                                             "DOMScheduler")) {
     replay_strong_signal_.insert(signal);
   }

--- a/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
+++ b/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
@@ -50,10 +50,10 @@ void DOMScheduler::ContextDestroyed() {
     fixed_priority_task_queues_.size(),
     signal_to_task_queue_map_.size());
 
-  fixed_priority_task_queues_.clear();
-  // Keep queue alive via pinned signal until DOMScheduler itself is GC-collected.
+  // Keep queues alive until DOMScheduler itself is GC-collected.
   if (!recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
                                             "DOMScheduler")) {
+    fixed_priority_task_queues_.clear();
     signal_to_task_queue_map_.clear();
   }
 }

--- a/third_party/blink/renderer/platform/heap_observer_set.h
+++ b/third_party/blink/renderer/platform/heap_observer_set.h
@@ -25,7 +25,7 @@ class PLATFORM_EXPORT HeapObserverSet {
     CHECK(iteration_state_ & kAllowingAddition);
     DCHECK(!HasObserver(observer));
     observers_.insert(observer);
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                              "HeapObserverSet"))
       replay_observers_strong_.insert(observer);
   }
@@ -35,7 +35,7 @@ class PLATFORM_EXPORT HeapObserverSet {
   void RemoveObserver(ObserverType* observer) {
     CHECK(iteration_state_ & kAllowingRemoval);
     observers_.erase(observer);
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                              "HeapObserverSet"))
       replay_observers_strong_.erase(observer);
   }
@@ -55,7 +55,7 @@ class PLATFORM_EXPORT HeapObserverSet {
   void Clear() {
     CHECK(iteration_state_ & kAllowingRemoval);
     observers_.clear();
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers",
+    if (recordreplay::IsRecordingOrReplaying("leak-references",
                                              "HeapObserverSet"))
       replay_observers_strong_.clear();
   }

--- a/third_party/blink/renderer/platform/loader/fetch/resource.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource.cc
@@ -298,7 +298,7 @@ void Resource::TriggerNotificationForFinishObservers(
   // [RUN-1457 cleanup]
   HeapVector<Member<ResourceFinishObserver>>* new_collections_strong =
       MakeGarbageCollected<HeapVector<Member<ResourceFinishObserver>>>();
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource")) {
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource")) {
     new_collections_strong->AppendRange(replay_finish_observers_strong_.begin(), replay_finish_observers_strong_.end());
     replay_finish_observers_strong_.clear();
   }
@@ -648,7 +648,7 @@ void Resource::AddClient(ResourceClient* client,
 
   if (is_revalidating_) {
     clients_.insert(client);
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
       replay_clients_strong_.insert(client);
     return;
   }
@@ -658,7 +658,7 @@ void Resource::AddClient(ResourceClient* client,
   if ((ErrorOccurred() || !GetResponse().IsNull()) &&
       !NeedsSynchronousCacheHit(GetType(), options_)) {
     clients_awaiting_callback_.insert(client);
-    if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
         replay_clients_strong_.insert(client);
     if (!async_finish_pending_clients_task_.IsActive()) {
       async_finish_pending_clients_task_ =
@@ -670,7 +670,7 @@ void Resource::AddClient(ResourceClient* client,
   }
 
   clients_.insert(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
     replay_clients_strong_.insert(client);
   DidAddClient(client);
   return;
@@ -685,7 +685,7 @@ void Resource::RemoveClient(ResourceClient* client) {
     clients_awaiting_callback_.erase(client);
   else
     clients_.erase(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
     replay_clients_strong_.erase(client);
 
   if (clients_awaiting_callback_.empty() &&
@@ -703,7 +703,7 @@ void Resource::AddFinishObserver(ResourceFinishObserver* client,
 
   WillAddClientOrObserver();
   finish_observers_.insert(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
     replay_finish_observers_strong_.insert(client);
   if (IsLoaded())
     TriggerNotificationForFinishObservers(task_runner);
@@ -713,7 +713,7 @@ void Resource::RemoveFinishObserver(ResourceFinishObserver* client) {
   CHECK(!is_add_remove_client_prohibited_);
 
   finish_observers_.erase(client);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "Resource"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "Resource"))
     replay_finish_observers_strong_.erase(client);
   DidRemoveClientOrObserver();
 }

--- a/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/main_thread/agent_group_scheduler_impl.cc
@@ -125,14 +125,14 @@ void AgentGroupSchedulerImpl::AddAgent(Agent* agent) {
   DCHECK(agents_->find(agent) == agents_->end());
   agents_->insert(agent);
   
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "AgentGroupSchedulerImpl"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "AgentGroupSchedulerImpl"))
     replay_agents_strong_->insert(agent);
 }
 
 void AgentGroupSchedulerImpl::RemoveAgent(Agent* agent) {
   DCHECK(agents_->find(agent) != agents_->end());
   agents_->erase(agent);
-  if (recordreplay::IsRecordingOrReplaying("avoid-weak-pointers", "AgentGroupSchedulerImpl"))
+  if (recordreplay::IsRecordingOrReplaying("leak-references", "AgentGroupSchedulerImpl"))
     replay_agents_strong_->erase(agent);
 }
 

--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_impl.cc
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_impl.cc
@@ -216,6 +216,8 @@ void WidgetInputHandlerImpl::Release() {
   // invoked. Note, this method will always be called on the Mojo-bound thread
   // first and then again on the main thread, the callback will always be
   // called on the Mojo-bound thread though.
+  recordreplay::Assert("WidgetInputHandlerImpl::Release %d",
+                       !!input_processed_ack_);
   if (input_processed_ack_)
     std::move(input_processed_ack_).Run();
 


### PR DESCRIPTION
# [crash-0057] Problem

* ReplayMismatch at `BudgetPool::RemoveThrottler` `PointerId`.
* DominantWarning: GC sweep of `MainThreadWebSchedulingTaskQueueImpl` under `EventsDisallowed`.
* Cause: `DOMScheduler::ContextDestroyed` still cleared `fixed_priority_task_queues_` unconditionally.
* Fix: skip that clear under the existing `leak-references` / `DOMScheduler` guard.

* Problem type: ReplayMismatch.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] crashes/replay-divergences.md
* report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in report.json when needed.

### RepoSrc

* backend
* chromium/src

## Important Context

* buildId: linux-chromium-20260730-5726bcc6312f-97130a07511f
* linkerVersion: linker-linux-16068-97130a07511f
* recordingId: 828665d6-3394-4d2c-91dc-6867774602a6

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2507755,
      "checkpoint": 1085
    }
  },
  "recorded": "[TT-1465-1466] BudgetPool::RemoveThrottler 9946",
  "replayed": "[TT-1465-1466] BudgetPool::RemoveThrottler 2470",
  "threadId": 1,
  "backtrace": {
    "progress": 2507755,
    "threadId": 1,
    "checkpoint": 1083
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::scheduler::BudgetPool::RemoveThrottler(base::TimeTicks,.blink::scheduler::TaskQueueThrottler*)+173",
    "blink::scheduler::FrameSchedulerImpl::RemoveThrottleableQueueFromBudgetPools(blink::scheduler::MainThreadTaskQueue*)+129",
    "blink::scheduler::FrameSchedulerImpl::~FrameSchedulerImpl()+131",
    "blink::scheduler::FrameSchedulerImpl::~FrameSchedulerImpl()+14",
    "blink::LocalFrame::DetachImpl(blink::FrameDetachType)+1337",
    "blink::Frame::Detach(blink::FrameDetachType)+115",
    "blink::Frame::SwapImpl(blink::WebFrame*,.mojo::PendingAssociatedRemote<blink::mojom::blink::RemoteFrameHost>,.mojo::PendingAssociatedReceiver<blink::mojom::blink::RemoteFrame>)+234"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::scheduler::BudgetPool::RemoveThrottler(base::TimeTicks,.blink::scheduler::TaskQueueThrottler*)+173",
    "blink::scheduler::FrameSchedulerImpl::RemoveThrottleableQueueFromBudgetPools(blink::scheduler::MainThreadTaskQueue*)+129",
    "blink::scheduler::FrameSchedulerImpl::~FrameSchedulerImpl()+131",
    "blink::scheduler::FrameSchedulerImpl::~FrameSchedulerImpl()+14",
    "blink::LocalFrame::DetachImpl(blink::FrameDetachType)+1337",
    "blink::Frame::Detach(blink::FrameDetachType)+115",
    "blink::Frame::SwapImpl(blink::WebFrame*,.mojo::PendingAssociatedRemote<blink::mojom::blink::RemoteFrameHost>,.mojo::PendingAssociatedReceiver<blink::mojom::blink::RemoteFrame>)+234"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recording assertion with events disallowed: [TT-1465] FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed 2460 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 24,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "blink::scheduler::FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed(blink::scheduler::MainThreadTaskQueue*)+46",
      "blink::scheduler::MainThreadWebSchedulingTaskQueueImpl::~MainThreadWebSchedulingTaskQueueImpl()+119",
      "blink::scheduler::MainThreadWebSchedulingTaskQueueImpl::~MainThreadWebSchedulingTaskQueueImpl()+14",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::scheduler::TaskAttributionTrackerImpl::V8Adapter::SetValue(blink::ScriptState*,.absl::optional<blink::scheduler::TaskAttributionId>)+350",
      "blink::scheduler::TaskAttributionTrackerImpl::CreateTaskScope(blink::ScriptState*,.absl::optional<blink::scheduler::TaskAttributionId>,.blink::scheduler::TaskAttributionTracker::TaskScopeType)+153",
      "blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase,.(blink::bindings::CallbackInvokeHelperMode)0,.(blink::bindings::CallbackReturnTypeIsPromise)1>::PrepareForCall(blink::bindings::V8ValueOrScriptWrappableAdapter)+283",
      "blink::V8FrameRequestCallback::Invoke(blink::bindings::V8ValueOrScriptWrappableAdapter,.double)+202",
      "blink::V8FrameRequestCallback::InvokeAndReportException(blink::bindings::V8ValueOrScriptWrappableAdapter,.double)+125",
      "blink::V8FrameCallback::Invoke(double)+80",
      "blink::FrameRequestCallbackCollection::ExecuteFrameCallbacks(double,.double)+715",
      "blink::ScriptedAnimationController::ServiceScriptedAnimations(base::TimeTicks,.bool)+695",
      "blink::Document::ServiceScriptedAnimations(base::TimeTicks,.bool)+75",
      "blink::LocalFrameView::ServiceScriptedAnimations(base::TimeTicks)+631",
      "blink::PageAnimator::ServiceScriptedAnimations(base::TimeTicks)+244",
      "blink::Page::Animate(base::TimeTicks)+56",
      "blink::WebFrameWidgetImpl::BeginMainFrame(base::TimeTicks)+435",
      "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+1039",
      "base::internal::Invoker<base::internal::BindState<void.(reporting::EncryptedReportingUploadProvider::UploadHelper::*)(std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>),.base::WeakPtr<reporting::EncryptedReportingUploadProvider::UploadHelper>,.std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+144",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629"
    ],
    "threadId": 1,
    "processId": 3,
    "absoluteTime": 1785458113347.772,
    "wasRecording": true
  }
]
```

# Previous Work

## Previous Findings

* crash-0003 / solution: same `[TT-1465-1466] BudgetPool::RemoveThrottler` `PointerId(throttler)` Data mismatch.
  * Ordinal is assigned at `TaskQueueThrottler` construction (`RegisterPointer`); teardown only consumes it.
  * `RegisterPointer` silently skips under `EventsDisallowed` → ordinal stream order can diverge.
  * Non-deterministic trigger: cppgc sweep of `MainThreadWebSchedulingTaskQueueImpl` → `OnWebSchedulingTaskQueueDestroyed` (warning stack).
  * Owner chain: `DOMTaskSignal` weak key in `signal_to_task_queue_map_` → strong `DOMTaskQueue` → `unique_ptr<WebSchedulingTaskQueue>`.
  * Existing `replay_strong_signal_` pin already keeps the queue alive transitively; `ContextDestroyed` clearing pin/map re-enabled GC-timed teardown.
* crash-0033 / solution: same mismatch leaf after that intervention.
  * Confirmed write site of the mismatched value is `RegisterPointer` in `TaskQueueThrottler` ctor.

## Previous Changes

* crash-0003 → `dom_scheduler.cc` `ContextDestroyed`:
  * Under `IsRecordingOrReplaying("leak-references", "DOMScheduler")`: do not `signal_to_task_queue_map_.clear()`.
  * Removed `replay_strong_signal_.clear()` so pins survive until `DOMScheduler` GC.
* crash-0033 → `task_queue_throttler.cc` ctor:
  * `REPLAY_ASSERT("TaskQueueThrottler::TaskQueueThrottler %d", recordreplay::PointerId(this));` right after `RegisterPointer`.


## Difference between New and Old

* Same mismatch leaf + stacks as crash-0003 / crash-0033.
* Build `5726bcc6312f` already contains both prior changes (`#1364` keep-alive, `#1394` ctor assert).
* Warning still shows GC-sweep `~MainThreadWebSchedulingTaskQueueImpl` → `OnWebSchedulingTaskQueueDestroyed` under `EventsDisallowed` — keep-alive did not stop that path here.
* Warning allocate site differs only in caller: rAF / `TaskAttributionTrackerImpl` (this) vs `getBoundingClientRect` (0003) vs young-gen `CollectGarbage` (0033).
* Ctor diagnostic did not move the mismatch earlier; hit is still `BudgetPool::RemoveThrottler`.

# DominantWarning

* Warning: `[TT-1465] FrameSchedulerImpl::OnWebSchedulingTaskQueueDestroyed 2460 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]` (`count` 24, `wasRecording: true`).
* Stack: cppgc `SweepForAllocationIfRunning` → `~MainThreadWebSchedulingTaskQueueImpl` → `OnWebSchedulingTaskQueueDestroyed` (allocate site: rAF / `TaskAttributionTrackerImpl`).
* Precedes mismatch: same `TT-1465` family; warning queue id `2460` sits next to replayed leaf throttler id `2470`.
* Explains mismatch:
  * GC-timed queue dtor tears down throttlers under `EventsDisallowed` → `(Un)RegisterPointer` / budget-pool removal perturb the `PointerId` ordinal stream.
  * Mismatch leaf later reads that stream at `BudgetPool::RemoveThrottler` via `~FrameSchedulerImpl` (sibling teardown path to the same `RemoveThrottleableQueueFromBudgetPools`).

# Data Write Provenance

Mismatched Assert input: `recordreplay::PointerId(throttler)` (`recorded` 9946 / `replayed` 2470).

```cpp
// third_party/blink/renderer/platform/scheduler/common/throttling/task_queue_throttler.cc
TaskQueueThrottler::TaskQueueThrottler(...) {
  // [Write] NOT-ASSERTABLE already-asserted
  // Assigns PointerId via gNextPointerId++ / RecordReplayValueWithStack.
  // Skips (no id) when AreEventsDisallowed() — silent; no Assertable value.
  recordreplay::RegisterPointer("TaskQueueThrottler", this);
  // Existing [crash-0033] diagnostic — did not become the mismatch hit.
  REPLAY_ASSERT("TaskQueueThrottler::TaskQueueThrottler %d",
                recordreplay::PointerId(this));
}

// third_party/blink/renderer/platform/scheduler/common/throttling/budget_pool.cc
void BudgetPool::RemoveThrottler(..., TaskQueueThrottler* throttler) {
  ...
  REPLAY_ASSERT("[TT-1465-1466] BudgetPool::RemoveThrottler %d",
                recordreplay::PointerId(throttler));  // <<< RECORDED LEAF / <<< REPLAYED LEAF
}
```

# Solution

* Recipe: `determinism-leak-memory`.
* Site: `DOMScheduler::ContextDestroyed` in `dom_scheduler.cc`.
* Change: under `IsRecordingOrReplaying("leak-references", "DOMScheduler")`, do not `fixed_priority_task_queues_.clear()`.
  * Same guard already used for `signal_to_task_queue_map_.clear()` (`#1364`).
  * Queues stay alive until `DOMScheduler` GC.

## Why

* `#1364` only kept the signal-map path.
* `fixed_priority_task_queues_.clear()` still runs unconditionally.
* Those `DOMTaskQueue`s own the same `MainThreadWebSchedulingTaskQueueImpl` family.
* Clear → unreferenced → cppgc sweep under `EventsDisallowed` → DominantWarning → `PointerId` stream perturbs → `RemoveThrottler` leaf.

<hr>

# [crash-0056] Problem

* StackCommonFrame mismatch in `MultiplexRouter::ProcessNotifyErrorTask` after `NotifyError`.
* Recorded path runs `error_handler_` → `WidgetInputHandlerImpl::Release` → power-mode voter teardown.
* Replayed leaf is post-`NotifyError` cleanup in the same `ProcessNotifyErrorTask`.
* Existing `encountered_error_` Assert matched; divergence is client identity / handler arms / side branches.
* Diagnostics: extend `NotifyError` Assert; add Asserts on `OnConnectionError` flush and `Release` ack.

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] crashes/replay-divergences.md
* report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in report.json when needed.

### RepoSrc

* backend
* chromium/src

## Important Context

* buildId: linux-chromium-20260730-5726bcc6312f-97130a07511f
* linkerVersion: linker-linux-16068-97130a07511f
* recordingId: d5f80366-c34c-475c-9616-10ed83a5ce74

### Crash Report Core
```json
{
  "why": "RecordedCallStackMismatch",
  "name": "Value TryLock",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2275174,
      "checkpoint": 56
    }
  },
  "threadId": 9,
  "recordedStack": [
    "power_scheduler::PowerModeArbiter::OnVoterDestroyed(power_scheduler::PowerModeVoter*)+28",
    "blink::WidgetInputHandlerManager::~WidgetInputHandlerManager()+99",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+120",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+14",
    "blink::WidgetInputHandlerImpl::Release()+56",
    "mojo::InterfaceEndpointClient::NotifyError(absl::optional<mojo::DisconnectReason>.const&)+306",
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+342",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316"
  ],
  "replayedStack": [
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+361",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316",
    "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+975",
    "mojo::Connector::HandleError(bool,.bool)+539",
    "base::RepeatingCallback<void.(int)>::Run(int).const.&+39",
    "mojo::SimpleWatcher::OnHandleReady(int,.unsigned.int,.mojo::HandleSignalsState.const&)+291",
    "base::internal::Invoker<base::internal::BindState<void.(mojo::SimpleWatcher::*)(int,.unsigned.int,.mojo::HandleSignalsState.const&),.base::WeakPtr<mojo::SimpleWatcher>,.int,.unsigned.int,.mojo::HandleSignalsState>,.void.()>::RunOnce(base::internal::BindStateBase*)+142",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257"
  ]
}
```

# Basic Facts

## FrameCandidates

* `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(...)+342` (recorded)
  * location: `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:1046` (return address right after the `NotifyError` call)
  * code: `client->NotifyError(disconnect_reason);`
* `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(...)+361` (replayed)
  * location: `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:1039-1047` (inlined cleanup of `disconnect_reason`/`MayAutoUnlock` scope after `NotifyError` returns; return address is after a call to a small static free/deallocation helper, nearest-symbol-mismatched to `absl::base_internal::LowLevelAlloc::Alloc+2660`)
  * code: `MayAutoUnlock unlocker(&lock_);` (closing scope, `}` at line 1047)

## MismatchProvenance

* `MultiplexRouter::ProcessNotifyErrorTask` (`mojo/public/cpp/bindings/lib/multiplex_router.cc`)
  * `client->NotifyError(disconnect_reason);` // recorded +342
  * `}` // <<< REPLAYED LEAF (+361, after NotifyError returns)
* `InterfaceEndpointClient::NotifyError` (`mojo/public/cpp/bindings/lib/interface_endpoint_client.cc`)
  * // [Branch] BOTH: not-taken
    `if (encountered_error_) return;`
    * Assert: `InterfaceEndpointClient::NotifyError %d` (`encountered_error_`) — matched; same CF through here (instance may still differ)
  * // [Write] CANDIDATE — client identity (`RegisterPointer("InterfaceEndpointClient")`)
    `this` / `interface_name_`
  * // [Branch] RECORDED: taken
    `if (error_handler_)`
    `std::move(error_handler_).Run()` // → `WidgetInputHandlerImpl::Release` (recorded stack)
  * // [Branch] RECORDED: not-taken
    `else if (error_with_reason_handler_)`
  * // [Branch] UNPROVEN
    `if (reason)`
* `ControlMessageProxy::OnConnectionError` (`mojo/public/cpp/bindings/lib/control_message_proxy.cc`)
  * // [Branch] CANDIDATE
    `if (!pending_flush_callback_.is_null())`
* `WidgetInputHandlerImpl::Release` (`third_party/blink/renderer/platform/widget/input/widget_input_handler_impl.cc`)
  * // [Branch] CANDIDATE
    `if (input_processed_ack_)` // no else; `delete this` always follows
  * `delete this`
* `~WidgetInputHandlerImpl` (`third_party/blink/renderer/platform/widget/input/widget_input_handler_impl.cc`)
  * `input_handler_manager_` dtor
* `~WidgetInputHandlerManager` (`third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc`)
  * `response_power_mode_voter_` dtor
* `~PowerModeVoter` (`components/power_scheduler/power_mode_voter.cc`)
  * `delegate_->OnVoterDestroyed(this)`
* `PowerModeArbiter::OnVoterDestroyed` (`components/power_scheduler/power_mode_arbiter.cc`)
  * // <<< RECORDED LEAF

## NewCandidates

* `InterfaceEndpointClient::NotifyError`
  * location: `mojo/public/cpp/bindings/lib/interface_endpoint_client.cc:750`
  * code: extend existing Assert (before `if (encountered_error_)`)
  * Assert: `encountered_error_`, `PointerId(this)`, `interface_name_`, `!!error_handler_`, `!!error_with_reason_handler_`
  * provenance:
    * One Assert; folds identity + handler arms into the existing `encountered_error_` site.
    * `InterfaceEndpointClient` is `RegisterPointer`'d; `InterfaceEndpoint` is not.
* `ControlMessageProxy::OnConnectionError`
  * location: `mojo/public/cpp/bindings/lib/control_message_proxy.cc:210`
  * code: before `if (!pending_flush_callback_.is_null())`
  * Assert: `!pending_flush_callback_.is_null()`
  * provenance: `pending_flush_callback_` is private — cannot fold into `NotifyError`.
* `WidgetInputHandlerImpl::Release`
  * location: `third_party/blink/renderer/platform/widget/input/widget_input_handler_impl.cc:219`
  * code: before `if (input_processed_ack_)`
  * Assert: `!!input_processed_ack_`
  * provenance: other class; only on recorded `error_handler_` path — cannot fold into `NotifyError`.

## Solution

* Add Asserts at NewCandidates.
