### PR TITLE
[crash-0064-3] Throw on blob create, location navigate, and click after diverge

### DIFF
--- a/third_party/blink/renderer/core/fileapi/blob.cc
+++ b/third_party/blink/renderer/core/fileapi/blob.cc
@@ -119,7 +119,7 @@ Blob::~Blob() = default;
 Blob* Blob::Create(ExecutionContext* context,
                    const HeapVector<Member<V8BlobPart>>& blob_parts,
                    const BlobPropertyBag* options) {
-  if (RecordReplayThrowIfEventsUnavailable("Blob"))
+  if (RecordReplayThrowIfEventsUnavailable("Blob.constructor"))
     return nullptr;
 
   DCHECK(options->hasType());
@@ -240,7 +240,8 @@ ReadableStream* Blob::stream(ScriptState* script_state) const {
 static ScriptPromise ReadBlobHelper(
     const scoped_refptr<BlobDataHandle>& blob_data_handle,
     ScriptState* script_state,
-    FileReaderLoader::ReadType read_type) {
+    FileReaderLoader::ReadType read_type,
+    const char* operation_name) {
   ScriptPromiseResolver* resolver =
       MakeGarbageCollected<ScriptPromiseResolver>(script_state);
   auto promise = resolver->Promise();
@@ -248,7 +249,8 @@ static ScriptPromise ReadBlobHelper(
   if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
     resolver->Reject(MakeGarbageCollected<DOMException>(
         DOMExceptionCode::kNotReadableError,
-        "Cannot replay operation Blob.read because it was not recorded."));
+        String("Cannot replay operation ") + operation_name +
+            " because it was not recorded."));
     return promise;
   }
 
@@ -261,13 +263,14 @@ static ScriptPromise ReadBlobHelper(
 }
 
 blink::ScriptPromise Blob::text(ScriptState* script_state) {
-  auto read_type = FileReaderLoader::kReadAsText;
-  return ReadBlobHelper(blob_data_handle_, script_state, read_type);
+  return ReadBlobHelper(blob_data_handle_, script_state,
+                        FileReaderLoader::kReadAsText, "Blob.text");
 }
 
 blink::ScriptPromise Blob::arrayBuffer(ScriptState* script_state) {
-  auto read_type = FileReaderLoader::kReadAsArrayBuffer;
-  return ReadBlobHelper(blob_data_handle_, script_state, read_type);
+  return ReadBlobHelper(blob_data_handle_, script_state,
+                        FileReaderLoader::kReadAsArrayBuffer,
+                        "Blob.arrayBuffer");
 }
 
 void Blob::AppendTo(BlobData& blob_data) const {

--- a/third_party/blink/renderer/core/fileapi/blob.cc
+++ b/third_party/blink/renderer/core/fileapi/blob.cc
@@ -45,6 +45,7 @@
 #include "third_party/blink/renderer/core/frame/web_feature.h"
 #include "third_party/blink/renderer/core/url/dom_url.h"
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
+#include "third_party/blink/renderer/platform/bindings/record_replay_throw.h"
 #include "third_party/blink/renderer/platform/bindings/script_state.h"
 #include "third_party/blink/renderer/platform/blob/blob_url.h"
 #include "third_party/blink/renderer/platform/instrumentation/use_counter.h"
@@ -58,6 +59,10 @@ constexpr char kReplayBlobReadUnavailableMessage[] =
     "This evaluation tried to read file or blob contents that were not "
     "captured in the recording. Replay cannot perform fresh file/blob reads "
     "divergently.";
+
+constexpr char kReplayBlobCreateUnavailableMessage[] =
+    "This evaluation tried to construct a Blob that requires IPC not "
+    "available divergently. Replay cannot register blobs divergently.";
 
 }  // namespace
 
@@ -127,6 +132,11 @@ Blob::~Blob() = default;
 Blob* Blob::Create(ExecutionContext* context,
                    const HeapVector<Member<V8BlobPart>>& blob_parts,
                    const BlobPropertyBag* options) {
+  // BlobDataHandle registration uses sync Mojo IPC that never completes after
+  // diverge.
+  if (RecordReplayThrowIfEventsUnavailable(kReplayBlobCreateUnavailableMessage))
+    return nullptr;
+
   DCHECK(options->hasType());
   DCHECK(options->hasEndings());
   bool normalize_line_endings_to_native = (options->endings() == "native");

--- a/third_party/blink/renderer/core/fileapi/blob.cc
+++ b/third_party/blink/renderer/core/fileapi/blob.cc
@@ -53,19 +53,6 @@
 
 namespace blink {
 
-namespace {
-
-constexpr char kReplayBlobReadUnavailableMessage[] =
-    "This evaluation tried to read file or blob contents that were not "
-    "captured in the recording. Replay cannot perform fresh file/blob reads "
-    "divergently.";
-
-constexpr char kReplayBlobCreateUnavailableMessage[] =
-    "This evaluation tried to construct a Blob that requires IPC not "
-    "available divergently. Replay cannot register blobs divergently.";
-
-}  // namespace
-
 // TODO(https://crbug.com/989876): This is not used any more, refactor
 // PublicURLManager to deprecate this.
 class NullURLRegistry final : public URLRegistry {
@@ -132,9 +119,7 @@ Blob::~Blob() = default;
 Blob* Blob::Create(ExecutionContext* context,
                    const HeapVector<Member<V8BlobPart>>& blob_parts,
                    const BlobPropertyBag* options) {
-  // BlobDataHandle registration uses sync Mojo IPC that never completes after
-  // diverge.
-  if (RecordReplayThrowIfEventsUnavailable(kReplayBlobCreateUnavailableMessage))
+  if (RecordReplayThrowIfEventsUnavailable("Blob"))
     return nullptr;
 
   DCHECK(options->hasType());
@@ -260,15 +245,10 @@ static ScriptPromise ReadBlobHelper(
       MakeGarbageCollected<ScriptPromiseResolver>(script_state);
   auto promise = resolver->Promise();
 
-  // Blob reads go through FileReaderLoader and the browser-side Blob service,
-  // which uses async Mojo callbacks and data pipes. Even byte-backed blobs can
-  // hit that machinery, so when events are unavailable we reject consistently
-  // instead of trying to distinguish supposedly safe in-memory blobs from
-  // file-backed blobs here.
   if (recordreplay::AreEventsUnavailable("divergent-side-effect")) {
     resolver->Reject(MakeGarbageCollected<DOMException>(
         DOMExceptionCode::kNotReadableError,
-        kReplayBlobReadUnavailableMessage));
+        "Cannot replay operation Blob.read because it was not recorded."));
     return promise;
   }
 

--- a/third_party/blink/renderer/core/frame/location.cc
+++ b/third_party/blink/renderer/core/frame/location.cc
@@ -39,11 +39,20 @@
 #include "third_party/blink/renderer/core/loader/frame_loader.h"
 #include "third_party/blink/renderer/core/url/dom_url_utils_read_only.h"
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
+#include "third_party/blink/renderer/platform/bindings/record_replay_throw.h"
 #include "third_party/blink/renderer/platform/bindings/v8_dom_activity_logger.h"
 #include "third_party/blink/renderer/platform/weborigin/kurl.h"
 #include "third_party/blink/renderer/platform/weborigin/security_origin.h"
 
 namespace blink {
+namespace {
+
+constexpr char kReplayLocationNavigateUnavailableMessage[] =
+    "This evaluation tried to navigate that requires frame load machinery "
+    "not available divergently. Replay cannot perform location navigation "
+    "divergently.";
+
+}  // namespace
 
 Location::Location(DOMWindow* dom_window) : dom_window_(dom_window) {}
 
@@ -279,6 +288,13 @@ void Location::SetLocation(const String& url,
     argv.push_back(entered_document->Url());
     argv.push_back(completed_url);
     activity_logger->LogEvent("blinkSetAttribute", argv.size(), argv.data());
+  }
+
+  // Frame::Navigate never completes after diverge and can sync-dispatch
+  // navigate listeners that reach other unguarded DivergedOps.
+  if (RecordReplayThrowIfEventsUnavailable(
+          kReplayLocationNavigateUnavailableMessage, exception_state)) {
+    return;
   }
 
   FrameLoadRequest request(incumbent_window, ResourceRequest(completed_url));

--- a/third_party/blink/renderer/core/frame/location.cc
+++ b/third_party/blink/renderer/core/frame/location.cc
@@ -282,7 +282,8 @@ void Location::SetLocation(const String& url,
     activity_logger->LogEvent("blinkSetAttribute", argv.size(), argv.data());
   }
 
-  if (RecordReplayThrowIfEventsUnavailable("location", exception_state)) {
+  // Shared by Location.assign / replace / href and URL-part setters.
+  if (RecordReplayThrowIfEventsUnavailable("Location.set", exception_state)) {
     return;
   }
 

--- a/third_party/blink/renderer/core/frame/location.cc
+++ b/third_party/blink/renderer/core/frame/location.cc
@@ -45,14 +45,6 @@
 #include "third_party/blink/renderer/platform/weborigin/security_origin.h"
 
 namespace blink {
-namespace {
-
-constexpr char kReplayLocationNavigateUnavailableMessage[] =
-    "This evaluation tried to navigate that requires frame load machinery "
-    "not available divergently. Replay cannot perform location navigation "
-    "divergently.";
-
-}  // namespace
 
 Location::Location(DOMWindow* dom_window) : dom_window_(dom_window) {}
 
@@ -290,10 +282,7 @@ void Location::SetLocation(const String& url,
     activity_logger->LogEvent("blinkSetAttribute", argv.size(), argv.data());
   }
 
-  // Frame::Navigate never completes after diverge and can sync-dispatch
-  // navigate listeners that reach other unguarded DivergedOps.
-  if (RecordReplayThrowIfEventsUnavailable(
-          kReplayLocationNavigateUnavailableMessage, exception_state)) {
+  if (RecordReplayThrowIfEventsUnavailable("location", exception_state)) {
     return;
   }
 

--- a/third_party/blink/renderer/core/html/html_element.cc
+++ b/third_party/blink/renderer/core/html/html_element.cc
@@ -89,6 +89,7 @@
 #include "third_party/blink/renderer/core/trustedtypes/trusted_script.h"
 #include "third_party/blink/renderer/core/xml_names.h"
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
+#include "third_party/blink/renderer/platform/bindings/record_replay_throw.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/instrumentation/use_counter.h"
 #include "third_party/blink/renderer/platform/text/bidi_resolver.h"
@@ -109,6 +110,10 @@ struct AttributeTriggers {
 };
 
 namespace {
+
+constexpr char kReplayHtmlElementClickUnavailableMessage[] =
+    "This evaluation tried to synthesize a click that is not available "
+    "divergently. Replay cannot dispatch simulated clicks divergently.";
 
 // https://html.spec.whatwg.org/multipage/interaction.html#editing-host
 // An editing host is either an HTML element with its contenteditable attribute
@@ -1180,6 +1185,13 @@ void HTMLElement::setSpellcheck(bool enable) {
 }
 
 void HTMLElement::click() {
+  // Simulated click fires arbitrary script; no usable in-process substitute
+  // after diverge.
+  if (RecordReplayThrowIfEventsUnavailable(
+          kReplayHtmlElementClickUnavailableMessage)) {
+    return;
+  }
+
   DispatchSimulatedClick(nullptr, SimulatedClickCreationScope::kFromScript);
   if (IsA<HTMLInputElement>(this)) {
     UseCounter::Count(GetDocument(),

--- a/third_party/blink/renderer/core/html/html_element.cc
+++ b/third_party/blink/renderer/core/html/html_element.cc
@@ -111,10 +111,6 @@ struct AttributeTriggers {
 
 namespace {
 
-constexpr char kReplayHtmlElementClickUnavailableMessage[] =
-    "This evaluation tried to synthesize a click that is not available "
-    "divergently. Replay cannot dispatch simulated clicks divergently.";
-
 // https://html.spec.whatwg.org/multipage/interaction.html#editing-host
 // An editing host is either an HTML element with its contenteditable attribute
 // in the true state, or a child HTML element of a Document whose design mode
@@ -1185,10 +1181,7 @@ void HTMLElement::setSpellcheck(bool enable) {
 }
 
 void HTMLElement::click() {
-  // Simulated click fires arbitrary script; no usable in-process substitute
-  // after diverge.
-  if (RecordReplayThrowIfEventsUnavailable(
-          kReplayHtmlElementClickUnavailableMessage)) {
+  if (RecordReplayThrowIfEventsUnavailable("HTMLElement.click")) {
     return;
   }
 

--- a/third_party/blink/renderer/core/loader/cookie_jar.cc
+++ b/third_party/blink/renderer/core/loader/cookie_jar.cc
@@ -29,11 +29,6 @@
 namespace blink {
 namespace {
 
-constexpr char kReplayCookieUnavailableMessage[] =
-    "This evaluation tried to access cookies that require IPC not available "
-    "divergently. Replay cannot perform fresh cookie reads or writes "
-    "divergently.";
-
 enum class CookieCacheLookupResult {
   kCacheMissFirstAccess = 0,
   kCacheHitAfterGet = 1,
@@ -101,8 +96,7 @@ void CookieJar::SetCookie(const String& value,
   if (cookie_url.IsEmpty())
     return;
 
-  // Cookie IPC never completes after diverge.
-  if (RecordReplayThrowIfEventsUnavailable(kReplayCookieUnavailableMessage,
+  if (RecordReplayThrowIfEventsUnavailable("document.cookie",
                                            &exception_state)) {
     return;
   }
@@ -164,8 +158,7 @@ String CookieJar::Cookies(ExceptionState& exception_state) {
   if (cookie_url.IsEmpty())
     return String();
 
-  // Cookie IPC never completes after diverge.
-  if (RecordReplayThrowIfEventsUnavailable(kReplayCookieUnavailableMessage,
+  if (RecordReplayThrowIfEventsUnavailable("document.cookie",
                                            &exception_state)) {
     return String();
   }

--- a/third_party/blink/renderer/core/scroll/scrollable_area.cc
+++ b/third_party/blink/renderer/core/scroll/scrollable_area.cc
@@ -353,11 +353,7 @@ void ScrollableArea::ProgrammaticScrollHelper(
     bool is_sequenced_scroll,
     gfx::Vector2d animation_adjustment,
     ScrollCallback on_finish) {
-  // Programmatic scroll can WaitForCommitCompletion on the compositor; that
-  // wait never completes after diverge.
-  if (RecordReplayThrowIfEventsUnavailable(
-          "This evaluation tried to programmatically scroll. Replay cannot "
-          "perform compositor scroll commits divergently.")) {
+  if (RecordReplayThrowIfEventsUnavailable("programmatic scroll")) {
     if (on_finish)
       std::move(on_finish).Run();
     return;

--- a/third_party/blink/renderer/platform/bindings/record_replay_throw.cc
+++ b/third_party/blink/renderer/platform/bindings/record_replay_throw.cc
@@ -7,15 +7,18 @@
 #include "base/record_replay.h"
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
 #include "third_party/blink/renderer/platform/bindings/v8_throw_exception.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 #include "v8/include/v8-isolate.h"
 #include "v8/include/v8-local-handle.h"
 
 namespace blink {
 
-bool RecordReplayThrowIfEventsUnavailable(const char* message,
+bool RecordReplayThrowIfEventsUnavailable(const char* operation_name,
                                           ExceptionState* exception_state) {
   if (!recordreplay::AreEventsUnavailable("divergent-side-effect"))
     return false;
+  String message = String("Cannot replay operation ") + operation_name +
+                   " because it was not recorded.";
   if (exception_state) {
     exception_state->ThrowTypeError(message);
     return true;

--- a/third_party/blink/renderer/platform/bindings/record_replay_throw.h
+++ b/third_party/blink/renderer/platform/bindings/record_replay_throw.h
@@ -11,11 +11,12 @@ namespace blink {
 
 class ExceptionState;
 
-// If events are unavailable: throw `message` and return true (caller returns).
-// Without an `exception_state` the throw needs an entered V8 context; the
-// `true` return bails out either way.
+// If events are unavailable: throw
+// "Cannot replay operation <operation_name> because it was not recorded."
+// and return true (caller returns). Without an `exception_state` the throw
+// needs an entered V8 context; the `true` return bails out either way.
 PLATFORM_EXPORT bool RecordReplayThrowIfEventsUnavailable(
-    const char* message,
+    const char* operation_name,
     ExceptionState* exception_state = nullptr);
 
 }  // namespace blink


### PR DESCRIPTION
# Summary

* Pause hang on `base::ConditionVariable::Wait` / `ReplayCvar::Wait` after diverge.
* Recorded chain from pause CDP entry:
  * `SendCDPMessage` → `Runtime.evaluate` → `HTMLElement::click`
  * → `Location::SetLocation` / `Navigate` → navigate listener
  * → `Blob::Create` → sync Mojo `BlobRegistryProxy::Register` → forever wait.
* Hang site: unguarded `Blob::Create` issues sync Mojo that cannot complete once diverged.
* Earlier DivergedOps on the same chain are also unguarded refuse sites:
  * `HTMLElement::click` → `DispatchSimulatedClick` fires arbitrary script.
  * `Location::SetLocation` → `Frame::Navigate` starts non-replayable navigation and reaches the Blob path.

* Also: Fix: `RecordReplayThrowIfEventsUnavailable` to be more concise.

# Problem

* Problem type: ReplayPauseCrash.
* operatorId: `57fe24b7-d665-4110-90e9-ca4e45d2ebd8`
* Buckets: Pause/base::ConditionVariable::Wait.
* Don't start before having read ALL MUST-READ documents transitively and completely.
* If you don't have a good enough recording and cannot reproduce or otherwise find proof for a possible root cause:
  * You MUST keep your investigation short and stop before discovering all unknowns because it is literally impossible to find the proof needed.
  * You MUST stop investigating and instead propose a solution that only improves error chaining and/or inserts a few diagnostics.

## Data sources

## Important Context

* buildId: linux-chromium-20260901-3b213f05e6e7-fc75f2df4f2b
* linkerVersion: linker-linux-16124-fc75f2df4f2b
* recordingId: 0d3ece89-d7f4-4a95-8ea7-6b963d2484ff

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "PauseChild",
  "manifest": "pauseRequest",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingOnCvar": {
          "ptr": true,
          "lock": true,
          "waiters": [
            1
          ]
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+714",
          "new_pthread_cond_wait(void*,.void*)+50",
          "ReplaySpace+1340305484",
          "InvokeFunctionSpecifier(recordreplay::RecordedFunctionSpecifierFull.const&,.recordreplay::CallArguments*)+148",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+250",
          "ReplaySpace+1340301408",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::WaitMany(base::WaitableEvent**,.unsigned.long)+1064",
          "mojo::WaitSet::State::Wait(base::WaitableEvent**,.unsigned.long*,.mojo::Handle*,.unsigned.int*,.MojoHandleSignalsState*)+1814",
          "mojo::SyncHandleRegistry::Wait(bool.const**,.unsigned.long)+275",
          "mojo::SyncEventWatcher::SyncWatch(bool.const**,.unsigned.long)+601",
          "mojo::SequenceLocalSyncEventWatcher::SyncWatch(bool.const*)+153",
          "mojo::InterfaceEndpointClient::SendMessageWithResponder(mojo::Message*,.bool,.mojo::InterfaceEndpointClient::SyncSendMode,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+680",
          "mojo::internal::SendMojoMessage(mojo::MessageReceiverWithResponder&,.mojo::Message&,.std::Cr::unique_ptr<mojo::MessageReceiver,.std::Cr::default_delete<mojo::MessageReceiver>.>)+94",
          "blink::mojom::blink::BlobRegistryProxy::Register(mojo::PendingReceiver<blink::mojom::blink::Blob>,.WTF::String.const&,.WTF::String.const&,.WTF::String.const&,.WTF::Vector<mojo::StructPtr<blink::mojom::blink::DataElement>,.0u,.WTF::PartitionAllocator>)+1207",
          "blink::BlobDataHandle::BlobDataHandle(std::Cr::unique_ptr<blink::BlobData,.std::Cr::default_delete<blink::BlobData>.>,.unsigned.long)+477",
          "blink::Blob::Create(blink::ExecutionContext*,.blink::HeapVector<cppgc::internal::BasicMember<blink::V8UnionArrayBufferOrArrayBufferViewOrBlobOrUSVString,.cppgc::internal::StrongMemberTag,.cppgc::internal::DijkstraWriteBarrierPolicy,.cppgc::internal::DisabledCheckingPolicy>,.0u>.const&,.blink::BlobPropertyBag.const*)+273",
          "blink::(anonymous.namespace)::v8_blob::ConstructorCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+882",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+652",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+279",
          "ReplaySpace+44022455096",
          "ReplaySpace+44021879762",
          "ReplaySpace+44023170897",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021882460",
          "ReplaySpace+44021881735",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::Function::Call(v8::Local<v8::Context>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*)+763",
          "blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>,.blink::ExecutionContext*,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.v8::Isolate*)+931",
          "blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase,.(blink::bindings::CallbackInvokeHelperMode)0,.(blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int,.v8::Local<v8::Value>*)+91",
          "blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::Event*)+227",
          "blink::JSBasedEventListener::Invoke(blink::ExecutionContext*,.blink::Event*)+689",
          "blink::EventTarget::FireEventListeners(blink::Event&,.blink::EventTargetData*,.blink::HeapVector<blink::RegisteredEventListener,.1u>&)+1851",
          "blink::EventTarget::FireEventListeners(blink::Event&)+383",
          "blink::EventTarget::DispatchEventInternal(blink::Event&)+64",
          "blink::NavigationApi::DispatchNavigateEvent(blink::NavigateEventDispatchParams*)+1978",
          "blink::FrameLoader::StartNavigation(blink::FrameLoadRequest&,.blink::WebFrameLoadType)+3042",
          "blink::LocalFrame::Navigate(blink::FrameLoadRequest&,.blink::WebFrameLoadType)+209",
          "blink::Location::SetLocation(WTF::String.const&,.blink::LocalDOMWindow*,.blink::LocalDOMWindow*,.blink::ExceptionState*,.blink::Location::SetLocationPolicy)+1385",
          "blink::(anonymous.namespace)::v8_location::AssignOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+346",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "ReplaySpace+44022455096",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+43489580778",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021882460",
          "ReplaySpace+44021881735",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::Call(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>,.int,.v8::internal::Handle<v8::internal::Object>*)+284",
          "v8::Function::Call(v8::Local<v8::Context>,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*)+763",
          "blink::V8ScriptRunner::CallFunction(v8::Local<v8::Function>,.blink::ExecutionContext*,.v8::Local<v8::Value>,.int,.v8::Local<v8::Value>*,.v8::Isolate*)+931",
          "blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase,.(blink::bindings::CallbackInvokeHelperMode)0,.(blink::bindings::CallbackReturnTypeIsPromise)0>::Call(int,.v8::Local<v8::Value>*)+91",
          "blink::V8EventListener::InvokeWithoutRunnabilityCheck(blink::bindings::V8ValueOrScriptWrappableAdapter,.blink::Event*)+227",
          "blink::JSBasedEventListener::Invoke(blink::ExecutionContext*,.blink::Event*)+689",
          "blink::EventTarget::FireEventListeners(blink::Event&,.blink::EventTargetData*,.blink::HeapVector<blink::RegisteredEventListener,.1u>&)+1851",
          "blink::EventTarget::FireEventListeners(blink::Event&)+383",
          "blink::EventDispatcher::DispatchEventAtBubbling()+217",
          "blink::EventDispatcher::Dispatch()+880",
          "blink::EventDispatcher::DispatchSimulatedClick(blink::Node&,.blink::Event.const*,.blink::SimulatedClickCreationScope)+769",
          "blink::HTMLElement::click()+18",
          "blink::(anonymous.namespace)::v8_html_element::ClickOperationCallback(v8::FunctionCallbackInfo<v8::Value>.const&)+178",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "ReplaySpace+44022455096",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021882460",
          "ReplaySpace+44021881735",
          "v8::internal::(anonymous.namespace)::Invoke(v8::internal::Isolate*,.v8::internal::(anonymous.namespace)::InvokeParams.const&)+5141",
          "v8::internal::Execution::CallScript(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::internal::Handle<v8::internal::Object>,.v8::internal::Handle<v8::internal::Object>)+285",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::JSFunction>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+459",
          "v8::internal::DebugEvaluate::Global(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::String>,.v8::debug::EvaluateGlobalMode,.v8::internal::REPLMode)+237",
          "v8::debug::EvaluateGlobal(v8::Isolate*,.v8::Local<v8::String>,.v8::debug::EvaluateGlobalMode,.bool)+117",
          "v8_inspector::V8RuntimeAgentImpl::evaluate(v8_inspector::String16.const&,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<int>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<double>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<bool>,.v8_crdtp::detail::ValueMaybe<v8_inspector::String16>,.v8_crdtp::detail::ValueMaybe<bool>,.std::Cr::unique_ptr<v8_inspector::protocol::Runtime::Backend::EvaluateCallback,.std::Cr::default_delete<v8_inspector::protocol::Runtime::Backend::EvaluateCallback>.>)+1092",
          "v8_inspector::protocol::Runtime::DomainDispatcherImpl::evaluate(v8_crdtp::Dispatchable.const&)+846",
          "v8_crdtp::UberDispatcher::DispatchResult::Run()+36",
          "v8_inspector::V8InspectorSessionImpl::dispatchProtocolMessage(v8_inspector::StringView)+709",
          "blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+1241",
          "v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+345",
          "v8::internal::MaybeHandle<v8::internal::Object>.v8::internal::(anonymous.namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*,.v8::internal::Handle<v8::internal::HeapObject>,.v8::internal::Handle<v8::internal::FunctionTemplateInfo>,.v8::internal::Handle<v8::internal::Object>,.unsigned.long*,.int)+908",
          "v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments,.v8::internal::Isolate*)+296",
          "ReplaySpace+44022455096",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068",
          "ReplaySpace+44021889068"
        ],
        "progress": 9045205,
        "threadId": 1,
        "checkpoint": 261
      }
    }
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Thread::WaitForeverForRecordedCall epoll_wait [HasDivergedFromRecording]",
    "count": 2,
    "stack": [
      "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+1423"
    ],
    "progress": 9044936,
    "threadId": 2,
    "processId": 651,
    "checkpoint": 261,
    "absoluteTime": 1788319737093.9211,
    "wasRecording": false
  }
]
```

# Data

## Previous Work

* Searched all `crash-*/problem.md` for `Problem type: ReplayPauseCrash` + `Buckets: Pause/base::ConditionVariable::Wait`.
* crash-0064-2: only match on both fields.
  * Root cause: missing `AreEventsUnavailable` diverge guard in `CookieJar::CookiesEnabled()` → sync Mojo IPC hang post-diverge.
  * Already ran this same search itself; found no earlier match.
* Others with `Problem type: ReplayPauseCrash` (crash-0095, crash-0087, crash-0054, crash-0064) have different/missing `Buckets`.

## PauseSite

* Hang: `base::ConditionVariable::Wait` (innermost recorded wait `recordreplay::ReplayCvar::Wait`), tid1; owner unresolvable (cvar wait dumps no owner).
* 3 pinning frames (offsets preserved, tid1 backtrace):
  * Innermost wait (symptom): `recordreplay::ReplayCvar::Wait(recordreplay::ReplayLock*,.timespec*,.bool)+714`
  * **DivergedOp**: `blink::mojom::blink::BlobRegistryProxy::Register(...)+1207`
    * Called from `blink::BlobDataHandle::BlobDataHandle(...)+477` ← `blink::Blob::Create(...)+273` (the `new Blob(...)` ctor path).
    * Sync Mojo IPC confirmed by wait chain beneath it: `mojo::InterfaceEndpointClient::SendMessageWithResponder(..., SyncSendMode, ...)+680` → `SequenceLocalSyncEventWatcher::SyncWatch` → `SyncEventWatcher::SyncWatch` → `SyncHandleRegistry::Wait` → `WaitSet::State::Wait` → `WaitableEvent::WaitMany` → `ConditionVariable::Wait`.
  * Pause-command entry: `blink::SendCDPMessage(v8::FunctionCallbackInfo<v8::Value>.const&)+1241`
    * Blink→Replay JS→C++ entry point (`linker-commands.md`: `AutoDisallowEvents`, dispatches to inspector session).
    * Chain: `SendCDPMessage` → `V8InspectorSessionImpl::dispatchProtocolMessage` → CDP `Runtime.evaluate` dispatch → `DebugEvaluate::Global` → nested script execution (click handler → navigate event → `new Blob(...)`).
* Scan (`blink/renderer/core/fileapi/blob.cc`): `Blob::Create` has no `AreEventsUnavailable` guard before constructing `BlobDataHandle`; the file's only existing guard is in the unrelated blob-read path, not this ctor path.
* Earlier DivergedOps on the same recorded chain (not the hang site; refuse sites for Part2/Part3):
  * `blink::Location::SetLocation(...)+1385` ← `v8_location::AssignOperationCallback(...)+346`
  * `blink::HTMLElement::click()+18` ← `v8_html_element::ClickOperationCallback(...)+178`
* Scan (`blink/renderer/core/frame/location.cc`): `Location::SetLocation` has no diverge guard before `Frame::Navigate`.
* Scan (`blink/renderer/core/html/html_element.cc`): `HTMLElement::click` has no diverge guard before `DispatchSimulatedClick`.

PlacementParent: crash-0064-2

## RootCause

* Part1
  * DivergedOp: `blink::mojom::blink::BlobRegistryProxy::Register(...)` — sync Mojo IPC issued from `BlobDataHandle`'s ctor, called by `Blob::Create(ExecutionContext*, ...)` (the `new Blob(...)` path). Non-replayable: needs a live browser-process reply that can never arrive once diverged, so tid1 blocks forever (symptom: `ReplayCvar::Wait`/`ConditionVariable::Wait`, cvar dumps no owner).
  * Unguarded, confirmed by code scan (`blink/renderer/core/fileapi/blob.cc`): `Blob::Create(ExecutionContext*, ...)` builds `BlobData` then directly does `MakeGarbageCollected<Blob>(BlobDataHandle::Create(...))` — no `AreEventsUnavailable(...)` check on this path. The file's only such guard is in `ReadBlobHelper` (backs `Blob::text()`/`arrayBuffer()`), an unrelated read path.
  * Reached diverged (not just execution order):
    * Crash Report Core: `category: "PauseChild"`, `manifest: "pauseRequest"`, tid1.
    * `linker-commands.md`: `PauseRequestHandler::Start` → `DivergeFromRecording()` (sets `HasDivergedFromRecording()`) → `PerformPauseDataRequest`, on thread 1.
    * Pause-command entry frame `blink::SendCDPMessage(...)+1241` matches `record_replay_interface.cc`'s `SendCDPMessage`, confirmed wrapped in `recordreplay::AutoDisallowEvents disallow("SendCDPMessage")` (`AreEventsDisallowed()` true there). `AreEventsUnavailable()` = `AreEventsDisallowed() || HasDivergedFromRecording()` → unavailable on both counts at the Blob-construction callsite.
    * Full recorded chain (Crash Report Core backtrace, not inferred): `SendCDPMessage` → `V8InspectorSessionImpl::dispatchProtocolMessage` → CDP `Runtime.evaluate` → `DebugEvaluate::Global` → nested script → `HTMLElement::click` → `Location::SetLocation` → navigate event → `new Blob(...)`.
  * Collateral, not root: tid2 `epoll_wait`/`HasDivergedFromRecording` warning is unrelated post-diverge noise on a different thread.

* Part2
  * DivergedOp: `blink::Location::SetLocation(...)` — reaches `dom_window_->GetFrame()->Navigate(...)`. Non-replayable: starts a client navigation that cannot complete divergently, and in this report synchronously dispatches `navigate` listeners that reach Part1.
  * Unguarded: `location.cc` `SetLocation` builds `FrameLoadRequest` and calls `Navigate` with no `AreEventsUnavailable` / `RecordReplayThrowIfEventsUnavailable` check.
  * On the recorded chain above Part1: `v8_location::AssignOperationCallback(...)+346` → `Location::SetLocation(...)+1385` → `Navigate` → navigate-event dispatch → listener → `Blob::Create`.
  * Same diverge proof as Part1 (`PauseChild` / `pauseRequest` / `SendCDPMessage` + `AutoDisallowEvents`).
  * `Location::assign` / `replace` / `setHref` / URL-part setters all funnel through `SetLocation`; `reload()` does not (separate `Frame::Reload` path, not in this backtrace).

* Part3
  * DivergedOp: `blink::HTMLElement::click()` — reaches `DispatchSimulatedClick(...)`. Non-replayable: synthetic click fires arbitrary script (here: the handler that calls `location.assign`), with no usable in-process substitute once diverged.
  * Unguarded: `html_element.cc` `HTMLElement::click` calls `DispatchSimulatedClick` with no diverge throw.
  * On the recorded chain above Part2: `v8_html_element::ClickOperationCallback(...)+178` → `HTMLElement::click()+18` → `DispatchSimulatedClick` → bubbling click → script → `Location::assign`.
  * Same diverge proof as Part1.
  * `AccessKeyAction` also calls `DispatchSimulatedClick` directly and bypasses `click()`; not on this backtrace.


## SuggestedCourseOfAction

* Part1
  * No usable in-process substitute for `BlobRegistryProxy::Register`.
    * Without registration, a `Blob` cannot read, clone, or mint object URLs.
    * `ReadBlobHelper` already refuses divergent reads even for byte-backed blobs.
  * Throw in `Blob::Create(ExecutionContext*, const HeapVector<Member<V8BlobPart>>&, const BlobPropertyBag*)`.
    * First statement, before `BlobData` / `BlobDataHandle::Create`.
    * `if (RecordReplayThrowIfEventsUnavailable(kReplayBlobCreateUnavailableMessage)) return nullptr;`
    * Add `kReplayBlobCreateUnavailableMessage` beside `kReplayBlobReadUnavailableMessage` in `blob.cc`.
  * Only that overload.

* Part2
  * No usable in-process substitute for divergent `Frame::Navigate`.
  * Throw in `Location::SetLocation`.
    * After attach / URL / `CanNavigate` early returns, immediately before `FrameLoadRequest` / `Navigate`.
    * `if (RecordReplayThrowIfEventsUnavailable(kReplayLocationNavigateUnavailableMessage, exception_state)) return;`
    * Add `kReplayLocationNavigateUnavailableMessage` in `location.cc`.
  * Covers `assign` (this report's `AssignOperationCallback`), `replace`, and the `setHref` / URL-part setters that share `SetLocation`.
  * Do not guard `reload()` here.

* Part3
  * No usable in-process substitute for divergent synthetic click.
  * Throw in `HTMLElement::click()`.
    * First statement, before `DispatchSimulatedClick`.
    * `if (RecordReplayThrowIfEventsUnavailable(kReplayHtmlElementClickUnavailableMessage)) return;`
    * Add `kReplayHtmlElementClickUnavailableMessage` in `html_element.cc`.
  * Message-only form: `click()` has no `ExceptionState&` (same pattern as `scrollable_area.cc`).
  * Do not move the guard into `DispatchSimulatedClick` / `AccessKeyAction` for this fix.

# Solution


## Implementation

CAN_IMPLEMENT:
* `problem.md` `RootCause`/`SuggestedCourseOfAction` name each DivergedOp, guard call, and placement.
* `RecordReplayThrowIfEventsUnavailable` (`record_replay_throw.h:17`) confirmed live: message-only form at `scrollable_area.cc:358`, `ExceptionState*` form at `cookie_jar.cc:105,168`.
* `blob.cc:57` `kReplayBlobReadUnavailableMessage` is read-specific; not reusable for construction.
* `location.cc` / `html_element.cc` lack `#include` of `record_replay_throw.h`.

### Sites

* Part1 — guard `Blob::Create(ExecutionContext*, const HeapVector<Member<V8BlobPart>>&, const BlobPropertyBag*)`
  * `third_party/blink/renderer/core/fileapi/blob.cc`: add `constexpr char kReplayBlobCreateUnavailableMessage[]` at `:57` beside `kReplayBlobReadUnavailableMessage` (construction, not read); `record_replay_throw.h` already included.
  * At `:127-129`, first statement before `DCHECK` / `BlobData`: `if (RecordReplayThrowIfEventsUnavailable(kReplayBlobCreateUnavailableMessage)) return nullptr;`
  * Message-only form — overload has no `ExceptionState&`; returns `Blob*`.

* Part2 — guard `Location::SetLocation`
  * `third_party/blink/renderer/core/frame/location.cc`: add `constexpr char kReplayLocationNavigateUnavailableMessage[]` (anonymous namespace) plus `#include "third_party/blink/renderer/platform/bindings/record_replay_throw.h"`.
  * In `SetLocation` (`:238`), after the attach / URL / `CanNavigate` early returns and immediately before `FrameLoadRequest` / `Navigate` (`:284-291`): `if (RecordReplayThrowIfEventsUnavailable(kReplayLocationNavigateUnavailableMessage, exception_state)) return;`
  * `ExceptionState*` form — `exception_state` is already that type (`location.h:105-109`).

* Part3 — guard `HTMLElement::click()`
  * `third_party/blink/renderer/core/html/html_element.cc`: add `constexpr char kReplayHtmlElementClickUnavailableMessage[]` plus `#include "third_party/blink/renderer/platform/bindings/record_replay_throw.h"`.
  * At `:1182`, first statement before `DispatchSimulatedClick`: `if (RecordReplayThrowIfEventsUnavailable(kReplayHtmlElementClickUnavailableMessage)) return;`
  * Message-only form — `click()` has no `ExceptionState&` (`html_element.h`).
