### PR TITLE
[crash-0079] Fix ShapeSegment null deref after diverged font fallback

### DIFF
--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
@@ -161,6 +161,10 @@ scoped_refptr<FontDataForRangeSet> FontFallbackIterator::Next(
         return UniqueOrNext(base::AdoptRef(new FontDataForRangeSet(system_font)),
                             hint_list);
       }
+      // [RecordReplay] crash-0079: match upstream kOutOfLuck — empty set, never
+      // null. Diverged UniqueSystemFontForHintList can leave first_candidate_
+      // unset; returning null made ShapeSegment skipCheck-break without clear.
+      return base::AdoptRef(new FontDataForRangeSet());
     }
     return first_candidate_;
   }

--- a/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
+++ b/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
@@ -40,7 +40,6 @@
 
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
-#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "third_party/blink/renderer/platform/fonts/font.h"
 #include "third_party/blink/renderer/platform/fonts/font_description.h"
@@ -790,15 +789,10 @@ void HarfBuzzShaper::ShapeSegment(
       current_font_data_for_range_set =
           fallback_iterator.Next(fallback_chars_hint);
 
-      // [RecordReplay] https://linear.app/replay/issue/RUN-1302#comment-0930eb4f
-      // When replaying and diverged from the recording, the `fallback_iterator.Next()`
-      // call can return null.
-      bool skipCheck =
-        recordreplay::HasDivergedFromRecording() &&
-        !current_font_data_for_range_set;
-
-      if (skipCheck || !current_font_data_for_range_set->FontData()) {
-        DCHECK(range_data->reshape_queue.empty());
+      if (!current_font_data_for_range_set->FontData()) {
+        // [RecordReplay] crash-0079: clear leftover kReshapeQueueRange so the
+        // next ShapeSegment does not drain it with a null/empty font.
+        range_data->reshape_queue.clear();
         break;
       }
       font_cycle_queued = false;


### PR DESCRIPTION
# Summary

* Problem: null deref in `ShapeSegment` at `current_font_data_for_range_set->FontData()`
* Root cause:
  * Diverged `UniqueSystemFontForHintList` can leave `first_candidate_` unset
  * `Next` then returned null; `skipCheck` broke without clearing `reshape_queue`
  * Next `ShapeSegment` drained leftover `kReshapeQueueRange` with a null local
* Fix:
  * `Next`: if `!first_candidate_`, return empty `FontDataForRangeSet` (upstream `kOutOfLuck`)
  * `ShapeSegment` give-up arm: `reshape_queue.clear()` before `break`
  * `skipCheck` removed — its only job was avoiding null deref on `->FontData()`; empty set makes that safe via `!FontData()`

# Problem

* Problem type: ReplayOtherCrash.
* Buckets: Other/blink::HarfBuzzShaper::Shape.

## Important Context

* buildId: linux-chromium-20260802-b841856e4633-bdda21cf9aa2
* linkerVersion: linker-linux-16069-bdda21cf9aa2
* recordingId: 52cefdbf-fa8d-44ec-9bd4-c09e007d56f8

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Segmentation fault",
  "category": "PauseChild",
  "threadId": 1,
  "backtrace": {
    "frames": [
      "blink::HarfBuzzShaper::Shape(blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.WTF::Vector<blink::RunSegmenter::RunSegmenterRange,.0u,.WTF::PartitionAllocator>.const&).const+326",
      "blink::NGInlineItemSegments::ShapeText(blink::HarfBuzzShaper.const*,.blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.unsigned.int).const+129",
      "blink::NGInlineNode::ShapeText(blink::NGInlineItemsData*,.WTF::String.const*,.blink::HeapVector<blink::NGInlineItem,.0u>.const*,.blink::Font.const*).const+2773",
      "blink::NGInlineNode::ShapeTextIncludingFirstLine(blink::NGInlineNodeData::ShapingState,.blink::NGInlineNodeData*,.WTF::String.const*,.blink::HeapVector<blink::NGInlineItem,.0u>.const*).const+95",
      "blink::NGInlineNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBreakToken.const*,.blink::NGColumnSpannerPath.const*,.blink::NGInlineChildLayoutContext*).const+68",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+1037",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::LayoutWithInlineChildLayoutContext(blink::NGLayoutInputNode.const&)+86",
      "blink::NGBlockLayoutAlgorithm::Layout()+107",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGGridLayoutAlgorithm::ContributionSizeForGridItem(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::GridTrackSizingDirection,.blink::GridItemContributionType,.blink::GridItemData*).const::$_7::operator()().const+252",
      "blink::NGGridLayoutAlgorithm::ContributionSizeForGridItem(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::GridTrackSizingDirection,.blink::GridItemContributionType,.blink::GridItemData*).const+1350",
      "blink::NGGridLayoutAlgorithm::IncreaseTrackSizesToAccommodateGridItems(blink::GridItems::IteratorBase<false>,.blink::GridItems::IteratorBase<false>,.blink::NGGridLayoutData.const&,.bool,.blink::SizingConstraint,.blink::GridItemContributionType,.blink::NGGridSizingTrackCollection*).const+780",
      "blink::NGGridLayoutAlgorithm::ResolveIntrinsicTrackSizes(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::NGGridSizingTrackCollection*,.blink::GridItems*).const+377",
      "blink::NGGridLayoutAlgorithm::ComputeUsedTrackSizes(blink::NGGridLayoutData.const&,.blink::NGGridProperties.const&,.blink::SizingConstraint,.blink::GridItems*,.blink::NGGridLayoutTrackCollection*,.bool*).const+310",
      "blink::NGGridLayoutAlgorithm::ComputeGridGeometry(blink::NGGridPlacementData.const&,.blink::GridItems*,.blink::NGGridLayoutData*,.blink::LayoutUnit*)+884",
      "blink::NGGridLayoutAlgorithm::LayoutInternal()+223",
      "blink::NGGridLayoutAlgorithm::Layout()+14",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGGridLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
      "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
      "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::LayoutNGView::UpdateBlockLayout(bool)+97",
      "blink::LayoutBlock::UpdateLayout()+124",
      "blink::LayoutView::UpdateLayout()+691",
      "blink::LocalFrameView::PerformLayout()+2901",
      "blink::LocalFrameView::UpdateLayout()+444",
      "blink::LocalFrameView::UpdateStyleAndLayoutInternal()+319",
      "blink::LocalFrameView::UpdateStyleAndLayout()+346",
      "blink::LocalFrameView::UpdateStyleAndLayoutIfNeededRecursive()+131",
      "blink::LocalFrameView::RunStyleAndLayoutLifecyclePhases(blink::DocumentLifecycle::LifecycleState)+72",
      "blink::LocalFrameView::UpdateLifecyclePhasesInternal(blink::DocumentLifecycle::LifecycleState)+270",
      "blink::LocalFrameView::UpdateLifecyclePhases(blink::DocumentLifecycle::LifecycleState,.blink::DocumentUpdateReason)+458",
      "blink::LayoutView::HitTest(blink::HitTestLocation.const&,.blink::HitTestResult&)+53",
      "blink::TreeScope::ElementsFromPoint(double,.double).const+274",
      "blink::(anonymous.namespace)::v8_document::ElementsFromPointOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+435",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
      "0x100a3ff15b38",
      "0x100a3fe8b82c",
      "0x100a3fe8b82c",
      "0x100a3fe8b82c",
      "0x100a3fe8b82c",
      "0x100a3fe89e5c",
      "0x100a3fe89b87",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
      "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
      "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+459",
      "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::String>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+237",
      "v8::debug::EvaluateGlobal(v8::Isolate*,.v8::Local<v8::String>,.v8::debug::EvaluateGlobalMode,.bool)+117",
      "v8_inspector::V8RuntimeAgentImpl::evaluate(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<double>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::EvaluateCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::EvaluateCallback>.>)+1092",
      "v8_inspector::protocol::Runtime::DomainDispatcherImpl::evaluate(v8_crdtp::Dispatchable.const&)+846",
      "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
      "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+709",
      "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+1241",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 1727283,
    "threadId": 1,
    "checkpoint": 285
  },
  "faultAddress": "0x10",
  "instructionPointer": "blink::HarfBuzzShaper::ShapeSegment(blink::RangeData*,.blink::RunSegmenter::RunSegmenterRange.const&,.blink::ShapeResult*).const+952"
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed SkImageFilterCache [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 12,
    "stack": [
      "(anonymous.namespace)::CacheImpl::purgeByImageFilter(SkImageFilter.const*)+37",
      "SkImageFilter_Base::~SkImageFilter_Base()+40",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+30",
      "cc::PaintFlags::~PaintFlags()+188",
      "cc::PaintOpBuffer::Reset()+229",
      "cc::PaintOpBuffer::~PaintOpBuffer()+39",
      "cc::DisplayItemList::~DisplayItemList()+93",
      "cc::PictureLayer::~PictureLayer()+111",
      "cc::PictureLayer::~PictureLayer()+14",
      "blink::ContentLayerClientImpl::~ContentLayerClientImpl()+14",
      "blink::PendingLayer::~PendingLayer()+33",
      "blink::PaintArtifactCompositor::~PaintArtifactCompositor()+107",
      "blink::LocalFrameView::~LocalFrameView()+202",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::DOMTimerCoordinator::InstallNewTimeout(blink::ExecutionContext*,.blink::ScheduledAction*,.base::TimeDelta,.bool)+259",
      "blink::(anonymous.namespace)::v8_window::SetTimeoutOperationOverload1(v8::FunctionCallbackInfo<v8::Value>.const&)+535",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 83964,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 4,
    "absoluteTime": 1785719437203.613,
    "wasRecording": true
  },
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait [HasDivergedFromRecording]",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 1727283,
    "threadId": 2,
    "processId": 271,
    "checkpoint": 285,
    "absoluteTime": 1785719519527.7988,
    "wasRecording": false
  },
  {
    "text": "Thread::WaitForeverForRecordedCall pthread_detach [HasDivergedFromRecording]",
    "count": 1,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 1727283,
    "threadId": 6,
    "processId": 271,
    "checkpoint": 285,
    "absoluteTime": 1785719519528.0823,
    "wasRecording": false
  }
]
```

# Data

## FailureMode

* `Fault`
  * `why`: `LinkerFault`
  * `category`: `PauseChild`
  * `signal`: `Segmentation fault`
  * fatal message: none
  * `faultAddress`: `0x10`
  * `instructionPointer`: `blink::HarfBuzzShaper::ShapeSegment(blink::RangeData*,.blink::RunSegmenter::RunSegmenterRange.const&,.blink::ShapeResult*).const+952`

## InterestingFrames

* `blink::HarfBuzzShaper::ShapeSegment(blink::RangeData*,.blink::RunSegmenter::RunSegmenterRange.const&,.blink::ShapeResult*).const+952`
* `blink::HarfBuzzShaper::Shape(blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.WTF::Vector<blink::RunSegmenter::RunSegmenterRange,.0u,.WTF::PartitionAllocator>.const&).const+326`
* `blink::NGInlineItemSegments::ShapeText(blink::HarfBuzzShaper.const*,.blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.unsigned.int).const+129`

## FrameAnchors

* Proof: , `Shape_Vector_disasm.txt`, `ShapeText_disasm.txt`, `ShapeSegment_NextFont_path.txt` — objdump on `linker-debug-storage/builds/linux-chromium-20260802-b841856e4633-bdda21cf9aa2/chrome`
* `blink::HarfBuzzShaper::ShapeSegment(blink::RangeData*,.blink::RunSegmenter::RunSegmenterRange.const&,.blink::ShapeResult*).const+952`
  * location: `HarfBuzzShaper::ShapeSegment` at `harfbuzz_shaper.cc:809`
  * code: `current_font_data_for_range_set->FontData()`
  * disasm: `+0x3b1` `mov -0xf8(%rbp),%rax`; `+0x3b8` `mov 0x10(%rax),%rax` — matches `faultAddress` `0x10`
  * inlineChain: `FontDataForRangeSet::FontData` (`font_data_for_range_set.h:59`)
  * state: `Resolved`
* `blink::HarfBuzzShaper::Shape(blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.WTF::Vector<blink::RunSegmenter::RunSegmenterRange,.0u,.WTF::PartitionAllocator>.const&).const+326`
  * location: `HarfBuzzShaper::Shape` at `harfbuzz_shaper.cc:972`
  * code: `ShapeSegment(&range_data, segmented_range, result.get());`
  * disasm: `+0x141` `call ShapeSegment`; `+0x146` return site
  * inlineChain: none
  * state: `Resolved`
* `blink::NGInlineItemSegments::ShapeText(blink::HarfBuzzShaper.const*,.blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.unsigned.int).const+129`
  * location: `NGInlineItemSegments::ShapeText` at `ng_inline_item_segment.cc:248`
  * code: `shaper->Shape(font, direction, start_offset, end_offset, ranges);`
  * disasm: `+0x7c` `call Shape(...Vector...)`; `+0x81` return site
  * inlineChain: none
  * state: `Resolved`

## CrashSiteProvenance

* FaultSite: `## FrameAnchors` `ShapeSegment+952` — `harfbuzz_shaper.cc:809` `current_font_data_for_range_set->FontData()`
* FaultOperand: null `current_font_data_for_range_set`
  * `rax` ← `-0xf8(%rbp)` was `0`; fault at `rax+0x10` = `faultAddress` `0x10`
* Producer
  * `harfbuzz_shaper.cc:776` — `scoped_refptr<FontDataForRangeSet> current_font_data_for_range_set;`
  * Same-invocation `:790`→`:809`: excluded — null/`!FontData()` `break`s at `:800-802`
  * Leftover-queue path: prior `:800-802` `break` without `clear`; `Shape` reuses `range_data` at `:972`; next `ShapeSegment` takes leftover `kReshapeQueueRange` with `:776` still null → `:809`
  * Not Producers of FaultOperand:
    * `UniqueSystemFontForHintList` (`:277`) — on `kSystemFonts`, Diverged `nullptr` falls through to last-resort `UniqueOrNext`
    * `:790` via `:796-798` `skipCheck` — post-write gate, not the write that reaches FaultSite
* Proof: , `ShapeSegment_fault_exact.txt`, `ShapeSegment_NextFont_path.txt`, `ShapeSegment_after_null_store.txt`
* Outline:
  * `HarfBuzzShaper::ShapeSegment`
    * `// [Producer]`
    * `scoped_refptr<FontDataForRangeSet> current_font_data_for_range_set;`
    * `kReshapeQueueNextFont`: `Next(...)`; `skipCheck = HasDivergedFromRecording() && !...;` `if (skipCheck || !...->FontData()) break;` — no queue clear
    * `// <<< FAULT`
    * `current_font_data_for_range_set->FontData();`
  * `HarfBuzzShaper::Shape`
    * `for (ranges) ShapeSegment(&range_data, ...);` — shared `reshape_queue`

## RootCause

* Null deref at `harfbuzz_shaper.cc:809`: `current_font_data_for_range_set->FontData()`
* Upstream missing-font path does not crash
  * `FontFallbackIterator::Next` returns a non-null empty `FontDataForRangeSet` (`kOutOfLuck`)
  * `ShapeSegment` then `break`s on `!FontData()` with `DCHECK(reshape_queue.empty())`
  * Last font commits `.notdef` instead of leaving queue work
* Replay when `HasDivergedFromRecording`:
  * `UniqueSystemFontForHintList` early-outs `nullptr` to avoid font-lookup hangs (`font_fallback_iterator.cc:277-282`) — that alone falls through to last-resort
  * `Next` still returns null refptr via `return first_candidate_` (`:165`) when `first_candidate_` was never set (last-resort/`UniqueOrNext` failed; diverged re-lookup at `:158` also returns `nullptr`)
  * Upstream would return empty `FontDataForRangeSet` (`kOutOfLuck`), never null
  * `skipCheck` (`harfbuzz_shaper.cc:796-802`, RUN-1302) avoids the immediate null deref on `->FontData()`
  * But `break`s without `reshape_queue.clear()`, while a `kReshapeQueueRange` is still queued
* `Shape` at `:972` reuses `range_data` across ranges
* Next `ShapeSegment` drains the leftover `kReshapeQueueRange` with a fresh null local → crash at `:809`

### Hypothesis 1: Missing font alone should not crash

* Correct
* Upstream exhausted fallback → empty `FontDataForRangeSet`, not null refptr, not crash
* Crash requires Replay path:
  * `Next` returns null refptr when `!first_candidate_`
  * `skipCheck` `break` without clearing `reshape_queue`

## SuggestedCourseOfAction

* Required: `reshape_queue.clear()` before the give-up `break` at `:800-802` (shared arm: `skipCheck` or `!FontData()`), same as `:786`
  * Empty `FontDataForRangeSet` alone does not fix the crash — leftover `kReshapeQueueRange` still reaches the next `ShapeSegment`
* Prefer: in `FontFallbackIterator::Next` at `:165`, if `!first_candidate_`, return empty `FontDataForRangeSet` (upstream `kOutOfLuck` contract), not null refptr
  * `UniqueSystemFontForHintList` diverged `nullptr` is fine — that path falls through to last-resort
  * Null comes from `return first_candidate_` when it was never set
  * After that, `skipCheck` can be removed
