### PR TITLE
[crash-0084-2] Assert SkImageFilter cache get/set identity

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': 'b726d47fabe4fd871ae74409df384ad8ac38f0f5',
+  'skia_revision': 'df6f902313f51b0e9e051e4164bd240ba3a95ba9',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '39e5d0421c656714ed15c1a50635234341c04ed7',
+  'skia_revision': 'b726d47fabe4fd871ae74409df384ad8ac38f0f5',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-skia/pull/47
# Summary

* `ControlFlowMismatch` at `SkImageFilter_Base::filterImage`: recorded cache-get hit, replayed miss-arm → `MakeFromBitmap`.
* `NoRoot`. Asserts only:
  * cache-get identity: `fUniqueID`, `!!context.cache()`, `srcGenID`, `srcSubset`
  * `CacheImpl::set` write: filter `uniqueID`
* Endgoal: a later hit on both sides with divergent values (`DataMismatch`).

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* operatorId: `02057cdd-d790-47d6-995b-531cca3d5c44`
* Buckets: Mismatch/[RUN-593-1863] SkImage::MakeFromBitmap, Mismatch/anonymous.namespace::CacheImpl::get.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* Crash Report Core below.
* The RAW report when needed.

### RepoSrc

* backend
* chromium/src

## Important Context

* buildId: linux-chromium-20260808-3aefa452b8bf-33a69264625e
* linkerVersion: linker-linux-16086-33a69264625e
* recordingId: 128de2fa-81f8-4c25-a124-58891e805bdd

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 7456354,
  "category": "newBranch",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 4604660,
      "checkpoint": 355
    }
  },
  "recorded": "OrderedLock SkImageFilterCache 7497",
  "replayed": "[RUN-593-1863] SkImage::MakeFromBitmap 1",
  "threadId": 9,
  "backtrace": {
    "progress": 4596980,
    "threadId": 9,
    "checkpoint": 352
  },
  "recordedStack": [
    "(anonymous.namespace)::CacheImpl::get(SkImageFilterCacheKey.const&,.skif::FilterResult*).const+36",
    "SkImageFilter_Base::filterImage(skif::Context.const&).const+437",
    "SkBaseDevice::drawFilteredImage(skif::Mapping.const&,.SkSpecialImage*,.SkImageFilter.const*,.SkSamplingOptions.const&,.SkPaint.const&)+726",
    "SkCanvas::onDrawImage2(SkImage.const*,.float,.float,.SkSamplingOptions.const&,.SkPaint.const*)+1257",
    "SkCanvas::drawImage(SkImage.const*,.float,.float,.SkSamplingOptions.const&,.SkPaint.const*)+251",
    "viz::SoftwareRenderer::ApplyImageFilter(SkImageFilter*,.viz::AggregatedRenderPassDrawQuad.const*,.SkBitmap.const&,.bool,.SkIRect*).const+560",
    "viz::SoftwareRenderer::DrawRenderPassQuad(viz::AggregatedRenderPassDrawQuad.const*)+556",
    "viz::SoftwareRenderer::DoDrawQuad(viz::DrawQuad.const*,.gfx::QuadF.const*)+1627"
  ],
  "replayedStack": [
    "SkRecordReplayAssert(char.const*,....)+158",
    "SkImage::MakeFromBitmap(SkBitmap.const&)+33",
    "SkSpecialImage_Raster::onDraw(SkCanvas*,.float,.float,.SkSamplingOptions.const&,.SkPaint.const*).const+68",
    "(anonymous.namespace)::SkColorFilterImageFilter::onFilterImage(skif::Context.const&,.SkIPoint*).const+811",
    "SkImageFilter_Base::onFilterImage(skif::Context.const&).const+43",
    "SkImageFilter_Base::filterImage(skif::Context.const&).const+469",
    "SkImageFilter_Base::filterInput(int,.skif::Context.const&).const+373",
    "SkLocalMatrixImageFilter::onFilterImage(skif::Context.const&,.SkIPoint*).const+397"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Ordered lock with events disallowed SkImageFilterCache [EventsDisallowed:~PaintOpBuffer]",
    "count": 98,
    "stack": [
      "(anonymous.namespace)::CacheImpl::purgeByImageFilter(SkImageFilter.const*)+37",
      "SkImageFilter_Base::~SkImageFilter_Base()+40",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::PaintFlags::~PaintFlags()+188",
      "cc::PaintOpBuffer::Reset()+229",
      "cc::PaintOpBuffer::~PaintOpBuffer()+39",
      "cc::DisplayItemList::~DisplayItemList()+93",
      "cc::RasterSource::~RasterSource()+58",
      "cc::PictureLayerImpl::UpdateRasterSource(scoped_refptr<cc::RasterSource>,.cc::Region*,.cc::PictureLayerTilingSet.const*,.base::flat_map<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>,.std::Cr::less<void>,.std::Cr::vector<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>,.std::Cr::allocator<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>.>.>.>.const*)+1672",
      "cc::PictureLayerImpl::PushPropertiesTo(cc::LayerImpl*)+239",
      "cc::TreeSynchronizer::PushLayerProperties(cc::LayerTreeImpl*,.cc::LayerTreeImpl*)+193",
      "cc::LayerTreeHostImpl::ActivateSyncTree()+258",
      "cc::Scheduler::ProcessScheduledActions()+1091",
      "cc::TileManager::IssueSignals()+127",
      "cc::TileManager::CheckPendingGpuWorkAndIssueSignals()+902",
      "cc::TileManager::FlushAndIssueSignals()+89",
      "cc::UniqueNotifier::Notify()+68",
      "base::internal::Invoker<base::internal::BindState<base::internal::IgnoreResultHelper<void.(web_app::WebAppFileHandlerManager::*)()>,.base::WeakPtr<web_app::WebAppFileHandlerManager>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+132",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
      "base::(anonymous.namespace)::ThreadFunc(void*)+86"
    ],
    "progress": 188814,
    "threadId": 9,
    "processId": 2,
    "checkpoint": 4,
    "absoluteTime": 1786847760049.5186,
    "wasRecording": true
  },
  {
    "text": "Recording assertion with events disallowed: CreateOrderedLock SkImageFilterCache [EventsDisallowed:~PaintOpBuffer]",
    "count": 2,
    "stack": [
      "SkImageFilterCache::Get()+140",
      "SkImageFilter_Base::~SkImageFilter_Base()+28",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::PaintFlags::~PaintFlags()+188",
      "cc::PaintOpBuffer::Reset()+229",
      "cc::PaintOpBuffer::~PaintOpBuffer()+39",
      "cc::DisplayItemList::~DisplayItemList()+93",
      "cc::RasterSource::~RasterSource()+58",
      "cc::PictureLayerImpl::UpdateRasterSource(scoped_refptr<cc::RasterSource>,.cc::Region*,.cc::PictureLayerTilingSet.const*,.base::flat_map<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>,.std::Cr::less<void>,.std::Cr::vector<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>,.std::Cr::allocator<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>.>.>.>.const*)+1672",
      "cc::PictureLayerImpl::PushPropertiesTo(cc::LayerImpl*)+239",
      "cc::TreeSynchronizer::PushLayerProperties(cc::LayerTreeImpl*,.cc::LayerTreeImpl*)+193",
      "cc::LayerTreeHostImpl::ActivateSyncTree()+258",
      "cc::Scheduler::ProcessScheduledActions()+1091",
      "cc::TileManager::IssueSignals()+127",
      "cc::TileManager::CheckPendingGpuWorkAndIssueSignals()+902",
      "cc::TileManager::FlushAndIssueSignals()+89",
      "cc::UniqueNotifier::Notify()+68",
      "base::internal::Invoker<base::internal::BindState<base::internal::IgnoreResultHelper<void.(web_app::WebAppFileHandlerManager::*)()>,.base::WeakPtr<web_app::WebAppFileHandlerManager>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+132",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
      "base::(anonymous.namespace)::ThreadFunc(void*)+86",
      "recordreplay::Thread::ThreadMainOwnStack(void*)+78",
      "InvokeOnNewStack+11"
    ],
    "progress": 1548464,
    "threadId": 9,
    "processId": 14,
    "checkpoint": 20,
    "absoluteTime": 1786847770339.679,
    "wasRecording": false
  },
  {
    "text": "Recorded value with events disallowed CreateOrderedLock [EventsDisallowed:~PaintOpBuffer]",
    "count": 2,
    "stack": [],
    "progress": 1548464,
    "threadId": 9,
    "processId": 14,
    "checkpoint": 20,
    "absoluteTime": 1786847770340.8943,
    "wasRecording": false
  }
]
```

# Data

## Previous Work

* crash-0084: same `Problem type: ReplayMismatch`, shares the `Mismatch/anonymous.namespace::CacheImpl::get` bucket (its other bucket is `Mismatch/SkImageFilterCache::Get`, not `Mismatch/[RUN-593-1863] SkImage::MakeFromBitmap`). Also an `OrderedLock`/`CreateOrderedLock` `SkImageFilterCache` mismatch on the same `CacheImpl`/`SkImageFilter_Base::filterImage` cache-lookup path; concluded `NoRoot`/`Unproven` (no write-then-read trail found for the racing `SkImageFilterCache` lock-id assignment) and proposed no intervention.
* No other `crash-*/problem.md` mentions `SkImage::MakeFromBitmap` or shares either `Buckets:` value.

PlacementParent: crash-0084

## DominantWarning

* None: all Warnings are hundreds of `checkpoint`s in front of the mismatch's `backtrace` (`checkpoint` 352) — the `SkImageFilterCache` ones at `checkpoint` 4 and 20.

## InterestingFrames

* Shared top-most frame (required by `StackCommonFrame`): `SkImageFilter_Base::filterImage` (recordedStack[1]/replayedStack[5]; only common base-name frame).
  * `SkImageFilter.cpp:222-258`: `SkImageFilterCacheKey key(...)`; `if (context.cache() && context.cache()->get(key, &result)) return result;` else `result = this->onFilterImage(context);` then `context.cache()->set(key, this, result)`.
  * That cache-get branch dominates: recorded is in the `get` call (→ `CacheImpl::get` leaf), replayed on the else-arm (→ `onFilterImage` → … → `MakeFromBitmap` leaf).
* recordedStack picks:
  * `CacheImpl::get+36` — leaf/mismatch frame. `SkImageFilterCache.cpp:54-68`: `SkAutoMutexExclusive mutex(fMutex); if (Value* v = fLookup.find(key)) { *result = v->fImage; return true; } return false;` — `find(key)` is the hit/miss decision.
  * `SkImageFilter_Base::filterImage` (shared frame, above).
  * `SkBaseDevice::drawFilteredImage+726`. `SkDevice.cpp:322-351`: builds `skif::Context ctx(..., cache.get(), ...)` from `getImageFilterCache()`, then `filterImage(ctx).imageAndOffset(&offset)` — supplies the `cache` read above.
* replayedStack picks:
  * `SkImage::MakeFromBitmap+33` — leaf/`AssertSite` of the replayed value `1`. `SkImage.cpp:547-554`: existing assert on the `bm.pixelRef()` branch.
  * `SkImageFilter_Base::filterImage` (shared frame, above; not duplicated).
  * `SkLocalMatrixImageFilter::onFilterImage+397` — most caller-ward non-generic frame. `SkLocalMatrixImageFilter.cpp:48-54`: `filterInput(0, localCtx, offset)` → `imageAndOffset` resolve path reaching the raster draw.

## ResolvedFrames

* All `FrameRecord`s: direct symbol match, no inlining → `inlineChain: none`, `state: Resolved`.
* `FrameRecord` `CacheImpl::get+36` (recordedStack leaf): `third_party/skia/src/core/SkImageFilterCache.cpp:54`, code `if (Value* v = fLookup.find(key)) {`.
* `FrameRecord` `SkImageFilter_Base::filterImage.const` (shared top-most frame; recordedStack[1]+437 / replayedStack[5]+469): `third_party/skia/src/core/SkImageFilter.cpp:241`, code `if (context.cache() && context.cache()->get(key, &result)) {`.
* `FrameRecord` `SkBaseDevice::drawFilteredImage+726`: `third_party/skia/src/core/SkDevice.cpp:342`, code `sk_sp<SkSpecialImage> result = as_IFB(filter)->filterImage(ctx).imageAndOffset(&offset);`.
* `FrameRecord` `SkImage::MakeFromBitmap+33` (replayedStack leaf = replayed `AssertSite`): `third_party/skia/src/image/SkImage.cpp:548`, code `SkRecordReplayAssert("[RUN-593-1863] SkImage::MakeFromBitmap %d", !!bm.pixelRef());`.
* `FrameRecord` `SkLocalMatrixImageFilter::onFilterImage.const+397`: `third_party/skia/src/core/SkLocalMatrixImageFilter.cpp:54`, code `return this->filterInput(0, localCtx, offset);`.
* `AssertSite` recorded (`"OrderedLock SkImageFilterCache 7497"`): `backend/src/cpp/recording/OrderedLock.cpp:148` in `recordreplay::OrderedLock(void*, int)`: `RecordReplayAssertWithStack(aStackPointer, "OrderedLock %s %d", info->mName, aLock);` — absent from `recordedStack` since `RecordReplayAssertWithStack` re-roots at `OrderedLock`'s caller.
* `AssertSite` replayed (`"[RUN-593-1863] SkImage::MakeFromBitmap 1"`): same site as the `SkImage::MakeFromBitmap` `FrameRecord` above (`SkImage.cpp:548`); it IS the replayedStack leaf frame, one below `SkRecordReplayAssert(char.const*,....)+158`.

## DominantWarningProvenance

* `NoDominantWarning`.

## MismatchProvenance

* `MismatchShape`: `ControlFlowMismatch` — different `AssertSite`s (`OrderedLock.cpp:148` / `SkImage.cpp:548`). `LastNonHitAssert`: not reported.
* `Anchor`: `SkImageFilter_Base::filterImage` (`SkImageFilter.cpp:241`; `+437` / `+469`).
* Outline:
  * `SkImageFilter_Base::filterImage` [SkImageFilter.cpp:222-258]
    * `SkImageFilterCacheKey key(fUniqueID, layerMatrix, clipBounds, srcGenID, srcSubset);`
      * `// [Identity] UNPROVEN` — recorded enters from `drawFilteredImage` (top-level filter), replayed from `filterInput` under `SkLocalMatrixImageFilter` (child filter).
    * `if (context.cache() && context.cache()->get(key, &result))`
      * `// [Branch] RECORDED: taken` — replayed took the else-arm `result = this->onFilterImage(context);` (`+469`).
    * `if (context.cache()) context.cache()->set(key, this, result);`
  * `CacheImpl::get` [SkImageFilterCache.cpp:54-68]
    * `SkAutoMutexExclusive mutex(fMutex);` → `OrderedLock` → `// <<< RECORDED LEAF`
    * `if (Value* v = fLookup.find(key))`
      * `// [Branch] UNPROVEN` — after the recorded leaf.
  * `CacheImpl::set` [SkImageFilterCache.cpp:70-94]
    * `fLookup.add(v);`
      * `// [Write] UNPROVEN` — sole population of `fLookup` under `key`; feeds `find(key)`.
  * `SkImage::MakeFromBitmap` [SkImage.cpp:547-554]
    * `SkRecordReplayAssert("[RUN-593-1863] SkImage::MakeFromBitmap %d", !!bm.pixelRef());` → `// <<< REPLAYED LEAF`

## AssertCandidates

* `SkImageFilter_Base::filterImage`
  * assertable: `:241` in front of the `if` — `[Branch]` `!!context.cache()` + `[Identity]` `fUniqueID`/`srcGenID`/`srcSubset` — `get()` mutates the LRU, so the condition cannot be re-evaluated.
  * provenance: Anchor branch → recorded `OrderedLock` leaf / else-arm → `MakeFromBitmap` leaf.
* `CacheImpl::set`
  * assertable: `:70-94` before `fLookup.add(v)` — `[Write]` `filter->uniqueID()` — what a later `find(key)` can hit.
  * provenance: earlier miss-arm → `set` → later `get` → Anchor branch.
* `CacheImpl::get`
  * not-assertable: `:54-68` `fLookup.find(key)` — `[Branch]` — behind the recorded Assert.

## DivergenceRoot

* `NoRoot`. `NoDominantWarning`; `# Symptoms` in determinism-synchronization: no match (`UnnamedLock` needs a `## DominantWarning`, `fMutex` is named, and the span still holds `ASSERTABLE` candidates).

## PossibleInterventions

* None — `NoRoot`.

## SuggestedCourseOfAction

* Assert, no intervention:
  * `SkImageFilter.cpp:241`, before the cache-get `if`: `SkRecordReplayAssert("SkImageFilter_Base::filterImage %u %d %u %d %d", fUniqueID, !!context.cache(), srcGenID, srcSubset.width(), srcSubset.height());`
  * `SkImageFilterCache.cpp:70-94`, before `fLookup.add(v)`: `SkRecordReplayAssert("CacheImpl::set %u", filter ? as_IFB(filter)->uniqueID() : 0);`
* Endgoal (`ControlFlowMismatch`): a future report hitting one of these on both sides with divergent values (`DataMismatch`).