### PR TITLE
[crash-0077] Order SkImageFilterCache mutex

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': 'c5715ef3a48be1b7a9845a8256e6537b3350efaf',
+  'skia_revision': '9b33928334ec6d6f549b6cf5eff030851b344caa',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '9b33928334ec6d6f549b6cf5eff030851b344caa',
+  'skia_revision': 'ca1147a17890c6a4e21b1d996e202d109fdb6625',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-skia/pull/45

# Summary

* **OrderedLockStall**: tid 1 waits on OrderedLock 247 (`OperationsController`) with `nextOwner=11`.
* **UnorderedCacheMutexWait**: tid 11 is in `CacheImpl::get` on a default `SkMutex` (`fOrderedLockId == 0`) via `SkSemaphore` / `ReplayCvar::Wait`.
* Cause: `CacheImpl::fMutex` is unordered; sibling `SkResourceCache` uses named ordered mutex.
* Fix: `mutable SkMutex fMutex{"SkImageFilterCache"};`

# Problem

* Problem type: ReplayHang.
* Buckets: HangLocked:base::internal::OperationsController::T.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ]
*  - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in  when needed.

### RepoSrc

*
*

## Important Context

* buildId: linux-chromium-20260801-a926ce52b2ef-bdda21cf9aa2
* linkerVersion: linker-linux-16069-bdda21cf9aa2
* recordingId: 03bc63bc-20b5-45aa-90da-cbec4344babf

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "SaplingBranch",
  "manifest": "runToPoint",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingOnOrderedLock": {
          "id": 247,
          "nextOwner": 11,
          "waitPosition": 110616,
          "actualPosition": 110616
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::OrderedLock(void*,.int)+360",
          "RecordReplayOrderedLock(int)+26",
          "base::internal::OperationsController::TryBeginOperation()+24",
          "base::sequence_manager::internal::TaskQueueImpl::GuardedTaskPoster::PostTask(base::sequence_manager::internal::PostedTask)+176",
          "base::sequence_manager::internal::TaskQueueImpl::TaskRunner::PostDelayedTask(base::Location.const&,.base::OnceCallback<void.()>,.base::TimeDelta)+199",
          "base::TaskRunner::PostTask(base::Location.const&,.base::OnceCallback<void.()>)+39",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2297",
          "base::internal::Invoker<base::internal::BindState<void.(reporting::EncryptedReportingUploadProvider::UploadHelper::*)(std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>),.base::WeakPtr<reporting::EncryptedReportingUploadProvider::UploadHelper>,.std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+144",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "content::ContentMainRunnerImpl::Run()+673",
          "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
          "content::ContentMain(content::ContentMainParams)+95",
          "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
          "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
          "headless::HeadlessShellMain(int,.char.const**)+55",
          "ChromeMain+629",
          "new_libc_start_main(void.(*)(int,.char.const**))+22",
          "_start+42"
        ],
        "onstack": [
          "recordreplay::OrderedLock(void*,.int)+360",
          "base::TaskRunner::PostTask(base::Location.const&,.base::OnceCallback<void.()>)+39",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2297",
          "RecordReplayOrderedLock(int)+26",
          "base::internal::OperationsController::TryBeginOperation()+24",
          "base::sequence_manager::internal::TaskQueueImpl::GuardedTaskPoster::PostTask(base::sequence_manager::internal::PostedTask)+176",
          "BindingRecordReplayAssert(char.const*,.__va_list_tag*)+32",
          "recordreplay::Assert(char.const*,....)+141",
          "mspace_malloc(void*,.unsigned.long)+3935",
          "linker+11435312",
          "base::sequence_manager::internal::TaskQueueImpl::TaskRunner::PostDelayedTask(base::Location.const&,.base::OnceCallback<void.()>,.base::TimeDelta)+199",
          "chrome+21107293",
          "chrome+22244602",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2126",
          "chrome+21107293",
          "chrome+22244602",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2126",
          "base::TaskRunner::PostTask(base::Location.const&,.base::OnceCallback<void.()>)+39",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2297",
          "_fini+45901",
          "content::RendererMain(content::MainFunctionParams)+1435",
          "cc::ProxyImpl::NotifyReadyToCommitOnImpl(cc::CompletionEvent*,.std::Cr::unique_ptr<cc::CommitState,.std::Cr::default_delete<cc::CommitState>.>,.cc::ThreadUnsafeCommitState.const*,.base::TimeTicks,.viz::BeginFrameArgs.const&,.bool,.cc::CommitTimestamps*,.bool)",
          "chrome+21107293",
          "chrome+22244602",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2126",
          "cc::ProxyMain::BeginMainFrame(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>)",
          "base::internal::Invoker<base::internal::BindState<void.(reporting::EncryptedReportingUploadProvider::UploadHelper::*)(std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>),.base::WeakPtr<reporting::EncryptedReportingUploadProvider::UploadHelper>,.std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+144",
          "chrome+251049800",
          "chrome+251049800",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "cc::ProxyImpl::ScheduledActionSendBeginMainFrame(viz::BeginFrameArgs.const&)+550",
          "mojo::Connector::ScheduleDispatchOfPendingMessagesOrWaitForMore(unsigned.long)+109",
          "mojo::SimpleWatcher::Context::Notify(unsigned.int,.MojoHandleSignalsState,.unsigned.int)+383",
          "chrome+250307168",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "chrome+251056832",
          "chrome+251056832",
          "chrome+250310016",
          "chrome+250309328",
          "recordreplay::Stream::ReadValue(recordreplay::Stream::ReadMode)+24",
          "recordreplay::OrderedLock(void*,.int)+541",
          "recordreplay::ReplayLock::NotifyWaiter()+148",
          "recordreplay::ReplayLock::Unlock()+145",
          "recordreplay::OrderedUnlock(void*,.int)+73",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "chrome+251056832",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "chrome+223730384",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "decltype(auto).std::Cr::stack<base::sequence_manager::internal::ThreadController::RunLevelTracker::RunLevel,.std::Cr::vector<base::sequence_manager::internal::ThreadController::RunLevelTracker::RunLevel,.std::Cr::allocator<base::sequence_manager::internal::ThreadController::RunLevelTracker::RunLevel>.>.>::emplace[abi:v160000]<base::sequence_manager::internal::ThreadController::RunLevelTracker::State&,.bool.const&,.base::sequence_manager::internal::ThreadController::RunLevelTracker::TimeKeeper&,.base::LazyNow&>(base::sequence_manager::internal::ThreadController::RunLevelTracker::State&,.bool.const&,.base::sequence_manager::internal::ThreadController::RunLevelTracker::TimeKeeper&,.base::LazyNow&)+56",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "chrome+251056832",
          "base::RunLoop::Run(base::Location.const&)+461",
          "base::SampleVectorBase::Accumulate(int,.int)+58",
          "chrome+223727040",
          "chrome+26913488",
          "base::Histogram::AddCount(int,.int)+53",
          "chrome+26913488",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "chrome+20705427",
          "chrome+22244777",
          "content::RendererMain(content::MainFunctionParams)+1422",
          "recordreplay::ReplayLock::NotifyWaiter()+74",
          "chrome+223734744",
          "chrome+223734800",
          "headless::HeadlessContentMainDelegate::RunProcess(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams)+54",
          "chrome+223448992",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "base::CommandLine::HasSwitch(char.const*).const+104",
          "linker+1936944",
          "chrome+26912864",
          "content::ContentMainRunnerImpl::Run()+673",
          "std::Cr::__tree_iterator<std::Cr::__value_type<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.>,.std::Cr::__tree_node<std::Cr::__value_type<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.>,.void*>*,.long>.std::Cr::__tree<std::Cr::__value_type<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.>,.std::Cr::__map_value_compare<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::__value_type<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.>,.std::Cr::less<void>,.true>,.std::Cr::allocator<std::Cr::__value_type<std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.>.>.>::find<base::BasicStringPiece<char,.std::Cr::char_traits<char>.>.>(base::BasicStringPiece<char,.std::Cr::char_traits<char>.>.const&)+209",
          "base::CommandLine::GetSwitchValueNative(base::BasicStringPiece<char,.std::Cr::char_traits<char>.>).const+44",
          "chrome+26913137",
          "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
          "linker+10858752",
          "recordreplay::ptmalloc::malloc(unsigned.long)+240",
          "linker+10858752",
          "chrome+221486056",
          "content::ContentMain(content::ContentMainParams)+95",
          "linker+10858752",
          "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
          "linker+10858752",
          "linker+10858752",
          "chrome+223449368",
          "chrome+223449224",
          "linker+1936872",
          "chrome+29836288",
          "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
          "new_syscall(int,.unsigned.long,.unsigned.long)+189",
          "linker+10858752",
          "recordreplay::Thread::GetAllThreadIds(std::vector<unsigned.long,.std::allocator<unsigned.long>.>&)+112",
          "linker+10858752",
          "linker+10858752",
          "_fini+29544",
          "headless::HeadlessShellMain(int,.char.const**)+55",
          "mspace_malloc(void*,.unsigned.long)+624",
          "recordreplay::LoadOrderedResourceId(recordreplay::CallContext&,.unsigned.long)+71",
          "recordreplay::ptmalloc::malloc(unsigned.long)+240"
        ],
        "progress": 2714792,
        "threadId": 1,
        "checkpoint": 113
      }
    },
    {
      "state": {
        "threadId": 11,
        "waitingOnCvar": {
          "ptr": true,
          "lock": true,
          "waiters": [
            9,
            11
          ]
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941",
          "new_sem_wait(int*)+72",
          "SkSemaphore::osWait()+104",
          "(anonymous.namespace)::CacheImpl::get(SkImageFilterCacheKey.const&,.skif::FilterResult*).const+59",
          "SkImageFilter_Base::filterImage(skif::Context.const&).const+437",
          "SkBaseDevice::drawFilteredImage(skif::Mapping.const&,.SkSpecialImage*,.SkImageFilter.const*,.SkSamplingOptions.const&,.SkPaint.const&)+726",
          "SkCanvas::internalDrawDeviceWithFilter(SkBaseDevice*,.SkBaseDevice*,.SkImageFilter.const*,.SkPaint.const&,.SkCanvas::DeviceCompatibleWithFilter,.float)+1174",
          "SkCanvas::internalRestore()+514",
          "SkCanvas::restore()+68",
          "cc::PaintOpBuffer::Playback(SkCanvas*,.cc::PlaybackParams.const&,.std::Cr::vector<unsigned.long,.std::Cr::allocator<unsigned.long>.>.const*).const+660",
          "cc::DisplayItemList::Raster(SkCanvas*,.cc::ImageProvider*).const+430",
          "cc::RasterSource::PlaybackDisplayListToCanvas(SkCanvas*,.cc::ImageProvider*).const+111",
          "cc::RasterSource::PlaybackToCanvas(SkCanvas*,.gfx::Size.const&,.gfx::Rect.const&,.gfx::Rect.const&,.gfx::AxisTransform2d.const&,.cc::RasterSource::PlaybackSettings.const&).const+508",
          "cc::RasterBufferProvider::PlaybackToMemory(void*,.viz::ResourceFormat,.gfx::Size.const&,.unsigned.long,.cc::RasterSource.const*,.gfx::Rect.const&,.gfx::Rect.const&,.gfx::AxisTransform2d.const&,.gfx::ColorSpace.const&,.bool,.cc::RasterSource::PlaybackSettings.const&)+478",
          "cc::(anonymous.namespace)::BitmapRasterBufferImpl::Playback(cc::RasterSource.const*,.gfx::Rect.const&,.gfx::Rect.const&,.unsigned.long,.gfx::AxisTransform2d.const&,.cc::RasterSource::PlaybackSettings.const&,.GURL.const&)+189",
          "cc::(anonymous.namespace)::RasterTaskImpl::RunOnWorkerThread()+162",
          "blink::CategorizedWorkerPoolImpl::RunTaskInCategoryWithLockAcquired(cc::TaskCategory)+244",
          "blink::CategorizedWorkerPoolImpl::Run(std::Cr::vector<cc::TaskCategory,.std::Cr::allocator<cc::TaskCategory>.>.const&,.base::ConditionVariable*)+107",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "onstack": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941",
          "new_sem_wait(int*)+72",
          "SkSemaphore::osWait()+104",
          "(anonymous.namespace)::CacheImpl::get(SkImageFilterCacheKey.const&,.skif::FilterResult*).const+59",
          "SkImageFilter_Base::filterImage(skif::Context.const&).const+437",
          "SkBaseDevice::drawFilteredImage(skif::Mapping.const&,.SkSpecialImage*,.SkImageFilter.const*,.SkSamplingOptions.const&,.SkPaint.const&)+726",
          "SkCanvas::internalDrawDeviceWithFilter(SkBaseDevice*,.SkBaseDevice*,.SkImageFilter.const*,.SkPaint.const&,.SkCanvas::DeviceCompatibleWithFilter,.float)+1174",
          "recordreplay::ptmalloc::free(void*)+71",
          "cc::PaintOpBuffer::PlaybackFoldingIterator::FindNextOp()+35",
          "cc::PaintOpBuffer::Playback(SkCanvas*,.cc::PlaybackParams.const&,.std::Cr::vector<unsigned.long,.std::Cr::allocator<unsigned.long>.>.const*).const+1059",
          "SkCanvas::internalRestore()+514",
          "cc::PaintOpBuffer::OffsetIterator::operator++()+204",
          "cc::PaintOpBuffer::PlaybackFoldingIterator::NextUnfoldedOp()+114",
          "SkCanvas::restore()+68",
          "cc::PaintOpBuffer::Playback(SkCanvas*,.cc::PlaybackParams.const&,.std::Cr::vector<unsigned.long,.std::Cr::allocator<unsigned.long>.>.const*).const+660",
          "chrome+224244200",
          "cc::DisplayItemList::Raster(SkCanvas*,.cc::ImageProvider*).const+430",
          "cc::RasterSource::PlaybackDisplayListToCanvas(SkCanvas*,.cc::ImageProvider*).const+111",
          "cc::RasterSource::PlaybackToCanvas(SkCanvas*,.gfx::Size.const&,.gfx::Rect.const&,.gfx::Rect.const&,.gfx::AxisTransform2d.const&,.cc::RasterSource::PlaybackSettings.const&).const+508",
          "cc::RasterBufferProvider::PlaybackToMemory(void*,.viz::ResourceFormat,.gfx::Size.const&,.unsigned.long,.cc::RasterSource.const*,.gfx::Rect.const&,.gfx::Rect.const&,.gfx::AxisTransform2d.const&,.gfx::ColorSpace.const&,.bool,.cc::RasterSource::PlaybackSettings.const&)+478",
          "linker+2467104",
          "mspace_malloc(void*,.unsigned.long)+6440",
          "base::sequence_manager::internal::PostedTask::PostedTask(base::sequence_manager::internal::PostedTask&&)+97",
          "linker+2467336",
          "linker+2467072",
          "recordreplay::ptmalloc::free(void*)+71",
          "cc::(anonymous.namespace)::BitmapRasterBufferImpl::Playback(cc::RasterSource.const*,.gfx::Rect.const&,.gfx::Rect.const&,.unsigned.long,.gfx::AxisTransform2d.const&,.cc::RasterSource::PlaybackSettings.const&,.GURL.const&)+189",
          "cc::(anonymous.namespace)::BitmapRasterBufferImpl::Playback(cc::RasterSource.const*,.gfx::Rect.const&,.gfx::Rect.const&,.unsigned.long,.gfx::AxisTransform2d.const&,.cc::RasterSource::PlaybackSettings.const&,.GURL.const&)+123",
          "linker+1936384",
          "cc::(anonymous.namespace)::RasterTaskImpl::RunOnWorkerThread()+162",
          "chrome+250307168",
          "blink::CategorizedWorkerPoolImpl::RunTaskInCategoryWithLockAcquired(cc::TaskCategory)+244",
          "base::ConditionVariable::Wait()+146",
          "linker+1936408",
          "blink::CategorizedWorkerPoolImpl::Run(std::Cr::vector<cc::TaskCategory,.std::Cr::allocator<cc::TaskCategory>.>.const&,.base::ConditionVariable*)+107",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11"
        ],
        "progress": 2714792,
        "threadId": 11,
        "checkpoint": 113
      }
    }
  ]
}
```

# Investigation

## Code Scan

### CrashReport → code map (tid 1)

* `waitingOnOrderedLock.id=247`, `nextOwner=11`, `waitPosition=actualPosition=110616`
* Frame chain (innermost first):
  * `recordreplay::OrderedLock` → `thread->Wait()` — `backend/src/cpp/recording/OrderedLock.cpp`
  * `RecordReplayOrderedLock(int)` — `backend/src/cpp/linker/BindingInternal.cpp`
  * `OperationsController::TryBeginOperation` → `recordreplay::OrderedLock(ordered_lock_id_)` — `base/task/common/operations_controller.cc`
  * `GuardedTaskPoster::PostTask` → `operations_controller_.TryBeginOperation()` — `base/task/sequence_manager/task_queue_impl.cc`
  * `TaskQueueImpl::TaskRunner::PostDelayedTask` → `task_poster_->PostTask(...)`
  * `TaskRunner::PostTask` → `PostDelayedTask(..., TimeDelta())`
  * `cc::ProxyMain::BeginMainFrameWithBlocking` → `ImplThreadTaskRunner()->PostTask(... NotifyReadyToCommitOnImpl ...)` — `cc/trees/proxy_main.cc`

### CrashReport → code map (tid 11)

* `waitingOnCvar.waiters=[9,11]` (`ptr`/`lock` present; no owner field in this JSON shape)
* Frame chain (innermost first):
  * `ReplayCvar::Wait` — `backend/src/cpp/linker/ReplayLock.cpp`
  * `new_sem_wait` → `Semaphore::Wait` — `backend/src/cpp/linker/BindingLocks.cpp`
  * `SkSemaphore::osWait` → `OSSemaphore::wait` → `sem_wait` — `third_party/skia/src/core/SkSemaphore.cpp`
  * `SkMutex::acquire` else-branch (`fOrderedLockId == 0`) → `fSemaphore.wait()` — `third_party/skia/include/private/SkMutex.h`
  * `SkAutoMutexExclusive` ctor → `fMutex.acquire()` — same header
  * `CacheImpl::get` → `SkAutoMutexExclusive mutex(fMutex)` — `third_party/skia/src/core/SkImageFilterCache.cpp:54-68`
  * `SkImageFilter_Base::filterImage` → `context.cache()->get(key, &result)` — `third_party/skia/src/core/SkImageFilter.cpp:243`

### `CacheImpl::fMutex` construction

* Member: `mutable SkMutex fMutex;` — default ctor — `SkImageFilterCache.cpp:149`
* `SkMutex()` → `fOrderedLockId = 0` — `SkMutex.h:23,61`
* `SkMutex(const char* ordered_name)` → `fOrderedLockId = SkRecordReplayCreateOrderedLock(ordered_name)` — `SkMutex.h:24-26`
* Ordered examples elsewhere: `SkMutex("SkResourceCache")` — `SkResourceCache.cpp:482`; `SkMutex("f_t_mutex")` — `SkFontHost_FreeType.cpp:197`

### `Semaphore` / cvar wait semantics

* `Semaphore::{mLock,mCvar,mValue}`; `Wait` decrements `mValue`, cvar-waits if `< 0` — `BindingLocks.cpp:308-345`
* `ReplayCvar::Wait` unlocks `aLock` for the wait; `ToJSON` emits `ptr`/`lock`/`waiters` only — no owner — `ReplayLock.cpp:291-363`
* `ThreadWaitState::ToJSON`: `ownsLock` / `waitingToAcquireLock.owner` exist for `ReplayLock*`; `waitingOnCvar` has no owner — `Thread.cpp:483-525`

### Hang thread selection

* `collectSelectedHangedThreads`: start tid 1 (or `waitingForForkId`); follow `waitingOnOrderedLock.nextOwner` / `waitingToAcquireLock.owner` / pipe-write tid — `process-crash-state.ts:302-341`
* tid 9 is a cvar co-waiter in the report but is not selected by that walk

### Unknowns

* **MutexHolder** — see Root Cause / Linkerdebug Results (unresolved)
* Whether **MutexHolder** is itself waiting on OrderedLock 247
* Full `CrashThreadState` set at hang (report only has selected `hangedThreads`)

## Linkerdebug Results

* Session recording: `03bc63bc-20b5-45aa-90da-cbec4344babf`
* `rrnew` + `cont` → SIGINT at futex
  * Last `ReachedCheckpoint`: checkpoint 25, progress ~1164743 (report hang: 113 / 2714792)
  * gdb T1: `UploadScannedHits` / `EnterInnerLinker`
  * gdb T9: `AddReferencedObjects` under `pthread_cond_wait`
  * Other gdb threads: `read` (Replay wait pipes)
  * Dump: dump/rr-thread-apply-all-bt.txt
* `runRecording` reproduced stall: last log checkpoint 52 / progress 1657812, then silence; process still alive under linkerdebug
  * Detached mode skips `InstallSignalHandlers` unless `RECORD_REPLAY_DETACHED_SIGNAL_HANDLERS` — no `DumpThreads` / `CrashThreadState` on signal
  * Host `ptrace_scope=1` blocked gdb attach to the hung linker
* Selected hang states from report: dump/hangedThreads-selected.json
* **MutexHolder** (Replay tid that completed `CacheImpl::fMutex` acquire and has not released): not obtained at runtime

# Root Cause

* **OrderedLockStall**: tid 1 waits on OrderedLock id 247 (`OperationsController`) with `nextOwner=11` and `waitPosition == actualPosition` — schedule is ready for tid 11, not advancing.
* **UnorderedCacheMutexWait**: tid 11 is in `CacheImpl::get` → default `SkMutex` → `SkSemaphore`/`new_sem_wait` → `ReplayCvar::Wait`, co-waiters `[9, 11]`.
* `CacheImpl::fMutex` is default-constructed → `fOrderedLockId == 0` → unordered path. Sibling pattern: `SkResourceCache` uses `SkMutex("SkResourceCache")`.
* Hang selector only walks OrderedLock `nextOwner`, so tid 9 (same cvar) never appears in `hangedThreads`.
* **MutexHolder** unknown. `waitingOnCvar` JSON has no owner; `Semaphore` does not keep `ownsLock` across the SkMutex critical section.

# Solution

* Make `CacheImpl::fMutex` ordered, matching `SkResourceCache`:
  * `mutable SkMutex fMutex{"SkImageFilterCache"};` in `third_party/skia/src/core/SkImageFilterCache.cpp`
* Optional diagnostics (if holder still needed after fix):
  * Hang selection: also follow `waitingOnCvar.waiters`
  * `Semaphore` / `waitingOnCvar` dump: emit `mValue` (and any holder tracking if added)
