### PR TITLE
[bk] syncRepo: fetch origin only

### DIFF
--- a/replay_build_scripts/common.mjs
+++ b/replay_build_scripts/common.mjs
@@ -86,7 +86,7 @@ export function toNumber(str) {
 export function syncRepo(dir, treeish) {
   log(`Syncing ${dir} to ${treeish}`);
   try {
-    spawnChecked("git", ["fetch", "--all"], { cwd: dir, stdio: "inherit" });
+    spawnChecked("git", ["fetch", "origin"], { cwd: dir, stdio: "inherit" });
   } catch (e) {
     // Ignore errors due to being at a detached head.
   }


### PR DESCRIPTION
* Follow-up to #1424: pipeline fetch was fixed, but `update-all-repos` → `syncRepo` still ran `git fetch --all`.
* That re-fetched chromium `upstream` and hung the same agent again.
* `syncRepo` now fetches `origin` only.

