### PR TITLE
use engflow_auth credential helper for chromium linux RBE auth

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,15 +43,12 @@ steps:
           env:
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-buildevents
-          file:
-            - path: "/home/ubuntu/chromium/engflow.crt"
-              secret-id: engflow-certificate
-            - path: "/home/ubuntu/chromium/engflow.key"
-              secret-id: engflow-key
+            ENGFLOW_CRED: engflow-credential
       - replayio/buildevents#76b6f57: ~
     commands:
       - "be_cmd git-fetch-origin -- git fetch origin"
       - "be_cmd git-reset-branch -- git reset --hard origin/$BUILDKITE_BRANCH"
+      - "be_cmd setup-engflow-auth -- bash replay_build_scripts/setup_engflow_auth.sh"
       - "be_cmd clean-artifacts-dir -- node replay_build_scripts/clean_artifacts.mjs"
       - "be_cmd update-all-repos -- node replay_build_scripts/update-all-repos.mjs"
       - "be_cmd chromium-build -- node buildLinux.mjs"
@@ -59,8 +56,8 @@ steps:
     env:
       RECORD_REPLAY_BACKEND_DIR: /home/ubuntu/chromium/backend
       RBE_service: simpsonite.cluster.engflow.com:443
-      RBE_service_no_auth: "true"
-      RBE_use_application_default_credentials: "true"
+      RBE_experimental_credentials_helper: /chromium/engflow_auth
+      RBE_experimental_credentials_helper_args: "get"
     agents:
       - "runtimeType=chromiumbuild"
       - "os=linux"

--- a/buildLinux.mjs
+++ b/buildLinux.mjs
@@ -16,14 +16,16 @@ const dockerArgs = [
   "DRIVER_REVISION",
   "-e",
   "RBE_service",
+  // reproxy authenticates via the engflow_auth credential helper instead of mTLS
+  // certs. the binary + imported token store both live on the mounted /chromium
+  // dir; XDG_CONFIG_HOME points engflow_auth at that store inside the container.
+  // see replay_build_scripts/setup_engflow_auth.sh
   "-e",
-  "RBE_service_no_auth",
+  "RBE_experimental_credentials_helper=/chromium/engflow_auth",
   "-e",
-  "RBE_use_application_default_credentials",
+  "RBE_experimental_credentials_helper_args=get",
   "-e",
-  "RBE_tls_client_auth_cert=/chromium/engflow.crt",
-  "-e",
-  "RBE_tls_client_auth_key=/chromium/engflow.key",
+  "XDG_CONFIG_HOME=/chromium/.engflow",
   "-v",
   `${path.join(process.env.HOME, "chromium")}:/chromium`,
   "-v",

--- a/replay_build_scripts/setup_engflow_auth.sh
+++ b/replay_build_scripts/setup_engflow_auth.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# fetch the pinned engflow_auth binary and import the CI credential into a file
+# store on the mounted /chromium dir, so reproxy (which runs inside the build
+# container) can call engflow_auth as its RBE credential helper instead of using
+# the old 90-day mTLS certs.
+#
+# the binary lands at ~/chromium/engflow_auth and the token store under
+# ~/chromium/.engflow, both of which the build container sees at /chromium/...
+# via the bind mount in buildLinux.mjs.
+#
+# NOT VALIDATED END-TO-END YET. open questions:
+#   - does the in-container `engflow_auth get` read the store via XDG_CONFIG_HOME,
+#     or does it need HOME/.config (and/or an explicit -store=file)?
+#   - exact _args for the helper (`get` vs `get -store=file` vs cluster url)
+#   - does reproxy accept engflow_auth's expiry field/format, or do we need a
+#     thin wrapper to reshape the JSON?
+# needs the `engflow-credential` secret to exist in AWS SM us-east-2 first (one
+# `engflow_auth login` + `export` as a service account).
+set -euo pipefail
+
+DEST=/home/ubuntu/chromium/engflow_auth
+URL=https://github.com/EngFlow/auth/releases/download/v0.0.14/engflow_auth_linux_x64
+SHA=1f78c0a56fde3e2b234c7ad0932688322f6b56d4cd621ce6f19350cbf03d9d4a
+STORE=/home/ubuntu/chromium/.engflow
+
+# download + verify the binary (skip if already present and matching)
+if [ ! -f "$DEST" ] || ! echo "$SHA  $DEST" | sha256sum -c - >/dev/null 2>&1; then
+  curl -fsSL "$URL" -o "$DEST"
+  echo "$SHA  $DEST" | sha256sum -c -
+  chmod +x "$DEST"
+fi
+
+# import the credential (loaded by the aws-sm plugin into ENGFLOW_CRED) into a
+# file store the build container can read
+mkdir -p "$STORE"
+XDG_CONFIG_HOME="$STORE" "$DEST" import -store=file <<< "${ENGFLOW_CRED:?ENGFLOW_CRED not set}"


### PR DESCRIPTION
migrate chromium linux RBE auth off the 90-day engflow mTLS certs to the engflow_auth credential helper.

**draft / not ready to merge** - needs validation on a scratch build first, plus a prerequisite secret that doesn't exist yet.

## what changes
- `pipeline.yml` (linux step): drop the engflow.crt/.key file secrets, load the credential as `ENGFLOW_CRED`, add a `setup-engflow-auth` step, swap the mTLS `RBE_*` env for `RBE_experimental_credentials_helper`
- `buildLinux.mjs`: pass the helper env into the container instead of the cert paths
- `setup_engflow_auth.sh` (new): fetch + verify the pinned engflow_auth binary (v0.0.14) and import the credential into a file store on the mounted dir

reproxy 0.126.0 already supports `-experimental_credentials_helper`, so no reclient bump needed.

## before this can merge
- [ ] create the `engflow-credential` secret in AWS SM us-east-2 (one `engflow_auth login` + `export`, ideally as a service account)
- [ ] confirm reproxy accepts engflow_auth's expiry field/format, else add a thin wrapper
- [ ] confirm the in-container store path (`XDG_CONFIG_HOME`) and the exact helper `_args` (`get` vs `get -store=file`)
- [ ] green scratch build on this branch: no `Unable to authenticate with RBE`, and a real `RBE Stats: ... N remote executions` line

## note
engflow_auth tokens are also ~90-day by default. this kills the fragile cert-rotation dance but not the cadence itself - truly low-touch needs a long-lived service-account token from engflow.
