### PR TITLE
[crash-0085] Assert WasmStreaming use_count after Unpack

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '10a2ba0a9aa8503018a09fdb60fc88fd9f2c2ea9',
+  'v8_revision': '6e7fc878950f46c98f56d2d6b8eaaece425253b5',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'd76ef062834562d4e71112d5219a73ecdf80f2c1',
+  'v8_revision': '79962d785df66785ae1b9d5c589e4efea1c9245f',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '6e7fc878950f46c98f56d2d6b8eaaece425253b5',
+  'v8_revision': 'd76ef062834562d4e71112d5219a73ecdf80f2c1',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/319
# Summary
* `Managed::Destructor` DataMismatch on `WasmStreaming` refcount at Isolate teardown (recorded 2, replayed 4).
* NoRoot → Assert `streaming.use_count()` after `Unpack` in the two wasm-js callbacks that copy the shared_ptr.


# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data
* Buckets: Mismatch/Managed::Destructor.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260805-ff353501a523-5fa7b5572b6d
* linkerVersion: linker-linux-16081-5fa7b5572b6d
* recordingId: 189f5c63-c167-443d-b5e9-9f4a383c9ec0

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 2665164,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2743455,
      "checkpoint": 88
    }
  },
  "recorded": "Managed::Destructor 2",
  "replayed": "Managed::Destructor 4",
  "threadId": 18,
  "backtrace": {
    "progress": 2735988,
    "threadId": 18,
    "checkpoint": 86
  },
  "recordedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31",
    "v8::internal::Isolate::Deinit()+1064",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100",
    "gin::IsolateHolder::~IsolateHolder()+42",
    "blink::V8PerIsolateData::Destroy(v8::Isolate*)+249",
    "blink::WorkerBackingThread::ShutdownOnBackingThread()+151",
    "blink::WorkerThread::PerformShutdownOnWorkerThread()+525"
  ],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31",
    "v8::internal::Isolate::Deinit()+1064",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100",
    "gin::IsolateHolder::~IsolateHolder()+42",
    "blink::V8PerIsolateData::Destroy(v8::Isolate*)+249",
    "blink::WorkerBackingThread::ShutdownOnBackingThread()+151",
    "blink::WorkerThread::PerformShutdownOnWorkerThread()+525"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recording assertion with events disallowed: ScopedInterfaceEndpointHandle::State::Close cached_group_controller 0 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 1,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "mojo::ScopedInterfaceEndpointHandle::State::Close(absl::optional<mojo::DisconnectReason>.const&)+205",
      "mojo::ScopedInterfaceEndpointHandle::~ScopedInterfaceEndpointHandle()+39",
      "blink::IDBOpenDBRequest::~IDBOpenDBRequest()+73",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::CSSPropertyValueSet::MutableCopy().const+72",
      "blink::StyleRule::MutableProperties()+41",
      "blink::CSSStyleRule::style().const+50",
      "blink::(anonymous.namespace)::v8_css_style_rule::StyleAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+132"
    ],
    "threadId": 1,
    "processId": 2,
    "checkpoint": 1,
    "absoluteTime": 1785994611957.4165,
    "wasRecording": true
  }
]
```

# Data

## Previous Work

* No related prior issues found.
* Searched `$DETERMINATOR_DIR/issues/crash-*/problem.md` for NamedBucket `Managed::Destructor` and Assert leaf/mismatch pair `Managed::Destructor` vs `Managed::Destructor`.
* crash-0011, crash-0013, crash-0014, crash-0015 mention `Managed::Destructor` only inside peripheral Warnings (GC second-pass phantom callback noise), not as their actual mismatch/Assert leaf pair.
  * None share this issue's `Managed::Destructor` vs `Managed::Destructor` recorded/replayed pair (crash-0015's pair is `Managed::Destructor 1` vs `OrderedLock atomic 2671`; crash-0013's is `TaskQueueImpl::TaskRunner::PostDelayedTask` vs `MainThreadSchedulerImpl::PerformMicrotaskCheckpoint`).
* No prior ProblemDoc names a ResidualRisk lineage to this signature.

PlacementParent: none

## DominantWarning

* None.
  * The report's only Warning (`ScopedInterfaceEndpointHandle::State::Close cached_group_controller 0 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]`) is unrelated to the mismatch:
    * threadId 1 vs mismatch's threadId 18.
    * checkpoint 1 vs mismatch's checkpoint 86–88.
    * Stack is mojo IPC endpoint teardown during a cppgc sweep triggered by CSS style allocation — no shared lock, object, or stream with the mismatch's `Managed<v8::WasmStreaming>::Destructor` call during `Isolate::Deinit`/`WorkerThread` shutdown.

## InterestingFrames

* MismatchKind `Data` → single mismatch frame, per rule.
* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31`
  * Shared leaf directly beneath `v8::recordreplay::Assert(...)` in both identical `recordedStack`/`replayedStack`.
* No `DominantWarning` stack (confirmed unrelated above), so no extra subject.

## ResolvedFrames

* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31` — `state: Resolved` (source-mapped directly, no linkerdebug needed).
  * `location`: `Managed<CppType>::Destructor` (template, instantiated for `CppType = v8::WasmStreaming`) at managed.h#L107.
  * `code`: `AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());` at managed.h#L109.
  * `inlineChain`: none — `AssertManagedDestructorRefcount` is declared out-of-line (managed.h#L41-43) specifically so callers of `Destructor` don't need recordreplay headers; it's a real callee frame, just absent from both stacks because `RecordReplayAssertWithStack` re-roots the stack at the caller.
* `AssertSite` (one site serves both `recorded`/`replayed` sides — `Data`-kind mismatch, same call site, divergent value):
  * managed.cc#L47-49, function `v8::internal::AssertManagedDestructorRefcount(long use_count)`:
    * `recordreplay::Assert("Managed::Destructor %ld", use_count);` — matches `"Managed::Destructor 2"` (recorded) / `"Managed::Destructor 4"` (replayed) verbatim modulo the `%ld` value.
  * Verified unique via `rg "Managed::Destructor"` across `chromium/src` and `backend` — exactly this one call site repo-wide.
  * Called with `shared_ptr_ptr->use_count()` from `Managed<CppType>::Destructor` (managed.h#L107-111).

## DominantWarningProvenance

* `DominanceVerdict`: `NoDominantWarning` — `## DominantWarning` is `None`.
* No trail gathered: verdict short-circuits per rule; no `DominanceShape` applies without a candidate warning.

## MismatchProvenance

* `MismatchShape`: `DataMismatch` — both `recordedStack`/`replayedStack` share the one `AssertSite` (managed.cc#L47-49); stacks identical down to the leaf.
  * Per bible `## MismatchShape`, `DataMismatch` → `DivergenceCandidate`s are always Writes (shape-level override of the general `[Branch]`/`[Write]` split, which does not apply here — the "refcounts protecting dtors" `[Branch]` example is for `ControlFlowMismatch`, not this shape).
* `Anchor` (`MismatchKind: Data` → `FrameRecord` of the hit Assert): `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)` — already resolved in `## ResolvedFrames` (managed.h#L107-111).
* `DivergenceCandidate`:
  * The Assert's input, `shared_ptr_ptr->use_count()` (managed.h#L109), is a read, not itself a Write — it is not a `DivergenceCandidate`; it's the mismatched value whose provenance we trace back to Writes.
  * `[Write] UNPROVEN` — the `std::shared_ptr<WasmStreaming>` copy-constructions that mutate this refcount, traced to wasm-js.cc: `std::shared_ptr<v8::WasmStreaming> streaming = v8::WasmStreaming::Unpack(...)` in `WasmStreamingCallbackForTesting` (wasm-js.cc#L529) and `WasmStreamingPromiseFailedCallback` (wasm-js.cc#L552) — stack-scoped locals, lifetime ends at callback return.
    * Further tracing (why one side retains an extra live copy at Isolate teardown, e.g. in-flight streaming callback not yet returned) needs runtime state beyond static reads — stopping point per "trace at most a few links, only while statically safe."
  * No [InvalidAssertValues] violation: both `use_count()` and the shared_ptr copy sites are genuine program-observable state, not driver/linker/recorder values, not inside a Disallow/PassThrough guard, not sync-primitive state.
  * Both sides share this same single candidate — no side left without one.
* Outline:
  ```
  v8::WasmStreamingCallbackForTesting(const v8::FunctionCallbackInfo<v8::Value>& args)
    // [Write] UNPROVEN
    std::shared_ptr<v8::WasmStreaming> streaming = v8::WasmStreaming::Unpack(...);
    // stack-scoped local; lifetime ends at callback return

  v8::WasmStreamingPromiseFailedCallback(const v8::FunctionCallbackInfo<v8::Value>& args)
    // [Write] UNPROVEN
    std::shared_ptr<v8::WasmStreaming> streaming = v8::WasmStreaming::Unpack(...);
    // stack-scoped local; lifetime ends at callback return

  v8::internal::Managed<v8::WasmStreaming>::Destructor(void* ptr)
    auto shared_ptr_ptr = reinterpret_cast<shared_ptr<WasmStreaming>*>(ptr);
    AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());  // <<< RECORDED LEAF / REPLAYED LEAF (recorded=2, replayed=4)
    delete shared_ptr_ptr;

  v8::internal::AssertManagedDestructorRefcount(long use_count)
    recordreplay::Assert("Managed::Destructor %ld", use_count);
  ```

## AssertCandidates

* Both `## MismatchProvenance` `DivergenceCandidate`s decided `ASSERTABLE` — no guard (`AreEventsDisallowed`/`PassThrough`/`DisallowEvents`) around either site (wasm-js.cc checked), not an address/driver/sync value.
* `v8::WasmStreamingCallbackForTesting`
  * assertable: wasm-js.cc#L538 — `streaming.use_count()` right after `streaming = v8::WasmStreaming::Unpack(...)` — proves whether this callback's copy is the extra live ref at teardown.
  * not-assertable: none.
  * provenance: this copy feeds `Managed<WasmStreaming>::Destructor`'s `use_count()` (managed.h#L107-111) → `AssertManagedDestructorRefcount` (managed.cc#L47-49) → hit Assert.
* `v8::WasmStreamingPromiseFailedCallback`
  * assertable: wasm-js.cc#L555 — `streaming.use_count()` right after `streaming = v8::WasmStreaming::Unpack(...)` — same rationale.
  * not-assertable: none.
  * provenance: shared trail with the sibling callback above (both feed the same `Managed<WasmStreaming>::Destructor` refcount at Isolate teardown).
* `v8::WasmStreaming::Unpack` (both call sites) resolves to the real impl in wasm-js.cc (`managed->get()`, returning `const shared_ptr<CppType>&`, copied at each caller) — not the `!V8_ENABLE_WEBASSEMBLY` stub in `api.cc`.
* `MismatchKind` is `Data`, not `StackNoCommonFrame` — no caller-most-frame entry Assert applies.

## DivergenceRoot

* `NoRoot`.
  * `DominantWarningRoot` inapplicable: `## DominantWarningProvenance` verdict is `NoDominantWarning` (short-circuited — no `## DominantWarning` candidate existed), not `Verified`.
  * `AssertCandidateRoot` inapplicable: both `## AssertCandidates` entries (`WasmStreamingCallbackForTesting`, `WasmStreamingPromiseFailedCallback`) are unhit, `ASSERTABLE` proposed Assert *locations* — not sites proven to be the root.
  * Re-checked before settling on `NoRoot`:
    * `DominantWarningProvenance` had no candidate Warning to begin with — not a case of only checking `StateTrail` while skipping `SuppressedEvent`.
    * `determinism-synchronization.md` `# Symptoms` inapplicable — that trigger requires every `## AssertCandidates` entry `NOT-ASSERTABLE`; here both are `ASSERTABLE` (`not-assertable: none` on both).
    * Not a masked "Assert-machinery guards only" case either — both candidates are genuine `[Write]` sites (`shared_ptr<WasmStreaming>` copy construction in wasm-js.cc), not driver/linker/Assert-machinery guards.
  * Ordinary "no Assert hit yet with divergent values": the existing hit Assert only proves the refcount mismatch itself; the two `AssertCandidates` are genuine unhit candidates awaiting a future crash to prove/disprove them.

## PossibleInterventions

* `NoRoot` — none.

## SuggestedCourseOfAction

* `DivergenceRoot` is `NoRoot` → Assert (not an intervention recipe). Endgoal: a future report where the same Assert is hit with divergent values (`DataMismatch`); no single Assert below guarantees that conversion by itself.
* Assert both `## AssertCandidates`:
  * wasm-js.cc#L538 — Assert `streaming.use_count()` in `WasmStreamingCallbackForTesting`, right after `streaming = v8::WasmStreaming::Unpack(...)`.
  * wasm-js.cc#L555 — Assert `streaming.use_count()` in `WasmStreamingPromiseFailedCallback`, right after `streaming = v8::WasmStreaming::Unpack(...)`.