### PR TITLE
Assert OnPipeConnectionError endpoint id and client presence

### DIFF
--- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
+++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
@@ -845,6 +845,8 @@ void MultiplexRouter::OnPipeConnectionError(bool force_async_dispatch) {
     endpoint_vector.push_back(pair.second);
 
   for (const auto& endpoint : endpoint_vector) {
+    REPLAY_ASSERT("MultiplexRouter::OnPipeConnectionError %u %d",
+                  endpoint->id(), !!endpoint->client());
     if (endpoint->client()) {
       base::flat_set<uint64_t> request_ids =
           endpoint->UnregisterAllExternalSyncWaiters();


### PR DESCRIPTION
# Summary

* MultiplexRouter `OnPipeConnectionError` ControlFlowMismatch (crash-0056-2).
* No DivergenceRoot yet — Assert both AssertCandidates upstream of the mismatch.
* Probe: per-endpoint `id` (`[IterationOrder]`) and `client()` presence (`[Branch]`).


# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame
* operatorId: `72bb8a84-fcc6-4e85-8aab-0bfa21d6b149`
* Buckets: Mismatch/mojo::internal::MultiplexRouter::ProcessNotifyErro.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-divergences.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260823-fbf02f60497c-a8c7df57fa75
* linkerVersion: linker-linux-16107-a8c7df57fa75
* recordingId: 391fcde3-2786-4f4e-a8bf-9c2e3c0c3dad

### Crash Report Core
```json
{
  "why": "Mismatch",
  "order": 619976,
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 1753707,
      "checkpoint": 26
    }
  },
  "recorded": "WidgetInputHandlerManager::~WidgetInputHandlerManager",
  "replayed": "Value TryLock",
  "threadId": 9,
  "backtrace": {
    "progress": 1753707,
    "threadId": 9,
    "checkpoint": 26
  },
  "recordedStack": [
    "recordreplay::Assert(char.const*,....)+141",
    "blink::WidgetInputHandlerManager::~WidgetInputHandlerManager()+33",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+120",
    "blink::WidgetInputHandlerImpl::~WidgetInputHandlerImpl()+14",
    "blink::WidgetInputHandlerImpl::Release()+81",
    "mojo::InterfaceEndpointClient::NotifyError(absl::optional<mojo::DisconnectReason>.const&)+371",
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+342",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316"
  ],
  "replayedStack": [
    "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*,.mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+361",
    "mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior,.base::SequencedTaskRunner*)+316",
    "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+975",
    "mojo::Connector::HandleError(bool,.bool)+539",
    "base::RepeatingCallback<void.(int)>::Run(int).const.&+39",
    "mojo::SimpleWatcher::OnHandleReady(int,.unsigned.int,.mojo::HandleSignalsState.const&)+291",
    "base::internal::Invoker<base::internal::BindState<void.(mojo::SimpleWatcher::*)(int,.unsigned.int,.mojo::HandleSignalsState.const&),.base::WeakPtr<mojo::SimpleWatcher>,.int,.unsigned.int,.mojo::HandleSignalsState>,.void.()>::RunOnce(base::internal::BindStateBase*)+142",
    "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257"
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recorded value with events disallowed CreateOrderedLock [EventsDisallowed:~PaintOpBuffer]",
    "count": 2,
    "stack": [],
    "progress": 357084,
    "threadId": 9,
    "processId": 2,
    "checkpoint": 7,
    "absoluteTime": 1787627282908.2039,
    "wasRecording": false
  },
  {
    "text": "Recording assertion with events disallowed: CreateOrderedLock SkImageFilterCache [EventsDisallowed:~PaintOpBuffer]",
    "count": 2,
    "stack": [
      "SkImageFilterCache::Get()+140",
      "SkImageFilter_Base::~SkImageFilter_Base()+28",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+30",
      "cc::PaintFlags::~PaintFlags()+188",
      "cc::PaintOpBuffer::Reset()+229",
      "cc::PaintOpBuffer::~PaintOpBuffer()+39",
      "cc::DisplayItemList::~DisplayItemList()+93",
      "cc::RasterSource::~RasterSource()+58",
      "cc::PictureLayerImpl::UpdateRasterSource(scoped_refptr<cc::RasterSource>,.cc::Region*,.cc::PictureLayerTilingSet.const*,.base::flat_map<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>,.std::Cr::less<void>,.std::Cr::vector<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>,.std::Cr::allocator<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>.>.>.>.const*)+1672",
      "cc::PictureLayerImpl::PushPropertiesTo(cc::LayerImpl*)+239",
      "cc::TreeSynchronizer::PushLayerProperties(cc::LayerTreeImpl*,.cc::LayerTreeImpl*)+193",
      "cc::LayerTreeHostImpl::ActivateSyncTree()+258",
      "cc::Scheduler::ProcessScheduledActions()+1091",
      "cc::TileManager::IssueSignals()+127",
      "cc::TileManager::CheckPendingGpuWorkAndIssueSignals()+902",
      "cc::TileManager::FlushAndIssueSignals()+89",
      "cc::UniqueNotifier::Notify()+68",
      "base::internal::Invoker<base::internal::BindState<base::internal::IgnoreResultHelper<void.(web_app::WebAppFileHandlerManager::*)()>,.base::WeakPtr<web_app::WebAppFileHandlerManager>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+132",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
      "base::(anonymous.namespace)::ThreadFunc(void*)+86",
      "recordreplay::Thread::ThreadMainOwnStack(void*)+89",
      "InvokeOnNewStack+11"
    ],
    "progress": 357084,
    "threadId": 9,
    "processId": 2,
    "checkpoint": 7,
    "absoluteTime": 1787627282908.158,
    "wasRecording": false
  },
  {
    "text": "Ordered lock with events disallowed SkImageFilterCache [EventsDisallowed:~PaintOpBuffer]",
    "count": 12,
    "stack": [
      "(anonymous.namespace)::CacheImpl::purgeByImageFilter(SkImageFilter.const*)+37",
      "SkImageFilter_Base::~SkImageFilter_Base()+40",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+30",
      "cc::PaintFlags::~PaintFlags()+188",
      "cc::PaintOpBuffer::Reset()+229",
      "cc::PaintOpBuffer::~PaintOpBuffer()+39",
      "cc::DisplayItemList::~DisplayItemList()+93",
      "cc::RasterSource::~RasterSource()+58",
      "cc::PictureLayerImpl::UpdateRasterSource(scoped_refptr<cc::RasterSource>,.cc::Region*,.cc::PictureLayerTilingSet.const*,.base::flat_map<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>,.std::Cr::less<void>,.std::Cr::vector<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>,.std::Cr::allocator<std::Cr::pair<scoped_refptr<cc::PaintWorkletInput.const>,.std::Cr::pair<int,.sk_sp<cc::PaintOpBuffer>.>.>.>.>.>.const*)+1672",
      "cc::PictureLayerImpl::PushPropertiesTo(cc::LayerImpl*)+239",
      "cc::TreeSynchronizer::PushLayerProperties(cc::LayerTreeImpl*,.cc::LayerTreeImpl*)+193",
      "cc::LayerTreeHostImpl::ActivateSyncTree()+258",
      "cc::Scheduler::ProcessScheduledActions()+1091",
      "cc::TileManager::IssueSignals()+127",
      "cc::TileManager::CheckPendingGpuWorkAndIssueSignals()+902",
      "cc::TileManager::FlushAndIssueSignals()+89",
      "cc::UniqueNotifier::Notify()+68",
      "base::internal::Invoker<base::internal::BindState<base::internal::IgnoreResultHelper<void.(web_app::WebAppFileHandlerManager::*)()>,.base::WeakPtr<web_app::WebAppFileHandlerManager>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+132",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
      "base::(anonymous.namespace)::ThreadFunc(void*)+86"
    ],
    "threadId": 9,
    "processId": 2,
    "checkpoint": 1,
    "absoluteTime": 1787627280679.8123,
    "wasRecording": true
  }
]
```

# Data

## Previous Work

* crash-0071-2
  * exact `Buckets:` match: `Mismatch/mojo::internal::MultiplexRouter::ProcessNotifyErro`.
  * same replayed leaf (`MultiplexRouter::ProcessNotifyErrorTask` → `Value TryLock`) and same recorded-side teardown family (`ScopedInterfaceEndpointHandle`/`cached_group_controller`, `WidgetInputHandlerManager`/`InterfaceEndpointClient`).
  * root-caused there as `cached_group_controller` nullness `ControlFlowMismatch`; itself points to `crash-0071` as `PlacementParent`.
* PlacementParent: crash-0071-2

## DominantWarning

* none
  * all 3 warnings sit at checkpoint 1 / checkpoint 7 (progress ≈357084), mismatch `backtrace` is at checkpoint 26 (progress 1753707) — far in front, disqualifying regardless of apparent relatedness.
  * content also unrelated: warnings concern `SkImageFilterCache`/`PaintOpBuffer` teardown (compositor/raster thread) vs. mismatch's `mojo::MultiplexRouter`/`WidgetInputHandlerManager` teardown + `TryLock` desync — no shared lock/object identity.

## InterestingFrames

* recordedStack:
  * `mojo::internal::MultiplexRouter::ProcessTasks` — top-most shared frame with replayedStack.
  * `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask` — dominating `[Branch]` `if (!endpoint->client()) return true;`, no preceding Assert on that value.
  * (no third candidate: `WidgetInputHandlerImpl::Release`'s branch and `InterfaceEndpointClient::NotifyError`'s branch are each preceded by an existing Assert capturing that exact value — disqualified; both `WidgetInputHandlerImpl::~WidgetInputHandlerImpl` frames are `= default` with no branch; `WidgetInputHandlerManager::~WidgetInputHandlerManager` is the leaf itself, its only branch gates on a driver/recorder flag — invalid per [InvalidAssertValues]).
* replayedStack:
  * `mojo::internal::MultiplexRouter::ProcessTasks` — same shared top-most frame.
  * `mojo::internal::MultiplexRouter::ProcessNotifyErrorTask` — dominating `[Branch]` `if (!endpoint->client()) return true;` decides whether `NotifyError` runs at all; offset delta (+342 recorded vs. +361 replayed) straddles this branch/call.
  * `mojo::internal::MultiplexRouter::OnPipeConnectionError` — dominating `[Branch]` `if (endpoint->client())` per-endpoint decides whether a `NotifyErrorTask` is queued at all, feeding `ProcessTasks`/`ProcessNotifyErrorTask`.
* no `## DominantWarning` stack subject (none).

## ResolvedFrames

* `MultiplexRouter::ProcessTasks` (shared top-most frame, both stacks)
  * location: `MultiplexRouter::ProcessTasks` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:934`
  * code: `ProcessNotifyErrorTask(task.get(), client_call_behavior, current_task_runner)` (`:959`, inside ternary `:957-960` gated by `task->IsNotifyErrorTask()`)
  * inlineChain: none
  * state: Resolved
* `MultiplexRouter::ProcessNotifyErrorTask` (both stacks)
  * location: `MultiplexRouter::ProcessNotifyErrorTask` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:1014`
  * code: `if (!endpoint->client()) return true;` (`:1024-1025`); `if (client_call_behavior != ALLOW_DIRECT_CLIENT_CALLS || endpoint->task_runner() != current_task_runner) { MaybePostToProcessTasks(endpoint->task_runner()); return false; }` (`:1027-1031`); non-early-return path calls `client->NotifyError(disconnect_reason);` (`:1046`)
  * inlineChain: none
  * state: Resolved
* `MultiplexRouter::OnPipeConnectionError` (replayedStack only)
  * location: `MultiplexRouter::OnPipeConnectionError` at `mojo/public/cpp/bindings/lib/multiplex_router.cc:831`
  * code: `if (endpoint->client()) { ... tasks_.push_back(Task::CreateNotifyErrorTask(endpoint.get())); }` (`:848-858`), feeding `ProcessTasks(call_behavior, connector_.task_runner());` (`:869`)
  * inlineChain: none
  * state: Resolved
* all three: non-inlined, single-definition member functions (verified unique in `multiplex_router.cc`) — resolved directly from source, no linkerdebug needed.
* AssertSite — recorded (`"WidgetInputHandlerManager::~WidgetInputHandlerManager"`, literal, no format args, verified unique):
  * `third_party/blink/renderer/platform/widget/input/widget_input_handler_manager.cc:282` — `REPLAY_ASSERT("WidgetInputHandlerManager::~WidgetInputHandlerManager");`
  * enclosing function: `WidgetInputHandlerManager::~WidgetInputHandlerManager()` (`:281`)
* AssertSite — replayed (`"Value TryLock"`):
  * `backend/src/cpp/recording/RecordedValue.cpp:36` — `RecordReplayAssertWithStack(aStackPointer, "Value %s", aWhy);`, called with `aWhy="TryLock"` from the pthread/Windows `TryLock` wrappers (`RecordReplayValueWithStack(stackPointer, "TryLock", ...)` in `FunctionPthreads.cpp`/`FunctionWindows.cpp`)
  * enclosing function: `recordreplay::RecordReplayValueWithStack` (`RecordedValue.cpp:31-49`)
  * absent from both stacks: `RecordReplayAssertWithStack` re-roots the stack at the caller (the `TryLock` wrapper), not shown in the truncated `replayedStack`.

## DominantWarningProvenance

* `DominanceVerdict`: `NoDominantWarning` — `## DominantWarning` is none, no site to anchor a trail on.
* `DominanceShape` checks: N/A, no Warning site exists to check `StateTrail` or `SuppressedEvent` against.

## MismatchProvenance

* `MismatchShape`: `ControlFlowMismatch` — no shared `AssertSite` (recorded: `WidgetInputHandlerManager::~WidgetInputHandlerManager`; replayed: `Value TryLock`).
* `Anchor`s: `MultiplexRouter::ProcessTasks`, `MultiplexRouter::ProcessNotifyErrorTask` (lowest frames matching both stacks).
* Sibling proof (decisive, reused rather than re-derived): crash-0071/problem.md `## ResolvedFrames`/`## MismatchProvenance`, disassembly `artifacts/dumps/ProcessNotifyErrorTask_disasm.txt`, and crash-0071-2/problem.md `## MismatchProvenance` all resolve the exact same replayed offset, `ProcessNotifyErrorTask+361`, to `multiplex_router.cc:1047` `lock_->Acquire()` inside the inlined `MayAutoUnlock::~MayAutoUnlock` (disasm: `+356` trylock, `+361` `test %eax`). That destructor only runs at scope-exit of the `MayAutoUnlock unlocker(&lock_);` block that wraps `client->NotifyError(disconnect_reason);` at `:1046` — i.e. **after** `NotifyError` has already been called and returned. Both `:1024` (`if (!endpoint->client()) return true;`) and `:1027-1031` (the `client_call_behavior`/`task_runner` early-return) are early-return guards strictly upstream of `:1046`; reaching the offset-+361 leaf requires having already fallen through both of them on **both** sides (recorded reaches `:1046` per its own stack; replayed reaches the same `+361` offset in the same function, which is unreachable without also falling through the same two guards). Neither branch can therefore be the site where recorded and replayed arms differ — both sides pass through them identically to reach the unlock. Dropped as `DivergenceCandidate`s on this sibling proof (not because of [InvalidAssertValues], but because they are proven pass-through, not gating, for this leaf).
* With both `ProcessNotifyErrorTask` branches dropped, the only remaining candidate on the span is `OnPipeConnectionError`'s per-endpoint queuing branch/iteration (replayed-only, feeding whether/which `NotifyErrorTask` is queued at all) — kept, still `UNPROVEN`.
* Recorded side: no candidate remains after dropping — `ProcessNotifyErrorTask`'s two branches were the only ones proposed on the recorded span (see `## InterestingFrames`), and both are now proven pass-through, not gating. No candidate is backfilled.
* `DivergenceCandidate`s:
  * `OnPipeConnectionError`, `multiplex_router.cc:848` `if (endpoint->client()) { ...push_back(CreateNotifyErrorTask...) }` — `[Branch]` `UNPROVEN`. Replayed-only; gates whether a `NotifyErrorTask` is queued for that endpoint, feeding the visible `ProcessTasks`/`ProcessNotifyErrorTask` call.
  * `OnPipeConnectionError`, `multiplex_router.cc:846` `for (const auto& endpoint : endpoint_vector)` — `[IterationOrder]` `UNPROVEN`. Picks which endpoint's `client()` is tested, hence which `NotifyErrorTask`s get queued/ordered.

## AssertCandidates

* `MultiplexRouter::OnPipeConnectionError`
  * assertable:
    * `mojo/public/cpp/bindings/lib/multiplex_router.cc:848` — `if (endpoint->client())` — `[Branch]` — gates whether a `NotifyErrorTask` is queued for this endpoint, directly upstream of the visible `ProcessTasks`/`ProcessNotifyErrorTask` frames; no existing Assert on this value.
    * `mojo/public/cpp/bindings/lib/multiplex_router.cc:846` — `for (const auto& endpoint : endpoint_vector)` — `[IterationOrder]` — picks which endpoint's `client()`/`id()` is tested each iteration, hence which/how many `NotifyErrorTask`s get queued and in what order; `endpoint->id()` (`InterfaceId`) is a non-address, non-driver value usable for identity, and `endpoint_vector` order is fixed by `endpoints_`'s (`std::map<InterfaceId,...>`) iteration at `:844`, so no existing Assert covers this.
  * not-assertable: none
  * provenance:
    * `OnPipeConnectionError` (`:831`), `MayAutoLock locker(&lock_);` (`:835`, synchronization — never asserted, not a candidate)
    * `for (const auto& endpoint : endpoint_vector)` (`:846`)
    * `if (endpoint->client())` (`:848`) → `tasks_.push_back(Task::CreateNotifyErrorTask(endpoint.get()));` (`:857`)
    * feeds `ProcessTasks(call_behavior, connector_.task_runner());` (`:869`) → `ProcessNotifyErrorTask` → recorded leaf `WidgetInputHandlerManager::~WidgetInputHandlerManager` / replayed leaf `MayAutoUnlock::~MayAutoUnlock` (`Value TryLock`).

### Rendering

```cpp
// mojo/public/cpp/bindings/lib/multiplex_router.cc

void MultiplexRouter::OnPipeConnectionError(bool force_async_dispatch) {
  // ... (replayedStack only)
  for (const auto& endpoint : endpoint_vector) {
    // [IterationOrder] UNPROVEN
    if (endpoint->client()) {
      // [Branch] UNPROVEN
      tasks_.push_back(Task::CreateNotifyErrorTask(endpoint.get()));
    }
    UpdateEndpointStateMayRemove(endpoint.get(), PEER_ENDPOINT_CLOSED);
  }
  ProcessTasks(call_behavior, connector_.task_runner());
}

void MultiplexRouter::ProcessTasks(
    ClientCallBehavior client_call_behavior,
    base::SequencedTaskRunner* current_task_runner) {
  while (!tasks_.empty() && !paused_) {
    bool processed =
        task->IsNotifyErrorTask()
            ? ProcessNotifyErrorTask(task.get(), client_call_behavior,
                                     current_task_runner)  // <<< enters shared frame
            : ProcessIncomingMessage(...);
  }
}

bool MultiplexRouter::ProcessNotifyErrorTask(
    Task* task,
    ClientCallBehavior client_call_behavior,
    base::SequencedTaskRunner* current_task_runner) {
  InterfaceEndpoint* endpoint = task->endpoint_to_notify.get();
  if (!endpoint->client())
    // [Branch] dropped — proven pass-through both sides (sibling disasm), not gating
    return true;

  if (client_call_behavior != ALLOW_DIRECT_CLIENT_CALLS ||
      endpoint->task_runner() != current_task_runner) {
    // [Branch] dropped — proven pass-through both sides (sibling disasm), not gating
    MaybePostToProcessTasks(endpoint->task_runner());
    return false;
  }

  ...
  InterfaceEndpointClient* client = endpoint->client();
  {
    MayAutoUnlock unlocker(&lock_);
    client->NotifyError(disconnect_reason);  // :1046, recorded side takes this arm
  }
  return true;
}  // scope-exit of `unlocker` calls ~MayAutoUnlock, inlined below

void InterfaceEndpointClient::NotifyError(
    const absl::optional<DisconnectReason>& reason) {
  recordreplay::Assert(
      "InterfaceEndpointClient::NotifyError %d %d %s %d %d", ...);  // already-asserted, skipped
  if (encountered_error_)
    return;
  ...
}

void WidgetInputHandlerImpl::Release() {
  recordreplay::Assert("WidgetInputHandlerImpl::Release %d",
                       !!input_processed_ack_);  // already-asserted, skipped
  if (input_processed_ack_)
    std::move(input_processed_ack_).Run();
  delete this;
}

WidgetInputHandlerImpl::~WidgetInputHandlerImpl() = default;  // no branch

WidgetInputHandlerManager::~WidgetInputHandlerManager() {
  REPLAY_ASSERT("WidgetInputHandlerManager::~WidgetInputHandlerManager");  // <<< RECORDED LEAF
  // sole branch below gates on a driver/config flag (leak-references) — dropped, [InvalidAssertValues]
  if (recordreplay::IsRecordingOrReplaying("leak-references", "WidgetInputHandlerManager")) {
    response_power_mode_voter_.release();
  }
}

// mojo/public/cpp/bindings/lib/may_auto_lock.h
MayAutoUnlock::~MayAutoUnlock() {  // :57, inlined into ProcessNotifyErrorTask
  if (lock_)
    lock_->Acquire();  // :59 → pthread_mutex_trylock — <<< REPLAYED LEAF (offset +361, per sibling disasm)
}
```

## SuggestedCourseOfAction

* No `## DivergenceRoot` (SKIP: `DominanceVerdict` is not `Verified`, no `## AssertCandidates` entry proven as root).
* Assert both `## AssertCandidates` entries:
  * `mojo/public/cpp/bindings/lib/multiplex_router.cc:848` — `if (endpoint->client())` — `[Branch]`.
  * `mojo/public/cpp/bindings/lib/multiplex_router.cc:846` — `for (const auto& endpoint : endpoint_vector)` — `[IterationOrder]`, Assert on `endpoint->id()`.
* Neither is already-asserted; neither is invalid per [InvalidAssertValues].
* `MismatchShape` is `ControlFlowMismatch`: endgoal is a future report where one of these two Asserts is hit with divergent values between recorded and replayed.
* Neither Assert by itself guarantees that outcome.
