### PR TITLE
[crash-0095] Serve cached typefaces after diverge

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '795a6d0384c9f4b21ce763afae1e17a06b724122',
+  'skia_revision': '4c76119760b600082b756fd4aedd3cf9ee4f3151',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': 'df6f902313f51b0e9e051e4164bd240ba3a95ba9',
+  'skia_revision': '795a6d0384c9f4b21ce763afae1e17a06b724122',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/components/services/font/public/cpp/font_service_thread.cc
+++ b/components/services/font/public/cpp/font_service_thread.cc
@@ -46,6 +46,14 @@ bool FontServiceThread::MatchFamilyName(
     SkString* out_family_name,
     SkFontStyle* out_style) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+
+  // Every proxy below waits on a font service reply that never arrives when
+  // events are unavailable. Refuse instead of hanging: callers already handle
+  // this as a disconnected font service.
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return false;
+  }
+
   bool out_valid = false;
   // This proxies to the other thread, which proxies to mojo. Only on the reply
   // from mojo do we return from this.
@@ -68,6 +76,10 @@ bool FontServiceThread::FallbackFontForCharacter(
     bool* out_is_bold,
     bool* out_is_italic) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return false;
+  }
+
   bool out_valid = false;
   base::WaitableEvent done_event;
   task_runner_->PostTask(
@@ -89,6 +101,10 @@ bool FontServiceThread::FontRenderStyleForStrike(
     float device_scale_factor,
     font_service::mojom::FontRenderStylePtr* out_font_render_style) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return false;
+  }
+
   bool out_valid = false;
   base::WaitableEvent done_event;
   task_runner_->PostTask(
@@ -104,6 +120,10 @@ bool FontServiceThread::MatchFontByPostscriptNameOrFullFontName(
     std::string postscript_name_or_full_font_name,
     mojom::FontIdentityPtr* out_identity) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return false;
+  }
+
   bool out_valid = false;
   base::WaitableEvent done_event;
   task_runner_->PostTask(
@@ -125,6 +145,10 @@ void FontServiceThread::MatchFontWithFallback(
     uint32_t fallback_family_type,
     base::File* out_font_file_handle) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return;
+  }
+
   base::WaitableEvent done_event;
   task_runner_->PostTask(
       FROM_HERE,
@@ -138,6 +162,9 @@ void FontServiceThread::MatchFontWithFallback(
 scoped_refptr<MappedFontFile> FontServiceThread::OpenStream(
     const SkFontConfigInterface::FontIdentity& identity) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
+    return nullptr;
+  }
 
   base::File stream_file;
   // This proxies to the other thread, which proxies to mojo. Only on the


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium-skia/pull/48
# Summary

* Pause-time `document.elementsFromPoint` forces ink-overflow recalc and null-derefs `Font::PrimaryFont()` in `SetLineBox`.
* Post-diverge `onLegacyMakeTypeface` refused `fCache` hits, `FontPlatformDataCache` stored `nullptr`, last-resort fallback failed.
* Serve `fCache` hits after diverge; refuse `FontServiceThread` IPC waits at the chokepoint so the served typeface cannot hang.

# Problem

* Problem type: ReplayPauseCrash.
* operatorId: `c8b25ade-d8a9-4121-a6c6-109f1c0f497b`
* Buckets: Pause/blink::NGFragmentItem::RecalcInkOverflow.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

Use the following data sources:
* [MUST-READ] $RUNTIME_BIBLE/crashes/replay-pause-crashes.md
* $WORKSPACE/report.json - RAW/noisy crash report. Use this only if you have a good reason. Else use "Crash Report Core".
* The RAW report is in $WORKSPACE/report.json when needed.

### RepoSrc

* $REPLAY_DIR/backend
* $REPLAY_DIR/chromium/src

## Important Context

* buildId: linux-chromium-20260828-6e3fa6a5fac7-fc75f2df4f2b
* linkerVersion: linker-linux-16124-fc75f2df4f2b
* recordingId: 8ea8f1b2-92e9-4e0c-99eb-aa0010c0a650

### Crash Report Core
```json
{
  "why": "LinkerFault",
  "signal": "Segmentation fault",
  "category": "PauseChild",
  "threadId": 1,
  "backtrace": {
    "frames": [
      "blink::NGFragmentItem::RecalcInkOverflow(blink::NGInlineCursor.const&,.blink::NGInlinePaintContext*,.blink::PhysicalRect*)+701",
      "blink::NGFragmentItem::RecalcInkOverflowForCursor(blink::NGInlineCursor*,.blink::NGInlinePaintContext*)+200",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+324",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::NGPhysicalBoxFragment::RecalcContentsInkOverflow()+667",
      "blink::NGPhysicalBoxFragment::RecalcInkOverflow()+97",
      "blink::LayoutBox::RecalcFragmentsVisualOverflow()+77",
      "blink::PaintLayer::UpdateDescendantDependentFlags()+1477",
      "blink::PaintLayer::UpdateDescendantDependentFlags()+201",
      "blink::PaintLayer::UpdateDescendantDependentFlags()+201",
      "blink::PaintLayer::UpdateDescendantDependentFlags()+201",
      "void.absl::functional_internal::InvokeObject<blink::LocalFrameView::RunCompositingInputsLifecyclePhase(blink::DocumentLifecycle::LifecycleState)::$_21,.void,.blink::LocalFrameView&>(absl::functional_internal::VoidPtr,.absl::functional_internal::ForwardT<blink::LocalFrameView&>::type)+110",
      "blink::LocalFrameView::ForAllNonThrottledLocalFrameViews(base::FunctionRef<void.(blink::LocalFrameView&)>,.blink::LocalFrameView::TraversalOrder)+52",
      "blink::LocalFrameView::RunCompositingInputsLifecyclePhase(blink::DocumentLifecycle::LifecycleState)+151",
      "blink::LocalFrameView::UpdateLifecyclePhasesInternal(blink::DocumentLifecycle::LifecycleState)+557",
      "blink::LocalFrameView::UpdateLifecyclePhases(blink::DocumentLifecycle::LifecycleState,.blink::DocumentUpdateReason)+458",
      "blink::LayoutView::HitTest(blink::HitTestLocation.const&,.blink::HitTestResult&)+53",
      "blink::TreeScope::ElementsFromPoint(double,.double).const+274",
      "blink::(anonymous.namespace)::v8_document::ElementsFromPointOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+435",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
      "ReplaySpace+44022455096",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021882460",
      "ReplaySpace+44021881735",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
      "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
      "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+459",
      "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::String>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+237",
      "v8::debug::EvaluateGlobal(v8::Isolate*,.v8::Local<v8::String>,.v8::debug::EvaluateGlobalMode,.bool)+117",
      "v8_inspector::V8RuntimeAgentImpl::evaluate(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<double>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::EvaluateCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::EvaluateCallback>.>)+1092",
      "v8_inspector::protocol::Runtime::DomainDispatcherImpl::evaluate(v8_crdtp::Dispatchable.const&)+846",
      "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
      "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+709",
      "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+1241",
      "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
      "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
      "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
      "ReplaySpace+44022455096",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021889068",
      "ReplaySpace+44021882460",
      "ReplaySpace+44021881735",
      "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
      "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
      "v8::internal::CommandCallback(char.const*,.char.const*)+943",
      "recordreplay::SendCommand(char.const*,.Json::Value.const&,.bool)+1137",
      "EvaluateInGlobalCommand::Process(Json::Value.const&,.std::__cxx11::basic_string<char,.std::char_traits<char>,.std::allocator<char>.>&)+38",
      "CommandRequest::Process(Json::Value.const&)+376",
      "recordreplay::PerformPauseDataRequest(Json::Value.const&)+372",
      "PauseRequestHandler::Start(Json::Value.const&)+93",
      "ManifestFinished(Json::Value*)+1112",
      "RunToPointHandler::ReachedDestination(Json::Value.const&)+651",
      "recordreplay::OnCheckpoint(unsigned.long)+63",
      "recordreplay::NewCheckpoint(void*,.bool,.bool)+564",
      "RecordReplayFinishRecording()+77",
      "v8::FinishRecordingTask::Run()+24",
      "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
      "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
      "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
      "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
      "base::RunLoop::Run(base::Location.const&)+461",
      "content::RendererMain(content::MainFunctionParams)+1434",
      "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
      "content::ContentMainRunnerImpl::Run()+673",
      "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
      "content::ContentMain(content::ContentMainParams)+95",
      "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
      "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
      "headless::HeadlessShellMain(int,.char.const**)+55",
      "ChromeMain+629",
      "new_libc_start_main(void.(*)(int,.char.const**))+22",
      "_start+42"
    ],
    "progress": 35010183,
    "threadId": 1,
    "checkpoint": 807
  },
  "faultAddress": "0x14",
  "instructionPointer": "blink::NGInlinePaintContext::SetLineBox(blink::NGInlineCursor.const&)+355"
}
```

# Data

## Previous Work

* Searched all `crash-*/problem.md` for `Problem type: ReplayPauseCrash` and `Buckets: Pause/blink::NGFragmentItem::RecalcInkOverflow`.
* Other `ReplayPauseCrash` issues found (none match this bucket):
  * crash-0087: `Buckets: Pause/Json::throwRuntimeError`.
  * crash-0064, crash-0064-2, crash-0054: no matching `Buckets:` field.
* Direct search for `RecalcInkOverflow` across all `problem.md` files: no matches.
* PlacementParent: none.

## PauseSite

* Fatal `Die` on tid1 (not a hang): `Segmentation fault`, `faultAddress: 0x14`, `category: PauseChild`, `why: LinkerFault`.
* Fault frame (`instructionPointer`): `blink::NGInlinePaintContext::SetLineBox(const NGInlineCursor&)+355`.
* Pinning frames (offsets preserved, top of `backtrace.frames`, innermost first):
  1. Innermost/symptom: `blink::NGFragmentItem::RecalcInkOverflow(const NGInlineCursor&, NGInlinePaintContext*, PhysicalRect*)+701` — calls into the fault frame above.
  2. DivergedOp: `blink::LayoutView::HitTest(const HitTestLocation&, HitTestResult&)+53` — JS-triggered hit-test/layout-recalc reached via `TreeScope::ElementsFromPoint` from a V8 `EvaluateGlobal` call; not a generic wait/lock frame, the actual op doing layout work post-diverge.
  3. Pause-command entry: `PauseRequestHandler::Start(const Json::Value&)+93` — entry into pause path: `PerformPauseDataRequest` → `CommandRequest::Process` → `EvaluateInGlobalCommand::Process` → V8 eval → `ElementsFromPoint` → `LayoutView::HitTest`.

## RootCause

* DivergedOp: `blink::TreeScope::ElementsFromPoint(double, double)` (PauseSite frame 2's caller) → `document.GetLayoutView()->HitTest(location, result)`.
  * Confirmed by source (`chromium/src/third_party/blink/renderer/core/dom/tree_scope.cc`): `document.GetLayoutView()->HitTest(location, result);` matches `LayoutView::HitTest+53` in the backtrace verbatim.
  * Reached from JS-facing `document.elementsFromPoint()` during pause-eval (`report.json` `requestInfo.requestCommandMethod: "Pause.evaluateInGlobal"`), i.e. PauseSite frame 3 (`PauseRequestHandler::Start`) → V8 `EvaluateGlobal` → PauseSite frame 2.
  * `HitTest` forces `LocalFrameView::UpdateLifecyclePhases(...)` (present verbatim in `backtrace.frames`): an un-recorded recompute of compositing-inputs/layout/ink-overflow state on the live post-divergence layout tree.
  * Not specific to `ElementsFromPoint`: every layout-forcing script API reaches `UpdateLifecyclePhases` the same way.
* The forced recalculation is not what faults. Three font-path interventions make it fatal. Each step below is proven in the rr reproduction; see `### Provenance`.
  1. `SkFontMgr_FCI::onLegacyMakeTypeface` refuses every typeface post-diverge.
     * `SkFontMgr_FontConfigInterface.cpp:302`: `if (SkRecordReplayHasDivergedFromRecording()) return nullptr;`
     * The guard sits ahead of both in-process caches (`fCache` request cache at line 309, `fTFCache` identity cache at line 324) and ahead of the `fFCI->matchFamilyName` IPC at line 317.
     * A typeface already resolved during recording is therefore refused as well, though serving it needs no recording data.
     * Proven: at diverge time `fCache` holds `Arial` and `Sans` at the exact style the crashing cascade requests, so the guard discards live cache hits. dump/skia-cache-probe.md
     * Observed: `CreateTypeface("sans-serif")` and `CreateTypeface("Arial")` both return `nullptr` post-diverge.
     * Observed for the `"sans-serif"` call: control reaches `SkTypeface_Factory::FromFamilyNameAndFontStyle`, which returns `nullptr` without calling `FontLoader::matchFamilyName` or `FontServiceThread::MatchFamilyName`.
  2. `FontPlatformDataCache` records that refusal as a permanent negative entry.
     * `font_platform_data_cache.cc:196`: `size_to_data_map_.insert(rounded_size, nullptr)` runs before creation, and the `nullptr` from `CreateFontPlatformData` is left in the map.
     * On the next lookup `!add_result.is_new_entry` returns that `nullptr` without retrying.
     * The map is process-global and shared with non-diverged code; a divergent failure is written into it.
     * Observed: the first post-diverge `GetLastResortFallbackFont` cascade attempts `"sans-serif"`, `"Sans"`, `"Arial"`; the crashing cascade re-requests the same three and gets cached `nullptr` for each, with no creation attempted.
  3. `FontFallbackList::FontDataAt` returns `nullptr` and no caller handles it.
     * `font_fallback_list.cc:262`, added by `6125d1d9d41e7` "RUN-2625: More font early-outs (#922)".
     * `DeterminePrimarySimpleFontDataCore` answers a `nullptr` `FontDataAt` with `GetLastResortFallbackFont`, which is disabled by steps 1 and 2, so it returns `nullptr`.
     * `PrimarySimpleFontData` caches that `nullptr`; its `DCHECK` is a no-op in Release.
     * Observed: `FeatureEnabled("replay-code","FontFallbackList::FontDataAt")` is true, `family_index_` is `0`, `font_list_` is empty, and `FontFallbackList::GetFontData` is never reached.
* `report.json` `processNonFatal.why: "MissingReport"` — no mismatch recorded tying the fault to an earlier divergence; consistent with the fault arising inside the pause itself.
* Not supported by the reproduction: recalculation over destroyed or moved layout objects. `NGFragmentItem::RecalcInkOverflow` reaches `SetLineBox` normally; the only invalid value in play is the `SimpleFontData` pointer.

## Crash Investigations

### ExactFault

* `instructionPointer` `SetLineBox+355` = `movss 0x14(%rax), %xmm0`; `$rax` is `0x0` in the reproduction.
  * `faultAddress: 0x14` = the `FixedAscent` field offset read off a null `SimpleFontData`.
* Source: `ng_inline_paint_context.cc:278`
  * `offset.top -= style.GetFont().PrimaryFont()->GetFontMetrics().FixedAscent();`
* **NullOperand**: `SimpleFontData*` from `Font::PrimaryFont()` / `FontFallbackList::DeterminePrimarySimpleFontData`.
* Not `LineBoxFragment()->Metrics().ascent` (earlier in the same function; null fragment would fault at `0x18`).
* `Font::PrimaryFont()` is documented nullable (`font.h:202`); `SetLineBox` dereferences it unguarded.

### Provenance

* Reproduced deterministically under rr on the crash build `linux-chromium-20260828-6e3fa6a5fac7-fc75f2df4f2b`.
  * `rrnew --manifests=`dump/repro-man.json: `runToPoint` to `{checkpoint: 807, progress: 35010183}`, then a `pauseRequest` dispatching `Pause.evaluateInGlobal` with `document.elementsFromPoint(innerWidth/2, innerHeight/2).length`.
  * Fault matches the report exactly: `SetLineBox+355`, `movss 0x14(%rax),%xmm0`, SIGSEGV.
* Registers, breakpoint sequence, branch map and cache-poisoning trace: dump/rr-repro.md.
* Session log: .debug_session.linkerdebug.log.

### Finding

* Crash is a null-deref of `Font::PrimaryFont()` inside divergent ink-overflow recalculation, not an I/O/wait fault.
* The null is produced by Replay interventions, not by the diverged layout state.
  * `family_index_` is `0` and `font_list_` is empty, so unmodified Blink would have called `GetFontData` and resolved a font.
  * Upstream's last-resort fallback, which exists for exactly this case, is disabled by the typeface refusal and the cached `nullptr`.
* One refusal (`onLegacyMakeTypeface`) is broader than it needs to be, one is persisted where it must not be (`FontPlatformDataCache`), and one has no null-handling downstream (`FontDataAt`).


# Solution

* Recipe: `divergent-side-effect` — refuse only the non-replayable operation, not the whole function.
* Governing contract: fonts-after-divergence.md, `## Strategy` / `SeamWorkList` item 1.
* Change 1 — serve `fCache` hits instead of refusing them. This is the crash fix.
  * Move the existing `SkRecordReplayHasDivergedFromRecording()` guard in `SkFontMgr_FCI::onLegacyMakeTypeface` from the top of the function to below `fCache.findAndRef`, directly above `fFCI->matchFamilyName`.
  * SkFontMgr_FontConfigInterface.cpp#L306-L309
  * `fTFCache` stays behind the guard.
* Change 2 — close every blocking font-service IPC at its single chokepoint.
  * Every `FontServiceThread` proxy is `PostTask` + `done_event.Wait()`. Post-diverge the reply never arrives, so each is an unbounded hang. Change 1 makes three of them newly reachable.
  * Guard each with `recordreplay::AreEventsUnavailable("divergent-side-effect")`, returning the value the method already returns when the font service is disconnected.
  * font_service_thread.cc
  * All six guarded locations:
    * `MatchFamilyName` → `false`. Reached by `onLegacyMakeTypeface` on `fCache` miss.
    * `OpenStream` → `nullptr`. Reached by `onOpenStream` when a served typeface has no `FaceRec` yet.
    * `FontRenderStyleForStrike` → `false`. Reached by `FontPlatformData::QuerySystemRenderStyle`.
    * `FallbackFontForCharacter` → `false`.
    * `MatchFontByPostscriptNameOrFullFontName` → `false`.
    * `MatchFontWithFallback` (PDF) → returns with `out_font_file_handle` left invalid.
* Status: implemented in the checkout. Not built, not run.
* Out of scope, deliberately: the divergent `nullptr` persisted at font_platform_data_cache.cc#L196.
  * With change 1 this path stores a real `FontPlatformData`, so nothing negative is written here.
  * Fixing it would be a second intervention.
* Out of scope: `FontDataAt` (RUN-2625) still disables primary-font resolution post-diverge.
* Rejected: throw from `TreeScope::ElementsFromPoint`.
* Rejected: null-check `PrimaryFont()` in `SetLineBox`.
* Rejected: guard at the Blink/Skia call sites instead of `FontServiceThread`.
  * Each caller has its own in-process cache (`fCache`, `mapped_font_files_`, `unicode_font_families_`) that a guard above it would wrongly refuse.
  * Guarding the chokepoint keeps every cache live and refuses only the IPC.

# Solution Facts

* Change 1 without change 2 turns the segfault into a permanent hang. That is why they land together.
  * With a non-null typeface, `CreateFontPlatformData` no longer bails: `FontPlatformData` → `QuerySystemRenderStyle` → `FontServiceThread::FontRenderStyleForStrike` → `done_event.Wait()`, waiting on a font-service reply that never comes post-diverge.
* `fFCI->matchFamilyName` is the font-service IPC, the only thing in `onLegacyMakeTypeface` needing recording data.
* `fCache.findAndRef` is `SkResourceCache::find`, pure in-process. No Replay guard on `find`/`add`.
* `fTFCache` is keyed by `FontIdentity`, obtainable only from the IPC.
* Refusal semantics per site, all pre-existing upstream paths.
  * `WebSandboxSupportLinux::GetWebFontRenderStyleForStrike` writes `*out = WebFontRenderStyle()` before the call and returns on `false`, so a refusal yields upstream hinting/AA defaults. No layout metrics involved. Covers `ScaleFontPlatformData` too, which delegates to the same constructor.
  * A null stream makes `FaceRec::Make` return `nullptr`, `SkScalerContext_FreeType` fail construction, and `onCreateScalerContext` fall back to `SkScalerContext::MakeEmpty`. No crash, no hang.
* `fCache` at `DivergeFromRecording` holds 14 entries at 596 of 32768 bytes, so nothing was purged.
  * Evidence: dump/skia-cache-probe.md.
* The crashing `GetLastResortFallbackFont` cascade requests `sans-serif`, `Sans`, `Arial`, all at style `0x50190`.
  * `Arial` and `Sans` are `fCache` entries 5 and 6. Both resolve post-move.
  * `sans-serif` misses and hits the relocated guard, returning null with no IPC.
    * Same fall-through the cascade already takes pre-diverge, where `matchFamilyName` rejects it too.
* `onOpenStream` fires at most once per typeface: `getFaceRec()` is `fFTFaceOnce(FaceRec::Make)`, and `FaceRec::Make` → `makeFontData()` → `onOpenStream`. A typeface holding a `FaceRec` never calls it again.
  * All 5 typefaces `fCache` references already hold one, so this recording never reaches that IPC. Recording-specific, which is why change 2 guards it rather than relying on it.
* The negative entry at `font_platform_data_cache.cc:196` is order-dependent: a null already cached for a `(family, rounded_size)` is returned forever. The first post-diverge cascade is the inserter, so the guard move pre-empts it.
* `PrimaryFont()` is then non-null and `SetLineBox+355` no longer reads `0x14` off null.
* Source reading closes the continuation from a served `fCache` hit to `FontMetrics::FixedAscent` as IPC-free; residual gaps in the contract's `## Unestablished`.
* Rejection grounds.
  * `TreeScope::ElementsFromPoint`: fixes one entry point only. `getBoundingClientRect`, `offsetTop` and `getComputedStyle` force the same `UpdateLifecyclePhases` and reach the same null. Also removes a pause-time capability that works whenever fonts resolve.
  * `SetLineBox` null-check: `Font::PrimaryFont()` is dereferenced unguarded across Blink. Not the root.
  * `FontDataAt` (RUN-2625): last-resort font is used instead of the page's font — wrong metrics, not a crash.
