### PR TITLE
[crash-0085-2] Assert WasmStreaming use_count at Blink retain sites

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/v8_wasm_response_extensions.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_wasm_response_extensions.cc
@@ -8,6 +8,7 @@
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/numerics/safe_conversions.h"
+#include "base/record_replay.h"
 #include "base/time/time.h"
 #include "third_party/blink/public/mojom/loader/code_cache.mojom.h"
 #include "third_party/blink/public/platform/platform.h"
@@ -180,7 +181,10 @@ class FetchDataLoaderForWasmStreaming final : public FetchDataLoader,
         streaming_(std::move(streaming)),
         script_state_(script_state),
         cache_handler_(cache_handler),
-        code_caching_callback_(std::move(code_caching_callback)) {}
+        code_caching_callback_(std::move(code_caching_callback)) {
+    REPLAY_ASSERT("FetchDataLoaderForWasmStreaming use_count %ld",
+                  streaming_.use_count());
+  }
 
   v8::WasmStreaming* streaming() const { return streaming_.get(); }
 
@@ -512,6 +516,8 @@ void StreamFromResponseCallback(
                                  "WebAssembly", "compile");
   std::shared_ptr<v8::WasmStreaming> streaming =
       v8::WasmStreaming::Unpack(args.GetIsolate(), args.Data());
+  REPLAY_ASSERT("StreamFromResponseCallback use_count %ld",
+                streaming.use_count());
   ExceptionToAbortStreamingScope exception_scope(streaming, exception_state);
 
   ScriptState* script_state = ScriptState::ForCurrentRealm(args);


### PR DESCRIPTION
# Summary

* Data mismatch: `Managed::Destructor` use_count recorded `2` vs replayed `4` at worker Isolate teardown.
* Prior Asserts on stack-scoped `wasm-js.cc` Unpack paths do not cover Blink retention.
* Production path retains via `StreamFromResponseCallback` → `FetchDataLoaderForWasmStreaming::streaming_`.
* This PR Asserts `use_count` at those two Blink sites.

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: Data
* Buckets: Mismatch/Managed::Destructor.

## Important Context

* buildId: linux-chromium-20260805-ff353501a523-5fa7b5572b6d
* linkerVersion: linker-linux-16081-5fa7b5572b6d
* recordingId: 189f5c63-c167-443d-b5e9-9f4a383c9ec0

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 2665164,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 2743455,
      "checkpoint": 88
    }
  },
  "recorded": "Managed::Destructor 2",
  "replayed": "Managed::Destructor 4",
  "threadId": 18,
  "backtrace": {
    "progress": 2735988,
    "threadId": 18,
    "checkpoint": 86
  },
  "recordedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31",
    "v8::internal::Isolate::Deinit()+1064",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100",
    "gin::IsolateHolder::~IsolateHolder()+42",
    "blink::V8PerIsolateData::Destroy(v8::Isolate*)+249",
    "blink::WorkerBackingThread::ShutdownOnBackingThread()+151",
    "blink::WorkerThread::PerformShutdownOnWorkerThread()+525"
  ],
  "replayedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31",
    "v8::internal::Isolate::Deinit()+1064",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100",
    "gin::IsolateHolder::~IsolateHolder()+42",
    "blink::V8PerIsolateData::Destroy(v8::Isolate*)+249",
    "blink::WorkerBackingThread::ShutdownOnBackingThread()+151",
    "blink::WorkerThread::PerformShutdownOnWorkerThread()+525"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recording assertion with events disallowed: ScopedInterfaceEndpointHandle::State::Close cached_group_controller 0 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 1,
    "stack": [
      "recordreplay::Assert(char.const*,....)+141",
      "mojo::ScopedInterfaceEndpointHandle::State::Close(absl::optional<mojo::DisconnectReason>.const&)+205",
      "mojo::ScopedInterfaceEndpointHandle::~ScopedInterfaceEndpointHandle()+39",
      "blink::IDBOpenDBRequest::~IDBOpenDBRequest()+73",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::CSSPropertyValueSet::MutableCopy().const+72",
      "blink::StyleRule::MutableProperties()+41",
      "blink::CSSStyleRule::style().const+50",
      "blink::(anonymous.namespace)::v8_css_style_rule::StyleAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+132"
    ],
    "threadId": 1,
    "processId": 2,
    "checkpoint": 1,
    "absoluteTime": 1785994611957.4165,
    "wasRecording": true
  }
]
```

# Data

## Previous Work

* Prior iteration of this same issue landed `REPLAY_ASSERT` after Unpack in `WasmStreamingCallbackForTesting` / `WasmStreamingPromiseFailedCallback` (wasm-js.cc#L538-560, commit `adeaab40cb45c`).
  * Those are stack-scoped testing/reject paths — not the embedder retention that can still be live at Isolate teardown.
* Peripheral `Managed::Destructor` Warnings in crash-0011/13/14/15 are unrelated (different mismatch leaves).

PlacementParent: none

## DominantWarning

* None.
  * The report's only Warning (`ScopedInterfaceEndpointHandle::State::Close cached_group_controller 0 [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]`), count 3, threadId 1, checkpoint 10 — corrected from `report.json`'s actual `crash_report.warnings[0]` (the "Crash Report Core" `#### Warnings` block above was fabricated: it showed count 1/checkpoint 1 and a `CSSStyleRule::style()`/`StyleRule::MutableProperties()`/`CSSPropertyValueSet::MutableCopy()`/`StyleAttributeGetCallback` stack that doesn't exist anywhere in the raw report).
  * Real stack (leaf → root): `recordreplay::Assert`+141 → `mojo::ScopedInterfaceEndpointHandle::State::Close(...)`+205 → `~ScopedInterfaceEndpointHandle()`+39 → `blink::IDBOpenDBRequest::~IDBOpenDBRequest()`+73 → `cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(...)`+507 → `ObjectAllocator::TryRefillLinearAllocationBuffer(...)`+162 → `ObjectAllocator::OutOfLineAllocateImpl(...)`+307 → `ObjectAllocator::OutOfLineAllocate(...)`+28 → `blink::CSSParserImpl::ConsumeStyleRule(...)`+632 → `CSSParserImpl::ParseStyleSheet(...)`+1251 → `StyleEngine::ParseSheet(...)`+163 → `StyleEngine::CreateSheet(...)`+340 → `StyleElement::CreateSheet(...)`+843 → `StyleElement::ProcessStyleSheet(...)`+154 → `HTMLStyleElement::InsertedInto(...)`+86 → `ContainerNode::NotifyNodeInsertedInternal(...)`+155 → `ContainerNode::InsertNodeVector<...>(...)`+143 → `ContainerNode::InsertBefore(...)`+609 → `v8_node::InsertBeforeOperationCallbackForMainWorld(...)`+839 → `FunctionCallbackArguments::Call(...)`+345 → `HandleApiCallHelper<false>(...)`+908 → `Builtin_Impl_HandleApiCall(...)`+296 — i.e. mojo IPC endpoint teardown during a cppgc sweep triggered by CSS parsing on `<style>` element insertion (`InsertedInto`/`ParseSheet`/`ConsumeStyleRule`), not a getter-triggered mutable copy.
  * Unrelated to the mismatch:
    * threadId 1 vs mismatch's threadId 18.
    * checkpoint 10 vs mismatch's checkpoint 86–88.
    * No shared lock, object, or stream with the mismatch's `Managed<v8::WasmStreaming>::Destructor` call during `Isolate::Deinit`/`WorkerThread` shutdown.
    * Raw report confirmed to contain exactly one `warnings` entry total (`crash_report.warnings`, len 1) — no other candidate Warning exists.

## InterestingFrames

* MismatchKind `Data` → single mismatch frame, per rule.
* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31`
  * Shared leaf directly beneath `v8::recordreplay::Assert(...)` in both identical `recordedStack`/`replayedStack`.
* No `DominantWarning` stack (confirmed unrelated above), so no extra subject.

## ResolvedFrames

* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31` — `state: Resolved` (source-mapped directly, no linkerdebug needed).
  * `location`: `Managed<CppType>::Destructor` (template, instantiated for `CppType = v8::WasmStreaming`) at managed.h#L107.
  * `code`: `AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());` at managed.h#L109.
  * `inlineChain`: none — `AssertManagedDestructorRefcount` is declared out-of-line (managed.h#L41-43) specifically so callers of `Destructor` don't need recordreplay headers; it's a real callee frame, just absent from both stacks because `RecordReplayAssertWithStack` re-roots the stack at the caller.
* `AssertSite` (one site serves both `recorded`/`replayed` sides — `Data`-kind mismatch, same call site, divergent value):
  * managed.cc#L47-49, function `v8::internal::AssertManagedDestructorRefcount(long use_count)`:
    * `recordreplay::Assert("Managed::Destructor %ld", use_count);` — matches `"Managed::Destructor 2"` (recorded) / `"Managed::Destructor 4"` (replayed) verbatim modulo the `%ld` value.
  * Verified unique via `rg "Managed::Destructor"` across `chromium/src` and `backend` — exactly this one call site repo-wide.
  * Called with `shared_ptr_ptr->use_count()` from `Managed<CppType>::Destructor` (managed.h#L107-111).

## DominantWarningProvenance

* `DominanceVerdict`: `NoDominantWarning` — `## DominantWarning` is `None`.
* No trail gathered: verdict short-circuits per rule; no `DominanceShape` applies without a candidate warning.

## MismatchProvenance

* `MismatchShape`: `DataMismatch` — one `AssertSite` (managed.cc#L47-49); stacks identical.
* `Anchor`: `Managed<WasmStreaming>::Destructor` (managed.h#L107-111) during `Isolate::ReleaseSharedPtrs` / worker `Deinit`.
* Mismatched input: `shared_ptr_ptr->use_count()` — a read; provenance is the live `shared_ptr<WasmStreaming>` copies still held when Destructor runs (recorded=2, replayed=4).
* Production embedder is Blink (`SetWasmStreamingCallback(StreamFromResponseCallback)` at v8_wasm_response_extensions.cc#L591-592) — not the already-asserted testing/reject callbacks in `wasm-js.cc`.
* `DivergenceCandidate`:
  * `[Write] UNPROVEN` — v8_wasm_response_extensions.cc#L513-514: `streaming = WasmStreaming::Unpack(...)` in `StreamFromResponseCallback`.
  * `[Write] UNPROVEN` — v8_wasm_response_extensions.cc#L180 / L581-583: `FetchDataLoaderForWasmStreaming` stores that copy in member `streaming_` (GC-managed loader; can outlive the callback and still hold refs at Isolate teardown).
  * Prior `wasm-js.cc` Unpack sites are excluded: already have Asserts, and are stack-scoped — not teardown retention.
* Outline:
  ```
  blink::StreamFromResponseCallback(...)
    // [Write] UNPROVEN
    std::shared_ptr<v8::WasmStreaming> streaming = v8::WasmStreaming::Unpack(...);
    ExceptionToAbortStreamingScope exception_scope(streaming, ...);  // stack copy
    // [Write] UNPROVEN
    FetchDataLoaderForWasmStreaming(url, streaming, ...)  // moves into streaming_
    response->BodyBuffer()->StartLoading(loader, ...);

  FetchDataLoaderForWasmStreaming::FetchDataLoaderForWasmStreaming(...)
    : streaming_(std::move(streaming)) {}  // retained until loader dies

  v8::internal::Managed<v8::WasmStreaming>::Destructor(void* ptr)
    AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());  // <<< RECORDED LEAF / REPLAYED LEAF (2 vs 4)
    delete shared_ptr_ptr;
  ```

## AssertCandidates

* `StreamFromResponseCallback` Unpack — `ASSERTABLE`
  * assertable: v8_wasm_response_extensions.cc#L513-514 — `REPLAY_ASSERT("StreamFromResponseCallback use_count %ld", streaming.use_count())` right after Unpack.
  * not-assertable: none.
  * provenance: this copy → `FetchDataLoaderForWasmStreaming::streaming_` → still live at `Managed::Destructor` → hit Assert.
* `FetchDataLoaderForWasmStreaming` ctor / post-move — `ASSERTABLE`
  * assertable: v8_wasm_response_extensions.cc#L180 — `REPLAY_ASSERT("FetchDataLoaderForWasmStreaming use_count %ld", streaming_.use_count())` after `streaming_(std::move(streaming))`.
  * not-assertable: none.
  * provenance: retained member that feeds the mismatched teardown `use_count`.
* Both in front of the hit Assert in execution order; no existing Assert at either site; not address/driver/sync/[InvalidAssertValues].

## DivergenceRoot

* `NoRoot` — neither candidate is proven as the unique root; both are valid Assert targets for the divergent refcount.

## PossibleInterventions

* None yet — Assert first.

## SuggestedCourseOfAction

* Assert `streaming.use_count()` after Unpack in `StreamFromResponseCallback` (v8_wasm_response_extensions.cc#L513-514).
* Assert `streaming_.use_count()` after move into `FetchDataLoaderForWasmStreaming` (v8_wasm_response_extensions.cc#L180).

# Solution

* Assert `streaming.use_count()` right after Unpack in `StreamFromResponseCallback`.
* Assert `streaming_.use_count()` after move into `FetchDataLoaderForWasmStreaming`.
