### PR TITLE
[crash-0051-3] Order ImageFrameGenerator::ClientLock

### DIFF
--- a/third_party/blink/renderer/platform/graphics/image_frame_generator.h
+++ b/third_party/blink/renderer/platform/graphics/image_frame_generator.h
@@ -177,7 +177,7 @@ class PLATFORM_EXPORT ImageFrameGenerator final
 
   struct ClientLock {
     int ref_count = 0;
-    base::Lock lock;
+    base::Lock lock{"ImageFrameGenerator::ClientLock"};
   };
 
   // Note that it is necessary to use HashMap here to ensure that references


### PR DESCRIPTION
# Summary

* HangLocked: unordered `ImageFrameGenerator::ClientLock` vs ordered `ImageDecodingStore`.
* WaitSink cycle `{3, 11}`: tid3 waits on that mutex. tid11 holds it and waits on ordered `ImageDecodingStore` with `nextOwner` tid3.
* Construct `ClientLock::lock` with ordered name `"ImageFrameGenerator::ClientLock"`.

# Problem

* Problem type: ReplayHang.
* operatorId: `eb84444a-fecc-4617-a765-9ac07196ec61`
* Buckets: HangLocked:base::ConditionVariable::TimedWait.

## Important Context

* buildId: linux-chromium-20260808-3aefa452b8bf-33a69264625e
* linkerVersion: linker-linux-16086-33a69264625e
* recordingId: e1d7e2f3-2e5e-4312-a50b-94045ff68275

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "newBranch",
  "manifest": "runToPoint",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingOnOrderedLock": {
          "id": 4106,
          "nextOwner": 9,
          "waitPosition": 16,
          "actualPosition": 16
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::OrderedLock(void*,.int)+360",
          "Op_pthread_cond_anywait(recordreplay::CallContext&)+126",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+222",
          "0x10005065c060",
          "base::ConditionVariable::TimedWait(base::TimeDelta.const&)+313",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+988",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+277",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "content::ContentMainRunnerImpl::Run()+673",
          "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
          "content::ContentMain(content::ContentMainParams)+95",
          "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
          "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
          "headless::HeadlessShellMain(int,.char.const**)+55",
          "ChromeMain+629",
          "new_libc_start_main(void.(*)(int,.char.const**))+22",
          "_start+42"
        ],
        "progress": 761723,
        "threadId": 1,
        "checkpoint": 90
      }
    },
    {
      "state": {
        "threadId": 9,
        "waitingOnOrderedLock": {
          "id": 4105,
          "nextOwner": 3,
          "waitPosition": 16,
          "actualPosition": 16
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::OrderedLock(void*,.int)+360",
          "Op_pthread_cond_anywait(recordreplay::CallContext&)+126",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+222",
          "0x10005065c060",
          "base::ConditionVariable::TimedWait(base::TimeDelta.const&)+313",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+988",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+277",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "progress": 761723,
        "threadId": 9,
        "checkpoint": 90
      }
    },
    {
      "state": {
        "threadId": 3,
        "waitingToAcquireLock": {
          "ptr": "0x100a0b6ab7b8",
          "owner": 11
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayLock::Lock()+264",
          "new_pthread_mutex_lock(void*)+21",
          "0x10005058b04c",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "0x10005058a060",
          "base::internal::LockImpl::LockInternalWithTracking()+70",
          "blink::ImageFrameGenerator::ClientAutoLock::ClientAutoLock(blink::ImageFrameGenerator*,.int)+395",
          "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+478",
          "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
          "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "cc::SoftwareImageDecodeCache::DecodeImageInTask(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCache::DecodeTaskType)+491",
          "cc::(anonymous.namespace)::SoftwareImageDecodeTaskImpl::RunOnWorkerThread()+328",
          "cc::ImageController::ProcessNextImageDecodeOnWorkerThread(cc::ImageController::WorkerState*)+541",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::internal::TaskTracker::RunTaskImpl(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+72",
          "base::internal::TaskTracker::RunContinueOnShutdown(base::internal::Task&,.base::TaskTraits.const&,.base::internal::TaskSource*,.base::SequenceToken.const&)+65",
          "base::internal::TaskTracker::RunTask(base::internal::Task,.base::internal::TaskSource*,.base::TaskTraits.const&)+334",
          "base::internal::TaskTracker::RunAndPopNextTask(base::internal::RegisteredTaskSource)+502",
          "base::internal::WorkerThread::RunWorker()+503",
          "base::internal::WorkerThread::RunPooledWorker()+13",
          "base::internal::WorkerThread::ThreadMain()+119",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "progress": 761723,
        "threadId": 3,
        "checkpoint": 90
      }
    },
    {
      "state": {
        "ownsLock": [
          "0x100a0b6ab7b8"
        ],
        "threadId": 11,
        "waitingOnOrderedLock": {
          "id": 3924,
          "nextOwner": 3,
          "waitPosition": 48,
          "actualPosition": 48
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::OrderedLock(void*,.int)+360",
          "Op_pthread_mutex_trylock(recordreplay::CallContext&)+143",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+222",
          "0x10005061a060",
          "blink::ImageDecodingStore::Instance()+33",
          "blink::ImageDecoderWrapper::Decode(blink::ImageDecoderFactory*,.unsigned.int*,.bool*)+46",
          "blink::ImageFrameGenerator::DecodeAndScale(blink::SegmentReader*,.bool,.unsigned.int,.SkImageInfo.const&,.void*,.unsigned.long,.blink::ImageDecoder::AlphaOption,.int)+619",
          "blink::DecodingImageGenerator::GetPixels(SkImageInfo.const&,.void*,.unsigned.long,.unsigned.long,.int,.unsigned.int)+943",
          "cc::PaintImage::Decode(void*,.SkImageInfo*,.sk_sp<SkColorSpace>,.unsigned.long,.int).const+155",
          "cc::SoftwareImageDecodeCacheUtils::DoDecodeImage(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.SkColorType,.int,.base::OnceCallback<void.()>)+231",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+640",
          "cc::SoftwareImageDecodeCache::GetDecodedImageForDrawInternal(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&)+146",
          "cc::SoftwareImageDecodeCache::DecodeImageIfNecessary(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCacheUtils::CacheEntry*)+2010",
          "cc::SoftwareImageDecodeCache::DecodeImageInTask(cc::SoftwareImageDecodeCacheUtils::CacheKey.const&,.cc::PaintImage.const&,.cc::SoftwareImageDecodeCache::DecodeTaskType)+491",
          "cc::(anonymous.namespace)::SoftwareImageDecodeTaskImpl::RunOnWorkerThread()+328",
          "blink::CategorizedWorkerPoolImpl::RunTaskInCategoryWithLockAcquired(cc::TaskCategory)+244",
          "blink::CategorizedWorkerPoolImpl::Run(std::Cr::vector<cc::TaskCategory,.std::Cr::allocator<cc::TaskCategory>.>.const&,.base::ConditionVariable*)+107",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "progress": 761723,
        "threadId": 11,
        "checkpoint": 90
      }
    }
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed SkImageFilterCache [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 100,
    "stack": [
      "(anonymous.namespace)::CacheImpl::purgeByImageFilter(SkImageFilter.const*)+37",
      "SkImageFilter_Base::~SkImageFilter_Base()+40",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::FilterOperations::~FilterOperations()+63",
      "base::RefCounted<blink::EffectPaintPropertyNodeOrAlias,.blink::PaintPropertyNodeRefCountedTraits<blink::EffectPaintPropertyNodeOrAlias,.blink::EffectPaintPropertyNode>.>::Release().const+159",
      "blink::ObjectPaintProperties::~ObjectPaintProperties()+275",
      "cppgc::internal::FinalizerTrait<blink::FragmentData::RareData>::Finalize(void*)+68",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::LocalDOMWindow::getComputedStyle(blink::Element*,.WTF::String.const&).const+85",
      "blink::(anonymous.namespace)::v8_window::GetComputedStyleOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+645",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296"
    ],
    "progress": 7026,
    "threadId": 1,
    "processId": 2,
    "checkpoint": 28,
    "absoluteTime": 1786975842726.7876,
    "wasRecording": true
  }
]
```

# Data

## Previous Work

* crash-0045: first `ImageDecodingStore::Instance` ctor-order mismatch; added `REPLAY_ASSERT("ImageDecodingStore::Instance %d", HasInstance())` — same function held/contended by thread 11 here.
* crash-0051: same Assert leaf `1` vs `0` on `gHasInstance`; replaced it with `recordreplay::OrderedAtomic`.
* crash-0073: that `OrderedAtomic` caused a StreamTouch-under-Sweeper mismatch; reverted to `std::atomic` + skip `~ImageFrameGenerator` cleanup when `EventsDisallowed`; flagged ResidualRisk that the `gHasInstance` Assert may still return on unordered visibility.
* crash-0051-2: recurrence of the same Assert leaf `1` vs `0`, still open (no solution.md) — direct continuation of the crash-0051/crash-0073 lineage.
* PlacementParent: crash-0051-2

## WaitSink

* Wait chain (CrashReport `hangedThreads`): tid1 →nextOwner→ tid9 →nextOwner→ tid3 →owner(mutex `0x100a0b6ab7b8`)→ tid11 →nextOwner→ tid3.
* WaitSink: 2-cycle `{3, 11}` — tid3 waits on the mutex tid11 owns; tid11's ordered-lock nextOwner is tid3.
* ScheduleReady: holds for both edges into/inside the sink — tid9's ordered lock 4105 (waitPosition=actualPosition=16) and tid11's ordered lock 3924 (waitPosition=actualPosition=48).
* Threads outside WaitSink (by tid, code not mapped): `1`, `9`.
* SyncPrimitive — tid 3:
  * InterestingFrames / FrameRecords:
    * `frame`: `base::internal::LockImpl::LockInternalWithTracking()+70`; `location`: `LockImpl::LockInternalWithTracking` at `base/synchronization/lock_impl_posix.cc:115`; `code`: `int rv = pthread_mutex_lock(&native_handle_);`; `inlineChain`: none; `state`: Resolved.
    * `frame`: `blink::ImageFrameGenerator::ClientAutoLock::ClientAutoLock(blink::ImageFrameGenerator*,.int)+395`; `location`: `ImageFrameGenerator::ClientAutoLock::ClientAutoLock` at `third_party/blink/renderer/platform/graphics/image_frame_generator.cc`; `code`: `lock_->Acquire();`; `inlineChain`: `base::Lock::Acquire` → `base::internal::LockImpl::Lock` (both inlined); `state`: Resolved.
  * Primitive: `base::Lock lock;` member of `ImageFrameGenerator::ClientLock`, declared `third_party/blink/renderer/platform/graphics/image_frame_generator.h:179`. Type `base::Lock` (`base/synchronization/lock.h:23`, ctor `Lock(const char* ordered_name = nullptr)`). Construction site: default member-init at `image_frame_generator.h:179`, instantiated via `std::make_unique<ClientLock>()` in `ClientAutoLock::ClientAutoLock` (`image_frame_generator.cc`). Ctor arguments: none (default `nullptr`).
  * OrderedState: Unordered.
  * OrderedPeers: `new Lock("Time::GetHighResLock")` at `base/time/time_win.cc` — only other RepoSrc `base::Lock` construction found using an ordered name.
* SyncPrimitive — tid 11:
  * InterestingFrames / FrameRecords:
    * `frame`: `blink::ImageDecodingStore::Instance()+33`; `location`: `ImageDecodingStore::Instance` at `third_party/blink/renderer/platform/graphics/image_decoding_store.cc:68`; `code`: `DEFINE_ORDERED_THREAD_SAFE_STATIC_LOCAL_LOCK(ImageDecodingStore, "ImageDecodingStore");`; `inlineChain`: macro-expanded `base::AutoLock` ctor → `base::Lock::Acquire` → `base::internal::LockImpl::Lock` (all inlined); `state`: Resolved.
  * Primitive: `static base::Lock& s_ImageDecodingStore_ordered_lock`, macro-defined at `third_party/blink/renderer/platform/wtf/std_lib_extras.h:72`, expanded at call site `image_decoding_store.cc:68-69`. Type `base::Lock`. Construction: `*new base::Lock(ordered_name)` with `ordered_name = "ImageDecodingStore"`.
  * OrderedState: Ordered (name `"ImageDecodingStore"`).
  * OrderedPeers: none — no other RepoSrc `base::Lock` ordered construction shares this name (only other ordered-name site is `"Time::GetHighResLock"` in `base/time/time_win.cc`).

## LockedRootCause

* Root: `MissingOrdering`, targeting the tid3 `SyncPrimitive` — the `base::Lock lock;` member of `ImageFrameGenerator::ClientLock` (`third_party/blink/renderer/platform/graphics/image_frame_generator.h:179`).
* Evidence:
  * WaitSink cycle `{3, 11}`: tid3 waits to acquire mutex `0x100a0b6ab7b8`, owned by tid11; tid11's ordered lock 3924 has `nextOwner: 3`.
  * tid3 `SyncPrimitive`: `base::Lock` in `ImageFrameGenerator::ClientLock` — OrderedState `Unordered`.
  * tid11 `SyncPrimitive`: `base::Lock` in `ImageDecodingStore::Instance` — OrderedState `Ordered` (name `"ImageDecodingStore"`).
  * ScheduleReady holds at both edges reaching the sink: tid9's ordered lock 4105 (`waitPosition == actualPosition == 16`) and tid11's ordered lock 3924 (`waitPosition == actualPosition == 48`).
* Unknowns: none — ScheduleReady and the `Unordered` `SyncPrimitive` on tid3 are both proven from the CrashReport and RepoSrc.

# Solution

* Recipe: `MissingOrdering` — construct the tid3 `SyncPrimitive` ordered.
* `ImageFrameGenerator::ClientLock::lock` is default-constructed `base::Lock` → `ordered_name == nullptr` → Unordered.
* Pass a literal name, matching `ImageDecodingStore` / `Time::GetHighResLock`:
  * `base::Lock lock{"ImageFrameGenerator::ClientLock"};` in `third_party/blink/renderer/platform/graphics/image_frame_generator.h`
