### PR TITLE
[crash-0048-2] Assert WebSQL opened_ open/close gate and SandboxedVfs fd identity

### DIFF
--- a/sql/sandboxed_vfs_file.cc
+++ b/sql/sandboxed_vfs_file.cc
@@ -137,9 +137,8 @@ void SandboxedVfsFile::Create(base::File file,
 #endif  // DCHECK_IS_ON()
                               SandboxedVfs* vfs,
                               sqlite3_file& buffer) {
-  recordreplay::Assert("SandboxedVfsFile::Create %s %d",
-                       file_path.AsUTF8Unsafe().c_str(),
-                       file.GetPlatformFile());
+  REPLAY_ASSERT("SandboxedVfsFile::Create %s %d",
+                file_path.AsUTF8Unsafe().c_str(), file.GetPlatformFile());
   SandboxedVfsFileSqliteBridge& bridge =
       SandboxedVfsFileSqliteBridge::FromSqliteFile(buffer);
   bridge.sandboxed_vfs_file =
@@ -158,10 +157,9 @@ SandboxedVfsFile& SandboxedVfsFile::FromSqliteFile(sqlite3_file& sqlite_file) {
 }
 
 int SandboxedVfsFile::Close() {
-  recordreplay::Assert("SandboxedVfsFile::Close %d %s %d",
-                       recordreplay::PointerId(this),
-                       file_path_.AsUTF8Unsafe().c_str(),
-                       file_.GetPlatformFile());
+  REPLAY_ASSERT("SandboxedVfsFile::Close %d %s %d",
+                recordreplay::PointerId(this),
+                file_path_.AsUTF8Unsafe().c_str(), file_.GetPlatformFile());
   file_.Close();
   delete this;
   return SQLITE_OK;

--- a/sql/sandboxed_vfs_file.cc
+++ b/sql/sandboxed_vfs_file.cc
@@ -14,6 +14,7 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/notreached.h"
+#include "base/record_replay.h"
 #include "base/threading/platform_thread.h"
 #include "build/build_config.h"
 #include "sql/initialization.h"
@@ -136,6 +137,9 @@ void SandboxedVfsFile::Create(base::File file,
 #endif  // DCHECK_IS_ON()
                               SandboxedVfs* vfs,
                               sqlite3_file& buffer) {
+  recordreplay::Assert("SandboxedVfsFile::Create %s %d",
+                       file_path.AsUTF8Unsafe().c_str(),
+                       file.GetPlatformFile());
   SandboxedVfsFileSqliteBridge& bridge =
       SandboxedVfsFileSqliteBridge::FromSqliteFile(buffer);
   bridge.sandboxed_vfs_file =
@@ -154,6 +158,10 @@ SandboxedVfsFile& SandboxedVfsFile::FromSqliteFile(sqlite3_file& sqlite_file) {
 }
 
 int SandboxedVfsFile::Close() {
+  recordreplay::Assert("SandboxedVfsFile::Close %d %s %d",
+                       recordreplay::PointerId(this),
+                       file_path_.AsUTF8Unsafe().c_str(),
+                       file_.GetPlatformFile());
   file_.Close();
   delete this;
   return SQLITE_OK;

--- a/third_party/blink/renderer/modules/webdatabase/database.cc
+++ b/third_party/blink/renderer/modules/webdatabase/database.cc
@@ -428,12 +428,11 @@ const char* Database::DatabaseInfoTableName() {
 
 void Database::CloseDatabase() {
   bool opened = opened_.load(std::memory_order_relaxed);
-  recordreplay::Assert("Database::CloseDatabase %d %d", RecordReplayId(),
-                       opened);
+  REPLAY_ASSERT("Database::CloseDatabase %d %d", RecordReplayId(), opened);
   if (!opened)
     return;
 
-  recordreplay::Assert("Database::opened_ store %d 0", RecordReplayId());
+  REPLAY_ASSERT("Database::opened_ store %d 0", RecordReplayId());
   opened_.store(false, std::memory_order_release);
   sqlite_database_.Close();
   // See comment at the top this file regarding calling removeOpenDatabase().
@@ -447,7 +446,7 @@ void Database::CloseDatabase() {
 
 bool Database::Opened() {
   bool opened = opened_.load(std::memory_order_acquire);
-  recordreplay::Assert("Database::Opened %d %d", RecordReplayId(), opened);
+  REPLAY_ASSERT("Database::Opened %d %d", RecordReplayId(), opened);
   return opened;
 }
 
@@ -615,7 +614,7 @@ bool Database::PerformOpenAndVerify(bool should_set_version_in_new_database,
 
   // See comment at the top this file regarding calling addOpenDatabase().
   DatabaseTracker::Tracker().AddOpenDatabase(this);
-  recordreplay::Assert("Database::opened_ store %d 1", RecordReplayId());
+  REPLAY_ASSERT("Database::opened_ store %d 1", RecordReplayId());
   opened_.store(true, std::memory_order_release);
 
   // Declare success:

--- a/third_party/blink/renderer/modules/webdatabase/database.cc
+++ b/third_party/blink/renderer/modules/webdatabase/database.cc
@@ -30,6 +30,7 @@
 
 #include "base/synchronization/waitable_event.h"
 #include "base/thread_annotations.h"
+#include "base/record_replay.h"
 #include "third_party/blink/public/platform/platform.h"
 #include "third_party/blink/public/platform/task_type.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
@@ -426,9 +427,13 @@ const char* Database::DatabaseInfoTableName() {
 }
 
 void Database::CloseDatabase() {
-  if (!opened_.load(std::memory_order_relaxed))
+  bool opened = opened_.load(std::memory_order_relaxed);
+  recordreplay::Assert("Database::CloseDatabase %d %d", RecordReplayId(),
+                       opened);
+  if (!opened)
     return;
 
+  recordreplay::Assert("Database::opened_ store %d 0", RecordReplayId());
   opened_.store(false, std::memory_order_release);
   sqlite_database_.Close();
   // See comment at the top this file regarding calling removeOpenDatabase().
@@ -438,6 +443,12 @@ void Database::CloseDatabase() {
     base::AutoLock locker(cache.GetLock());
     cache.ReleaseGuid(guid_);
   }
+}
+
+bool Database::Opened() {
+  bool opened = opened_.load(std::memory_order_acquire);
+  recordreplay::Assert("Database::Opened %d %d", RecordReplayId(), opened);
+  return opened;
 }
 
 String Database::version() const {
@@ -604,6 +615,7 @@ bool Database::PerformOpenAndVerify(bool should_set_version_in_new_database,
 
   // See comment at the top this file regarding calling addOpenDatabase().
   DatabaseTracker::Tracker().AddOpenDatabase(this);
+  recordreplay::Assert("Database::opened_ store %d 1", RecordReplayId());
   opened_.store(true, std::memory_order_release);
 
   // Declare success:

--- a/third_party/blink/renderer/modules/webdatabase/database.h
+++ b/third_party/blink/renderer/modules/webdatabase/database.h
@@ -96,7 +96,7 @@ class Database final : public ScriptWrappable {
                           SQLTransaction::OnErrorCallback*,
                           SQLTransaction::OnSuccessCallback*);
 
-  bool Opened() { return opened_.load(std::memory_order_acquire); }
+  bool Opened();
   bool IsNew() const { return new_; }
 
   const SecurityOrigin* GetSecurityOrigin() const;

--- a/third_party/blink/renderer/modules/webdatabase/sqlite/sqlite_database.cc
+++ b/third_party/blink/renderer/modules/webdatabase/sqlite/sqlite_database.cc
@@ -27,6 +27,7 @@
 #include "third_party/blink/renderer/modules/webdatabase/sqlite/sqlite_database.h"
 
 #include "base/notreached.h"
+#include "base/record_replay.h"
 #include "sql/sandboxed_vfs.h"
 #include "third_party/blink/renderer/modules/webdatabase/database_authorizer.h"
 #include "third_party/blink/renderer/modules/webdatabase/sqlite/sandboxed_vfs_delegate.h"
@@ -130,6 +131,8 @@ bool SQLiteDatabase::Open(const String& filename) {
 }
 
 void SQLiteDatabase::Close() {
+  recordreplay::Assert("SQLiteDatabase::Close %d",
+                       recordreplay::PointerId(this));
   if (db_) {
     // FIXME: This is being called on the main thread during JS GC.
     // <rdar://problem/5739818>

--- a/third_party/blink/renderer/modules/webdatabase/sqlite/sqlite_database.cc
+++ b/third_party/blink/renderer/modules/webdatabase/sqlite/sqlite_database.cc
@@ -131,8 +131,7 @@ bool SQLiteDatabase::Open(const String& filename) {
 }
 
 void SQLiteDatabase::Close() {
-  recordreplay::Assert("SQLiteDatabase::Close %d",
-                       recordreplay::PointerId(this));
+  REPLAY_ASSERT("SQLiteDatabase::Close %d", recordreplay::PointerId(this));
   if (db_) {
     // FIXME: This is being called on the main thread during JS GC.
     // <rdar://problem/5739818>


### PR DESCRIPTION
# Summary

* Symptom: `Call __close Arg:0` DataMismatch on WebSQL `SandboxedClose` / `SQLiteDatabase::Close` (fd 185 vs 183).
* Leading candidate: unordered `Database::opened_` CrossThreadScalar gates which close runs.
* Intervention: Assert `opened_` loads/stores and secondary identity/fd Asserts on `SQLiteDatabase::Close` / `SandboxedVfsFile::{Create,Close}`.


# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data
* Buckets: Mismatch/base::internal::ScopedFDCloseTraits::Free.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260805-ff353501a523-5fa7b5572b6d
* linkerVersion: linker-linux-16081-5fa7b5572b6d
* recordingId: 934f61c1-35b3-4621-bc6a-c2b137a82bb1

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 2298579,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 682115,
      "checkpoint": 238
    }
  },
  "recorded": "Call __close Arg:0:185",
  "replayed": "Call __close Arg:0:183",
  "threadId": 19,
  "backtrace": {
    "progress": 678926,
    "threadId": 19,
    "checkpoint": 236
  },
  "recordedStack": [
    "base::internal::ScopedFDCloseTraits::Free(int)+11",
    "base::File::Close()+191",
    "sql::(anonymous.namespace)::SandboxedClose(sqlite3_file*)+18",
    "sqlite3PagerClose+393",
    "sqlite3BtreeClose+37",
    "sqlite3LeaveMutexAndCloseZombie+220",
    "sqlite3Close+296",
    "blink::SQLiteDatabase::Close()+60"
  ],
  "replayedStack": [
    "base::internal::ScopedFDCloseTraits::Free(int)+11",
    "base::File::Close()+191",
    "sql::(anonymous.namespace)::SandboxedClose(sqlite3_file*)+18",
    "sqlite3PagerClose+393",
    "sqlite3BtreeClose+37",
    "sqlite3LeaveMutexAndCloseZombie+220",
    "sqlite3Close+296",
    "blink::SQLiteDatabase::Close()+60"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed atomic [EventsDisallowed:Heap::CollectGarbage]",
    "count": 53,
    "stack": [
      "WTF::RecursiveMutex::unlock()+135",
      "blink::AudioNode::Dispose()+228",
      "blink::AudioNode::InvokePreFinalizer(cppgc::LivenessBroker.const&,.void*)+44",
      "cppgc::internal::PreFinalizerHandler::InvokePreFinalizers()+214",
      "cppgc::internal::HeapBase::ExecutePreFinalizers()+39",
      "v8::internal::CppHeap::TraceEpilogue()+210",
      "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector,.v8::internal::GarbageCollectionReason,.char.const*,.v8::GCCallbackFlags)+3404",
      "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,.v8::internal::GarbageCollectionReason,.v8::GCCallbackFlags)+2397",
      "v8::internal::Heap::HandleGCRequest()+223",
      "v8::internal::StackGuard::HandleInterrupts()+626",
      "v8::internal::Runtime_StackGuard(int,.unsigned.long*,.v8::internal::Isolate*)+314"
    ],
    "progress": 4429,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 13,
    "absoluteTime": 1785948555230.4968,
    "wasRecording": true
  },
  {
    "text": "Recording assertion with events disallowed: ScopedInterfaceEndpointHandle::State::Close cached_group_controller 0 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 5,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "mojo::ScopedInterfaceEndpointHandle::State::Close(absl::optional<mojo::DisconnectReason>.const&)+205",
      "mojo::ScopedInterfaceEndpointHandle::~ScopedInterfaceEndpointHandle()+39",
      "blink::IDBOpenDBRequest::~IDBOpenDBRequest()+73",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::Node::CreateRareData()+114",
      "blink::ContainerNode::Children()+23",
      "blink::(anonymous.namespace)::v8_document_fragment::ChildrenAttributeGetCallbackForMainWorld(v8::FunctionCallbackInfo<v8::Value>.const&)+129",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtins::InvokeApiFunction(v8::internal::Isolate*,.bool,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*,.v8::internal::Handle<v8::internal::HeapObject>)+646",
      "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+727",
      "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
      "v8::internal::LoadIC::Load(v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Name>,.bool,.v8::internal::Handle<v8::internal::Object>)+2457",
      "v8::internal::Runtime_LoadIC_Miss(int,.unsigned.long*,.v8::internal::Isolate*)+495"
    ],
    "progress": 4429,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 13,
    "absoluteTime": 1785948555230.5728,
    "wasRecording": true
  },
  {
    "text": "Recorded value with events disallowed TryLock [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 42,
    "stack": [
      "WTF::RecursiveMutex::lock()+59",
      "blink::BaseAudioContext::~BaseAudioContext()+83",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::NGInlineChildLayoutContext::NGInlineChildLayoutContext(blink::NGInlineNode.const&,.blink::NGBoxFragmentBuilder*)+100",
      "blink::NGBlockLayoutAlgorithm::LayoutWithInlineChildLayoutContext(blink::NGLayoutInputNode.const&)+75",
      "blink::NGBlockLayoutAlgorithm::Layout()+107",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::ComputeOutOfFlowBlockDimensions(blink::NGBlockNode.const&,.blink::ComputedStyle.const&,.blink::NGConstraintSpace.const&,.blink::NGLogicalOutOfFlowInsets.const&,.blink::NGBoxStrut.const&,.blink::NGLogicalStaticPosition.const&,.blink::LogicalSize,.absl::optional<blink::LogicalSize>.const&,.blink::WritingDirectionMode,.blink::Length::AnchorEvaluator.const*,.blink::NGLogicalOutOfFlowDimensions*)::$_1::operator()().const+694",
      "blink::ComputeOutOfFlowBlockDimensions(blink::NGBlockNode.const&,.blink::ComputedStyle.const&,.blink::NGConstraintSpace.const&,.blink::NGLogicalOutOfFlowInsets.const&,.blink::NGBoxStrut.const&,.blink::NGLogicalStaticPosition.const&,.blink::LogicalSize,.absl::optional<blink::LogicalSize>.const&,.blink::WritingDirectionMode,.blink::Length::AnchorEvaluator.const*,.blink::NGLogicalOutOfFlowDimensions*)+623",
      "blink::NGOutOfFlowLayoutPart::TryCalculateOffset(blink::NGOutOfFlowLayoutPart::NodeInfo.const&,.blink::ComputedStyle.const&,.blink::LayoutBox.const*,.blink::NGLogicalAnchorQuery.const*,.bool,.bool,.blink::NGOutOfFlowLayoutPart::OffsetInfo*)+1626",
      "blink::NGOutOfFlowLayoutPart::CalculateOffset(blink::NGOutOfFlowLayoutPart::NodeInfo.const&,.blink::LayoutBox.const*,.bool,.blink::NGLogicalAnchorQuery.const*)+260",
      "blink::NGOutOfFlowLayoutPart::LayoutCandidates(blink::HeapVector<blink::NGLogicalOutOfFlowPositionedNode,.0u>*,.blink::LayoutBox.const*,.blink::HeapHashSet<cppgc::internal::BasicMember<blink::LayoutObject.const,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>,.WTF::MemberHashRecordReplayId<blink::LayoutObject.const>,.WTF::HashTraits<cppgc::internal::BasicMember<blink::LayoutObject.const,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>.>.>*)+911",
      "blink::NGOutOfFlowLayoutPart::Run(blink::LayoutBox.const*)+230",
      "blink::NGBlockLayoutAlgorithm::FinishLayout(blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*)+2312",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+2827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
      "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
      "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
      "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
      "blink::NGBlockLayoutAlgorithm::Layout()+119",
      "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
      "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
      "blink::LayoutNGView::UpdateBlockLayout(bool)+97",
      "blink::LayoutBlock::UpdateLayout()+124",
      "blink::LayoutView::UpdateLayout()+691",
      "blink::LocalFrameView::PerformLayout()+2901",
      "blink::LocalFrameView::UpdateLayout()+444",
      "blink::LocalFrameView::UpdateStyleAndLayoutInternal()+319",
      "blink::LocalFrameView::UpdateStyleAndLayout()+346",
      "blink::LocalFrameView::UpdateStyleAndLayoutIfNeededRecursive()+131",
      "blink::LocalFrameView::RunStyleAndLayoutLifecyclePhases(blink::DocumentLifecycle::LifecycleState)+72",
      "blink::LocalFrameView::UpdateLifecyclePhasesInternal(blink::DocumentLifecycle::LifecycleState)+270",
      "blink::LocalFrameView::UpdateLifecyclePhases(blink::DocumentLifecycle::LifecycleState,.blink::DocumentUpdateReason)+458",
      "blink::LocalFrameView::UpdateAllLifecyclePhases(blink::DocumentUpdateReason)+145",
      "blink::PageAnimator::UpdateAllLifecyclePhases(blink::LocalFrame&,.blink::DocumentUpdateReason)+81",
      "blink::WebFrameWidgetImpl::UpdateLifecycle(blink::WebLifecycleUpdate,.blink::DocumentUpdateReason)+143",
      "non-virtual.thunk.to.blink::WidgetBase::UpdateVisualState()+76",
      "cc::LayerTreeHost::RequestMainFrameUpdate(bool)+23",
      "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+1092",
      "base::internal::Invoker<base::internal::BindState<void.(reporting::EncryptedReportingUploadProvider::UploadHelper::*)(std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>),.base::WeakPtr<reporting::EncryptedReportingUploadProvider::UploadHelper>,.std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+144",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629"
    ],
    "progress": 4716,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 18,
    "absoluteTime": 1785948555455.5642,
    "wasRecording": true
  },
  {
    "text": "JSInvoke:BLOCKED:NonDeterministicUserJS PC=589395 scriptId=-1 @https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:117315 stack=console.debug (<anonymous>)https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:117351https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:117404_I0Pa (https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:177221)https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:177226https://ynflift-com-clone-ug8lzbzr-cdevpc.netlify.app/__o/banti-static.cdn.bcebos.com/o/static/banti_4984ec8f17.js?_=247968:1:177264 [EventsDisallowed:V8InspectorImpl::forEachSession]",
    "count": 1,
    "stack": [
      "v8::recordreplay::Warning(char.const*,....)+140",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+3078",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+852",
      "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
      "v8::internal::Runtime::GetObjectProperty(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.bool*)+174",
      "v8::Object::Get(v8::Local<v8::Context>,.v8::Local<v8::Value>)+260",
      "v8_inspector::(anonymous.namespace)::descriptionForError(v8::Local<v8::Context>,.v8::Local<v8::Object>,.v8_inspector::(anonymous.namespace)::ErrorType)+186",
      "v8_inspector::ValueMirror::create(v8::Local<v8::Context>,.v8::Local<v8::Value>)+914",
      "v8_inspector::InjectedScript::wrapObject(v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_inspector::WrapMode,.v8::MaybeLocal<v8::Value>,.int,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::RemoteObject,.std::Cr::default_delete<v8_inspector::protocol::Runtime::RemoteObject>.>*)+104",
      "v8_inspector::InjectedScript::wrapObject(v8::Local<v8::Value>,.v8_inspector::String16.const&,.v8_inspector::WrapMode,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::RemoteObject,.std::Cr::default_delete<v8_inspector::protocol::Runtime::RemoteObject>.>*)+23",
      "v8_inspector::V8InspectorSessionImpl::wrapObject(v8::Local<v8::Context>,.v8::Local<v8::Value>,.v8_inspector::String16.const&,.bool)+138",
      "v8_inspector::V8ConsoleMessage::wrapArguments(v8_inspector::V8InspectorSessionImpl*,.bool).const+518",
      "v8_inspector::V8ConsoleMessage::reportToFrontend(v8_inspector::protocol::Runtime::Frontend*,.v8_inspector::V8InspectorSessionImpl*,.bool).const+565",
      "v8_inspector::V8RuntimeAgentImpl::messageAdded(v8_inspector::V8ConsoleMessage*)+44",
      "v8_inspector::V8InspectorImpl::forEachSession(int,.std::Cr::function<void.(v8_inspector::V8InspectorSessionImpl*)>.const&)+651",
      "v8_inspector::V8ConsoleMessageStorage::addMessage(std::Cr::unique_ptr<v8_inspector::V8ConsoleMessage,.std::Cr::default_delete<v8_inspector::V8ConsoleMessage>.>)+702",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType,.std::Cr::vector<v8::Local<v8::Value>,.std::Cr::allocator<v8::Local<v8::Value>.>.>.const&)+187",
      "v8_inspector::(anonymous.namespace)::ConsoleHelper::reportCall(v8_inspector::ConsoleAPIType)+185",
      "v8_inspector::V8Console::Debug(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&)+355",
      "v8::internal::(anonymous.namespace)::ConsoleCall(v8::internal::Isolate*,.v8::internal::BuiltinArguments.const&,.void.(v8::debug::ConsoleDelegate::*)(v8::debug::ConsoleCallArguments.const&,.v8::debug::ConsoleContext.const&))+800",
      "v8::internal::Builtin_ConsoleDebug(int,.unsigned.long*,.v8::internal::Isolate*)+74"
    ],
    "progress": 589395,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 235,
    "absoluteTime": 1785948565458.365,
    "wasRecording": false
  }
]
```

# Data

## Previous Work

* crash-0048 — same bucket `base::internal::ScopedFDCloseTraits::Free`; identical `Call __close Arg:0` mismatch on WebSQL `SandboxedClose`/`SQLiteDatabase::Close` stack.
  * Root cause: `SharedSyscallResourceUnorderedRead` — fd is a SharedSyscallResource read unordered via Mojo `PlatformHandle`/`TakePlatformFile` on a non-producing thread.
  * Fix recipe: `determinism-shared-syscall-resource` / `RecordReplayValue` at `Serializer<PlatformHandle>::Deserialize`.
* `PlacementParent: crash-0048`

## DominantWarning

* None.
  * All 4 warnings fire on threadId 1 (checkpoints 13, 18, 235); mismatch is threadId 19 (checkpoint 236).
  * **IdbCloseWarning** (not Dominant): `ScopedInterfaceEndpointHandle::State::Close` during `IDBOpenDBRequest::~IDBOpenDBRequest` under `EventsDisallowed:Sweeper::SweepForAllocationIfRunning`.
    * No fd on `IDBOpenDBRequest` — Mojo endpoint only (idb_open_db_request.cc:64).
    * No `StateTrail` into WebSQL/`SandboxedClose`.
  * Other warnings: GC `AudioNode::Dispose` lock, `BaseAudioContext` TryLock, blocked inspector JS — same: other thread, no fd/WebSQL trail.

## InterestingFrames

* `base::internal::ScopedFDCloseTraits::Free(int)+11` — sole InterestingFrame; MismatchKind is `Data`, and this is the shared leaf frame (identical in `recordedStack`/`replayedStack`) where the fd-value Assert hit.
* No `DominantWarning` stack exists, so no frames selected from it.

## ResolvedFrames

* `base::internal::ScopedFDCloseTraits::Free(int)+11`
  * location: `base::internal::ScopedFDCloseTraits::Free(int)` at scoped_file.cc:23
  * code: `int ret = IGNORE_EINTR(close(fd));` (scoped_file.cc:31)
  * inlineChain: none — `IGNORE_EINTR` is a retry-loop macro around the `close(fd)` libc call; no further Chromium function inlined here.
  * state: `Resolved`
* `AssertSite` (shared by both `recorded`/`replayed`, since a single Assert hit both sides):
  * RecordedCall.cpp:229-230, in `DoIntercept` (static, `RecordedCall.cpp`).
  * `RecordReplayAssertWithStack(aArguments->stackPointer, "Call %s%s", spec.mName, inputs.c_str())` → `spec.mName="__close"`, `inputs` = formatted `" Arg:0:<fd>"`.
  * Not visible in reported stacks: uses `aArguments->stackPointer` (captured at the intercepted `close(fd)` call site inside `Free`), re-rooting the stack there instead of through `DoIntercept`.
* `MismatchShape`: `DataMismatch` — both sides share the one `AssertSite` (`DoIntercept`); divergent `recorded`/`replayed` values (`Arg:0:185` vs `Arg:0:183`), not divergent Assert sites.

## DominantWarningProvenance

* `DominanceVerdict`: `NoDominantWarning`.
  * `## DominantWarning` is `None` (see above) — no Warning site exists to anchor a trail on.
  * All `DominanceShape`s vacuously fail: no `StateTrail` (no Warning writes state read by the mismatch path) and no `SuppressedEvent` (no Warning stack touches the fd/Mojo `PlatformHandle`/sqlite `File::Close` stream/lock).

## FrameAnchors

* `base::internal::ScopedFDCloseTraits::Free(int)+11` — sole anchor; MismatchKind `Data` selects the single non-divergent location of the hit Assert.
  * Only entry in `## ResolvedFrames`; identical on `recordedStack`/`replayedStack`.
  * location/code/state as recorded under `## ResolvedFrames` above.

## MismatchProvenance

* `DominanceVerdict` is `NoDominantWarning` (not `Verified`) → full provenance below (not skipped).
* `MismatchShape`: `DataMismatch` — mismatched input is `Arg:0` (`fd`).
* **OpenedAtomicBranch** — `Database::CloseDatabase` gates `sqlite_database_.Close()` on unordered atomic `opened_`:
  * [Branch] database.cc:430 — `if (!opened_.load(std::memory_order_relaxed)) return;`
  * Decl: `std::atomic_bool opened_` — written DB thread, read multi-thread.
  * Stores: `store(true, release)` on open success; `store(false, release)` on close path.
  * Other [Branch]s on `Opened()` (acquire): `CloseImmediately`, `SQLTransaction` / `SQLTransactionBackend`.
  * Divergent open/close via this atomic → which `SQLiteDatabase`/`SandboxedVfsFile` close runs → divergent `fd` cargo at hit.
* HitCloseBurst siblings `185→184→187→183` (dump/t19-closes-all.jsonl); replayed Arg = later sibling.
* Close path after the branch takes the open arm:
  * `SQLiteDatabase::Close` → `SandboxedVfsFile::Close` → `File::Close` → `Free(fd)` `// <<< LEAF`
* Fd cargo Write (still Mojo `TakeFd`/`Create`): secondary; symptom if **OpenedAtomicBranch** skews which file closes here.
* **IdbFdAssert**: infeasible — no fd on `IDBOpenDBRequest`.

## AssertCandidates

* `Database::CloseDatabase` / `opened_`
  * assertable:
    * database.cc:430 — Assert `RecordReplayId` + loaded `opened` **before** the relaxed-load branch.
    * store(true) / store(false) sites — Assert id + value written.
    * `Database::Opened` — Assert id + acquire-load value (feeds other open/close branches).
  * not-assertable: none.
  * provenance: `opened_` branch → `Close` → `Free(fd)` hit.
* `SQLiteDatabase::Close` / `SandboxedVfsFile::{Create,Close}` — identity+fd Asserts (cargo / which-file), secondary to the atomic branch.
* `IDBOpenDBRequest` — not-assertable for fd.

## DivergenceRoot

* `NoRoot` — **OpenedAtomicBranch** is the leading unproven candidate (`CrossThreadScalar` shape); not yet hit-proven.

## PossibleInterventions

* `NoRoot` → none yet.
* If **OpenedAtomicBranch** proves: `determinism-synchronization` / `OrderedAtomic` on `opened_` (determinism-synchronization.md `CrossThreadScalar`).

# Solution

* Assert the unordered `opened_` open/close gate:
  * `CloseDatabase` — id + relaxed load before branch.
  * `Opened()` — id + acquire load.
  * both `opened_` stores.
* Keep secondary identity/fd Asserts on `SQLiteDatabase::Close` / `SandboxedVfsFile::{Create,Close}`.
* Do **not** Assert `IDBOpenDBRequest` fd.
