### PR TITLE
crash-0082: EnterLeakMemory diagnostics at LeakMemory sites

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '8407a7d573c021f63570ac3f8e4593dd29a7a00b',
+  'skia_revision': '39e5d0421c656714ed15c1a50635234341c04ed7',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': 'ca1147a17890c6a4e21b1d996e202d109fdb6625',
+  'skia_revision': '8407a7d573c021f63570ac3f8e4593dd29a7a00b',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/base/record_replay.h
+++ b/base/record_replay.h
@@ -89,6 +89,14 @@ void ExitReplayCode();
 bool FeatureEnabled(const char* feature, const char* subfeature = nullptr);
 bool HasDisabledFeatures();
 
+// Gate a LeakMemory intervention and breadcrumb it into crash-report diagnostics.
+inline bool EnterLeakMemory(const char* label) {
+  if (!IsRecordingOrReplaying("leak-references", label))
+    return false;
+  Diagnostic("LeakMemory %s", label);
+  return true;
+}
+
 /**
  * Get the current JS stack, if there is any.
  */

--- a/third_party/blink/renderer/core/css/style_image_cache.cc
+++ b/third_party/blink/renderer/core/css/style_image_cache.cc
@@ -23,7 +23,7 @@ StyleFetchedImage* StyleImageCache::CacheStyleImage(Document& document,
             FetchParameters::ImageRequestBehavior::kDeferImageLoad,
         origin_clean == OriginClean::kTrue, is_ad_related, params.Url());
 
-    if (recordreplay::IsRecordingOrReplaying("leak-references", "StyleImageCache")) {
+    if (recordreplay::EnterLeakMemory("StyleImageCache")) {
       fetched_image_map_strong_.insert(result.stored_value->value);
     }
   }

--- a/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
+++ b/third_party/blink/renderer/core/loader/resource/image_resource_content.cc
@@ -130,8 +130,7 @@ void ImageResourceContent::HandleObserverFinished(
     if (it != observers_.end()) {
       observers_.erase(it);
       finished_observers_.insert(observer);
-      if (recordreplay::IsRecordingOrReplaying("leak-references",
-                                               "ImageResourceContent")) {
+      if (recordreplay::EnterLeakMemory("ImageResourceContent")) {
         replay_strong_observers_.erase(replay_strong_observers_.find(observer));
         replay_strong_finished_observers_.insert(observer);
       }
@@ -151,8 +150,7 @@ void ImageResourceContent::AddObserver(ImageResourceObserver* observer) {
         this);
     observers_.insert(observer);
     
-    if (recordreplay::IsRecordingOrReplaying("leak-references",
-                                              "ImageResourceContent")) {
+    if (recordreplay::EnterLeakMemory("ImageResourceContent")) {
       replay_strong_observers_.insert(observer);
     }
   }
@@ -179,8 +177,7 @@ void ImageResourceContent::RemoveObserver(ImageResourceObserver* observer) {
     fully_erased = observers_.erase(it) && finished_observers_.find(observer) ==
                                                finished_observers_.end();
     
-    if (recordreplay::IsRecordingOrReplaying("leak-references",
-                                              "ImageResourceContent")) {
+    if (recordreplay::EnterLeakMemory("ImageResourceContent")) {
       replay_strong_observers_.erase(replay_strong_observers_.find(observer));
     }
   } else {
@@ -188,8 +185,7 @@ void ImageResourceContent::RemoveObserver(ImageResourceObserver* observer) {
     DCHECK(it != finished_observers_.end());
     fully_erased = finished_observers_.erase(it);
     
-    if (recordreplay::IsRecordingOrReplaying("leak-references",
-                                              "ImageResourceContent")) {
+    if (recordreplay::EnterLeakMemory("ImageResourceContent")) {
       replay_strong_finished_observers_.erase(replay_strong_finished_observers_.find(observer));
     }
   }

--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
@@ -219,13 +219,15 @@ SVGImage::~SVGImage() {
 
   // Leak the agent_group_scheduler_ when removed during GC.
   // See https://linear.app/replay/issue/RUN-2056#comment-f827701f.
-  if (recordreplay::AreEventsDisallowed("~SVGImage"))
+  if (recordreplay::AreEventsDisallowed("~SVGImage") &&
+      recordreplay::EnterLeakMemory("SVGImage"))
     agent_group_scheduler_.release();
 
   if (page_) {
     // Leak the Page during nondeterministic GC sweep: WillBeDestroyed() would
     // erase it from AllPages(), diverging membership at iteration time.
-    if (recordreplay::AreEventsDisallowed("~SVGImage")) {
+    if (recordreplay::AreEventsDisallowed("~SVGImage") &&
+        recordreplay::EnterLeakMemory("SVGImage")) {
       DEFINE_STATIC_LOCAL(Persistent<HeapHashSet<Member<Page>>>, leaked_pages,
                           (MakeGarbageCollected<HeapHashSet<Member<Page>>>()));
       leaked_pages->insert(page_.Release());

--- a/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
+++ b/third_party/blink/renderer/modules/scheduler/dom_scheduler.cc
@@ -70,8 +70,7 @@ void DOMScheduler::ContextDestroyed() {
     signal_to_task_queue_map_.size());
 
   // Keep queues alive until DOMScheduler itself is GC-collected.
-  if (!recordreplay::IsRecordingOrReplaying("leak-references",
-                                            "DOMScheduler")) {
+  if (!recordreplay::EnterLeakMemory("DOMScheduler")) {
     fixed_priority_task_queues_.clear();
     signal_to_task_queue_map_.clear();
   }
@@ -199,8 +198,7 @@ void DOMScheduler::CreateTaskQueueFor(DOMTaskSignal* signal) {
   signal_to_task_queue_map_.insert(
       signal,
       MakeGarbageCollected<DOMTaskQueue>(std::move(task_queue), priority));
-  if (recordreplay::IsRecordingOrReplaying("leak-references",
-                                            "DOMScheduler")) {
+  if (recordreplay::EnterLeakMemory("DOMScheduler")) {
     replay_strong_signal_.insert(signal);
   }
   signal->AddPriorityChangeAlgorithm(


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-skia/pull/46
# Summary

* Add `EnterLeakMemory(label)` / `SkRecordReplayEnterLeakMemory(label)`.
  * Gates on `IsRecordingOrReplaying("leak-references", label)`.
  * Emits `Diagnostic("LeakMemory %s", label)` into crash-report diagnostics.
* Apply at crash-0082 mapped LeakMemory sites so future crashes show which interventions ran.

# Problem

* RecorderCrash in `CacheImpl::removeInternal` → `SkTHashTable::resize` oldSlots destroy.
* Fault shape: bad `SkAutoTArray` length cookie → null slot address.
* DataFlow unknown without rr.
* LeakMemory sites in the same build could have fired before the fault.
* report.json `diagnostics` had no per-site LeakMemory breadcrumb.

# Solution

* Solution Recipe: diagnostic gate on LeakMemory entry.
* Implementation
  * `recordreplay::EnterLeakMemory(label)` in `base/record_replay.h`.
  * `SkRecordReplayEnterLeakMemory(label)` in Skia `SkRecordReplay.h`.
  * Blink sites: `SVGImage`, `ImageResourceContent`, `StyleImageCache`, `DOMScheduler`.
  * Skia SkipCleanup sites: `SkPicture`, `SkImage`, `SkPixelRef` (under `AreEventsDisallowed`).
* Why this works
  * Crash reports already collect `Diagnostic` strings into `diagnostics`.
  * A hit site now leaves `LeakMemory <label>` before the fault path continues.

# Raw Data

* buildId: `linux-chromium-20260803-b62b5d2730cf-bdda21cf9aa2`
* linkerVersion: `linker-linux-16069-bdda21cf9aa2`
* recordingId: `01842b11-75de-4405-9f9c-651ede222e34`
* issue: crash-0082