### PR TITLE
[crash-0010-2] Assert DoDeriveKey cancelled and DidRunTask nesting_depth

### DIFF
--- a/base/task/sequence_manager/sequence_manager_impl.cc
+++ b/base/task/sequence_manager/sequence_manager_impl.cc
@@ -760,6 +760,8 @@ void SequenceManagerImpl::DidRunTask(LazyNow& lazy_now) {
   NotifyDidProcessTask(&executing_task, &lazy_now);
   main_thread_only().task_execution_stack.pop_back();
 
+  recordreplay::Assert("SequenceManagerImpl::DidRunTask nesting_depth %d",
+                       main_thread_only().nesting_depth);
   if (main_thread_only().nesting_depth == 0)
     CleanUpQueues();
 }

--- a/components/webcrypto/webcrypto_impl.cc
+++ b/components/webcrypto/webcrypto_impl.cc
@@ -638,6 +638,8 @@ void DoDeriveKeyReply(std::unique_ptr<DeriveKeyState> state) {
 void DoDeriveKey(std::unique_ptr<DeriveKeyState> passed_state) {
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "DoDeriveKey");
   DeriveKeyState* state = passed_state.get();
+  recordreplay::Assert("webcrypto::DoDeriveKey cancelled %d",
+                       state->cancelled());
   if (state->cancelled())
     return;
   state->status = webcrypto::DeriveKey(


### PR DESCRIPTION
# Summary

* StackCommonFrame: recorded `PostDelayedTask` vs replayed `CleanUpQueues`.
* `NoRoot`: Assert both innermost Branches on the spans.
  * `webcrypto::DoDeriveKey`: `cancelled` before the early-return Branch.
  * `SequenceManagerImpl::DidRunTask`: `nesting_depth` before `CleanUpQueues`.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* Buckets: Mismatch/[RUN-2217] SequenceManagerImpl::CleanUpQueues, Mismatch/TaskQueueImpl::TaskRunner::PostDelayedTask.
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Important Context

* buildId: linux-chromium-20260805-ff353501a523-5fa7b5572b6d
* linkerVersion: linker-linux-16081-5fa7b5572b6d
* recordingId: d99d40e9-1b00-4164-86e5-9fd46a957e67

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "CreateDiffRoot",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2345474,
      "checkpoint": 945
    }
  },
  "recorded": "TaskQueueImpl::TaskRunner::PostDelayedTask 44130",
  "replayed": "[RUN-2217] SequenceManagerImpl::CleanUpQueues 0",
  "threadId": 33,
  "backtrace": {
    "progress": 2341431,
    "threadId": 33,
    "checkpoint": 941
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "base::sequence_manager::internal::TaskQueueImpl::TaskRunner::PostDelayedTask(base::Location.const&,.base::OnceCallback<void.()>,.base::TimeDelta)+79",
    "base::TaskRunner::PostTask(base::Location.const&,.base::OnceCallback<void.()>)+39",
    "webcrypto::(anonymous.namespace)::DoDeriveKey(std::Cr::unique_ptr<webcrypto::(anonymous.namespace)::DeriveKeyState,.std::Cr::default_delete<webcrypto::(anonymous.namespace)::DeriveKeyState>.>)+297",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
    "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21"
  ],
  "replayedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "base::sequence_manager::internal::SequenceManagerImpl::CleanUpQueues()+41",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1078",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
    "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
    "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
    "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
    "base::RunLoop::Run(base::Location.const&)+461"
  ]
}
```

# Data

## Previous Work

* crash-0010 — same `CleanUpQueues()+41` Assert leaf, identical `DoWorkImpl+1078`/`+1001` frame pair (sides swapped there); root cause: unsynchronized `is_active_` read in `LowPrecisionTimer::SchedulableCallback::MaybeRun`, fixed via ordered-lock recipe.

PlacementParent: crash-0010

## DominantWarning

* None: `report.json`'s `crash_report.warnings` array is empty; no `EventsDisallowed` or other warning entries present.

## InterestingFrames

* Shared frames: `DoWorkImpl`/`DoWork`/`non-virtual thunk to DoWork`; top-most shared = `DoWorkImpl`.
* recordedStack:
  * `ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001` — top-most shared frame; task-selection loop guarded by unasserted `task_execution_allowed`/quit-loop branches (surrounds Asserts #5–#8 in `thread_controller_with_message_pump_impl.cc`).
  * `TaskQueueImpl::TaskRunner::PostDelayedTask(base::Location const&,.base::OnceCallback<void()>,.base::TimeDelta)+79` — leaf; Assert itself gated by unasserted `!AreEventsDisallowed() && !AreEventsPassedThrough()` (`task_queue_impl.cc`).
  * `webcrypto::(anonymous namespace)::DoDeriveKey(...)+297` — caller-ward, feature-specific frame invoking PostTask (not generic routing).
* replayedStack:
  * `ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1078` — same top-most shared frame, different offset/branch than recorded side.
  * `SequenceManagerImpl::CleanUpQueues()+41` — leaf; branches on unasserted `queues_to_gracefully_shutdown` iteration/`IsEmpty()` checks (`sequence_manager_impl.cc`).
* Code scan confirms `DoDeriveKey` (`components/webcrypto/webcrypto_impl.cc`): early-returns on unasserted `state->cancelled()`; otherwise runs `webcrypto::DeriveKey(...)` then `state->origin_thread->PostTask(FROM_HERE, BindOnce(DoDeriveKeyReply, ...))` — feature-specific, conditionally reaches `PostTask`, not generic routing.

## ResolvedFrames

* All offsets below are return addresses (post-`call`); each verified against its disasm `call` target and `RepoSrc`. All `state: Resolved`.
* `DoWorkImpl+1001` (recordedStack): `thread_controller_with_message_pump_impl.cc:458` — `task_annotator_.RunTask("ThreadControllerImpl::RunTask", selected_task->task, ...)`; inlineChain: `TaskAnnotator::RunTask` (header-inline) → `TaskAnnotator::RunTaskImpl` (real call).
* `DoWorkImpl+1078` (replayedStack): `thread_controller_with_message_pump_impl.cc:469` — `main_thread_only().task_source->DidRunTask(lazy_now_after_run_task);`; no inlining (virtual call, vtable slot `0x18`).
* `TaskQueueImpl::TaskRunner::PostDelayedTask+79`: `task_queue_impl.cc:160` — `recordreplay::Assert("TaskQueueImpl::TaskRunner::PostDelayedTask %d", recordreplay::PointerId(this));`; no inlining.
* `SequenceManagerImpl::CleanUpQueues+41`: `sequence_manager_impl.cc:1152` — `recordreplay::Assert("[RUN-2217] SequenceManagerImpl::CleanUpQueues %zu", main_thread_only().queues_to_gracefully_shutdown.size());`; no inlining.
* `DoDeriveKey+297`: `components/webcrypto/webcrypto_impl.cc:647` — `state->origin_thread->PostTask(FROM_HERE, base::BindOnce(DoDeriveKeyReply, std::move(passed_state)));`; no inlining.
* `AssertSite` recorded = `TaskQueueImpl::TaskRunner::PostDelayedTask+79`'s own site (`task_queue_impl.cc:160`, enclosing `TaskQueueImpl::TaskRunner::PostDelayedTask`) — format string matches `recorded: "TaskQueueImpl::TaskRunner::PostDelayedTask 44130"`.
* `AssertSite` replayed = `SequenceManagerImpl::CleanUpQueues+41`'s own site (`sequence_manager_impl.cc:1152`, enclosing `SequenceManagerImpl::CleanUpQueues`) — format string matches `replayed: "[RUN-2217] SequenceManagerImpl::CleanUpQueues 0"`.
* Both `AssertSite`s are absent from their stacks: `recordreplay::Assert(...)+141` is the re-rooted caller frame per `RecordReplayAssertWithStack`; disasm confirms both `+41` and `+79` are the return addresses immediately after their respective `call recordreplay::Assert`.

## DominantWarningProvenance

* `DominanceVerdict: NoDominantWarning` — `## DominantWarning` is `None` (`report.json`'s `warnings` array is `[]`), so there is no warning site to trail to the mismatch.

## MismatchProvenance

* MismatchShape: `ControlFlowMismatch` — sides don't share one `AssertSite` (two different Asserts hit; see `## ResolvedFrames`).
* Anchor: the shared `DoWorkImpl+1001`/`+1078` frame pair (`## ResolvedFrames`).
* `LastNonHitAssert` shared by both spans: `[RUN-1124] ...DoWorkImpl #6` (`thread_controller_with_message_pump_impl.cc:435`).
* DivergenceCandidate, recorded span (`#6` → `PostDelayedTask` Assert, via `RunTask` → task exec → `webcrypto::DoDeriveKey` → `PostTask`(passthrough, no branch) → `PostDelayedTask`):
  * `[Branch] if (state->cancelled()) return;` (`webcrypto_impl.cc:641`) — `RECORDED: else-arm` (proven: reached `PostTask` at `:647`).
  * Dropped: the Assert's own guard `!AreEventsDisallowed() && !AreEventsPassedThrough()` (`task_queue_impl.cc:159`) — unconditionally invalid per [InvalidAssertValues] (Assert-machinery gate, not divergence).
* DivergenceCandidate, replayed span (`#6` → `CleanUpQueues` Assert, via `DidRunTask` (`:469`) → `SequenceManagerImpl::DidRunTask`):
  * `[Branch] if (main_thread_only().nesting_depth == 0) CleanUpQueues();` (`sequence_manager_impl.cc:763`) — `REPLAYED: taken` (proven: reached `CleanUpQueues`).
* Rendering:
ThreadControllerWithMessagePumpImpl::DoWorkImpl  (thread_controller_with_message_pump_impl.cc)
  Assert("[RUN-1124] ...DoWorkImpl #6 ...")                          // :435, LastNonHitAssert
  task_annotator_.RunTask("ThreadControllerImpl::RunTask", ...)      // :458  (DoWorkImpl+1001)
  main_thread_only().task_source->DidRunTask(lazy_now_after_run_task) // :469  (DoWorkImpl+1078)

webcrypto::DoDeriveKey  (webcrypto_impl.cc)
  // [Branch] RECORDED: else-arm
  if (state->cancelled()) return;                                    // :641
  state->origin_thread->PostTask(FROM_HERE, ...DoDeriveKeyReply...)   // :647

base::TaskRunner::PostTask  (task_runner.cc)
  return PostDelayedTask(from_here, std::move(task), base::TimeDelta()); // :85, no branch

TaskQueueImpl::TaskRunner::PostDelayedTask  (task_queue_impl.cc)
  if (!AreEventsDisallowed() && !AreEventsPassedThrough())            // :159, invalid — Assert-machinery guard
    Assert("TaskQueueImpl::TaskRunner::PostDelayedTask %d", ...)      // :160  <<< RECORDED LEAF

SequenceManagerImpl::DidRunTask  (sequence_manager_impl.cc)
  // [Branch] REPLAYED: taken
  if (main_thread_only().nesting_depth == 0)                          // :763
    CleanUpQueues();                                                  // :764

SequenceManagerImpl::CleanUpQueues  (sequence_manager_impl.cc)
  Assert("[RUN-2217] SequenceManagerImpl::CleanUpQueues %zu", ...)    // :1152  <<< REPLAYED LEAF
```

## AssertCandidates

* `webcrypto::DoDeriveKey` (`webcrypto_impl.cc`)
  * assertable: `:641` — `if (state->cancelled()) return;` — else-arm taken (RECORDED); reads `result.Cancelled()`, a plain `DeriveKeyState` flag, side-effect-free, no addr/sync/PassThrough.
  * provenance: entry → `:641` branch → `:647` `PostTask` (feeds into RECORDED LEAF at `TaskQueueImpl::TaskRunner::PostDelayedTask:160`, per outline above).
* `SequenceManagerImpl::DidRunTask` (`sequence_manager_impl.cc:756`)
  * assertable: `:763` — `if (main_thread_only().nesting_depth == 0) CleanUpQueues();` — taken (REPLAYED); `nesting_depth` is a plain `int` in `MainThreadOnly` struct (`sequence_manager_impl.h:278`) via non-locking accessor, side-effect-free scalar read.
  * provenance: `DidRunTask` entry (called from `DoWorkImpl+1078` at `:469`) → `:763` branch → `CleanUpQueues()` (REPLAYED LEAF at `:1152`, per outline above).
* No not-assertable entries — both candidates are valid per [AssertsLocations]/[InvalidAssertValues].

## DivergenceRoot

* `NoRoot`.
* Not `DominantWarningRoot`: `## DominantWarningProvenance` verdict is `NoDominantWarning` (no warning at all), not `Verified`.
* Not `AssertCandidateRoot`: both `## AssertCandidates` entries (`DoDeriveKey:641`, `DidRunTask:763`) are `ASSERTABLE`, but each is only proven as the arm taken at this hit (`RECORDED: else-arm` / `REPLAYED: taken`), not proven as the actual divergence source — they are Assert targets for further evidence, not proven roots.
* Re-checks before settling on `NoRoot`:
  * `## DominantWarningProvenance` correctly evaluated all `DominanceShape`s (moot: no warning exists to trail).
  * `# Symptoms` in [](./../interventions/determinism-synchronization.md): doesn't apply — no `AssertCandidates` entry landed `NOT-ASSERTABLE`.
  * Sole-candidates-are-Assert-machinery-guards caveat doesn't apply: both candidates are genuine `[Branch]` DivergenceCandidates, not Assert-machinery guards (those guards, e.g. `task_queue_impl.cc:159`, were already dropped in `## MismatchProvenance` per [InvalidAssertValues]).

## PossibleInterventions

* None — `DivergenceRoot` is `NoRoot`; no root exists to match against any intervention recipe.

## SuggestedCourseOfAction

* Add both `## AssertCandidates` Asserts (`NoRoot`):
  * `webcrypto::DoDeriveKey` (`webcrypto_impl.cc:641`), before the early-return Branch — Assert on `state->cancelled()` (`result.Cancelled()`).
  * `SequenceManagerImpl::DidRunTask` (`sequence_manager_impl.cc:763`), before the taken branch — Assert on `main_thread_only().nesting_depth`.
