### PR TITLE
Skip ImageDecodingStore cleanup under EventsDisallowed (crash-0073)

### DIFF
--- a/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
+++ b/third_party/blink/renderer/platform/graphics/image_decoding_store.cc
@@ -28,11 +28,12 @@
 #include <memory>
 
 #include "base/bind.h"
-#include "base/record_replay_ordered_atomic.h"
 #include "base/synchronization/lock.h"
 #include "third_party/blink/renderer/platform/graphics/image_frame_generator.h"
 #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
 #include "third_party/blink/renderer/platform/wtf/threading.h"
+
+#include <atomic>
 
 namespace blink {
 
@@ -40,10 +41,7 @@ namespace {
 
 static const size_t kDefaultMaxTotalSizeOfHeapEntries = 32 * 1024 * 1024;
 
-recordreplay::OrderedAtomic<bool>& GetHasInstanceFlag() {
-  static recordreplay::OrderedAtomic<bool> flag{false};
-  return flag;
-}
+static std::atomic<bool> gHasInstance{false};
 
 }  // namespace
 
@@ -55,7 +53,7 @@ ImageDecodingStore::ImageDecodingStore()
           base::BindRepeating(&ImageDecodingStore::OnMemoryPressure,
                               base::Unretained(this))) {
   REPLAY_ASSERT("[TT-1524-1526] ImageDecodingStore::ImageDecodingStore");
-  GetHasInstanceFlag() = true;
+  gHasInstance = true;
 }
 
 ImageDecodingStore::~ImageDecodingStore() {
@@ -74,7 +72,7 @@ ImageDecodingStore& ImageDecodingStore::Instance() {
 }
 
 bool ImageDecodingStore::HasInstance() {
-  return GetHasInstanceFlag();
+  return gHasInstance;
 }
 
 bool ImageDecodingStore::LockDecoder(

--- a/third_party/blink/renderer/platform/graphics/image_frame_generator.cc
+++ b/third_party/blink/renderer/platform/graphics/image_frame_generator.cc
@@ -99,10 +99,9 @@ ImageFrameGenerator::ImageFrameGenerator(const SkISize& full_size,
 }
 
 ImageFrameGenerator::~ImageFrameGenerator() {
-  // Creating the store interacts with the recording so avoid instantiating
-  // it at non-deterministic points. If the store doesn't exist then it won't
-  // have any references to this generator.
-  if (recordreplay::AreEventsDisallowed() && !ImageDecodingStore::HasInstance())
+  // Sweeper / other EventsDisallowed paths must not StreamTouch the store
+  // (HasInstance / Instance / RemoveCacheIndexedByGenerator).
+  if (recordreplay::AreEventsDisallowed())
     return;
 
   // We expect all image decoders to be unlocked and catch with DCHECKs if not.


### PR DESCRIPTION
# Summary

* **Symptom:** ReplayMismatch at `ImageDecodingStore::HasInstance` — `OrderedLock atomic` vs `CreateOrderedLock atomic`.
* **Cause:** crash-0051 `OrderedAtomic` lazy static StreamTouched from Sweeper via `~ImageFrameGenerator`.
* **Fix:** `determinism-leak-memory` / **SkipCleanupSubset** — restore plain `gHasInstance`; skip store cleanup under `AreEventsDisallowed`.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* Buckets: Mismatch/blink::ImageDecodingStore::HasInstance.

## Important Context

* buildId: linux-chromium-20260801-a926ce52b2ef-bdda21cf9aa2
* linkerVersion: linker-linux-16069-bdda21cf9aa2
* recordingId: 0471f304-cdc6-4159-a1f6-4a78a442e357

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 560194,
  "category": "SaplingBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 837648,
      "checkpoint": 18
    },
    "getResumeData": [
      "annotations",
      "bookmarks",
      "consoleMessages",
      "events",
      "networkRequestEvents",
      "networkRequests",
      "networkStreamEvents",
      "sources",
      "widgetEvents"
    ]
  },
  "recorded": "OrderedLock atomic 2719",
  "replayed": "CreateOrderedLock atomic",
  "threadId": 11,
  "backtrace": {
    "progress": 418956,
    "threadId": 11,
    "checkpoint": 14
  },
  "recordedStack": [
    "blink::ImageDecodingStore::HasInstance()+31",
    "blink::ImageDecodingStore::Instance()+20",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
    "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640"
  ],
  "replayedStack": [
    "blink::ImageDecodingStore::HasInstance()+106",
    "blink::ImageDecodingStore::Instance()+20",
    "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
    "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
    "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
    "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
    "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
    "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 10,
    "stack": [
      "blink::ImageDecodingStore::HasInstance()+31",
      "blink::ImageFrameGenerator::~ImageFrameGenerator()+33",
      "blink::DeferredImageDecoder::~DeferredImageDecoder()+36",
      "blink::BitmapImage::~BitmapImage()+44",
      "cppgc::internal::FinalizerTrait<blink::ImageResourceContent>::Finalize(void*)+30",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::Node::CreateRareData()+114",
      "blink::Element::classList()+49",
      "blink::(anonymous.namespace)::v8_element::ClassListAttributeGetCallbackForMainWorld(v8::FunctionCallbackInfo<v8::Value>.const&)+129"
    ],
    "progress": 107935,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 11,
    "absoluteTime": 1785620466590.5037,
    "wasRecording": true
  },
  {
    "text": "Recording assertion with events disallowed: ImageDecodingStore::Instance 1 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 5,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "blink::ImageDecodingStore::Instance()+37",
      "blink::ImageFrameGenerator::~ImageFrameGenerator()+42",
      "blink::DeferredImageDecoder::~DeferredImageDecoder()+36",
      "blink::BitmapImage::~BitmapImage()+44",
      "cppgc::internal::FinalizerTrait<blink::ImageResourceContent>::Finalize(void*)+30",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::Node::CreateRareData()+114",
      "blink::Element::classList()+49",
      "blink::(anonymous.namespace)::v8_element::ClassListAttributeGetCallbackForMainWorld(v8::FunctionCallbackInfo<v8::Value>.const&)+129"
    ],
    "progress": 107935,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 11,
    "absoluteTime": 1785620466590.5803,
    "wasRecording": true
  }
]
```

## DominantWarning

* text: `Ordered lock with events disallowed atomic [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]`
* count: 10
* progress: `107935` (mismatch leaf progress `418956`)
* threadId: 1 / checkpoint: 11 / wasRecording: true
* stack: `HasInstance` ← `~ImageFrameGenerator` ← `Sweeper::SweepForAllocationIfRunning` ← Oilpan allocate
* SiblingWarning: `Recording assertion with events disallowed: ImageDecodingStore::Instance 1` — same Sweeper/`~ImageFrameGenerator` path after `HasInstance` returned true
* Dependency: DW hits the same `HasInstance` OrderedAtomic (`atomic`) that later mismatches as `OrderedLock atomic` vs `CreateOrderedLock atomic`
* verified: mismatch path must load that same lazy `GetHasInstanceFlag()` static; DW shows it is first touched under Sweeper `EventsDisallowed`, so `__cxa_guard` / `CreateOrderedLock` timing follows GC

# Root Cause

* crash-0051 replaced `gHasInstance` with lazy `static OrderedAtomic` in `GetHasInstanceFlag()`.
* `OrderedAtomic` ctor/`load` emit `CreateOrderedLock` / `OrderedLock` on the recording streams.
* `ImageFrameGenerator::~ImageFrameGenerator` probes `HasInstance()` (and may call `Instance()`) under Sweeper `EventsDisallowed`.
* That is GC-ordered StreamTouch of the OrderedAtomic lazy static.
* Recorded side already constructed the static → leaf `OrderedLock atomic 2719`.
* Replayed side still in `__cxa_guard` → leaf `CreateOrderedLock atomic`.
* OrderedAtomic was the wrong intervention: it ordered a cross-thread flag by putting StreamTouch on a GC-reachable probe.

# Solution

* Recipe: `determinism-leak-memory` / **SkipCleanupSubset**
* KeepAlive not viable: no Oilpan OwnerGraph cover for the off-heap `ImageDecodingStore` cache cleanup.
* Changes:
  1. Remove `OrderedAtomic` / `GetHasInstanceFlag()` — restore plain `std::atomic<bool> gHasInstance`.
  2. `~ImageFrameGenerator`: early-out on `AreEventsDisallowed()` alone — never call `HasInstance` / `Instance` from Sweeper.
* LeakBound: skipped `RemoveCacheIndexedByGenerator` orphans decoder entries keyed by a dead generator. Not unbounded — `ImageDecodingStore` still reclaims them via `Prune()` on insert (`heap_limit` 32 MB, LRU, `use_count==0`) and `OnMemoryPressure` CRITICAL → `Clear()`. DetachOrdered dtors still remove. Cost is delayed reclaim only.
* ResidualRisk: crash-0051 Assert `ImageDecodingStore::Instance %d` may return on unordered `gHasInstance` visibility; that is a separate Assert mismatch, not this StreamTouch.
