### PR TITLE
[crash-0064-2] Guard CookieJar::CookiesEnabled after diverge

### DIFF
--- a/third_party/blink/renderer/core/loader/cookie_jar.cc
+++ b/third_party/blink/renderer/core/loader/cookie_jar.cc
@@ -177,6 +177,9 @@ bool CookieJar::CookiesEnabled() {
   if (cookie_url.IsEmpty())
     return false;
 
+  if (recordreplay::AreEventsUnavailable("CookieJar::CookiesEnabled"))
+    return false;
+
   base::ElapsedTimer timer;
   bool requested = RequestRestrictedCookieManagerIfNeeded();
   bool cookies_enabled = false;


### PR DESCRIPTION
# Summary

* Pause hang after `DivergeFromRecording` when Pause eval reads `navigator.cookieEnabled`.
* `CookieJar::CookiesEnabled()` issued `[Sync]` Mojo `CookiesEnabledFor` with no `AreEventsUnavailable` early-out.
* Sibling `SetCookie()` / `Cookies()` already guard.
* Add the same guard: return `false` before the Mojo call.

# PauseSite

* Hang: `base::ConditionVariable::Wait` (innermost recorded wait `recordreplay::ReplayCvar::Wait`), tid1, owner unresolvable (cvar wait dumps no owner).
* Intervention `divergence-fail-impossible` → 3 pinning frames:
  * Innermost wait (symptom): `recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+941`
  * **DivergedOp**: `network::mojom::blink::RestrictedCookieManagerProxy::CookiesEnabledFor(blink::KURL.const&,.net::SiteForCookies.const&,.scoped_refptr<blink::SecurityOrigin.const>.const&,.bool*)+528`
    * Called from `blink::CookieJar::CookiesEnabled()+290`, invoked as the `navigator.cookieEnabled` getter (`v8_navigator::CookieEnabledAttributeGetCallback`).
    * Confirmed sync Mojo IPC: `mojo::InterfaceEndpointClient::SendMessageWithResponder(..., SyncSendMode, ...)`; `CookiesEnabledFor` is declared `[Sync]` in `services/network/public/mojom/restricted_cookie_manager.mojom` — requires an IPC peer reply unreachable post-diverge.
  * Pause-command entry: `EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+38`
    * Reached via `v8::internal::CommandCallback` → `Execution::Call`, matching `PauseRequestHandler` → `PerformPauseDataRequest` → command-callback flow.

# RootCause

* DivergedOp `blink::CookieJar::CookiesEnabled()` (`third_party/blink/renderer/core/loader/cookie_jar.cc`) is missing the diverge early-out guard.
* Sibling methods in the same file guard before any Mojo call:
  * `CookieJar::SetCookie()`: `if (recordreplay::AreEventsUnavailable("CookieJar::SetCookie")) return;`
  * `CookieJar::Cookies()`: `if (recordreplay::AreEventsUnavailable("CookieJar::Cookies")) return String();`
  * `CookieJar::CookiesEnabled()` has no such check — unconditionally calls `backend_->CookiesEnabledFor(...)`.
* `CookiesEnabledFor` is `[Sync]` Mojo (`services/network/public/mojom/restricted_cookie_manager.mojom`) → blocks tid1 in `mojo::SyncEventWatcher::SyncWatch` → `base::ConditionVariable::Wait`, awaiting an IPC peer reply unreachable post-diverge.
* Reached on tid1 post-`DivergeFromRecording()` via `navigator.cookieEnabled` getter (`v8_navigator::CookieEnabledAttributeGetCallback`), invoked from the `Pause.evaluateInGlobal` command path (`EvaluateInGlobalCommand::Process` → `CommandCallback` → `Execution::Call`).
* Thread 2's `epoll_wait` stall (`HasDivergedFromRecording`) is collateral post-diverge noise, not the root.
* Conclusion: root is the missing `AreEventsUnavailable("CookieJar::CookiesEnabled")` guard in `CookiesEnabled()`, not the wait frame itself.

# SuggestedCourseOfAction

* In `third_party/blink/renderer/core/loader/cookie_jar.cc`, `CookieJar::CookiesEnabled()`:
  * Add an early-out guard `if (recordreplay::AreEventsUnavailable("CookieJar::CookiesEnabled")) return false;` before the `backend_->CookiesEnabledFor(...)` call.
  * Place it in the same position as the analogous guards in `CookieJar::SetCookie()` and `CookieJar::Cookies()`: after the `cookie_url.IsEmpty()` check, before any further work.
  * This is the only fix; no other file or frame is touched.

# Raw Data

* buildId: `linux-chromium-20260808-3aefa452b8bf-33a69264625e`
* linkerVersion: `linker-linux-16086-33a69264625e`
* recordingId: `80186fca-99c8-4562-a03a-af1be3115713`
* operatorId: `8f17c066-840a-4559-aa8b-cddee7b770d1`
* Problem type: ReplayPauseCrash
* Intervention: divergence-fail-impossible
* Buckets: Pause/base::ConditionVariable::Wait
