### PR TITLE
[crash-0071-2] Assert entry of ~WidgetInputHandlerManager

### DIFF
--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
@@ -279,6 +279,7 @@ void WidgetInputHandlerManager::InitInputHandler() {
 }
 
 WidgetInputHandlerManager::~WidgetInputHandlerManager() {
+  recordreplay::Assert("WidgetInputHandlerManager::~WidgetInputHandlerManager");
   // leak-references: skip OnVoterDestroyed at divergent last-ref (events-allowed).
   if (recordreplay::IsRecordingOrReplaying(
           "leak-references", "WidgetInputHandlerManager")) {

--- a/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
+++ b/third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc
@@ -279,7 +279,7 @@ void WidgetInputHandlerManager::InitInputHandler() {
 }
 
 WidgetInputHandlerManager::~WidgetInputHandlerManager() {
-  recordreplay::Assert("WidgetInputHandlerManager::~WidgetInputHandlerManager");
+  REPLAY_ASSERT("WidgetInputHandlerManager::~WidgetInputHandlerManager");
   // leak-references: skip OnVoterDestroyed at divergent last-ref (events-allowed).
   if (recordreplay::IsRecordingOrReplaying(
           "leak-references", "WidgetInputHandlerManager")) {


### PR DESCRIPTION
# Summary

* `StackNoCommonFrame` mismatch: recorded tears down via `~WidgetInputHandlerManager`, replayed hits `Value TryLock`.
* No `DivergenceRoot`; mandatory recorded caller-most-frame entry Assert.

---


# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackNoCommonFrame
* Buckets: Mismatch/mojo::internal::MultiplexRouter::ProcessNotifyErro, Mismatch/ScopedInterfaceEndpointHandle::State::Close.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260805-ff353501a523-5fa7b5572b6d
* linkerVersion: linker-linux-16081-5fa7b5572b6d
* recordingId: 2fd8724f-8ba2-421c-8045-2383dd6b4edd

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 924546,
  "category": "Sapling",
  "recorded": "ScopedInterfaceEndpointHandle::State::Close cached_group_controller 1",
  "replayed": "Value TryLock",
  "threadId": 9,
  "backtrace": {
    "progress": 2341188,
    "threadId": 9,
    "checkpoint": 41
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "mojo::ScopedInterfaceEndpointHandle::State::Close(absl::optional<mojo::DisconnectReason>.const&)+205",
    "mojo::ScopedInterfaceEndpointHandle::~ScopedInterfaceEndpointHandle()+39",
    "mojo::InterfaceEndpointClient::~InterfaceEndpointClient()+261",
    "mojo::InterfaceEndpointClient::~InterfaceEndpointClient()+14",
    "mojo::internal::InterfacePtrStateBase::~InterfacePtrStateBase()+56",
    "mojo::SharedRemoteBase<mojo::Remote<storage::mojom::Directory>.>::RemoteWrapper::DeleteOnCorrectThread().const+85",
    "blink::WidgetInputHandlerManager::~WidgetInputHandlerManager()+291"
  ],
  "replayedStack": [
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+361",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316",
    "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+975",
    "mojo::Connector::HandleError(bool,.bool)+539",
    "base::RepeatingCallback<void.(int)>::Run(int).const.&+39",
    "mojo::SimpleWatcher::OnHandleReady(int,.unsigned.int,.mojo::HandleSignalsState.const&)+291",
    "base::internal::Invoker<base::internal::BindState<void.(mojo::SimpleWatcher::*)(int,.unsigned.int,.mojo::HandleSignalsState.const&),.base::WeakPtr<mojo::SimpleWatcher>,.int,.unsigned.int,.mojo::HandleSignalsState>,.void.()>::RunOnce(base::internal::BindStateBase*)+142",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257"
  ]
}
```

# Data

## Previous Work

* crash-0071 — closest match: same recorded assert leaf (`ScopedInterfaceEndpointHandle::State::Close` → `MultiplexRouter::CloseEndpointHandle`, `cached_group_controller`) and same replayed leaf (`RecordReplayValueWithStack` "Value TryLock" via `MultiplexRouter::ProcessNotifyErrorTask`). Already root-caused as a `cached_group_controller` nullness `ControlFlowMismatch`; proposed fix adds an Assert at `scoped_interface_endpoint_handle.cc:94` before `if (cached_group_controller)`.
* crash-0061 — same `Value TryLock` replayed leaf/mechanism (`StackCommonFrame`), but recorded side is `power_scheduler::PowerModeArbiter::OnVoterDestroyed`/`WidgetInputHandlerManager` teardown, not `MultiplexRouter`/`ScopedInterfaceEndpointHandle::State::Close`. Continuation of crash-0056.
* crash-0056 — root of the crash-0061 chain; same `Value TryLock` mismatch mechanism, unrelated recorded leaf.
* crash-0048-2 — `ScopedInterfaceEndpointHandle::State::Close` appears only incidentally in an unrelated Warning stack during GC sweep; actual bucket/assert leaf pair is `base::internal::ScopedFDCloseTraits::Free` (fd/sqlite), unrelated to this signature.

PlacementParent: crash-0071

## DominantWarning

* none
  * `crash_report.warnings` is `[]` — no Warning entries in report.json at all

## InterestingFrames

* No shared topmost frame between `recordedStack`/`replayedStack` (fully disjoint function names). No `DominantWarning` stack.
* recordedStack (Assert leaf frame and dup `~InterfaceEndpointClient` entry excluded)
  * `mojo::ScopedInterfaceEndpointHandle::State::Close` — dominant branch on `cached_group_controller` gating the Assert (scoped_interface_endpoint_handle.cc).
  * `mojo::InterfaceEndpointClient::~InterfaceEndpointClient` — dominant branch on `controller_` gating `DetachEndpointClient`/handle teardown into `Close` (interface_endpoint_client.cc).
  * `mojo::SharedRemoteBase<...>::RemoteWrapper::DeleteOnCorrectThread` — dominant branch on `task_runner_->RunsTasksInCurrentSequence()`; in-sequence `else { delete this; }` path drives teardown chain into next frame. Verified directly in `shared_remote.h` this session.
  * `blink::WidgetInputHandlerManager::~WidgetInputHandlerManager` — most caller-ward frame, feature-specific (not generic dispatch); dominant branch on `recordreplay::IsRecordingOrReplaying("leak-references", "WidgetInputHandlerManager")` gating `response_power_mode_voter_.release()`, which drives the teardown chain into the next frame (widget_input_handler_manager.cc).
* replayedStack
  * `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask` — dominant branch on `endpoint->client()` and `client_call_behavior`/`current_task_runner` match (multiplex_router.cc).
  * `mojo::internal::MultiplexRouter::OnPipeConnectionError` — sets `encountered_error_ = true`, iterates endpoints (multiplex_router.cc).
  * `mojo::Connector::HandleError` — dominant branch on `error_`/`message_pipe_.is_valid()`, `paused_`, `force_pipe_reset` (connector.cc).

## ResolvedFrames

* AssertSite (recorded) — `"ScopedInterfaceEndpointHandle::State::Close cached_group_controller %d"` at scoped_interface_endpoint_handle.cc:94-96, enclosing fn `mojo::ScopedInterfaceEndpointHandle::State::Close(const absl::optional<DisconnectReason>&)` (same file, L43). Matches leaf frame already in `recordedStack`.
* AssertSite (replayed) — `"Value %s"` (with `aWhy="TryLock"`) at RecordedValue.cpp:36, enclosing fn `recordreplay::RecordReplayValueWithStack(void*,.const.char*,.uintptr_t)` (L31). `aWhy="TryLock"` value itself originates from callers in `FunctionPthreads.cpp:159`/`FunctionWindows.cpp` (backend `RepoSrc`). Site absent from `replayedStack` because `RecordReplayAssertWithStack` re-roots the stack at `aStackPointer` (the caller), not at this frame.
* MismatchShape: two distinct `AssertSite`s (different files/functions) → sides do not share one `AssertSite` → `ControlFlowMismatch`, not `DataMismatch`.

## DominantWarningProvenance

* DominanceVerdict: `NoDominantWarning` — `## DominantWarning` is `none` (`crash_report.warnings` is `[]`).
* No Warning site exists to anchor on; `DominanceShape` check is moot.

## MismatchProvenance

* MismatchShape: `ControlFlowMismatch` — recorded `AssertSite` (`scoped_interface_endpoint_handle.cc:94-96`, `State::Close`) ≠ replayed `AssertSite` (`RecordedValue.cpp:36`, `RecordReplayValueWithStack`); no shared `AssertSite`.
* Matches crash-0071 provenance shape exactly (same replayed-side chain and mechanism); this report's recorded leaf sits one level shallower (`State::Close` itself, not via `MultiplexRouter::CloseEndpointHandle`).
* Anchors (`StackNoCommonFrame`, most caller-ward per stack):
  * recordedStack: `blink::WidgetInputHandlerManager::~WidgetInputHandlerManager` — only branch is `recordreplay::IsRecordingOrReplaying("leak-references", ...)`, a Replay driver/feature flag → invalid per [InvalidAssertValues], dropped on sight. **Recorded side has no valid `DivergenceCandidate` from this anchor.**
  * replayedStack: `base::TaskAnnotator::RunTaskImpl` — generic task-dispatch, no relevant branch.
* DivergenceCandidate
  * recorded: none kept — Assert at `scoped_interface_endpoint_handle.cc:94-96` fires unconditionally (no gating branch before it); `if (cached_group_controller)` is at `:97`, after the Assert, so does not gate the leaf.
  * replayed: none kept — the only branch on the span, `RecordReplayValueWithStack`'s `if (!CheckEventsAllowed(aStackPointer, "value", aWhy))` at RecordedValue.cpp:33, is itself a guard around the Assert machinery: `CheckEventsAllowed` (RecordedValue.cpp:15-28) checks only `HasDivergedFromRecording()`/`AreEventsPassedThrough()`/`AreEventsDisallowed()` — Replay's own driver/recorder state, which gates whether the Assert is *reported*, never whether the program *diverged* — invalid per [InvalidAssertValues], dropped on sight. Replayed side has no valid `DivergenceCandidate` from this anchor either.
* Outline:
  ```
  blink::WidgetInputHandlerManager::~WidgetInputHandlerManager
    // [Branch] NOT-ASSERTABLE (dropped — Replay driver/feature flag)
    if (recordreplay::IsRecordingOrReplaying("leak-references", "WidgetInputHandlerManager"))
      ... else response_power_mode_voter_.release() path → drives teardown chain
  mojo::ScopedInterfaceEndpointHandle::State::Close  // scoped_interface_endpoint_handle.cc:43
    recordreplay::Assert("ScopedInterfaceEndpointHandle::State::Close cached_group_controller %d", ...)  // :94-96
    // <<< RECORDED LEAF
    if (cached_group_controller)   // :97 — after the Assert, does not gate it

  mojo::internal::MultiplexRouter::ProcessNotifyErrorTask  // multiplex_router.cc:1014ish
    MayAutoUnlock unlocker(&lock_);  // scope-exit calls ~MayAutoUnlock
    client->NotifyError(disconnect_reason);
  mojo::internal::MayAutoUnlock::~MayAutoUnlock  // may_auto_lock.h:57
    if (lock_)
      lock_->Acquire();  // → pthread_mutex_trylock
  Op_pthread_mutex_trylock  // FunctionPthreads.cpp:159
    RecordReplayValueWithStack(..., "TryLock", ...)
  recordreplay::RecordReplayValueWithStack  // RecordedValue.cpp:31
    // [Branch] NOT-ASSERTABLE (dropped — Replay driver/recorder guard around Assert machinery)
    if (!CheckEventsAllowed(aStackPointer, "value", aWhy))  // :33
    RecordReplayAssertWithStack(aStackPointer, "Value %s", aWhy);  // :36, aWhy="TryLock"
    // <<< REPLAYED LEAF
  ```

## AssertCandidates

* `blink::WidgetInputHandlerManager::~WidgetInputHandlerManager` (mandatory `StackNoCommonFrame` caller-most-frame addition; recorded side)
  * assertable:
    * widget_input_handler_manager.cc:281 — `recordreplay::Assert("WidgetInputHandlerManager::~WidgetInputHandlerManager")` — new entry site; no branch required
  * provenance: dtor entry → teardown → `State::Close` Assert (`scoped_interface_endpoint_handle.cc:94-96`, RECORDED LEAF)
