### PR TITLE
[crash-0092] Assign cc::Task RecordReplayId at source and warn on dequeue of id 0

### DIFF
--- a/base/pending_task.cc
+++ b/base/pending_task.cc
@@ -22,8 +22,8 @@ PendingTask::PendingTask(const Location& posted_from,
       delayed_run_time(delayed_run_time),
       leeway(leeway),
       delay_policy(delay_policy) {
-  if (!recordreplay::AreEventsDisallowed() && !recordreplay::AreEventsPassedThrough()) {
-    // We use these for Asserts.
+  if (!recordreplay::AreEventsUnavailable() &&
+      !recordreplay::AreEventsPassedThrough()) {
     record_replay_id = recordreplay::NewIdAnyThread("PendingTask");
   }
 }

--- a/base/task/sequence_manager/sequence_manager_impl.cc
+++ b/base/task/sequence_manager/sequence_manager_impl.cc
@@ -686,8 +686,10 @@ SequenceManagerImpl::SelectNextTaskImpl(LazyNow& lazy_now,
     if (!work_queue)
       return absl::nullopt;
 
-    recordreplay::Assert(
-        "[RUN-1124-1803] SequenceManagerImpl::SelectNextTaskImpl A %zu %s", work_queue->Size(), work_queue->name());
+    REPLAY_ASSERT(
+        "[RUN-1124-1803] SequenceManagerImpl::SelectNextTaskImpl A %zu %s %d",
+        work_queue->Size(), work_queue->name(),
+        work_queue->GetFrontTask()->RecordReplayId());
 
     // If the head task was canceled, remove it and run the selector again.
     if (UNLIKELY(work_queue->RemoveAllCanceledTasksFromFront()))
@@ -737,9 +739,10 @@ SequenceManagerImpl::SelectNextTaskImpl(LazyNow& lazy_now,
     // be valid here (not canceled).
     executing_task.pending_task.WillRunTask();
 
-    recordreplay::Assert(
-        "[RUN-1124-1803] SequenceManagerImpl::SelectNextTaskImpl D %zu %s",
-        work_queue->Size(), work_queue->name());
+    REPLAY_ASSERT(
+        "[RUN-1124-1803] SequenceManagerImpl::SelectNextTaskImpl D %zu %s %d",
+        work_queue->Size(), work_queue->name(),
+        executing_task.pending_task.RecordReplayId());
 
     return SelectedTask(
         executing_task.pending_task,
@@ -758,10 +761,10 @@ void SequenceManagerImpl::DidRunTask(LazyNow& lazy_now) {
       *main_thread_only().task_execution_stack.rbegin();
 
   NotifyDidProcessTask(&executing_task, &lazy_now);
+  REPLAY_ASSERT("SequenceManagerImpl::DidRunTask nesting_depth %d %d",
+                       main_thread_only().nesting_depth,
+                       executing_task.pending_task.RecordReplayId());
   main_thread_only().task_execution_stack.pop_back();
-
-  recordreplay::Assert("SequenceManagerImpl::DidRunTask nesting_depth %d",
-                       main_thread_only().nesting_depth);
   if (main_thread_only().nesting_depth == 0)
     CleanUpQueues();
 }

--- a/base/task/sequence_manager/task_queue_impl.cc
+++ b/base/task/sequence_manager/task_queue_impl.cc
@@ -455,10 +455,6 @@ void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
     bool add_queue_time_to_tasks = sequence_manager_->GetAddQueueTimeToTasks();
     TimeTicks queue_time;
 
-    recordreplay::Assert(
-        "[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d",
-        add_queue_time_to_tasks || delayed_fence_allowed_);
-    
     if (add_queue_time_to_tasks || delayed_fence_allowed_)
       queue_time = sequence_manager_->any_thread_clock_maybe_events_disallowed()->NowTicks();
 
@@ -472,6 +468,11 @@ void TaskQueueImpl::PostImmediateTaskImplOrdered(PostedTask task,
 
     any_thread_.immediate_incoming_queue.push_back(
         Task(std::move(task), sequence_number, sequence_number, queue_time));
+
+    REPLAY_ASSERT(
+        "[RUN-1126] TaskQueueImpl::PostImmediateTaskImpl 1 %d %d",
+        add_queue_time_to_tasks || delayed_fence_allowed_,
+        any_thread_.immediate_incoming_queue.back().RecordReplayId());
 
 #if DCHECK_IS_ON()
     any_thread_.immediate_incoming_queue.back().cross_thread_ =

--- a/base/task/sequence_manager/work_queue.cc
+++ b/base/task/sequence_manager/work_queue.cc
@@ -258,8 +258,8 @@ Task WorkQueue::TakeTaskFromWorkQueue() {
     }
 
     // https://linear.app/replay/issue/RUN-1150
-    recordreplay::Assert("[RUN-1150] WorkQueue::TakeTaskFromWorkQueue #2 %zu",
-                         tasks_.size());
+    REPLAY_ASSERT("[RUN-1150] WorkQueue::TakeTaskFromWorkQueue #2 %zu %d",
+                         tasks_.size(), pending_task.RecordReplayId());
 
     // Since the queue is empty, now is a good time to consider reducing it's
     // capacity if we're wasting memory.

--- a/base/task/sequence_manager/work_queue.cc
+++ b/base/task/sequence_manager/work_queue.cc
@@ -246,6 +246,12 @@ Task WorkQueue::TakeTaskFromWorkQueue() {
 
   Task pending_task = std::move(tasks_.front());
   tasks_.pop_front();
+  if (!recordreplay::AreEventsUnavailable() &&
+      !recordreplay::AreEventsPassedThrough() &&
+      !pending_task.RecordReplayId()) {
+    recordreplay::Warning("WorkQueue::TakeTaskFromWorkQueue DivergentTask %s",
+                          pending_task.posted_from.ToString().c_str());
+  }
   // NB immediate tasks have a different pipeline to delayed ones.
   if (tasks_.empty()) {
     // NB delayed tasks are inserted via Push, no don't need to reload those.

--- a/cc/raster/task.cc
+++ b/cc/raster/task.cc
@@ -90,20 +90,19 @@ void TaskState::DidCancel() {
 }
 
 Task::Task() {
-  if (!recordreplay::AreEventsDisallowed() &&
-      !recordreplay::AreEventsPassedThrough() &&
-      !recordreplay::HasDivergedFromRecording()) {
-    record_replay_created_with_events_ = true;
+  if (!recordreplay::AreEventsUnavailable() &&
+      !recordreplay::AreEventsPassedThrough()) {
+    record_replay_id_ = recordreplay::NewIdAnyThread("Task");
   }
 }
 
 Task::~Task() = default;
 
 void Task::RecordReplayEnter() {
-  if (!record_replay_created_with_events_)
-    return;
-  if (!record_replay_id_)
-    record_replay_id_ = recordreplay::NewIdAnyThread("Task");
+  if (!recordreplay::AreEventsUnavailable() &&
+      !recordreplay::AreEventsPassedThrough() && !record_replay_id_) {
+    recordreplay::Warning("cc::Task dequeue RecordReplayId 0");
+  }
   REPLAY_ASSERT("cc::Task::Enter %d", record_replay_id_);
 }
 

--- a/cc/raster/task.cc
+++ b/cc/raster/task.cc
@@ -9,6 +9,7 @@
 
 #include "base/check.h"
 #include "base/notreached.h"
+#include "base/record_replay.h"
 
 namespace cc {
 
@@ -88,9 +89,23 @@ void TaskState::DidCancel() {
   value_ = Value::CANCELED;
 }
 
-Task::Task() = default;
+Task::Task() {
+  if (!recordreplay::AreEventsDisallowed() &&
+      !recordreplay::AreEventsPassedThrough() &&
+      !recordreplay::HasDivergedFromRecording()) {
+    record_replay_created_with_events_ = true;
+  }
+}
 
 Task::~Task() = default;
+
+void Task::RecordReplayEnter() {
+  if (!record_replay_created_with_events_)
+    return;
+  if (!record_replay_id_)
+    record_replay_id_ = recordreplay::NewIdAnyThread("Task");
+  REPLAY_ASSERT("cc::Task::Enter %d", record_replay_id_);
+}
 
 TaskGraph::TaskGraph() = default;
 

--- a/cc/raster/task.h
+++ b/cc/raster/task.h
@@ -97,7 +97,6 @@ class CC_EXPORT Task : public base::RefCountedThreadSafe<Task> {
  private:
   TaskState state_;
   int64_t frame_number_ = -1;
-  bool record_replay_created_with_events_ = false;
   int record_replay_id_ = 0;
 };
 

--- a/cc/raster/task.h
+++ b/cc/raster/task.h
@@ -80,6 +80,9 @@ class CC_EXPORT Task : public base::RefCountedThreadSafe<Task> {
   void set_frame_number(int64_t frame_number) { frame_number_ = frame_number; }
   int64_t frame_number() { return frame_number_; }
 
+  int RecordReplayId() const { return record_replay_id_; }
+  void RecordReplayEnter();
+
   // Subclasses should implement this method. RunOnWorkerThread may be called
   // on any thread, and subclasses are responsible for locking and thread
   // safety.
@@ -94,6 +97,8 @@ class CC_EXPORT Task : public base::RefCountedThreadSafe<Task> {
  private:
   TaskState state_;
   int64_t frame_number_ = -1;
+  bool record_replay_created_with_events_ = false;
+  int record_replay_id_ = 0;
 };
 
 // A task dependency graph describes the order in which to execute a set

--- a/cc/raster/task_graph_work_queue.cc
+++ b/cc/raster/task_graph_work_queue.cc
@@ -278,6 +278,7 @@ TaskGraphWorkQueue::PrioritizedTask TaskGraphWorkQueue::GetNextTaskToRun(
 
   // Add task to |running_tasks|.
   task.task->state().DidStart();
+  task.task->RecordReplayEnter();
   task_namespace->running_tasks.push_back(
       std::make_pair(task.category, task.task));
 

--- a/cc/tiles/software_image_decode_cache.cc
+++ b/cc/tiles/software_image_decode_cache.cc
@@ -97,7 +97,8 @@ class SoftwareImageDecodeTaskImpl : public TileTask {
         devtools_instrumentation::ScopedImageDecodeTask::kSoftware,
         ImageDecodeCache::ToScopedTaskType(tracing_info_.task_type),
         ImageDecodeCache::ToScopedImageType(image_type));
-    recordreplay::Assert("[RUN-593-1824] RunOnWorkerThread %s", image_key_.ToString().c_str());
+    REPLAY_ASSERT("[RUN-593-1824] RunOnWorkerThread %s %d",
+                         image_key_.ToString().c_str(), RecordReplayId());
     SoftwareImageDecodeCache::TaskProcessingResult result =
         cache_->DecodeImageInTask(image_key_, paint_image_, task_type_);
 


### PR DESCRIPTION
# Summary

* Two ReplayHangs, same two-thread deadlock.
  * crash-0092: SequenceManager take vs `CategorizedWorkerPoolImpl` wait.
  * crash-0051-4: SequenceManager wait vs SequenceManager post.
* No mismatches, no warnings.
  * That is probably because in this shallow, generic routing code, ASSERTing on stack alone doesn't have a lot of assertive power.
  * Existing asserts on those edges did not record which task was posted, taken, or entered.
* Assigning `cc::Task` id at enter hid tasks that arrived from a non-deterministic source.
* SLN: Diagnostics
  * `cc::Task` gets `RecordReplayId` at construction, iff events are available.
  * A non-divergent dequeue of id 0 files `recordreplay::Warning`.
  * Fold `PendingTask::RecordReplayId` into the existing SequenceManager post/take/run asserts.

# Problem

* Symptom: ReplayHang `LockCycle` on WaitSink `{tid9, tid11}`.
  * crash-0092: tid9 `TakeImmediateIncomingQueueTasks` / `any_thread_lock_`. tid11 `CategorizedWorkerPoolImpl::Run` cvar wait.
  * crash-0051-4: tid9 `WaitableEvent::Wait` / `SyncWaiter.lock_`. tid11 `PostImmediateTaskImplOrdered` / `AtomicFlag::SetActive`.
* Same handshake, opposite edges.
  * SequenceManager takes incoming or waits for work.
  * Worker waits for raster work or posts completion onto SequenceManager.
* Existing asserts on those paths recorded queue size/name, fence flags, or `nesting_depth`. Not the task.
* `cc::Task` had no id. Id at enter cannot tell whether the task was created on a deterministic path.

# Solution

* Recipe: id at source. Warn if a non-divergent queue dequeues id 0.
* Implementation
  * `cc::Task` ctor: `NewIdAnyThread("Task")` iff `!AreEventsUnavailable && !AreEventsPassedThrough`.
  * `PendingTask` ctor uses the same gate.
  * `GetNextTaskToRun` after `DidStart` calls `RecordReplayEnter`: warn on id 0, then `REPLAY_ASSERT("cc::Task::Enter %d", id)`.
  * `WorkQueue::TakeTaskFromWorkQueue` warns on id 0 and includes `posted_from`.
  * Fold `RecordReplayId` into:
    * `SelectNextTaskImpl` A/D
    * `DidRunTask` before `pop_back`
    * `PostImmediateTaskImpl` after `push_back`
    * `TakeTaskFromWorkQueue`
    * `SoftwareImageDecodeTaskImpl::RunOnWorkerThread`
* Why this works
  * Source id is 0 exactly when the task was created with events unavailable or passed through.
  * A deterministic dequeue of id 0 is a non-deterministic source leaking into a recorded queue.
  * SequenceManager post/take/run assert the same `PendingTask` id assigned at construction.

# Raw Data

* crash-0092
  * buildId: `linux-chromium-20260817-e7938ea0fd3a-cb0cc1873fcb`
  * recordingId: `dcbf6523-000c-41a2-a3dd-784e008ad92c`
* crash-0051-4
  * buildId: `linux-chromium-20260817-e7938ea0fd3a-cb0cc1873fcb`
  * recordingId: `ccf4e7ee-0f4d-4051-ade2-8985de426f7d`
