### PR TITLE
[crash-0071] Assert State::Close cached_group_controller nullness

### DIFF
--- a/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
+++ b/mojo/public/cpp/bindings/lib/scoped_interface_endpoint_handle.cc
@@ -91,6 +91,9 @@ class ScopedInterfaceEndpointHandle::State
       }
     }
 
+    recordreplay::Assert(
+        "ScopedInterfaceEndpointHandle::State::Close cached_group_controller %d",
+        !!cached_group_controller);
     if (cached_group_controller) {
       cached_group_controller->CloseEndpointHandle(cached_id, reason);
     } else if (cached_peer_state) {


### PR DESCRIPTION
# Summary

* ControlFlowMismatch: recorded hits `CloseEndpointHandle` Assert; replay hits `Value TryLock`.
* DivergenceCandidate: `State::Close` `if (cached_group_controller)` taken on record.
* Action: Assert `cached_group_controller` nullness before that branch.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackNoCommonFrame
* Bucket: Mismatch/[RUN-1209-1784] MultiplexRouter::CloseEndpointHandle, Mismatch/mojo::internal::MultiplexRouter::ProcessNotifyErrorTask.

## Important Context

* buildId: linux-chromium-20260801-a926ce52b2ef-bdda21cf9aa2
* linkerVersion: linker-linux-16069-bdda21cf9aa2
* recordingId: 17745197-f611-4ba6-b9e1-e95e30d73ce8

### Crash Report Core
```json
{
 "why": "Mismatch",
 "order": 1043759,
 "category": "SaplingBranch",
 "manifest": {
 "kind": "runToPoint",
 "endpoint": {
 "progress": 2305688,
 "checkpoint": 63
 },
 "getResumeData": [
 "annotations",
 "bookmarks",
 "consoleMessages",
 "events",
 "networkRequestEvents",
 "networkRequests",
 "networkStreamEvents",
 "sources",
 "widgetEvents"
 ]
 },
 "recorded": "[RUN-1209-1784] MultiplexRouter::CloseEndpointHandle 0 1 1 4294967295 ",
 "replayed": "Value TryLock",
 "threadId": 9,
 "backtrace": {
 "progress": 2305688,
 "threadId": 9,
 "checkpoint": 62
 },
 "recordedStack": [
 "recordreplay::Assert(char.const*,....)+141",
 "mojo::internal::MultiplexRouter::CloseEndpointHandle(unsigned.int,.absl::optional<mojo::DisconnectReason>.const&)+103",
 "mojo::ScopedInterfaceEndpointHandle::State::Close(absl::optional<mojo::DisconnectReason>.const&)+190",
 "mojo::ScopedInterfaceEndpointHandle::~ScopedInterfaceEndpointHandle+39",
 "mojo::InterfaceEndpointClient::~InterfaceEndpointClient+261",
 "mojo::InterfaceEndpointClient::~InterfaceEndpointClient+14",
 "mojo::internal::InterfacePtrStateBase::~InterfacePtrStateBase+56",
 "mojo::SharedRemoteBase<mojo::Remote<storage::mojom::Directory>.>::RemoteWrapper::DeleteOnCorrectThread.const+85"
 ],
 "replayedStack": [
 "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+361",
 "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316",
 "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+975",
 "mojo::Connector::HandleError(bool,.bool)+539",
 "base::RepeatingCallback<void.(int)>::Run(int).const.&+39",
 "mojo::SimpleWatcher::OnHandleReady(int,.unsigned.int,.mojo::HandleSignalsState.const&)+291",
 "base::internal::Invoker<base::internal::BindState<void.(mojo::SimpleWatcher::*)(int,.unsigned.int,.mojo::HandleSignalsState.const&),.base::WeakPtr<mojo::SimpleWatcher>,.int,.unsigned.int,.mojo::HandleSignalsState>,.void.>::RunOnce(base::internal::BindStateBase*)+142",
 "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257"
 ]
}
```

# Data

## DominantWarning

* none

## InterestingFrames

* recordedStack
 * `mojo::internal::MultiplexRouter::CloseEndpointHandle`
 * `mojo::ScopedInterfaceEndpointHandle::State::Close`
 * `mojo::SharedRemoteBase<mojo::Remote<storage::mojom::Directory>>::RemoteWrapper::DeleteOnCorrectThread`
* replayedStack
 * `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask`
 * `mojo::internal::MultiplexRouter::OnPipeConnectionError`
 * `mojo::Connector::HandleError`

## ResolvedFrames

* MismatchShape: `ControlFlowMismatch`
* AssertSite
 * recorded: `MultiplexRouter::CloseEndpointHandle` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:518`
 * `"[RUN-1209-1784] MultiplexRouter::CloseEndpointHandle %u %d %d %u %s"`
 * `Assert(` at `:517`; format string at `:518`
 * replayed: `RecordReplayValueWithStack` at `backend/src/cpp/recording/RecordedValue.cpp:36`
 * `"Value %s"` / `aWhy="TryLock"` → `"Value TryLock"`
 * absent from stacks (`RecordReplayAssertWithStack` re-roots)
* recordedStack
 * `CloseEndpointHandle(...)+103`
 * location: `MultiplexRouter::CloseEndpointHandle` at `multiplex_router.cc:522`
 * code: `recordreplay::Assert("[RUN-1209-1784] MultiplexRouter::CloseEndpointHandle %u %d %d %u %s", ...)`
 * disasm: `+98` call Assert, `+103` return site
 * inlineChain: none
 * state: `Resolved`
 * `State::Close(...)+190`
 * location: `ScopedInterfaceEndpointHandle::State::Close` at `scoped_interface_endpoint_handle.cc:95`
 * code: `cached_group_controller->CloseEndpointHandle(cached_id, reason);`
 * disasm: `+187` virtual call, `+190` return site
 * inlineChain: none
 * state: `Resolved`
 * `RemoteWrapper::DeleteOnCorrectThread.const+85`
 * location: `RemoteWrapper::DeleteOnCorrectThread` at `shared_remote.h:200`
 * code: `delete this;`
 * disasm: `+80` call `~InterfacePtrStateBase`, `+85` return site
 * inlineChain: none
 * state: `Resolved`
* replayedStack
 * `ProcessNotifyErrorTask(...)+361`
 * location: `MultiplexRouter::ProcessNotifyErrorTask` at `multiplex_router.cc:1047`
 * code: `lock_->Acquire;`
 * inlineChain: `MayAutoUnlock::~MayAutoUnlock` (`may_auto_lock.h:59`)
 * disasm: `+356` trylock, `+361` `test %eax`
 * state: `Resolved`
 * `OnPipeConnectionError(bool)+975`
 * location: `MultiplexRouter::OnPipeConnectionError` at `multiplex_router.cc:869`
 * code: `ProcessTasks(call_behavior, connector_.task_runner);`
 * disasm: `+970` call ProcessTasks, `+975` return site
 * inlineChain: none
 * state: `Resolved`
 * `Connector::HandleError(bool,.bool)+539`
 * location: `Connector::HandleError` at `connector.cc:716`
 * code: `std::move(connection_error_handler_).Run;`
 * disasm: `+536` call Run, `+539` return site
 * inlineChain: none
 * state: `Resolved`

## DominantWarningProvenance

* DominanceVerdict: `NoDominantWarning`
* `## DominantWarning` is none — no Warning site, no write/read trail

## FrameAnchors

* recordedStack: `RemoteWrapper::DeleteOnCorrectThread.const+85`
 * location: `RemoteWrapper::DeleteOnCorrectThread` at `shared_remote.h:200`
 * code: `delete this;`
 * disasm: `+80` call `~InterfacePtrStateBase`, `+85` return site
 * inlineChain: none
 * state: `Resolved`
* replayedStack: `Connector::HandleError(bool,.bool)+539`
 * location: `Connector::HandleError` at `connector.cc:716`
 * code: `std::move(connection_error_handler_).Run;`
 * disasm: `+536` call Run, `+539` return site
 * inlineChain: none
 * state: `Resolved`

## MismatchProvenance

* MismatchShape: `ControlFlowMismatch`
* DivergenceCandidate
 * recorded: `State::Close` `if (cached_group_controller)` — `RECORDED: taken`
 * proof: `State::Close+187` virtual `CloseEndpointHandle`
 * replayed: `RecordReplayValueWithStack` `if (!CheckEventsAllowed(...))` — `REPLAYED: not-taken`
 * proof: `replayed="Value TryLock"` is `RecordReplayAssertWithStack` at `RecordedValue.cpp:36`; only reached when `CheckEventsAllowed` returns true ( fall-through to `5c26f`)
* Outline
 * `RemoteWrapper::DeleteOnCorrectThread` — `shared_remote.h:185`
 * `if (!task_runner_->RunsTasksInCurrentSequence)` → else-arm
 * `delete this;` — `:200` → `~InterfacePtrStateBase` → `State::Close`
 * `ScopedInterfaceEndpointHandle::State::Close` — `scoped_interface_endpoint_handle.cc:43`
 * `// [Branch] RECORDED: taken`
 * `if (cached_group_controller)`
 * `cached_group_controller->CloseEndpointHandle(cached_id, reason);` — `:95`
 * `MultiplexRouter::CloseEndpointHandle` — `multiplex_router.cc:514`
 * `recordreplay::Assert("[RUN-1209-1784] MultiplexRouter::CloseEndpointHandle ...")` — `:517`
 * `// <<< RECORDED LEAF`
 * `Connector::HandleError` — `connector.cc:684`
 * `Assert A` — `:685`
 * `if (force_async_handler)` → else-arm
 * `Assert B` — `:713`
 * `if (connection_error_handler_)`
 * `std::move(connection_error_handler_).Run;` — `:716`
 * `MultiplexRouter::OnPipeConnectionError` — `multiplex_router.cc:831`
 * `ProcessTasks(...)` — `:869`
 * `MultiplexRouter::ProcessNotifyErrorTask` — `multiplex_router.cc:1014`
 * `MayAutoUnlock unlocker(&lock_);` — `:1045`
 * `client->NotifyError(disconnect_reason);` — `:1046`
 * `MayAutoUnlock::~MayAutoUnlock` — `may_auto_lock.h:57`
 * `if (lock_)`
 * `lock_->Acquire;` — `:59` → `pthread_mutex_trylock` (`+356`)
 * `Op_pthread_mutex_trylock` — `FunctionPthreads.cpp`
 * `RecordReplayValueWithStack(..., "TryLock", ...)`
 * `RecordReplayValueWithStack` — `RecordedValue.cpp:31`
 * `// [Branch] REPLAYED: not-taken`
 * `if (!CheckEventsAllowed(...))` — `:33`
 * `RecordReplayAssertWithStack(..., "Value %s", aWhy);` — `:36` · `aWhy="TryLock"`
 * `// <<< REPLAYED LEAF`

## AssertCandidates

* `ScopedInterfaceEndpointHandle::State::Close`
 * assertable:
 * `scoped_interface_endpoint_handle.cc:94` — `if (cached_group_controller)` — new site before RECORDED LEAF; nullness is side-effect-free branch input
 * provenance:
 * `State::Close` `:94` `if (cached_group_controller)` → `CloseEndpointHandle` → `:517` Assert · RECORDED LEAF
* `recordreplay::RecordReplayValueWithStack`
 * not-assertable:
 * `RecordedValue.cpp:33` — `if (!CheckEventsAllowed(...))` — Replay-driver / CheckEventsAllowed / sync-TryLock
 * provenance:
 * `RecordReplayValueWithStack` `:33` CheckEventsAllowed not-taken → `:36` `RecordReplayAssertWithStack("Value TryLock")` · REPLAYED LEAF

## DivergenceRoot

* `NoRoot`
 * `DominanceVerdict` is `NoDominantWarning` — not `DominantWarningRoot`
 * no `## AssertCandidates` entry proven as root — not `AssertCandidateRoot`

## PossibleInterventions

* none

## SuggestedCourseOfAction

* Assert `cached_group_controller` nullness at `scoped_interface_endpoint_handle.cc:94` before `if (cached_group_controller)`
