### PR TITLE
[pause] Early-out Linux PlatformFallbackFontForCharacter after diverge

### DIFF
--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
@@ -278,7 +278,7 @@ scoped_refptr<SimpleFontData> FontFallbackIterator::UniqueSystemFontForHintList(
   if (!hint_list.size())
     return nullptr;
 
-  if (recordreplay::IsReplaying() && recordreplay::HasDivergedFromRecording()) {
+  if (recordreplay::AreEventsUnavailable("UniqueSystemFontForHintList")) {
     // If we've run out of recording data, then following this chain of logic will lead to
     // hangs, as we await conditional vars on epoll waiters that don't actually exist, held
     // by threads that are dead (waiting forever.)  Luckily, it seems we can just early out 

--- a/third_party/blink/renderer/platform/fonts/linux/font_cache_linux.cc
+++ b/third_party/blink/renderer/platform/fonts/linux/font_cache_linux.cc
@@ -24,6 +24,7 @@
 
 #include "third_party/blink/renderer/platform/fonts/font_cache.h"
 
+#include "base/record_replay.h"
 #include "build/build_config.h"
 #include "third_party/blink/public/platform/linux/web_sandbox_support.h"
 #include "third_party/blink/public/platform/platform.h"
@@ -67,6 +68,12 @@ scoped_refptr<SimpleFontData> FontCache::PlatformFallbackFontForCharacter(
     UChar32 c,
     const SimpleFontData*,
     FontFallbackPriority fallback_priority) {
+  if (recordreplay::AreEventsDisallowed("PlatformFallbackFontForCharacter") ||
+      recordreplay::HasDivergedFromRecording()) {
+    // Post-diverge font-service Mojo cannot complete; return no fallback.
+    return nullptr;
+  }
+
   // The m_fontManager is set only if it was provided by the embedder with
   // WebFontRendering::setSkiaFontManager. This is used to emulate android fonts
   // on linux so we always request the family from the font manager and if none

--- a/third_party/blink/renderer/platform/fonts/linux/font_cache_linux.cc
+++ b/third_party/blink/renderer/platform/fonts/linux/font_cache_linux.cc
@@ -68,8 +68,7 @@ scoped_refptr<SimpleFontData> FontCache::PlatformFallbackFontForCharacter(
     UChar32 c,
     const SimpleFontData*,
     FontFallbackPriority fallback_priority) {
-  if (recordreplay::AreEventsDisallowed("PlatformFallbackFontForCharacter") ||
-      recordreplay::HasDivergedFromRecording()) {
+  if (recordreplay::AreEventsUnavailable("PlatformFallbackFontForCharacter")) {
     // Post-diverge font-service Mojo cannot complete; return no fallback.
     return nullptr;
   }

--- a/third_party/blink/renderer/platform/fonts/mac/font_cache_mac.mm
+++ b/third_party/blink/renderer/platform/fonts/mac/font_cache_mac.mm
@@ -129,8 +129,7 @@ scoped_refptr<SimpleFontData> FontCache::PlatformFallbackFontForCharacter(
       return emoji_font;
   }
 
-  if (recordreplay::AreEventsDisallowed("PlatformFallbackFontForCharacter") ||
-      recordreplay::HasDivergedFromRecording()) {
+  if (recordreplay::AreEventsUnavailable("PlatformFallbackFontForCharacter")) {
     // [RUN-2765] Circumvent a rabbit hole of MAC-related font calls.
     return nullptr;
   }


### PR DESCRIPTION
# Summary

* `pauseRequest` hang on Linux after diverge
* `PlatformFallbackFontForCharacter` → font-service Mojo `FallbackFontForCharacter` → `WaitableEvent::Wait`
* Intervention: `divergence-simulate-side-effects`
* Early-out `nullptr` under `AreEventsUnavailable` (Linux + Mac + `UniqueSystemFontForHintList`)

# Problem

* Criterion: PauseChild `pauseRequest` fatal hang
* Recording: `b0174e9c-3ced-4b00-8d4a-ec3476cef6ab`
* Report: `4c9fea17-0c6c-42de-a21c-f254342423e0`
* Causal chain:
  * Pause path diverges, then shapes text
  * `FontFallbackIterator` asks `FontCache::FallbackFontForCharacter`
  * Linux `PlatformFallbackFontForCharacter` calls sandbox `GetFallbackFontForCharacter`
  * That posts Mojo `FallbackFontForCharacter` and waits on `WaitableEvent`
  * Post-diverge the peer/result never arrives → hang on `ConditionVariable::Wait`

# Solution

* Solution Recipe: `divergence-simulate-side-effects`
* Implementation
  * In Linux/Mac `FontCache::PlatformFallbackFontForCharacter` and `FontFallbackIterator::UniqueSystemFontForHintList`, return `nullptr` when `AreEventsUnavailable(...)`
* Why does this work?
  * DivergedOp is the font-service IPC, not the wait frame
  * Stand-in skips the impossible side-effect; Blink continues without that fallback font

# Raw Data

* buildId: `linux-chromium-20260823-fbf02f60497c-a8c7df57fa75`
* kind: `fatal`
* session_id: `837299fb-eda6-4b80-9a08-ed387974e38c`
* controller_id: `fc724b9a-0528-48ef-a3dc-96dea8e313b7`
* created_at: `2026-08-24T05:37:23.185018+00:00`
* recording_id: `b0174e9c-3ced-4b00-8d4a-ec3476cef6ab`
* description: `{"operatorId":"0f23dd8f-8346-472d-ab01-06b4468f0c9b","requestId":""}`

### Crash Report Core

```json
{
  "why": "Hanged",
  "category": "PauseChild",
  "manifest": "pauseRequest",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "ownsLock": [
          "0x100a030455c8"
        ],
        "threadId": 1,
        "waitingOnCvar": {
          "ptr": true,
          "lock": true,
          "waiters": [
            1
          ]
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+714",
          "new_pthread_cond_wait(void*,.void*)+50",
          "0x10004fee804c",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+251",
          "0x10004fee7060",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+961",
          "base::WaitableEvent::Wait()+31",
          "font_service::internal::FontServiceThread::FallbackFontForCharacter(unsigned.int,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.mojo::StructPtr<font_service::mojom::FontIdentity>*,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>*,.bool*,.bool*)+298",
          "font_service::FontLoader::FallbackFontForCharacter(unsigned.int,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>,.mojo::StructPtr<font_service::mojom::FontIdentity>*,.std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>*,.bool*,.bool*)+59",
          "content::WebSandboxSupportLinux::GetFallbackFontForCharacter(int,.char.const*,.gfx::FallbackFontData*)+271",
          "blink::FontCache::PlatformFallbackFontForCharacter(blink::FontDescription.const&,.int,.blink::SimpleFontData.const*,.blink::FontFallbackPriority)+337",
          "blink::FontCache::FallbackFontForCharacter(blink::FontDescription.const&,.int,.blink::SimpleFontData.const*,.blink::FontFallbackPriority)+150",
          "blink::FontFallbackIterator::FallbackPriorityFont(int)+78",
          "blink::FontFallbackIterator::Next(WTF::Vector<int,.0u,.WTF::PartitionAllocator>.const&)+300",
          "blink::HarfBuzzShaper::ShapeSegment(blink::RangeData*,.blink::RunSegmenter::RunSegmenterRange.const&,.blink::ShapeResult*).const+1422",
          "blink::HarfBuzzShaper::Shape(blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.WTF::Vector<blink::RunSegmenter::RunSegmenterRange,.0u,.WTF::PartitionAllocator>.const&).const+326",
          "blink::NGInlineItemSegments::ShapeText(blink::HarfBuzzShaper.const*,.blink::Font.const*,.blink::TextDirection,.unsigned.int,.unsigned.int,.unsigned.int).const+129",
          "blink::NGInlineNode::ShapeText(blink::NGInlineItemsData*,.WTF::String.const*,.blink::HeapVector<blink::NGInlineItem,.0u>.const*,.blink::Font.const*).const+2773",
          "blink::NGInlineNode::ShapeTextIncludingFirstLine(blink::NGInlineNodeData::ShapingState,.blink::NGInlineNodeData*,.WTF::String.const*,.blink::HeapVector<blink::NGInlineItem,.0u>.const*).const+95",
          "blink::NGInlineNode::PrepareLayout(blink::NGInlineNodeData*).const+314",
          "blink::NGInlineNode::PrepareLayoutIfNeeded().const+144",
          "blink::NGInlineNode::EnsureData().const+14",
          "blink::NGBlockNode::FirstChild().const+364",
          "blink::CalculateMinMaxSizesIgnoringChildren(blink::NGBlockNode.const&,.blink::NGBoxStrut.const&)+183",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+58",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+1157",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGFlexLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+537",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGFlexLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+94",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+1157",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+1157",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+1157",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContribution(blink::ComputedStyle.const&,.blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput)+571",
          "blink::NGBlockLayoutAlgorithm::ComputeMinMaxSizes(blink::MinMaxSizesFloatInput.const&)+1157",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::ComputeMinMaxSizesWithAlgorithm(blink::NGLayoutAlgorithmParams.const&,.blink::MinMaxSizesFloatInput.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+88",
          "blink::NGBlockNode::ComputeMinMaxSizes(blink::WritingMode,.blink::MinMaxSizesType,.blink::NGConstraintSpace.const&,.blink::MinMaxSizesFloatInput).const+3071",
          "blink::ComputeMinAndMaxContentContributionForSelf(blink::NGBlockNode.const&,.blink::NGConstraintSpace.const&)+483",
          "blink::NGGridLayoutAlgorithm::ContributionSizeForGridItem(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::GridTrackSizingDirection,.blink::GridItemContributionType,.blink::GridItemData*).const::$_19::operator()(bool).const+36",
          "blink::NGGridLayoutAlgorithm::ContributionSizeForGridItem(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::GridTrackSizingDirection,.blink::GridItemContributionType,.blink::GridItemData*).const+1285",
          "blink::NGGridLayoutAlgorithm::IncreaseTrackSizesToAccommodateGridItems(blink::GridItems::IteratorBase<false>,.blink::GridItems::IteratorBase<false>,.blink::NGGridLayoutData.const&,.bool,.blink::SizingConstraint,.blink::GridItemContributionType,.blink::NGGridSizingTrackCollection*).const+780",
          "blink::NGGridLayoutAlgorithm::ResolveIntrinsicTrackSizes(blink::NGGridLayoutData.const&,.blink::SizingConstraint,.blink::NGGridSizingTrackCollection*,.blink::GridItems*).const+943",
          "blink::NGGridLayoutAlgorithm::ComputeUsedTrackSizes(blink::NGGridLayoutData.const&,.blink::NGGridProperties.const&,.blink::SizingConstraint,.blink::GridItems*,.blink::NGGridLayoutTrackCollection*,.bool*).const+310",
          "blink::NGGridLayoutAlgorithm::ComputeGridGeometry(blink::NGGridPlacementData.const&,.blink::GridItems*,.blink::NGGridLayoutData*,.blink::LayoutUnit*)+853",
          "blink::NGGridLayoutAlgorithm::LayoutInternal()+223",
          "blink::NGGridLayoutAlgorithm::Layout()+14",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGGridLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
          "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
          "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
          "blink::NGBlockLayoutAlgorithm::Layout()+119",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
          "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
          "blink::NGBlockLayoutAlgorithm::Layout()+119",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGBlockLayoutAlgorithm::HandleInflow(blink::NGLayoutInputNode,.blink::NGBreakToken.const*,.blink::NGPreviousInflowPosition*,.blink::NGInlineChildLayoutContext*,.blink::NGInlineBreakToken.const**)+996",
          "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1827",
          "blink::NGBlockLayoutAlgorithm::Layout()+119",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGFlexLayoutAlgorithm::ConstructAndAppendFlexItems(blink::NGFlexLayoutAlgorithm::Phase,.blink::HeapVector<cppgc::internal::BasicMember<blink::LayoutBox,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>,.0u>*)::$_2::operator()(blink::MinMaxSizesType).const+168",
          "blink::NGFlexLayoutAlgorithm::ConstructAndAppendFlexItems(blink::NGFlexLayoutAlgorithm::Phase,.blink::HeapVector<cppgc::internal::BasicMember<blink::LayoutBox,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>,.0u>*)+4137",
          "blink::NGFlexLayoutAlgorithm::PlaceFlexItems(blink::HeapVector<blink::NGFlexLine,.0u>*,.blink::HeapVector<cppgc::internal::BasicMember<blink::LayoutBox,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>,.0u>*,.bool)+47",
          "blink::NGFlexLayoutAlgorithm::LayoutInternal()+170",
          "blink::NGFlexLayoutAlgorithm::Layout()+14",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGFlexLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+89",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
          "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
          "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
          "blink::NGBlockLayoutAlgorithm::Layout()+119",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::NGBlockLayoutAlgorithm::LayoutNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGInflowChildData.const&,.blink::NGBfcOffset,.bool,.blink::NGBfcOffset*)+1456",
          "blink::NGBlockLayoutAlgorithm::HandleNewFormattingContext(blink::NGLayoutInputNode,.blink::NGBlockBreakToken.const*,.blink::NGPreviousInflowPosition*)+1220",
          "blink::NGBlockLayoutAlgorithm::Layout(blink::NGInlineChildLayoutContext*)+1747",
          "blink::NGBlockLayoutAlgorithm::Layout()+119",
          "void.blink::(anonymous.namespace)::CreateAlgorithmAndRun<blink::NGBlockLayoutAlgorithm,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*)>(blink::NGLayoutAlgorithmParams.const&,.blink::(anonymous.namespace)::LayoutWithAlgorithm(blink::NGLayoutAlgorithmParams.const&)::'lambda'(blink::NGLayoutAlgorithmOperations*).const&)+83",
          "blink::NGBlockNode::Layout(blink::NGConstraintSpace.const&,.blink::NGBlockBreakToken.const*,.blink::NGEarlyBreak.const*,.blink::NGColumnSpannerPath.const*).const+2343",
          "blink::LayoutNGView::UpdateBlockLayout(bool)+97"
        ]
      }
    }
  ]
}
```
