### PR TITLE
[crash-0064] Skip sync StorageArea GetAll when events unavailable

### DIFF
--- a/third_party/blink/renderer/modules/storage/cached_storage_area.cc
+++ b/third_party/blink/renderer/modules/storage/cached_storage_area.cc
@@ -13,6 +13,7 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/rand_util.h"
+#include "base/record_replay.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/platform/scheduler/public/main_thread.h"
@@ -592,6 +593,11 @@ void CachedStorageArea::MaybeApplyNonLocalMutationForKey(
 void CachedStorageArea::EnsureLoaded() {
   if (map_)
     return;
+  if (recordreplay::AreEventsUnavailable()) {
+    map_ = std::make_unique<StorageAreaMap>(
+        mojom::blink::StorageArea::kPerStorageAreaQuota);
+    return;
+  }
   if (!remote_area_)
     BindStorageArea();
 


### PR DESCRIPTION
# Summary

* ReplayPauseCrash: pause hang on diverged sync `StorageArea::GetAll`.
* Root: `CachedStorageArea::EnsureLoaded()` has no post-diverge guard; first `map_` access falls through to sync Mojo `GetAll`, then `ReplayCvar::Wait` forever.
* Fix: after `if (map_) return;`, if `AreEventsUnavailable()`, construct empty `StorageAreaMap` and return.

# Problem

* Problem type: ReplayPauseCrash.
* Intervention: divergence-fail-impossible

## Important Context

* buildId: linux-chromium-20260801-c62a9f358c8b-297cba1bc33b
* linkerVersion: linker-linux-16066-297cba1bc33b
* recordingId: 39580772-1542-4e53-92a3-090dbff338f4

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "PauseChild",
  "manifest": "pauseRequest",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingOnCvar": {
          "ptr": true,
          "lock": true,
          "waiters": [
            1
          ]
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941",
          "new_pthread_cond_wait(void*,.void*)+50",
          "0x10005054504c",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "0x100050544060",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::WaitMany(base::WaitableEvent**,.unsigned.long)+1064",
          "mojo::WaitSet::State::Wait(base::WaitableEvent**,.unsigned.long*,.mojo::Handle*,.unsigned.int*,.MojoHandleSignalsState*)+1814",
          "mojo::SyncHandleRegistry::Wait(bool.const**,.unsigned.long)+275",
          "mojo::SyncEventWatcher::SyncWatch(bool.const**,.unsigned.long)+601",
          "mojo::SequenceLocalSyncEventWatcher::SyncWatch(bool.const*)+153",
          "mojo::InterfaceEndpointClient::SendMessageWithResponder(mojo::Message*,.bool,.mojo::InterfaceEndpointClient::SyncSendMode,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+680",
          "mojo::internal::SendMojoMessage(mojo::MessageReceiverWithResponder&,.mojo::Message&,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+94",
          "blink::mojom::blink::StorageAreaProxy::GetAll(mojo::PendingRemote<blink::mojom::blink::StorageAreaObserver>,.WTF::Vector<mojo::StructPtr<blink::mojom::blink::KeyValue>,.0u,.WTF::PartitionAllocator>*)+331",
          "blink::CachedStorageArea::EnsureLoaded()+375",
          "blink::CachedStorageArea::GetLength()+14",
          "blink::(anonymous.namespace)::v8_storage::LengthAttributeGetCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+233",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
          "v8::internal::Builtins::InvokeApiFunction(v8::internal::Isolate*,.bool,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*,.v8::internal::Handle<v8::internal::HeapObject>)+646",
          "v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*)+727",
          "v8::internal::Object::GetProperty(v8::internal::LookupIterator*,.bool)+235",
          "v8::internal::LoadIC::Load(v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Name>,.bool,.v8::internal::Handle<v8::internal::Object>)+2457",
          "v8::internal::Runtime_LoadNoFeedbackIC_Miss(int,.unsigned.long*,.v8::internal::Isolate*)+238",
          "0x100a3ff15a38",
          "0x100a3ffb9f4f",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+459",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::String>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+237",
          "v8::debug::EvaluateGlobal(v8::Isolate*,.v8::Local<v8::String>,.v8::debug::EvaluateGlobalMode,.bool)+117",
          "v8_inspector::V8RuntimeAgentImpl::evaluate(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<double>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::EvaluateCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::EvaluateCallback>.>)+1092",
          "v8_inspector::protocol::Runtime::DomainDispatcherImpl::evaluate(v8_crdtp::Dispatchable.const&)+846",
          "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
          "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+709",
          "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+1241",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "0x100a3ff15b38",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::internal::CommandCallback(char.const*,.char.const*)+943",
          "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+442",
          "EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+38",
          "CommandRequest::Process(Json::Value.const&)+596",
          "recordreplay::PerformPauseDataRequest(Json::Value.const&)+356",
          "PauseRequestHandler::Start(Json::Value.const&)+210",
          "ManifestFinished(Json::Value*)+912",
          "RunToPointHandler::ReachedDestination(Json::Value.const&)+630",
          "recordreplay::OnScanTargetHit()+36",
          "recordreplay::OnInstrument(char.const*,.char.const*,.int)+3671",
          "v8::internal::OnInstrumentation(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.int)+208",
          "v8::internal::Runtime_RecordReplayInstrumentation(int,.unsigned.long*,.v8::internal::Isolate*)+270",
          "0x100a3ff15a38",
          "0x100a3fffafd1",
          "0x100a3fe8b82c",
          "0x100a3fe8b82c",
          "0x100a3fe89e5c",
          "0x100a3fe89b87",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::Function::Call(v8::Local<v8::Context>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*)+763",
          "blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>,.blink::ExecutionContext*,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.v8::Isolate*)+931",
          "blink::bindings::CallbackInvokeHelper<blink::CallbackFunctionBase,.(blink::bindings::CallbackInvokeHelperMode)2,.(blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int,.v8::Local<v8::Value>*)+91",
          "blink::V8Function::Invoke(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::HeapVector<blink::ScriptValue,.0u>.const&)+401",
          "blink::V8Function::InvokeAndReportException(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::HeapVector<blink::ScriptValue,.0u>.const&)+127",
          "blink::ScheduledAction::Execute(blink::ExecutionContext*)+231",
          "blink::DOMTimer::Fired()+548",
          "blink::TimerBase::RunInternal()+408",
          "base::DefaultDelayedTaskHandleDelegate::RunTask(base::OnceCallback<void.()>)+35",
          "base::internal::Invoker<base::internal::BindState<void.(base::DefaultDelayedTaskHandleDelegate::*)(base::OnceCallback<void.()>),.base::WeakPtr<base::DefaultDelayedTaskHandleDelegate>,.base::OnceCallback<void.()>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+159",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "content::ContentMainRunnerImpl::Run()+673",
          "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
          "content::ContentMain(content::ContentMainParams)+95",
          "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
          "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
          "headless::HeadlessShellMain(int,.char.const**)+55",
          "ChromeMain+629",
          "new_libc_start_main(void.(*)(int,.char.const**))+22"
        ]
      }
    }
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait [HasDivergedFromRecording]",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 2288498,
    "threadId": 2,
    "processId": 58,
    "checkpoint": 68,
    "absoluteTime": 1785565769907.4365,
    "wasRecording": false
  },
  {
    "text": "Thread::WaitForeverForRecordedCall pthread_detach [HasDivergedFromRecording]",
    "count": 1,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1119"
    ],
    "progress": 2288498,
    "threadId": 6,
    "processId": 58,
    "checkpoint": 68,
    "absoluteTime": 1785565769907.5322,
    "wasRecording": false
  }
]
```

# Data

## PauseSite

* Hang wait: `recordreplay::ReplayCvar::Wait`, tid1, owner unrecorded (cvar wait dumps no owner; `waitingOnCvar.waiters: [1]`).
* Frames (offsets preserved):
  * `recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941` — innermost wait (symptom).
  * `blink::CachedStorageArea::EnsureLoaded()+375` — DivergedOp: issues the synchronous Mojo call `remote_area_->GetAll(...)` (confirmed in `third_party/blink/renderer/modules/storage/cached_storage_area.cc`), which blocks on a peer response that cannot arrive post-diverge.
  * `PauseRequestHandler::Start(Json::Value.const&)+210` — pause-command entry.

## RootCause

* DivergedOp: `blink::CachedStorageArea::EnsureLoaded()` in `third_party/blink/renderer/modules/storage/cached_storage_area.cc`.
  * No `HasDivergedFromRecording()` / `AreEventsUnavailable()` guard anywhere in this file (confirmed via source scan).
  * Only guard is `if (map_) return;` — skips the load solely when `map_` was already populated pre-diverge.
  * Crash Report Core's pause-evaluate stack (`LengthAttributeGetCallback` → `GetLength` → `EnsureLoaded`) is the first access to this area's `map_`, so it falls through the guard.
  * Falls through to `remote_area_->GetAll(receiver_.BindNewPipeAndPassRemote(), &data)` — a synchronous Mojo call (`SendMessageWithResponder` → `SyncEventWatcher::SyncWatch` → `ReplayCvar::Wait`, matching the reported wait stack).
  * Per `linker-commands.md` (`## Pause / diverge semantics`): post-`DivergeFromRecording()`, thread 1 has no recording data for this point and must self-serve; no reply for this diverged sync IPC was ever recorded, so it cannot arrive — tid1 blocks forever in `ReplayCvar::Wait`.
  * The `ReplayCvar::Wait+941` frame is the symptom, not the root, per `divergence-fail-impossible`.

## SuggestedCourseOfAction

* Fix site: `CachedStorageArea::EnsureLoaded()` in `third_party/blink/renderer/modules/storage/cached_storage_area.cc`.
* Add an `AreEventsUnavailable()` guard right after the existing `if (map_) return;` check, before the `remote_area_->GetAll(...)` synchronous Mojo call, so the impossible wait is never entered.
* On divergence: skip `remote_area_->GetAll(...)`; instead construct `map_` as an empty `StorageAreaMap` (same construction as the normal path, minus item population), giving callers (`GetLength`, `GetKey`, `GetItem`, etc.) a clean empty result instead of a hang.
* Matches the established codebase pattern, e.g. `xml_http_request.cc`'s `AreEventsUnavailable()` check before a synchronous op that can't be served post-diverge, returning a clean failure/empty result instead of blocking.
