### PR TITLE
Mark HTML parse as interesting recording content

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': 'c99f6f5833523e526e681fc5fd5dd61aa5cdc098',
+  'v8_revision': '58bb081132fda47458565fa4446b2c777d650ac7',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-v8/pull/323

# Problem
* `replayio record https://example.com` produces no recording
* Verbose Chromium logs:
  * `RecordingUnusable` / `Recording invalidated: No interesting content`
  * no `NewSource` lines
* Contrast: a JS page emits `NewSource` and writes a recording
* Interesting gate is script-only
  * `RecordReplayAddInterestingSource` runs from script registration
  * `RecordReplayAddHTMLParse` only sets `uri` metadata
  * does not mark interesting
* On process exit, `FinishRecording` sees `!gRecordReplayInterestingRecording` and invalidates
* Static HTML pages fall through the same filter as empty utility frames

# Solution
* In `RecordReplayAddHTMLParse`, after existing URL filters, call `RecordReplayAddInterestingSource`
* `about:` / most `chrome:` URLs still ignored
* Static HTML pages keep their recording without requiring scripts
