### PR TITLE
[crash-0035-2] Warn FailedToReinstrument when freeze-true recompile drops opcodes

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'dbea5ad341d33122a1342ac3406e5663b45a21cb',
+  'v8_revision': 'a82b21cc3e07d1a4421d5b74780f3a112abfc4a9',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'a82b21cc3e07d1a4421d5b74780f3a112abfc4a9',
+  'v8_revision': 'c99f6f5833523e526e681fc5fd5dd61aa5cdc098',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/322
# Summary

* Add one `recordreplay::Warning` in `RecordReplayShouldEmitOpcodes` on the `FailedToReinstrument` path.
  * `FailedToReinstrument`: `gOpcodeEmitByScript[script_id]` is frozen `true`, but this compile has `record_replay_ignore && !IsMainThread()`, so the function returns `false` and that compile emits no instrumentation opcodes.
  * Until now this path was silent, so a script that was instrumented once and later recompiled uninstrumented left no trace in the recording or replay log.
* Purpose is diagnostic only.
  * A `ReplayMismatch` of `MismatchKind: Js` currently cannot be attributed between two candidate mechanisms without this signal.
  * The Warning distinguishes "the script was entered but its bytecode emits no Progress" from "the script was never entered".
* Warning, not `REPLAY_ASSERT`.
  * This path is permitted to differ between recording and replay.
  * It runs on a background compile thread and is not aligned with JS progress, so an assert would be unsound.

# Problem

* Criterion: observed symptom.
  * `ReplayMismatch`, `MismatchKind: Js`.
  * Earliest application-data mismatch is at `ContainerNode::AppendChild` with `recorded: []` versus `replayed: ["11::2940:43"]`.
  * Site `11::2940:43` is the function-entry position of a JS wrapper installed over `Node.prototype.appendChild` by the page under test.
  * Later in the same checkpoint the replay runs exactly one surplus progress tick.
* Causal chain to the modified location.
  * The application-data mismatch says only that replay pushed a JS progress entry for that site and the recording pushed none.
  * Two mechanisms produce that same shape.
    * `ResolveSplit`: only replay's property lookup resolves to the wrapper, so the recording never enters it.
    * `FailedToReinstrument`: both sides enter the wrapper, but only one side's bytecode carries instrumentation opcodes.
  * Application-data mismatch alone does not separate them.
  * `gOpcodeEmitByScript` already freezes the first emit decision per `script_id`, which removes stored `true` to `false` transitions as a cause.
  * The freeze does not cover the override branch inside `RecordReplayShouldEmitOpcodes`.
    * A stored `true` combined with `record_replay_ignore && !IsMainThread()` still yields `false` for that single compile.
    * `record_replay_ignore` reaches a background compile task through `SetRecordReplayFlags`.
    * Shape: script instrumented on the main thread, bytecode flushed, one side recompiles it on a worker without opcodes, that side then executes the wrapper without emitting Progress.
  * The override branch is therefore the only remaining unobserved producer of the observed shape, and it is the modified location.

# Solution

## Solution Recipe

* Emit a Warning at the exact point where a frozen-lit script is recompiled without opcodes.
* Include the `script_id` so the emitted event can be correlated with the `sourceId` in the application-data mismatch.
* Include the number of running background compile tasks so the worker-recompile shape can be confirmed rather than assumed.
* Keep the control flow unchanged.

## Implementation

* In `v8/src/debug/debug.cc`, `RecordReplayShouldEmitOpcodes`, immediately before the override `return false`:
  * `recordreplay::Warning("FailedToReinstrument scriptId=%d bct=%zu", script_id, NumRunningBackgroundCompileTasks());`
* No deduplication set.
* No deferred reporting.
* No new flag or status.

## Why does this work?

* The branch fires exactly when a script whose frozen decision is "emit" produces a compile that does not emit.
  * That is the definition of `FailedToReinstrument`, so the Warning has no false positives with respect to the mechanism.
* `script_id` makes the event joinable to the diverging `sourceId`.
* The background-compile-task count is read at the same instant as the decision, so it evidences the worker path directly.
* Interpretation limits, stated explicitly.
  * The Warning proves that a previously instrumented script was recompiled without opcodes.
  * It does not prove that the specific `AppendChild` in this report executed that uninstrumented bytecode.
  * Absence of the Warning in a future recording is the stronger result: it eliminates `FailedToReinstrument` and leaves `ResolveSplit`.

# Raw Data

* buildId: `linux-chromium-20260808-3aefa452b8bf-33a69264625e`
* linkerVersion: `linker-linux-16086-33a69264625e`
* recordingId: `149d0525-215a-4b8d-96d6-609e035c342c`
* operatorId: `0af233fc-9793-46c4-b20b-24a28e40cb23`