### PR TITLE
[crash-0061] Leak response_power_mode_voter_ at divergent WidgetInputHandlerManager last-ref

### DIFF
--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
@@ -278,7 +278,13 @@ void WidgetInputHandlerManager::InitInputHandler() {
   InputThreadTaskRunner()->PostTask(FROM_HERE, std::move(init_closure));
 }
 
-WidgetInputHandlerManager::~WidgetInputHandlerManager() = default;
+WidgetInputHandlerManager::~WidgetInputHandlerManager() {
+  // leak-references: skip OnVoterDestroyed at divergent last-ref (events-allowed).
+  if (recordreplay::IsRecordingOrReplaying(
+          "leak-references", "WidgetInputHandlerManager")) {
+    response_power_mode_voter_.release();
+  }
+}
 
 void WidgetInputHandlerManager::AddInterface(
     mojo::PendingReceiver<mojom::blink::WidgetInputHandler> receiver,


### PR DESCRIPTION
# Summary

* `WidgetInputHandlerManager` last-ref can diverge on the mojo `Release` path.
* That runs `~PowerModeVoter` → `OnVoterDestroyed` → OrderedLock mismatch.
* SkipCleanupSubset: leak `response_power_mode_voter_` under `leak-references` at manager dtor.

# Problem

* Continuation of crash-0056.
* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame

## Important Context

* buildId: linux-chromium-20260731-11eadee97ba5-97130a07511f
* linkerVersion: linker-linux-16068-97130a07511f
* recordingId: 601aaec1-61e6-4b1a-8a21-4cca6ff926f9

### Crash Report Core
```json
{
  "why": "RecordedCallStackMismatch",
  "name": "Value TryLock",
  "category": "SaplingBranch",
  "threadId": 9,
  "recordedStack": [
    "power_scheduler::PowerModeArbiter::OnVoterDestroyed(power_scheduler::PowerModeVoter*)+28",
    "blink::WidgetInputHandlerManager::~WidgetInputHandlerManager()+99",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+120",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+14",
    "blink::WidgetInputHandlerImpl::Release()+81",
    "mojo::InterfaceEndpointClient::NotifyError(absl::optional<mojo::DisconnectReason>.const&)+371",
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+342",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316"
  ],
  "replayedStack": [
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+361",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316",
    "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+975",
    "mojo::Connector::HandleError(bool,.bool)+539",
    "base::RepeatingCallback<void.(int)>::Run(int).const.&+39",
    "mojo::SimpleWatcher::OnHandleReady(int,.unsigned.int,.mojo::HandleSignalsState.const&)+291",
    "base::internal::Invoker<base::internal::BindState<void.(mojo::SimpleWatcher::*)(int,.unsigned.int,.mojo::HandleSignalsState.const&),.base::WeakPtr<mojo::SimpleWatcher>,.int,.unsigned.int,.mojo::HandleSignalsState>,.void.()>::RunOnce(base::internal::BindStateBase*)+142",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257"
  ]
}
```

# Facts

* `NotifyError` Assert matched → not an `InterfaceEndpointClient` identity/handler split.
* Both sides reach `WidgetInputHandlerImpl::Release` → unconditional `delete this`.
* `WidgetInputHandlerManager` is `RefCountedThreadSafe`.
  * `WidgetInputHandlerImpl` holds `scoped_refptr<WidgetInputHandlerManager> input_handler_manager_`.
  * `~WidgetInputHandlerImpl = default` releases that ref.
  * `~WidgetInputHandlerManager` (→ `response_power_mode_voter_` → `OnVoterDestroyed` → `PowerModeArbiter.lock_`) runs only on last-ref drop.
* Recorded stack enters `~WidgetInputHandlerManager` from `~WidgetInputHandlerImpl` → Impl held the last ref on record.
* Replayed leaf is after `NotifyError` returns / `MultiplexRouter.lock_` → no `OnVoterDestroyed` at that OrderedLock slot.
* Tell: divergent last-ref of `WidgetInputHandlerManager` under `delete this`.

## Ref Count Data Write Provenance

Each top-level bullet is one RefCount Write peer (AddRef and/or Release of `WidgetInputHandlerManager`):

* `WidgetBase::widget_input_handler_manager_`
  * AddRef: `InitializeCompositing` → `= Create(...)`
  * Release: `Shutdown` → `std::move` into posted cleanup → `manager.reset()`
  * Existing Assert there: `HasOneRef` / `HasAtLeastOneRef`
* `WidgetInputHandlerImpl::input_handler_manager_`
  * AddRef: `BindChannel` → `new WidgetInputHandlerImpl(this, ...)` ctor copy
  * Release: `Release` → `delete this` → `~WidgetInputHandlerImpl`
* **BindOnceMethodReceivers** — all `BindOnce(&WidgetInputHandlerManager::…, this, …)` sites
  * Semantics (`base/functional/bind_internal.h` `MakeBindStateTypeImpl`):
    * Method-receiver raw `T*` with `T` RefCounted → BindState stores `scoped_refptr<T>`.
    * AddRef when the callback is created.
    * Release when that callback's BindState is destroyed.
    * Not GC: no collector; lifetime is ownership of the `OnceCallback`.
    * Same posts + same runs ⇒ same Releases. Not inherently non-deterministic.
    * Divergent pending set (extra/missing callback still alive at `delete this`) ⇒ divergent last-ref.
    * If an owner is destroyed/reset while still holding the `OnceCallback`, that yoinks the callback → Release without the method running.
  * OnceCallback owners:
    * `SingleThreadTaskRunner` pending task
      * Keeps manager alive until the task runs or the runner drops it.
      * Sites: `AddInterface`→`BindChannel`; `ObserveGestureEventOnMainThread`; `DispatchScrollGestureToCompositor`; `FindScrollTargetOnMainThread` (main post + reply post of `FindScrollTargetReply`)
    * `InputHandlerProxy` → `EventWithCallback` (in-flight and/or `compositor_event_queue_`)
      * `WillShutdown` → `input_handler_proxy_.reset()` destroys queued callbacks.
      * Sites: `DispatchEvent`→`DidHandleInputEventSentToCompositor`; `ContinueScrollBeginAfterMainThreadHitTest`→same
    * `MainThreadEventQueue` → `QueuedWebInputEvent::callback_` (and coalesced `blocking_coalesced_callbacks_`)
      * Lives in `shared_state_.events_`; destroyed when the queued event is finished/dropped or the queue dies.
      * Sites: `DidHandleInputEventSentToCompositor`→`DidHandleInputEventSentToMain` via `HandleEvent`
    * `base::OneShotTimer` `dropped_event_counts_timer_` (member of manager)
      * `WillShutdown` / `~WidgetInputHandlerManager` → `reset()` / member dtor yoinks pending callback.
      * Sites: `SendDroppedPointerDownCounts`
    * Sync stack: `WidgetBaseInputHandler::HandleInputEvent`
      * Callback is a local arg; `Run` before return (not stored on `WidgetBase`).
      * Sites: `DispatchDirectlyToWidget`→`DidHandleInputEventSentToMainFromWidgetBase`
  * Sites:
    * `AddInterface` → `PostTask(BindOnce(&BindChannel, this, ...))`
    * `ObserveGestureEventOnMainThread` → `PostTask(BindOnce(&ObserveGestureEventOnInputHandlingThread, this, ...))`
    * `DispatchScrollGestureToCompositor` → `PostTask(BindOnce(&HandleInputEventWithLatencyOnInputHandlingThread, this, ...))`
    * `DispatchEvent` → `BindOnce(&DidHandleInputEventSentToCompositor, this, ...)`
    * `ContinueScrollBeginAfterMainThreadHitTest` → `BindOnce(&DidHandleInputEventSentToCompositor, this, ...)`
    * `FindScrollTargetReply` → `BindOnce(..., this, ...)`
    * `FindScrollTargetOnMainThread` → `PostTask(BindOnce(..., this, ...))`
    * `DispatchDirectlyToWidget` → `BindOnce(&DidHandleInputEventSentToMainFromWidgetBase, this, ...)`
    * `DidHandleInputEventSentToCompositor` → `BindOnce(&DidHandleInputEventSentToMain, this, ...)` into `input_event_queue_->HandleEvent`
    * `dropped_event_counts_timer_` → `Start(..., BindOnce(&SendDroppedPointerDownCounts, this))`

Not RefCount Writes:

* `InitOnInputHandlingThread` — `AsWeakPtr()`
* `InvokeInputProcessedCallback` — `AsWeakPtr()`
* `MainThreadEventQueue::client_` — raw ptr

# Idea: Leak Memory

## Required System Facts

* StreamTouch: `~PowerModeVoter` → `PowerModeArbiter::OnVoterDestroyed` → `OrderedLock PowerModeArbiter.lock_`
  * Detach-ordered site: last-ref of `WidgetInputHandlerManager` under `WidgetInputHandlerImpl::Release` → `delete this` (recorded leaf).
  * Not GC-ordered. Events allowed on this path.
* OwnerGraph (refcount, not Oilpan):
  * `WidgetInputHandlerManager` (`RefCountedThreadSafe`)
  * owns `response_power_mode_voter_` (`recordreplay::unique_leaky_ptr<PowerModeVoter>`)
* Chromium lifecycle:
  * Create: `WidgetBase::InitializeCompositing` → `WidgetInputHandlerManager::Create`
  * Explicit teardown peer: `WidgetBase::Shutdown` → post → `manager.reset()` (+ `WillShutdown` via compositor/`InputHandlerProxy` clears proxy/timer)
  * Mojo peer: `WidgetInputHandlerImpl::Release` → `delete this` → drops Impl's `scoped_refptr`
  * BindOnceMethodReceivers: pending OnceCallbacks hold extra refs until run/yoink (see Ref Count Data Write Provenance)
* Existing Replay pins:
  * [RUN-1227](https://github.com/replayio/chromium/pull/362) / [`unique_leaky_ptr`](https://github.com/replayio/chromium/blob/dc485c69fc6cf200f9ebdd2f101d27b9ba40faf2/base/record_replay.h): all `PowerModeVoter` members, including `response_power_mode_voter_`
    * Dtor leaks only under `AreEventsDisallowed("unique_leaky_ptr")`
    * Replaced older unconditional dtor-site voter leaks
  * [RUN-2224] Assert at `WidgetBase::Shutdown` cleanup: `manager->HasOneRef()` / `HasAtLeastOneRef()` — Shutdown reset is not always last-ref

## `unique_leaky_ptr` does not cover this path

* This mismatch's Detach-ordered site is events-allowed (`NotifyError` → `Release` → `delete this`).
* `unique_leaky_ptr` therefore does **not** `release()` → `~PowerModeVoter` runs → `OnVoterDestroyed` → OrderedLock.
* Gap vs RUN-1227 intent: that helper targets non-deterministic (events-disallowed) owner destruction; here owner last-ref itself diverges on a Detach-ordered path.

## KeepAlive via `DeterministicRetainer` (RefCounted)

* Current `DeterministicRetainer` is Oilpan-shaped — implementation detail, not a blocker.
  * RefCounted shape: static set of `scoped_refptr<T>`, same Retain / Release / Clear lifecycle, feature `leak-references`.
* Real blocker: **Release valve** — a site after which divergent cleanup is unreachable.

## Lifecycle cover assessment

Peer drop sites (natural refs):

* `WidgetBase::widget_input_handler_manager_`
  * Drop: `Shutdown` posted task `manager.reset()` (only if `layer_tree_view_`)
  * Joined by widget teardown: yes
* `WidgetInputHandlerImpl`
  * Drop: mojo disconnect → `Release` → `delete this`
  * Joined by widget teardown: **no**
  * `Shutdown` / `WillShutdown` / `ClearClient` do not destroy Impl or close its receiver
* InputHandlerProxy `EventWithCallback`
  * Drop: `WillShutdown` → `input_handler_proxy_.reset()`
  * Joined: yes — during `view.reset()`, before `manager.reset()`
* `dropped_event_counts_timer_`
  * Drop: `WillShutdown` / manager dtor
  * Joined: yes
* MainThreadEventQueue `callback_` (manager BindOnce)
  * Drop: event finish/drop or queue dtor
  * Joined: **no** — `ClearClient` nulls `client_` only; does not drain `events_`
* TaskRunner `PostTask(BindOnce(..., this))`
  * Drop: task runs
  * Joined: **no** — not cancelled by Shutdown/WillShutdown

Shutdown posted-task order (when `layer_tree_view_` set):

1. `view.reset()` → `~LayerTreeHostImpl` → `WillShutdown` → proxy + timer yoinked
2. `manager.reset()` — drops WidgetBase peer only
3. Impl / queue callbacks / pending PostTasks may still hold refs (RUN-2224 `HasOneRef`)

Crash is the Impl-vs-Shutdown cover proof:

* Recorded leaf: `NotifyError` → `Impl::Release` → last-ref → `OnVoterDestroyed`
* Impl drop is Mojo-ordered; independent of `WidgetBase::Shutdown`

### Why no mid-lifecycle Release valve

Release is valid only if after it, StreamTouch is unreachable. Manager StreamTouch runs at last-ref drop.

* Release before all natural peers gone → later natural last-ref can still StreamTouch divergently.
* Release at the natural last-ref site (e.g. inside `Impl::Release`) → StreamTouch stays there → same divergent OrderedLock vs `MultiplexRouter.lock_`.
* Deferred Release after natural last-ref (`TryRelease` until `HasOneRef`) → destruction tracks when the last natural peer dropped → inherits that divergent timing.
* Join(Shutdown, `Impl::Release`) then Release at the later of the two → record/replay can disagree which is later → StreamTouch OrderedLock slot still diverges.
* Forced peer drain before a Detach-ordered Release: **not in Chromium today**. Would be new teardown (close Impl receiver, drain queue callbacks, neutralize pending `PostTask(this)`), then Release.

### Verdict

* **Cannot** find an existing Release valve that covers the full peer set.
* Only valid manager KeepAlive without new teardown: **forever Retain** (never Release/Clear).
* SkipCleanupSubset on the voter needs no Release valve.

## Intervention ranking

* **SkipCleanupSubset (easiest, matches fork precedent)**
  * Suppress StreamTouch: under `IsRecordingOrReplaying(...)`, `response_power_mode_voter_.release()` before manager dtor destroys it (or broaden `unique_leaky_ptr` to always leak during RR — wider blast radius).
  * Isolatable: recorded leaf is exactly `OnVoterDestroyed` from this voter.
  * Sidesteps Release-valve problem entirely (leak the StreamTouch object, not the manager).
  * Impact: leaked `PowerModeVoter` stays in `PowerModeArbiter::votes_` (same tradeoff as RUN-1227 events-disallowed path).
  * ResidualRisk: other `~WidgetInputHandlerManager` member dtors still run at divergent last-ref; only this OrderedLock StreamTouch is proven.
* **KeepAlive manager forever** (`DeterministicRetainer`-shaped `scoped_refptr` set)
  * Only valid KeepAlive without inventing joining teardown.
  * Heavier than leaking the voter alone.

## Solution

* SkipCleanupSubset: `~WidgetInputHandlerManager` releases `response_power_mode_voter_` under `IsRecordingOrReplaying("leak-references", "WidgetInputHandlerManager")`.
* File: `third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc`
