### PR TITLE
crash-0096: SkipCleanup SkImageFilterCache purge under EventsDisallowed

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '4c76119760b600082b756fd4aedd3cf9ee4f3151',
+  'skia_revision': '9b34b80fb868c37902663af6eddfebffc1d6cfa4',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling Skia
   # and whatever else without interference from each other.
-  'skia_revision': '9b34b80fb868c37902663af6eddfebffc1d6cfa4',
+  'skia_revision': 'db09119f83a26368c1411b1dc1bf37c01b9a72cd',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.


### PR DESCRIPTION
# Summary

* paired w/ https://github.com/replayio/chromium-skia/pull/49
* ReplayHang `HangLocked:base::ConditionVariable::Wait`, manifest `runToPoint`, recording `2c3a39ec-6f25-4211-8919-34871a2a006d`.
  * Renderer main thread (id 1) waits in `cc::LayerTreeHost::WaitForCommitCompletion`.
  * Compositor thread (id 9) waits in `RecordReplayOrderedLock` from `CacheImpl::get` — the process-global `SkImageFilterCache` mutex.
* Divergence being fixed — that mutex's ordered-lock traffic originates on a GC-timed path.
  * Oilpan `Sweeper::SweepForAllocationIfRunning` finalizes `FragmentData::RareData` with events disallowed.
  * `~RareData` → `~ObjectPaintProperties` → `EffectPaintPropertyNode` last-ref `Release` → `~cc::FilterOperations` → `~ColorFilterPaintFilter` → `~SkColorFilterImageFilter` → `~SkImageFilter_Base`.
  * `~SkImageFilter_Base` unconditionally runs `SkImageFilterCache::Get()->purgeByImageFilter(this)`.
    * `Get()` is the singleton's once-init: constructs `SkMutex{"SkImageFilterCache"}` → `CreateOrderedLock`; `purgeByImageFilter` then acquires `fMutex` → `OrderedLock`.
  * Both are StreamTouch leaves, and both fire under `EventsDisallowed` → no stream write, `gNextLockId` still advances.
    * Witness: `Recorded value with events disallowed CreateOrderedLock` (×1) and `Ordered lock with events disallowed SkImageFilterCache` (×8), Sweeper stacks.
    * Recording-time id **6130** is a hole in clean replay's `gLocks` (dense `1..7826`); the singleton never exists on that side.
    * Not asserted to be hang lock **8028** — different snapshot id space; the established defect is the nondeterministic lock create/acquire, not a proven id equality.
* Why the intervention is at the Skia leaf `~SkImageFilter_Base`, not at `FragmentData`:
  * The Oilpan finalizer is only ONE reaching site. `~PaintOpBuffer` → PaintFilter dtors reaches the same leaf under `AutoDisallowEvents("~PaintOpBuffer")` with no Oilpan root at all — nothing at `FragmentData` can cover it.
  * A `DeterministicRetainer<FragmentData::RareData>` has no ReleaseSite that runs for the witness: `ClearPaintProperties` needs a `needs_paint_properties` true→false transition, and a filtered object holds `NeedsFilter` for life — so it dies with `paint_properties` set. LeakBound would be `Unbounded`, not `Assessed`.
  * Its RetainSite is far too wide: 8 of 10 `EnsureRareData` callers never touch `paint_properties`, `FragmentData` is one per `LayoutObject`, and a retained `RareData` pins `PaintLayer` → `LayoutObject` → DOM.
  * Closure is unprovable there: `sk_sp<SkImageFilter>` refs are also held by `PaintChunk`, `cc::EffectNode`, `PaintFlags`, `local_border_box_properties`.
  * The leaf is where the StreamTouch is emitted; gating it is the minimal cut and changes no object's lifetime on the ownership graph.
* Implementation — `SkipCleanup`, feature `"leak-references"`, label `"SkImageFilter"`; same shape as the in-tree `SkResourceCache` purge gates in `~SkPicture` / `~SkImage_Base` / `~SkPixelRef`.
  * `SkImageFilter_Base.h`: `mutable std::atomic<bool> fAddedToCache{false}` (plain `std::atomic`, NOT OrderedAtomic — a GC-reachable probe must emit no StreamTouch) + `notifyAddedToCache()`.
  * `SkImageFilterCache.cpp`: `CacheImpl` gains `fIsGlobal`; only the `Get()` singleton marks on `set`, so the three transient `Create()` caches never mark.
  * `SkImageFilter.cpp`: `~SkImageFilter_Base` purges only when `fAddedToCache`, and skips under `SkRecordReplayAreEventsDisallowed()` + `SkRecordReplayEnterLeakMemory("SkImageFilter")`.
  * Closes both halves: an unmarked filter never calls `Get()` (Sweeper can no longer be the singleton's first touch); a marked filter's acquire is skipped by the gate.
* LeakBound — `BoundKind`: **Unbounded**.
  * A skipped entry's `skif::FilterResult` stays in the `Get()` singleton for process lifetime.
  * LRU eviction in `set` (128 MiB `kDefaultCacheSize`) is a process-memory ceiling, NOT a Replay reclaim path: it runs under `fMutex` (itself a StreamTouch), frees no particular skipped entry, and its victim set depends on which purges the gate skipped.
  * `SkGraphics::PurgeAllCaches` is memory-pressure only; not reached on an ordinary recording.
  * Stale entries are unreachable, not wrong — keyed by monotonic, never-reused `fUniqueID`.
  * Must stay minor-perf or FAIL.

# Problem

* Problem type: ReplayHang.
* operatorId: `710b4ec8-22f6-4226-b949-71419d6b2fc8`
* Buckets: HangLocked:base::ConditionVariable::Wait.

## Important Context

* buildId: linux-chromium-20260903-d8e19d0986c4-f8993ddc5a88
* linkerVersion: linker-linux-16142-f8993ddc5a88
* recordingId: 2c3a39ec-6f25-4211-8919-34871a2a006d

### Crash Report Core
```json
{
  "why": "Hanged",
  "category": "Sapling",
  "manifest": "runToPoint",
  "threadId": 0,
  "hangedThreads": [
    {
      "state": {
        "threadId": 1,
        "waitingOnOrderedLock": {
          "id": 8028,
          "nextOwner": 9,
          "waitPosition": 16,
          "actualPosition": 16
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::Thread::Wait()+37",
          "recordreplay::OrderedLock(void*,.int)+474",
          "Op_pthread_cond_anywait(recordreplay::CallContext&)+131",
          "DoIntercept(unsigned.int,.recordreplay::CallArguments*)+221",
          "ReplaySpace+1351983200",
          "base::ConditionVariable::Wait()+146",
          "base::WaitableEvent::TimedWait(base::TimeDelta.const&)+961",
          "base::WaitableEvent::Wait()+31",
          "cc::LayerTreeHost::WaitForCommitCompletion(bool).const+164",
          "cc::ProxyMain::BeginMainFrameWithBlocking(std::Cr::unique_ptr<cc::BeginMainFrameAndCommitState,.std::Cr::default_delete<cc::BeginMainFrameAndCommitState>.>,.bool)+2324",
          "base::internal::Invoker<base::internal::BindState<void.(reporting::EncryptedReportingUploadProvider::UploadHelper::*)(std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>),.base::WeakPtr<reporting::EncryptedReportingUploadProvider::UploadHelper>,.std::Cr::unique_ptr<reporting::UploadClient,.std::Cr::default_delete<reporting::UploadClient>.>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+144",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "content::RendererMain(content::MainFunctionParams)+1434",
          "content::RunOtherNamedProcessTypeMain(std::Cr::basic_string<char,.std::Cr::char_traits<char>,.std::Cr::allocator<char>.>.const&,.content::MainFunctionParams,.content::ContentMainDelegate*)+686",
          "content::ContentMainRunnerImpl::Run()+673",
          "content::RunContentProcess(content::ContentMainParams,.content::ContentMainRunner*)+294",
          "content::ContentMain(content::ContentMainParams)+95",
          "headless::(anonymous.namespace)::RunContentMain(headless::HeadlessBrowser::Options,.base::OnceCallback<void.(headless::HeadlessBrowser*)>)+313",
          "headless::RunChildProcessIfNeeded(int,.char.const**)+373",
          "headless::HeadlessShellMain(int,.char.const**)+55",
          "ChromeMain+629",
          "new_libc_start_main(void.(*)(int,.char.const**))+22",
          "_start+42"
        ],
        "progress": 3387643,
        "threadId": 1,
        "checkpoint": 92
      }
    },
    {
      "state": {
        "threadId": 9,
        "waitingOnOrderedLock": {
          "id": 92624,
          "nextOwner": 0,
          "waitPosition": 0,
          "actualPosition": 0
        }
      },
      "backtrace": {
        "frames": [
          "recordreplay::Thread::Wait()+37",
          "recordreplay::OrderedLock(void*,.int)+474",
          "RecordReplayOrderedLock(int)+26",
          "(anonymous.namespace)::CacheImpl::get(SkImageFilterCacheKey.const&,.skif::FilterResult*).const+36",
          "SkImageFilter_Base::filterImage(skif::Context.const&).const+564",
          "SkBaseDevice::drawFilteredImage(skif::Mapping.const&,.SkSpecialImage*,.SkImageFilter.const*,.SkSamplingOptions.const&,.SkPaint.const&)+726",
          "SkCanvas::internalDrawDeviceWithFilter(SkBaseDevice*,.SkBaseDevice*,.SkImageFilter.const*,.SkPaint.const&,.SkCanvas::DeviceCompatibleWithFilter,.float)+1174",
          "SkCanvas::internalRestore()+514",
          "SkCanvas::onDrawImage2(SkImage.const*,.float,.float,.SkSamplingOptions.const&,.SkPaint.const*)+890",
          "SkCanvas::drawImage(SkImage.const*,.float,.float,.SkSamplingOptions.const&,.SkPaint.const*)+251",
          "viz::SoftwareRenderer::ApplyImageFilter(SkImageFilter*,.viz::AggregatedRenderPassDrawQuad.const*,.SkBitmap.const&,.bool,.SkIRect*).const+560",
          "viz::SoftwareRenderer::GetBackdropFilterShader(viz::AggregatedRenderPassDrawQuad.const*,.SkTileMode).const+1746",
          "viz::SoftwareRenderer::DrawRenderPassQuad(viz::AggregatedRenderPassDrawQuad.const*)+1312",
          "viz::SoftwareRenderer::DoDrawQuad(viz::DrawQuad.const*,.gfx::QuadF.const*)+1627",
          "viz::DirectRenderer::DrawRenderPass(viz::AggregatedRenderPass.const*)+950",
          "viz::DirectRenderer::DrawRenderPassAndExecuteCopyRequests(viz::AggregatedRenderPass*)+203",
          "viz::DirectRenderer::DrawFrame(std::Cr::vector<std::Cr::unique_ptr<viz::AggregatedRenderPass,.std::Cr::default_delete<viz::AggregatedRenderPass>.>,.std::Cr::allocator<std::Cr::unique_ptr<viz::AggregatedRenderPass,.std::Cr::default_delete<viz::AggregatedRenderPass>.>.>.>*,.float,.gfx::Size.const&,.gfx::DisplayColorSpaces.const&,.std::Cr::vector<gfx::Rect,.std::Cr::allocator<gfx::Rect>.>)+3136",
          "recordreplay::SubmitCompositorFrame(viz::LocalSurfaceId.const&,.viz::CompositorFrame.const&)+953",
          "cc::mojo_embedder::AsyncLayerTreeFrameSink::SubmitCompositorFrame(viz::CompositorFrame,.bool)+708",
          "cc::LayerTreeHostImpl::DrawLayers(cc::LayerTreeHostImpl::FrameData*)+1029",
          "cc::ProxyImpl::DrawInternal(bool)+376",
          "cc::Scheduler::DrawIfPossible()+133",
          "cc::Scheduler::ProcessScheduledActions()+1193",
          "cc::Scheduler::OnBeginImplFrameDeadline()+197",
          "base::DeadlineTimer::OnScheduledTaskInvoked()+45",
          "base::DefaultDelayedTaskHandleDelegate::RunTask(base::OnceCallback<void.()>)+35",
          "base::internal::Invoker<base::internal::BindState<void.(base::DefaultDelayedTaskHandleDelegate::*)(base::OnceCallback<void.()>),.base::WeakPtr<base::DefaultDelayedTaskHandleDelegate>,.base::OnceCallback<void.()>.>,.void.()>::RunOnce(base::internal::BindStateBase*)+159",
          "base::TaskAnnotator::RunTaskImpl(base::PendingTask&)+257",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*)+1001",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+127",
          "non-virtual.thunk.to.base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()+21",
          "base::MessagePumpDefault::Run(base::MessagePump::Delegate*)+154",
          "base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool,.base::TimeDelta)+355",
          "base::RunLoop::Run(base::Location.const&)+461",
          "blink::scheduler::NonMainThreadImpl::SimpleThreadImpl::Run()+232",
          "base::(anonymous.namespace)::ThreadFunc(void*)+86",
          "recordreplay::Thread::ThreadMainOwnStack(void*)+68",
          "InvokeOnNewStack+11",
          "(nil)"
        ],
        "progress": 3387643,
        "threadId": 9,
        "checkpoint": 92
      }
    }
  ]
}
```

#### Warnings
```json
[
  {
    "text": "Recorded value with events disallowed CreateOrderedLock [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 1,
    "stack": [],
    "threadId": 1,
    "processId": 2,
    "checkpoint": 1,
    "absoluteTime": 1788453564130.2026,
    "wasRecording": true
  },
  {
    "text": "Ordered lock with events disallowed SkImageFilterCache [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]",
    "count": 8,
    "stack": [
      "(anonymous.namespace)::CacheImpl::purgeByImageFilter(SkImageFilter.const*)+37",
      "SkImageFilter_Base::~SkImageFilter_Base()+40",
      "(anonymous.namespace)::SkColorFilterImageFilter::~SkColorFilterImageFilter()+38",
      "cc::ColorFilterPaintFilter::~ColorFilterPaintFilter()+82",
      "cc::FilterOperations::~FilterOperations()+63",
      "base::RefCounted<blink::EffectPaintPropertyNodeOrAlias,.blink::PaintPropertyNodeRefCountedTraits<blink::EffectPaintPropertyNodeOrAlias,.blink::EffectPaintPropertyNode>.>::Release().const+159",
      "blink::ObjectPaintProperties::~ObjectPaintProperties()+275",
      "cppgc::internal::FinalizerTrait<blink::FragmentData::RareData>::Finalize(void*)+68",
      "cppgc::internal::Sweeper::SweeperImpl::SweepForAllocationIfRunning(cppgc::internal::NormalPageSpace*,.unsigned.long,.v8::base::TimeDelta)+507",
      "cppgc::internal::ObjectAllocator::TryRefillLinearAllocationBuffer(cppgc::internal::NormalPageSpace&,.unsigned.long)+162",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocateImpl(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+307",
      "cppgc::internal::ObjectAllocator::OutOfLineAllocate(cppgc::internal::NormalPageSpace&,.unsigned.long,.cppgc::internal::AlignVal,.unsigned.short)+28",
      "blink::NGPhysicalBoxFragment::Create(blink::NGBoxFragmentBuilder*,.blink::WritingMode)+1566",
      "blink::NGBoxFragmentBuilder::ToBoxFragment(blink::WritingMode)+94"
      "... (68 more frames elided)"
    ],
    "threadId": 1,
    "processId": 2,
    "checkpoint": 1,
    "absoluteTime": 1788453564130.2563,
    "wasRecording": true
  }
]
```

# Part1: Why GC on first Render?

## Status
* **invalid** (prior **rooted** used post-cp1 / cp11 sample as if it were the cp1 GC)

## Scope note (prior contamination)
* Prior causal chain treated a **cp11-scoped** reverse sample (32× `CollectGarbage`) as the cp1 story.
  * Growth **11@1MiB → 15@2MiB → 6@4MiB**, tip Capacity=`4058112`, tip `Runtime_AllocateInYoungGeneration` fill, scripts @cp11 — all **out of scope**.
* Crash-report / op-log `checkpoint: 1` on `EventsDisallowed:Heap::CollectGarbage` / Sweeper warnings is **not** event time.
  * `emitWarnings` → `EmitRecordingWarnings()` dumps the Warnings stream at manifest **Start**, stamping `GetLastCheckpoint()` then (often branch root = 1). Stream itself stores no checkpoint.

## Causal chain (dead-stops at cp1)
* Isolate config (init, before any young GC): `ConfigureDefaults` → `ConfigureHeap`.
  * `max_semi=8MiB`, `initial_semi=1MiB`. Stock V8; no Replay young-gen override.
* **cp1 window** = recording from start through entering checkpoint 2.
  * linkerdebug `rrnew` + `runToPoint` endpoint `{checkpoint:2, progress:1}`.
  * Break `Heap::CollectGarbage` → reverse from end → **no hit** (runs to `_start`).
* Therefore at/before cp1:
  * **0** NEW_SPACE scavenges / `Heap::CollectGarbage` entries.
  * No Capacity / Available / request for a cp1 CollectGarbage — **no such hit**.
  * Growth 1→2→4 did **not** happen before cp1 (those sizes appear only in the later cp11-scoped sample).
* Part1 question (“why GC on first render / at cp1”) has no CollectGarbage event in-window to explain.

## Numbers (cp1 window only)
* `Heap::CollectGarbage` hits @/before cp1: **0**.
* Capacity / Available / request @ cp1 CollectGarbage: **n/a**.

## Evidence
* `man-cp1-gc.json` / `cp1-gc/` session: rr endpoint cp2/progress 1; CollectGarbage BP; reverse → no hit.
* Contrast (out of scope): prior 32-row sample was reverse from **cp11** endpoint.
* Warning stamp: `Warning.cpp` EmitWarning + `Manifest.cpp` `emitWarnings` → `EmitRecordingWarnings()` at Start.


# Part2: Why "Recorded value with events disallowed CreateOrderedLock"?

## Result
* Warning is `CreateOrderedLock` under EventsDisallowed during `Sweeper::SweepForAllocationIfRunning`.
  * Warnings: `Recorded value with events disallowed CreateOrderedLock [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]`.
    * `count: 1`, empty `stack`, `checkpoint: 1`, `threadId: 1`, `processId: 2`.
  * Oplog L7679 @ ~16:39:24, `checkpoint: 1`, no `progress`.
* OrderedLock named `SkImageFilterCache` — singleton `CacheImpl::fMutex` via first `SkImageFilterCache::Get()`.
  * Call path: dtor → `Get()->purgeByImageFilter` → once-init `CacheImpl` → `SkMutex{"SkImageFilterCache"}` → `CreateOrderedLock`.
    * Dtor: SkImageFilter.cpp L169–170.
    * `Get` once-init: SkImageFilterCache.cpp L161–166.
    * `fMutex` name: L152.
    * `purgeByImageFilter` lock: L108–109.
* Recording-time numeric id = **6130**.
  * `gNextLockId++` runs before `RecordReplayValue`.
    * OrderedLock.cpp L117–120.
  * EventsDisallowed → warning, no Values write, counter still advanced.
    * RecordedValue.cpp L23–26, return path L33–34.
* Id **6130** is a hole on clean replay at hang endpoint.
  * linkerdebug clean `runToPoint` `{checkpoint:92, progress:3387643}`:
    * `orderedLockStats.lockCount: 7827`.
    * `gLocks` dense `1..7826` except hole **6130** (`ptr` nil).
    * Neighbors: `6129` `SyncWaiter.lock_`, `6131` `WaitableEventKernel.lock_`.
    * No `SkImageFilterCache` in clean `gLocks`.
* Not hang lock **8028**.
  * Crash Report Core: `waitingOnOrderedLock.id: 8028`.
  * Same id space as Sapling hang snapshot.
  * OOB on clean `gLocks` max `7826`.
  * Do not equate to **6130**.
* Folded `SkImageFilterCache` OrderedLock warnings are same early disallow region, not adjacent to hang.
  * Warnings: `Ordered lock with events disallowed SkImageFilterCache`, `count: 8`.
  * Oplog eight hits L24786–L24804 @ ~16:39:26, `checkpoint: 1`.
  * ProcessHanged L31582.
  * ThreadBacktrace L34241: `checkpoint: 92`, `progress: 3387643`.
  * Gap ~9.4k lines / ~19s.
  * No pid-2 `RecordingWarning` near hang.

## Steps
* Break `CreateOrderedLock` under EventsDisallowed.
  * Confirm `gNextLockId++` then skipped Values write.
* Clean `runToPoint` hang endpoint.
  * Dump `gLocks` / `orderedLockStats`.

## Evidence
* Asserts: early `CreateOrderedLock` only for `FileDescriptor`.
  * `DisableAsserts` soon after.
  * No `SkImageFilterCache` `CreateOrderedLock` assert.
  * Assert gate: OrderedLock.cpp L105–108.
  * Disable: Assert.cpp L60–63.
* Count-8 folded warning matches OrderedLock-under-disallow.
  * OrderedLock.cpp L139–144.


# Part3: Analogous interventions

## Result
* Best prior art (1–3), by shape vs recommended OwnerGraph fix:
  * **crash-0073** — closest EventsDisallowed/Sweeper → dtor → singleton → `CreateOrderedLock` shape → **SkipCleanup** (+ undo bad OrderedAtomic ≈ reverse **replace-primitive**).
  * **crash-0091** — closest lazy-singleton `CreateOrderedLock` under GC-reachable path → **other** (`eager-initialization`; same “move init off non-det path” pressure as warmed-cache).
  * **crash-0058** — canonical OwnerGraph **DeterministicRelease** via `DeterministicRetainer` (matches `determinism-leak-memory.md` fix direction for this issue).
* Observation (not inference): no in-tree `leak-references` / SkipCleanup / eager-init on `SkImageFilterCache` / `purgeByImageFilter` today.
  * Surveyed in crash-0082 / crash-0082-2.
  * Closest Skia SkipCleanup is `SkResourceCache` purge skip in `~SkPicture` / `~SkImage_Base`, not this cache.
* Inference for crash-0096: OwnerGraph DeterministicRelease (or SkipCleanup on `~SkImageFilter` purge) is the established recipe family; eager-init of `SkImageFilterCache::Get()` is the established alternative when the StreamTouch is singleton once-init rather than ownership teardown.

## Examples

### 1. `~ImageFrameGenerator` under Sweeper — SkipCleanup (+ replace-primitive undo)
* Issue: crash-0073/problem.md.
* Observation — fault shape:
  * Warning: `Ordered lock with events disallowed atomic [EventsDisallowed:Sweeper::SweepForAllocationIfRunning]`.
  * Path: Sweeper → `~ImageFrameGenerator` → `HasInstance` / `Instance` → lazy OrderedAtomic → `CreateOrderedLock`.
  * Same `Sweeper::SweepForAllocationIfRunning` EventsDisallowed tag as crash-0096 Part2.
* Observation — shipped fix in tree:
  * From: GC/Sweeper-callable dtor body that probes store / emits OrderedLock StreamTouch.
  * To: early-return under `AreEventsDisallowed()` so dtor never reaches `Instance` / `RemoveCacheIndexedByGenerator`.
    * image_frame_generator.cc L101–108.
  * Also: OrderedAtomic → plain `std::atomic` (remove StreamTouch from the flag).
    * Recipe label in crash-0073: **SkipCleanupSubset**; OrderedAtomic reversal aligns with determinism-replace-primitive.md (wrong primitive for a GC-reachable probe).
* Class: **SkipCleanup** (primary); **replace-primitive** (secondary undo).
* Inference vs crash-0096: same Sweeper→dtor→lazy-init OrderedLock pattern; here SkipCleanup was chosen because KeepAlive had no Oilpan OwnerGraph cover for off-heap `ImageDecodingStore`.

### 2. `ImageDecodingStore` once-init — eager-initialization (other / warmed-cache-adjacent)
* Issue: crash-0091/problem.md.
* Observation — fault shape:
  * Mismatch leaves: recorded `Value TryLock` vs replayed `CreateOrderedLock ImageDecodingStore`.
  * First `Instance()` under unordered `__cxa_guard`; also reachable from GC sweep → `Ordered lock with events disallowed` warnings.
* Observation — shipped fix in tree:
  * From: first-touch `CreateOrderedLock` on decode / GC path via `DEFINE_ORDERED_THREAD_SAFE_STATIC_LOCAL_LOCK`.
  * To: deterministic main-thread construction in `Platform::InitializeMainThreadCommon`, then plain static local (no ordered lock on later `Instance()`).
    * Eager site: platform.cc L241–247 (`eager-initialization` / `ImageDecodingStore`).
    * Same feature as `PowerMonitor::GetInstance()` / `g_time_clamper.Get()` (cited in crash-0091).
* Class: **other** (`eager-initialization`); pressure matches determinism-warmed-cache.md (move / force init off EventsDisallowed / divergent first-touch), not Retain/Release.
* Inference vs crash-0096: `SkImageFilterCache::Get()` once-init of `CacheImpl`+`SkMutex{"SkImageFilterCache"}` is the same “lazy singleton CreateOrderedLock on first GC-ordered touch” leaf; eager `Get()` at a DetachOrdered/startup site is direct analog if OwnerGraph cover is unavailable.

### 3. `DOMScheduler` OwnerGraph — DeterministicRelease
* Issue: crash-0058/problem.md; recipe determinism-leak-memory.md DeterministicRelease.
* Observation — fault shape:
  * StreamTouch (`Now` / budget-pool teardown) ran GcOrdered via `~MainThreadWebSchedulingTaskQueueImpl` after prior SkipCleanup left queues alive past Detach.
* Observation — shipped fix in tree:
  * RetainSite: `DOMScheduler` ctor after `CreateFixedPriorityTaskQueues` → `DomSchedulerRetainer().Retain(this)`.
    * dom_scheduler.cc L54–64.
  * ReleaseSite: end of `~FrameSchedulerImpl`, after Detach-ordered StreamTouch loop + `CleanUpQueue`.
    * frame_scheduler_impl.cc L210–230.
  * Retainer: deterministic_retainer.h; feature `leak-references` / `EnterLeakMemory("DOMScheduler")`.
  * Keep SkipCleanup clear-skip in `ContextDestroyed` so queues stay on retained root until Release.
* Class: **DeterministicRelease**.
* Inference vs crash-0096: this is the OwnerGraph Retain→deterministic teardown→Release pattern named in Part2 fix direction for keeping `purgeByImageFilter` / cache once-init off Sweeper; apply to Oilpan ancestry that owns the filter/`ObjectPaintProperties` graph (not to process-global `CacheImpl` itself — that has no Oilpan root).

### Related (same Skia dtor→cache-purge family, different cache)
* Observation — SkipCleanup on `SkResourceCache` purge from Skia dtors under disallow + `EnterLeakMemory`:
  * SkPicture.cpp L51–60 — skip `PostPurgeSharedID`.
  * SkImage.cpp L285–295 — skip `SkNotifyBitmapGenIDIsStale`.
* Class: **SkipCleanup**.
* Observation: crash-0082 explicitly notes no such gate on `purgeByImageFilter` / `SkImageFilterCache`.


# DataDefinition

## StreamTouch

* `DivergingObject`: `SkImageFilter_Base`
  * Cleanup statement: SkImageFilter.cpp L169–170 — `~SkImageFilter_Base` → `SkImageFilterCache::Get()->purgeByImageFilter(this)`.
  * Not `CacheImpl` / process-global `SkImageFilterCache`:
    * `CacheImpl` is once-init create of the singleton (SkImageFilterCache.cpp L161–166); no Oilpan root (Part3).
    * StreamTouch leaf (`CreateOrderedLock` / `OrderedLock` on `fMutex{"SkImageFilterCache"}`) is a side-effect of `DivergingObject` cleanup, not cleanup of `CacheImpl`.
  * Evidence:
    * Warnings stack: `~SkImageFilter_Base` → `CacheImpl::purgeByImageFilter` under `EventsDisallowed:Sweeper::SweepForAllocationIfRunning`.
    * Part2: path `~SkImageFilter` → `Get()->purgeByImageFilter` → once-init `CacheImpl` → `CreateOrderedLock` id **6130**.

* Emitting statement — `CreateOrderedLock` (Values stream; divergent leaf):
  * Statement: SkMutex.h L24–26 — `SkMutex::SkMutex(const char*)` → `SkRecordReplayCreateOrderedLock(ordered_name)`.
  * Enclosing init: SkImageFilterCache.cpp L152 — `CacheImpl::fMutex{"SkImageFilterCache"}` during Create L157–158 / Get once L165.
  * Backend emit: OrderedLock.cpp L120 — `RecordReplayValue("CreateOrderedLock", lockId)` (export Driver.cpp L547–548).
  * Emitted event: Values `CreateOrderedLock` (name `"SkImageFilterCache"`); under EventsDisallowed → warning, no Values write, `gNextLockId` still advanced (Part2).

* Emitting statement — `OrderedLock` on same mutex (also StreamTouch when this cleanup reaches it):
  * Statement: SkMutex.h L32–34 — `SkMutex::acquire` → `SkRecordReplayOrderedLock`.
  * Cleanup acquire: SkImageFilterCache.cpp L108–109 — `CacheImpl::purgeByImageFilter` → `SkAutoMutexExclusive mutex(fMutex)`.
  * Backend: OrderedLock.cpp L130–144 — events allowed → OrderedLock stream; EventsDisallowed → warning `"Ordered lock with events disallowed SkImageFilterCache"`, no stream write.
  * Same `DivergingObject` cleanup StreamTouch: OrderedLock acquire via `purgeByImageFilter` (count×8 Warnings).
  * Not StreamTouch of this DivergingObject:
    * `CacheImpl::get` / `set` / `purge` (L56–59, L72–74, L99–100) during `filterImage` / paint.
    * Same mutex; not DivergingObject cleanup.

* Reaching site — `Ordering`: `GcOrdered`
  * Statement: fragment_data.cc L16 — `FragmentData::RareData::~RareData` (Oilpan finalizer) destroys fragment_data.h L224 `unique_ptr<ObjectPaintProperties> paint_properties`.
  * Enclosing: `cppgc::internal::FinalizerTrait<blink::FragmentData::RareData>::Finalize` ← `Sweeper::SweepForAllocationIfRunning`.
  * Chain: `~ObjectPaintProperties` → `EffectPaintPropertyNode` last-ref `Release` → `~cc::FilterOperations` → `~ColorFilterPaintFilter` (paint_filter.cc L476; drops `cached_sk_filter_`) → `~SkColorFilterImageFilter` → `~SkImageFilter_Base` L170.
  * Evidence: Warnings OrderedLock stack (count×8); CreateOrderedLock count×1 same Sweeper disallow region (Part2).

* Reaching site — `Ordering`: `DetachOrdered`
  * Statement: fragment_data.h L123–125 — `FragmentData::ClearPaintProperties` (`paint_properties = nullptr`).
  * Enclosing: paint_property_tree_builder.cc L3240–3259 — `PaintPropertyTreeBuilder::InitFragmentPaintProperties` when `!needs_paint_properties`.
  * Same DetachOrdered family (last-ref drop of effect nodes holding filters):
    * object_paint_properties.h L329–334 — `ObjectPaintProperties::Clear` via `ClearEffect` / `ClearFilter` / … (ADD_NODE L71, ADD_EFFECT L220–225).
    * `UpdateEffect` / `UpdateFilter` replacing `State` with empty/`CompositorFilterOperations` that drops prior filter ops (effect_paint_property_node.h L115).

* Reaching site — `Ordering`: `DetachOrdered`
  * Statement: paint_op_buffer.cc L2923–2925 — `~PaintOpBuffer` → `Reset()` (L2953–2957) → PaintFilter / `SkImageFilter` dtors → `~SkImageFilter_Base` L170.
  * Enclosing: compositor display-list teardown (e.g. crash-0082 `~DisplayItemList` / `~RasterSource` path).
  * Note: site opens `AutoDisallowEvents("~PaintOpBuffer")`; Ordering remains DetachOrdered (explicit teardown, not Oilpan finalizer).
  * No Oilpan root — not an `OwnerGraph` path.

## OwnerGraph

* Oilpan root: `FragmentData::RareData` (`GarbageCollected`)
  * Rooting statement: fragment_data.cc L61–63 — `FragmentData::EnsureRareData` → `rare_data_ = MakeGarbageCollected<RareData>()`.
  * Root holder: fragment_data.h L245 — `FragmentData::Member<RareData> rare_data_`.
  * StreamTouch GcOrdered site runs this root's finalizer (`FinalizerTrait<FragmentData::RareData>::Finalize`).

* Path `filter` (StreamTouch witness stack):
  * `FragmentData::RareData` → `ObjectPaintProperties`
    * Decl: fragment_data.h L224 — `std::unique_ptr<ObjectPaintProperties> paint_properties`
    * `EdgeStrength`: `Raw`
  * `ObjectPaintProperties` → `EffectPaintPropertyNode`
    * Decls (any one holds `State` with filters): object_paint_properties.h L220–225 — `ADD_EFFECT` → `scoped_refptr<EffectPaintPropertyNode>` `effect_` / `filter_` / `vertical_scrollbar_effect_` / `horizontal_scrollbar_effect_` / `mask_` / `clip_path_mask_`
    * `EdgeStrength`: `RefCounted` (`PaintPropertyNode` : `RefCounted`, paint_property_node.h L92–95)
    * StreamTouch DetachOrdered drops these edges via `ClearPaintProperties` / `ClearEffect` / `ClearFilter` / …
  * `EffectPaintPropertyNode` → `CompositorFilterOperations`
    * Decl: effect_paint_property_node.h L115 — `State::filter`, held in L312 `state_`
    * `EdgeStrength`: `Raw`
  * `CompositorFilterOperations` → `cc::FilterOperations`
    * Decl: compositor_filter_operations.h L70 — `cc::FilterOperations filter_operations_`
    * `EdgeStrength`: `Raw`
  * `cc::FilterOperations` → `cc::FilterOperation` (by-value vector elements)
    * Decl: filter_operations.h L95 — `std::vector<FilterOperation> operations_`
    * `EdgeStrength`: `Raw`
  * `cc::FilterOperation` → `cc::PaintFilter` (StreamTouch witness: `ColorFilterPaintFilter`)
    * Decl: filter_operation.h L290 — `sk_sp<PaintFilter> image_filter_`
    * `EdgeStrength`: `RefCounted` (`PaintFilter` : `SkRefCnt`, paint_filter.h L30)
  * `cc::PaintFilter` → `SkImageFilter_Base` (`DivergingObject`)
    * Decl: paint_filter.h L142 — `sk_sp<SkImageFilter> cached_sk_filter_`
    * `EdgeStrength`: `RefCounted`
    * Witness ctor sets it: paint_filter.cc L472–473 — `ColorFilterPaintFilter` → `SkImageFilters::ColorFilter` → `SkColorFilterImageFilter` : `SkImageFilter_Base`

* Path `backdrop_filter`:
  * Same edges through `ObjectPaintProperties` → `EffectPaintPropertyNode` as Path `filter`.
  * `EffectPaintPropertyNode` → `BackdropFilterInfo`
    * Decl: effect_paint_property_node.h L116 — `std::unique_ptr<BackdropFilterInfo> backdrop_filter_info`
    * `EdgeStrength`: `Raw`
  * `BackdropFilterInfo` → `CompositorFilterOperations`
    * Decl: effect_paint_property_node.h L87 — `CompositorFilterOperations operations`
    * `EdgeStrength`: `Raw`
  * Then same `CompositorFilterOperations` → `cc::FilterOperations` → `FilterOperation` → `PaintFilter` → `SkImageFilter_Base` as Path `filter`.

* Not on this `OwnerGraph`:
  * StreamTouch DetachOrdered `~PaintOpBuffer` — no Oilpan root (StreamTouch).
  * Process-global `CacheImpl` / `SkImageFilterCache` — no Oilpan root (StreamTouch, Part3).

* `DeterministicRetainer` inventory (per node):
  * `FragmentData::RareData`: none
  * `ObjectPaintProperties`: none
  * `EffectPaintPropertyNode`: none
  * `BackdropFilterInfo`: none
  * `CompositorFilterOperations`: none
  * `cc::FilterOperations` / `cc::FilterOperation`: none
  * `cc::PaintFilter` / `ColorFilterPaintFilter`: none
  * `SkImageFilter_Base`: none
  * Tree check: no `DeterministicRetainer` under `core/paint`, `cc/paint`, or `SkImageFilter*` / `SkImageFilterCache*` for these nodes.
  * Part3: `DeterministicRetainer` is Oilpan-only — only `FragmentData::RareData` (this Oilpan root) is eligible to retain.

# Analysis

## This problem

* Warning: `CreateOrderedLock` under `EventsDisallowed:Sweeper::SweepForAllocationIfRunning` — lock id **6130**, name `SkImageFilterCache`.
* Same disallow region: OrderedLock on that mutex via `purgeByImageFilter` (count×8).
* Reaching path: GcOrdered `FragmentData::RareData::~RareData` → filter OwnerGraph → `~SkImageFilter_Base` → first `SkImageFilterCache::Get()`.

## Fixed by Implementation

* Mechanism: `SkipCleanup` at the Skia leaf `~SkImageFilter_Base` (SkImageFilter.cpp L169–L180), feature `"leak-references"` / label `"SkImageFilter"` (Implementation).
* That Sweeper / `RareData` path cannot emit the `CreateOrderedLock` / OrderedLock StreamTouch under EventsDisallowed.
  * `CreateOrderedLock` half: `fAddedToCache` is set only by `CacheImpl::set` on the `fIsGlobal` singleton, so an unmarked filter's dtor never calls `SkImageFilterCache::Get()` — the Sweeper can no longer be the singleton's first touch.
  * `OrderedLock` half: for a marked filter the disallow gate skips `purgeByImageFilter`, so `fMutex` is never acquired from that dtor under disallow.
* Covers the off-graph `~PaintOpBuffer` reaching site too (StreamTouch) — same leaf, same gate; the rejected retainer covered only the Oilpan one.
* Nothing on the OwnerGraph is retained: `FragmentData::RareData` / `ObjectPaintProperties` / the filter chain die exactly when they did before.
* Cost is the `Unbounded` `BoundKind` of Implementation `LeakBound`: entries the skip left in the `Get()` singleton are stale for process lifetime.
  * Unreachable, not wrong — keyed by never-reused `fUniqueID`.
  * Must stay minor-perf or FAIL (determinism-leak-memory.md).

## Not this problem

* `~PaintOpBuffer` → filter dtor → `purgeByImageFilter` under `AutoDisallowEvents("~PaintOpBuffer")`.
  * Different reaching site. No Oilpan OwnerGraph. Not crash-0096's witness.
  * Gated anyway by the same leaf skip (Fixed by Implementation).
* Process-lifetime `CacheImpl` / OrderedLock after a successful create.
  * Not a divergence. Singleton once-init stays process-global by design.


# Rejected Implementation: DeterministicRelease on `FragmentData::RareData`

`DeterministicRetainer<FragmentData::RareData>` Retain at `EnsureRareData` / Release at `ClearPaintProperties` was rejected. RetainCover `SafeSet` is sound as a graph statement but fails on cost and on closure.

* `ReleaseSite` does not run for the witnessed instance.
  * `ClearPaintProperties` has one caller — paint_property_tree_builder.cc L3259 — reachable only on a `needs_paint_properties` true→false transition (L3242).
  * A filtered object holds `NeedsFilter` (L3977) for its life, so its `RareData` dies with `paint_properties` set — the GcOrdered StreamTouch path.
  * `LeakBound` is therefore `Unbounded`, not `Assessed`.
* `RetainSite` fires far wider than the filter path.
  * 8 of 10 `EnsureRareData` callers touch no `paint_properties` (fragment_data.h L218–L230) — sticky constraints, fragment id, cull rects, ids, layer, next fragment.
  * `FragmentData` is one per `LayoutObject`, allocated unconditionally (layout_object.cc L406); cull-rect writes reach `EnsureRareData` per `PaintLayer` per update (cull_rect_updater.cc L51).
* Retained `RareData` pins the layout tree and DOM.
  * `Member<PaintLayer> layer` → `layout_object_` (paint_layer.h L854) → `node_` / `parent_` (layout_object.h L4527).
  * `Member<FragmentData> next_fragment_` also defeats `ClearNextFragment` (fragment_data.cc L32–L39).
* Closure is not established: `ClearPaintProperties` is not proven to drop the last `sk_sp<SkImageFilter>` ref.
  * Independent holders: paint_chunk.h L151, effect_node.h L82, `local_border_box_properties` (cleared by `ClearLocalBorderBoxProperties`, not this site), paint_flags.h L210.
* `RareData` / `EnsureRareData` are `private` (fragment_data.h L201–L242) — the proposed namespace-scope accessor does not compile without a `friend`.


# Implementation

`SkipCleanup` at the Skia leaf. Feature `"leak-references"`, label `"SkImageFilter"`. Same shape as the three in-tree `SkResourceCache` purge gates (SkPicture.cpp L51–L61, SkImage.cpp L285–L296, SkPixelRef.cpp L99–L110).

* `third_party/skia/src/core/SkImageFilter_Base.h`
  * `mutable std::atomic<bool> fAddedToCache{false}` next to `fUniqueID`.
    * Plain `std::atomic`, not OrderedAtomic — a GC-reachable probe must emit no StreamTouch (determinism-replace-primitive.md, crash-0073).
  * `notifyAddedToCache() const` setter, mirroring `SkImage_Base::notifyAddedToRasterCache` (SkImage_Base.h L183–L185).

* `third_party/skia/src/core/SkImageFilterCache.cpp`
  * `CacheImpl` gains `fIsGlobal`; `CacheImpl::set` marks the filter only when set, alongside the `fImageFilterValues` bookkeeping it mirrors.
  * `Get()` constructs the singleton with `isGlobal=true`; `Create()` (transient caches) stays `false`.
    * Required: `CacheImpl` also backs three transient caches — Device.cpp L1404–L1409, SkPDFDevice.cpp L1751–L1755, SkImage.cpp L614–L615. Only SkBitmapDevice.cpp L613–L617 returns the global one.
    * Marking on a transient hit would set `fAddedToCache` for a filter with nothing in the cache the dtor purges, making the dtor still reach `Get()` on the Ganesh path.

* `third_party/skia/src/core/SkImageFilter.cpp`
  * `~SkImageFilter_Base`: purge only when `fAddedToCache`, and skip under `SkRecordReplayAreEventsDisallowed()` + `SkRecordReplayEnterLeakMemory("SkImageFilter")`.

## Why this closes it

* `CreateOrderedLock` half: a filter with no cache entry no longer calls `SkImageFilterCache::Get()` at all, so a dtor can never be the singleton's first touch. A filter with an entry had `Get()` called during `set` on the paint path, events allowed.
* `OrderedLock` half: the disallow gate skips `purgeByImageFilter` (SkImageFilterCache.cpp L108–L109), so neither the GcOrdered Sweeper site nor the off-graph `~PaintOpBuffer` site (StreamTouch) can acquire `fMutex` under disallow.
  * `SkMutex::acquire` emits an event on every acquire (SkMutex.h L32–L34), not only on the singleton's first construction — the gate is what covers that, the flag alone would not.
* Covers both reaching sites; the rejected retainer covered only the Oilpan one.
* Requires the `leak-references` / `SkImageFilter` feature enabled: `SkRecordReplayEnterLeakMemory` returns false when it is off (SkRecordReplay.h L25–L30) and the purge then still runs under disallow. Same gating as the three precedents.
* No missed purge is possible: `CacheImpl::set` is the sole insertion site and `CacheImpl` the sole `purgeByImageFilter` impl, so a filter cannot hold global-cache state without having been marked.

## LeakBound

* `BoundKind`: `Unbounded`.
  * No reclaim path runs on an ordinary run — a skipped entry is stale for process lifetime under the gate.

* What stays alive, and what keys it:
  * Key: the entry's `SkImageFilterCacheKey` in `fLookup` / `fLRU`; plus the freed `SkImageFilter*` as `fImageFilterValues` key.
  * Held: the `Value` — its `skif::FilterResult` pixels (SkImageFilterCache.cpp L41–L56) — and its bytes in `fCurrentBytes`.
  * Only the `Get()` singleton (`fIsGlobal`): transient caches never mark, so their entries are never skipped.

* Reclaim paths found — neither is a bound:
  * LRU eviction in `set` once `fCurrentBytes > fMaxBytes` (L94–L101), ceiling `kDefaultCacheSize` = 128 MiB (L27).
    * Process-memory ceiling on total cache bytes. It frees no particular skipped entry, and a run need never reach it.
    * Not a Replay reclaim path: eviction runs inside `set` under `fMutex` (SkMutex.h L32–L34) — itself an OrderedLock StreamTouch — and which entries it leaves depends on which `purgeByImageFilter` calls the gate skipped.
  * `purge()` (L104–L111) via `SkImageFilter_Base::PurgeCache` (SkImageFilter.cpp L692–L694) ← `SkGraphics::PurgeAllCaches` ← `RenderThreadImpl::ReleaseFreeMemory` (render_thread_impl.cc L1740).
    * Memory-pressure trigger only; not reached on an ordinary recording.

* Divergent cache contents (why eviction cannot carry the argument):
  * Record skip set ≠ replay skip set — the Sweeper reaches a given `~SkImageFilter_Base` under `EventsDisallowed` on one side only (StreamTouch).
  * So `fLookup` / `fCurrentBytes` differ per side. On a run that does reach the ceiling, eviction drops different `Value`s per side → different later `get` results → different `set` work and OrderedLock counts on `fMutex`.
  * Soundness rests on the gate skipping the acquire, not on eviction (Why this closes it).

* Stale entries are unreachable, not wrong.
  * `SkImageFilterCacheKey::fUniqueID` (SkImageFilterCache.h L34) is the filter's `fUniqueID`, monotonic and never reused (SkImageFilter.cpp L143–L152) — `get` cannot return a dead filter's result.
* `fAddedToCache` is never cleared, so the `[LEAK]` print is an upper bound: after an eviction or `purge()` a filter still takes the branch while leaking nothing. Same non-clearing `.load()` as the `SkPicture` / `SkImage` precedents.
* A stale `fImageFilterValues` entry keyed by the freed `SkImageFilter*` survives the skip.
  * Address reuse only appends a new filter's `Value`s to that vector; `removeInternal` / a later `purgeByImageFilter` clear both (L130–L149). No deref of the dead pointer — it is used as a hash key only.
