### PR TITLE
[crash-0074] Gate ConvertToString before ToPrimitive under EventsDisallowed

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '8956d930cce33d10f8d67e5f7b524fcc37767188',
+  'v8_revision': 'cd092114d1922fb2b3d531d5443cbff7cb7cf2cf',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '1f7b9340d436965f58da575081804fb72b60ef43',
+  'v8_revision': '8956d930cce33d10f8d67e5f7b524fcc37767188',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/317
# Summary

* Replay-only user JS ran during `console.debug` arg stringification under `EventsDisallowed`.
* Entry: `Value::ToString` → `Object::ConvertToString` → `ToPrimitive` → user `toString`/`valueOf`.
* Sibling `ObjectProtoToString` already gated (crash-0063); this path was not.
* Fix: same short-circuit in `ConvertToString` immediately before `ToPrimitive`.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Js
* Buckets: JSMismatch/v8::internal::Execution::Call.

## Important Context

* buildId: linux-chromium-20260801-a926ce52b2ef-bdda21cf9aa2
* linkerVersion: linker-linux-16069-bdda21cf9aa2
* recordingId: f76ffb26-8f34-4e8e-a989-6ee80d0f7abc

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "CreateDiffRoot",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 49809568,
      "checkpoint": 27
    }
  },
  "recorded": "NewProgressCheckpoint 48000000",
  "replayed": "NewProgressCheckpoint 48331067",
  "threadId": 1,
  "backtrace": {
    "progress": 48331067,
    "threadId": 1,
    "checkpoint": 24
  },
  "recordedStack": [],
  "replayedStack": [],
  "applicationDataMismatch": "{ \"lastDeterministicProgress\": 48000000, \"recorded\": [], \"replayed\": [\"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:47594\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"...truncated 331057 more\"] }"
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 50,
    "stack": [
      "WTF::RecursiveMutex::unlock()+135",
      "blink::AudioNode::Dispose()+228",
      "blink::AudioNode::InvokePreFinalizer(cppgc::LivenessBroker.const&,.void*)+44",
      "cppgc::internal::PreFinalizerHandler::InvokePreFinalizers()+214",
      "cppgc::internal::HeapBase::ExecutePreFinalizers()+39",
      "v8::internal::CppHeap::TraceEpilogue()+210",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+3404",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::Heap::HandleGCRequest()+223",
      "v8::internal::StackGuard::HandleInterrupts()+626",
      "v8::internal::Runtime_StackGuard(int,.unsigned.long*,.v8::internal::Isolate*)+314"
    ],
    "progress": 2000000,
    "threadId": 1,
    "processId": 3,
    "checkpoint": 5,
    "absoluteTime": 1785671151460.1301,
    "wasRecording": true
  },
  {
    "text": "[RUN-1919] JS ExecutionProgress in non-deterministic user JS PC=21517779 scriptId=11 @11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:135958 stack=os (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:135958)console.debug (<anonymous>)of.oB (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:178507)of.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:38405)os (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:137174)of.oq (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:99409)of.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:38268)os (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:137174)of.oq (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:99409)of.<computed>.<computed> [as run] (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:38268)os (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:137174)of.oq (https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g [EventsDisallowed:V8InspectorImpl::forEachSession]",
    "count": 1,
    "stack": [
      "v8::recordreplay::Warning(char.const*,....)+140",
      "v8::internal::Runtime_RecordReplayAssertExecutionProgress(int,.unsigned.long*,.v8::internal::Isolate*)+1055"
    ],
    "progress": 21517779,
    "threadId": 1,
    "processId": 178,
    "checkpoint": 11,
    "absoluteTime": 1785671359294.4617,
    "wasRecording": false
  },
  {
    "text": "Assertion application data mismatch: NewProgressCheckpoint 32000000 { \"lastDeterministicProgress\": 31215860, \"recorded\": [\"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:163660\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:163699\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:163104\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:241138\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:155353\", \"...truncated 784130 more\"], \"replayed\": [\"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AAAAAAADnPIDROrmt1Wwj/light/fbE/new/normal?lang=auto:1:164248\", \"11:https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/f/av0/rch/ufadj/0x4AA",
    "count": 17,
    "stack": [],
    "progress": 32000000,
    "threadId": 1,
    "processId": 178,
    "checkpoint": 19,
    "absoluteTime": 1785671377782.7383,
    "wasRecording": false
  },
  {
    "text": "XMLHttpRequest::Send length mismatch recorded(83991) != replayed(84002) toolarge=no",
    "count": 1,
    "stack": [
      "recordreplay::Warning(char.const*,....)+141",
      "blink::XMLHttpRequest::send(WTF::String.const&,.blink::ExceptionState&)+235",
      "blink::(anonymous.namespace)::v8_xml_http_request::SendOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+408",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 47331813,
    "threadId": 1,
    "processId": 178,
    "checkpoint": 23,
    "absoluteTime": 1785671383017.5994,
    "wasRecording": false
  },
  {
    "text": "Progress counter mismatch at checkpoint: got 47337011 expected 47331067 (lastCheckPoint 23)",
    "count": 1,
    "stack": [
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+848",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 47337011,
    "threadId": 1,
    "processId": 178,
    "checkpoint": 23,
    "absoluteTime": 1785671383171.4404,
    "wasRecording": false
  }
]
```

# Data

## EarliestDivergedProgress

* Full enumeration of EVERY `JSDivergenceIndicator` (all kinds, not narrowed):
  * `applicationDataMismatch` kind (2 occurrences):
    * `processNonFatal.applicationDataMismatch`: `lastDeterministicProgress = 48000000` → `DivergedProgress = 48000001` (backtrace checkpoint 24).
    * Warning (checkpoint 19, progress 32000000) embeds its own ADM: `lastDeterministicProgress = 31215860` → `DivergedProgress = 31215861`.
  * `NonDeterministicUserJS:UNGATED:JSProgress` Warning kind (1 occurrence, no `+1`):
    * `[RUN-1919]` Warning, checkpoint 11, `progress = 21517779` → `DivergedProgress = 21517779`.
  * "The mismatch itself" kind (1 occurrence):
    * `processNonFatal.backtrace.progress = 48331067` → `DivergedProgress = 48331067`.
* `EarliestSignal` = smallest `DivergedProgress` among all four = the `[RUN-1919]` `NonDeterministicUserJS:UNGATED:JSProgress` Warning (`21517779` < `31215861` < `48000001` < `48331067`).
* `EarliestDivergedProgress` = `21517779`, `checkpoint` = `11` (from `EarliestSignal`).
* `EarliestSignal` details:
  * `progress = 21517779`, `checkpoint = 11`, `threadId = 1`, `processId = 178`, `wasRecording: false`.
  * `PC = 21517779`, `scriptId = 11`, executing function `@11:.../turnstile/.../normal?lang=auto:1:135958`.
  * `stack=` (innermost-first, truncated): `os (…:1:135958)` ← `console.debug (<anonymous>)` ← `of.oB (…:1:178507)` ← `of.<computed>.<computed> [as run] (…:1:38405)` ← `os (…:1:137174)` ← `of.oq (…:1:99409)` ← `of.<computed>.<computed> [as run] (…:1:38268)` ← `os (…:1:137174)` ← `of.oq (…:1:99409)` ← `of.<computed>.<computed> [as run] (…:1:38268)`.
  * `DisallowLabel` = `V8InspectorImpl::forEachSession` (suffix `[EventsDisallowed:V8InspectorImpl::forEachSession]`).
  * No embedded `recorded`/`replayed` (this Warning kind carries no ADM).
  * Own C++ stack is emitter-only: `Runtime_RecordReplayAssertExecutionProgress` → `Warning` (no entry-path info).
* `sourceId`: `EarliestSignal` has no ADM → fallback to its `scriptId` = `11`.

## ReplayOnlyUserJsCall

* Judgment: **Proven**.
* Rests solely on: `[RUN-1919]` `NonDeterministicUserJS:UNGATED:JSProgress` Warning (checkpoint 11, progress 21517779) has `wasRecording: false` — the one and only condition the DataDefinition requires for `Proven`.
* Not grounds for `No` (per DataDefinition, explicitly disqualified): the Warning's own C++ stack being emitter-only (`Runtime_RecordReplayAssertExecutionProgress` → `Warning`, no entry path); its `progress` relative to `EarliestDivergedProgress`; the later checkpoint-27 `processNonFatal.applicationDataMismatch`'s non-empty `recorded`.

### UngatedUserJsEntry

* `EntryFrame`: innermost `NativeFrames` entry = `console.debug (<anonymous>)`; `CppEntry` = `V8Console::Debug` (`v8/src/inspector/v8-console.cc`).
* `EntryApi`: `V8Console::Debug` → `ConsoleHelper::reportCall` → `V8ConsoleMessage::createForConsoleAPI` → `V8ValueStringBuilder::toString`/`append(value)` → (plain-object arg) `v8::Value::ToString` (`api.cc`, no replay guard) → `i::Object::ToString`/`ConvertToString` (`objects-inl.h`/`objects.cc`) → `JSReceiver::ToPrimitive` (`js-objects.cc`) → `Execution::Call` on the object's `Symbol.toPrimitive`/`toString`/`valueOf` — value-conversion shape reaching arbitrary user JS.
  * Sibling API `v8::Object::ObjectProtoToString` (used for the non-plain-object arg path) already has an explicit replay guard (`AreEventsDisallowed() && !HasDivergedFromRecording()` → short-circuits to `"[object Object]"`, skips `CallBuiltin`); the generic `Value::ToString` path used here has no equivalent guard.
* `DisallowScope`: Warning's `DisallowLabel` = `V8InspectorImpl::forEachSession` (`AutoMaybeDisallowEvents disallow(replay_owned, m_isolate, "V8InspectorImpl::forEachSession")`, `v8-inspector-impl.cc`, keyed on session `m_replay_owned`). Off-path: this scope opens inside `V8ConsoleMessageStorage::addMessage`'s `forEachSession` call (`v8-console-message.cc`), which runs only *after* `reportCall`'s `createForConsoleAPI` (the stringification) has already completed and returned. No reconciliation.
* `GatesOnPath`: crosses exactly the one known gate, `Execution::Call` → `Execution::Invoke` → `RecordReplayIsDivergentUserJSWithoutPause` (`execution.cc`/`debug.cc`) → would block via `NonDeterministicUserJS:BLOCKED:JSInvoke`. Stayed silent because that gate is a narrow function-level check (`AreEventsDisallowed() && !HasDivergedFromRecording() && shared.script().IsScript() && RecordReplayHasRegisteredScript(...)` on the *callee's own* script), not an API-boundary guard — unlike `ObjectProtoToString`'s sibling short-circuit, `Value::ToString`/`Object::ConvertToString` has no such boundary guard before reaching `Execution::Invoke`.
* `BlockSite`: `Object::ConvertToString`/`v8::Value::ToString`, mirroring `ObjectProtoToString`'s existing guard — `EntryApi` must not reach user JS while `AreEventsDisallowed()` (the actual open `DisallowScope`, `forEachSession`, is off-path/unrelated, so widening it is not viable; gating `EntryApi` itself is).

# Root Cause

* `ReplayOnlyUserJsCall` Proven: `[RUN-1919]` `NonDeterministicUserJS:UNGATED:JSProgress` at `EarliestDivergedProgress` `21517779` (`wasRecording: false`).
* Entry under native `console.debug`: `V8Console::Debug` → `reportCall` → `createForConsoleAPI` → `V8ValueStringBuilder::append` → `v8::Value::ToString` → `Object::ConvertToString` → `JSReceiver::ToPrimitive` → `Execution::Call` into the arg's `Symbol.toPrimitive` / `toString` / `valueOf` (`scriptId=11`).
* Sibling path `Object::ObjectProtoToString` already short-circuits under `AreEventsDisallowed() && !HasDivergedFromRecording()` (crash-0063). `Value::ToString` / `ConvertToString` has no equivalent boundary guard.
* `Execution::Invoke`'s `NonDeterministicUserJS:BLOCKED:JSInvoke` gate is on the path but stayed silent — narrow callee-script check, not an API-boundary block.
* Warning `DisallowLabel` `V8InspectorImpl::forEachSession` is off-path (opens in `addMessage` after stringification returns). Not the span to widen.

# Solution

## Stop `Value::ToString` / `ConvertToString` from running user JS when events are disallowed

* `ConvertToString` reaches user JS only via `JSReceiver::ToPrimitive` (after Oddball/Number/Symbol/BigInt fast paths).
* Fix in `v8/src/objects/objects.cc` (`Object::ConvertToString`), immediately before `JSReceiver::ToPrimitive`:
  * If `AreEventsDisallowed() && !HasDivergedFromRecording()`:
  * Return `isolate->factory()->object_to_string()` (`"[object Object]"`) and do not call `ToPrimitive`.
* Same predicate and placeholder as `Object::ObjectProtoToString` in `v8/src/api/api.cc`.
* Do not put the guard at the top of `v8::Value::ToString` — that would also rewrite Number/BigInt/etc. under disallow.
* Effect: `console.debug` arg stringification no longer enters registered user JS through the plain `ToString` path; crash-0063 already covers the `ObjectProtoToString` branch.
