### PR TITLE
[crash-0097] HandleAudibility Assert; output AudioParams; capture AudioInputBuffer bytes

### DIFF
--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -413,6 +413,9 @@ void AudioInputDevice::AudioThreadCallback::MapSharedMemory() {
     ptr += segment_length_;
   }
 
+  if (recordreplay::IsRecordingOrReplaying())
+    capture_bus_ = media::AudioBus::Create(audio_parameters_);
+
   // Indicate that browser side capture initialization has succeeded and IPC
   // channel initialized. This effectively completes the
   // AudioCapturerSource::Start()' phase as far as the caller of that function
@@ -433,39 +436,34 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
 
   // Use pre-allocated audio bus wrapping existing block of shared memory.
   const media::AudioBus* audio_bus = audio_buses_[current_segment_id_].get();
-  AudioInputBufferParameters params = buffer->params;
+  const AudioInputBufferParameters* params = &buffer->params;
+  AudioInputBufferParameters recorded_params{};
   if (recordreplay::IsRecordingOrReplaying()) {
-    recordreplay::RecordReplayBytes("AudioInputDevice::Process params", &params,
-                                    sizeof(params));
-    if (recordreplay::IsReplaying()) {
-      if (!capture_bus_)
-        capture_bus_ = media::AudioBus::Create(audio_parameters_);
-      for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
-        recordreplay::RecordReplayBytes(
-            "AudioInputDevice::Process", capture_bus_->channel(ch),
-            static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
-      }
-      audio_bus = capture_bus_.get();
-    } else {
-      for (int ch = 0; ch < audio_bus->channels(); ++ch) {
-        recordreplay::RecordReplayBytes(
-            "AudioInputDevice::Process",
-            const_cast<float*>(audio_bus->channel(ch)),
-            static_cast<size_t>(audio_bus->frames()) * sizeof(float));
-      }
+    if (recordreplay::IsRecording()) {
+      audio_bus->CopyTo(capture_bus_.get());
+      recorded_params = buffer->params;
     }
+    recordreplay::RecordReplayBytes("AudioInputDevice::Process params",
+                                    &recorded_params, sizeof(recorded_params));
+    for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
+      recordreplay::RecordReplayBytes(
+          "AudioInputDevice::Process", capture_bus_->channel(ch),
+          static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
+    }
+    audio_bus = capture_bus_.get();
+    params = &recorded_params;
   }
 
   // Usually this will be equal but in the case of low sample rate (e.g. 8kHz,
   // the buffer may be bigger (on mac at least)).
-  DCHECK_GE(params.size,
+  DCHECK_GE(params->size,
             segment_length_ - sizeof(AudioInputBufferParameters));
 
   // Verify correct sequence.
-  if (params.id != last_buffer_id_ + 1) {
+  if (params->id != last_buffer_id_ + 1) {
     std::string message = base::StringPrintf(
         "Incorrect buffer sequence. Expected = %u. Actual = %u.",
-        last_buffer_id_ + 1, params.id);
+        last_buffer_id_ + 1, params->id);
     LOG(ERROR) << message;
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
@@ -478,7 +476,7 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
   }
-  last_buffer_id_ = params.id;
+  last_buffer_id_ = params->id;
 
   // Regularly inform that we have gotten data.
   frames_since_last_got_data_callback_ += audio_bus->frames();
@@ -492,12 +490,12 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   // the audio delay measurement.
   // TODO(olka, tommi): Take advantage of |capture_time| in the renderer.
   const base::TimeTicks capture_time =
-      base::TimeTicks() + base::Microseconds(params.capture_time_us);
+      base::TimeTicks() + base::Microseconds(params->capture_time_us);
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
-  capture_callback_->Capture(audio_bus, capture_time, params.volume,
-                             params.key_pressed);
+  capture_callback_->Capture(audio_bus, capture_time, params->volume,
+                             params->key_pressed);
 
   if (++current_segment_id_ >= total_segments_)
     current_segment_id_ = 0u;

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -436,34 +436,30 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
 
   // Use pre-allocated audio bus wrapping existing block of shared memory.
   const media::AudioBus* audio_bus = audio_buses_[current_segment_id_].get();
-  const AudioInputBufferParameters* params = &buffer->params;
-  AudioInputBufferParameters recorded_params{};
+  AudioInputBufferParameters params = buffer->params;
   if (recordreplay::IsRecordingOrReplaying()) {
-    if (recordreplay::IsRecording()) {
+    if (recordreplay::IsRecording())
       audio_bus->CopyTo(capture_bus_.get());
-      recorded_params = buffer->params;
-    }
-    recordreplay::RecordReplayBytes("AudioInputDevice::Process params",
-                                    &recorded_params, sizeof(recorded_params));
+    recordreplay::RecordReplayBytes("AudioInputDevice::Process params", &params,
+                                    sizeof(params));
     for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
       recordreplay::RecordReplayBytes(
           "AudioInputDevice::Process", capture_bus_->channel(ch),
           static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
     }
     audio_bus = capture_bus_.get();
-    params = &recorded_params;
   }
 
   // Usually this will be equal but in the case of low sample rate (e.g. 8kHz,
   // the buffer may be bigger (on mac at least)).
-  DCHECK_GE(params->size,
+  DCHECK_GE(params.size,
             segment_length_ - sizeof(AudioInputBufferParameters));
 
   // Verify correct sequence.
-  if (params->id != last_buffer_id_ + 1) {
+  if (params.id != last_buffer_id_ + 1) {
     std::string message = base::StringPrintf(
         "Incorrect buffer sequence. Expected = %u. Actual = %u.",
-        last_buffer_id_ + 1, params->id);
+        last_buffer_id_ + 1, params.id);
     LOG(ERROR) << message;
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
@@ -476,7 +472,7 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
   }
-  last_buffer_id_ = params->id;
+  last_buffer_id_ = params.id;
 
   // Regularly inform that we have gotten data.
   frames_since_last_got_data_callback_ += audio_bus->frames();
@@ -490,12 +486,12 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   // the audio delay measurement.
   // TODO(olka, tommi): Take advantage of |capture_time| in the renderer.
   const base::TimeTicks capture_time =
-      base::TimeTicks() + base::Microseconds(params->capture_time_us);
+      base::TimeTicks() + base::Microseconds(params.capture_time_us);
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
-  capture_callback_->Capture(audio_bus, capture_time, params->volume,
-                             params->key_pressed);
+  capture_callback_->Capture(audio_bus, capture_time, params.volume,
+                             params.key_pressed);
 
   if (++current_segment_id_ >= total_segments_)
     current_segment_id_ = 0u;

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -412,7 +412,6 @@ void AudioInputDevice::AudioThreadCallback::MapSharedMemory() {
         media::AudioBus::WrapReadOnlyMemory(audio_parameters_, buffer->audio));
     ptr += segment_length_;
   }
-  capture_bus_ = media::AudioBus::Create(audio_parameters_);
 
   // Indicate that browser side capture initialization has succeeded and IPC
   // channel initialized. This effectively completes the
@@ -432,26 +431,44 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   const AudioInputBuffer* buffer =
       reinterpret_cast<const AudioInputBuffer*>(ptr);
 
-  AudioInputBufferParameters params = buffer->params;
-  audio_buses_[current_segment_id_]->CopyTo(capture_bus_.get());
-  recordreplay::RecordReplayBytes("AudioInputDevice::Process params", &params,
-                                  sizeof(params));
-  for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
-    recordreplay::RecordReplayBytes(
-        "AudioInputDevice::Process", capture_bus_->channel(ch),
-        static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
+  // Use pre-allocated audio bus wrapping existing block of shared memory.
+  const media::AudioBus* audio_bus = audio_buses_[current_segment_id_].get();
+  const AudioInputBufferParameters* params = &buffer->params;
+  AudioInputBufferParameters recorded_params;
+  if (recordreplay::IsRecordingOrReplaying()) {
+    recorded_params = buffer->params;
+    recordreplay::RecordReplayBytes("AudioInputDevice::Process params",
+                                    &recorded_params, sizeof(recorded_params));
+    params = &recorded_params;
+    if (recordreplay::IsReplaying()) {
+      if (!capture_bus_)
+        capture_bus_ = media::AudioBus::Create(audio_parameters_);
+      for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
+        recordreplay::RecordReplayBytes(
+            "AudioInputDevice::Process", capture_bus_->channel(ch),
+            static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
+      }
+      audio_bus = capture_bus_.get();
+    } else {
+      for (int ch = 0; ch < audio_bus->channels(); ++ch) {
+        recordreplay::RecordReplayBytes(
+            "AudioInputDevice::Process",
+            const_cast<float*>(audio_bus->channel(ch)),
+            static_cast<size_t>(audio_bus->frames()) * sizeof(float));
+      }
+    }
   }
 
   // Usually this will be equal but in the case of low sample rate (e.g. 8kHz,
   // the buffer may be bigger (on mac at least)).
-  DCHECK_GE(params.size,
+  DCHECK_GE(params->size,
             segment_length_ - sizeof(AudioInputBufferParameters));
 
   // Verify correct sequence.
-  if (params.id != last_buffer_id_ + 1) {
+  if (params->id != last_buffer_id_ + 1) {
     std::string message = base::StringPrintf(
         "Incorrect buffer sequence. Expected = %u. Actual = %u.",
-        last_buffer_id_ + 1, params.id);
+        last_buffer_id_ + 1, params->id);
     LOG(ERROR) << message;
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
@@ -464,10 +481,10 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
   }
-  last_buffer_id_ = params.id;
+  last_buffer_id_ = params->id;
 
   // Regularly inform that we have gotten data.
-  frames_since_last_got_data_callback_ += capture_bus_->frames();
+  frames_since_last_got_data_callback_ += audio_bus->frames();
   if (frames_since_last_got_data_callback_ >=
       got_data_callback_interval_in_frames_) {
     got_data_callback_.Run();
@@ -478,12 +495,12 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   // the audio delay measurement.
   // TODO(olka, tommi): Take advantage of |capture_time| in the renderer.
   const base::TimeTicks capture_time =
-      base::TimeTicks() + base::Microseconds(params.capture_time_us);
+      base::TimeTicks() + base::Microseconds(params->capture_time_us);
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
-  capture_callback_->Capture(capture_bus_.get(), capture_time, params.volume,
-                             params.key_pressed);
+  capture_callback_->Capture(audio_bus, capture_time, params->volume,
+                             params->key_pressed);
 
   if (++current_segment_id_ >= total_segments_)
     current_segment_id_ = 0u;

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -15,6 +15,7 @@
 #include "base/memory/ptr_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/record_replay.h"
 #include "base/strings/stringprintf.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/time/time.h"
@@ -89,6 +90,7 @@ class AudioInputDevice::AudioThreadCallback
   size_t current_segment_id_;
   uint32_t last_buffer_id_;
   std::vector<std::unique_ptr<const media::AudioBus>> audio_buses_;
+  std::unique_ptr<media::AudioBus> capture_bus_;
   raw_ptr<CaptureCallback> capture_callback_;
 
   // Used for informing AudioInputDevice that we have gotten data, i.e. the
@@ -410,6 +412,7 @@ void AudioInputDevice::AudioThreadCallback::MapSharedMemory() {
         media::AudioBus::WrapReadOnlyMemory(audio_parameters_, buffer->audio));
     ptr += segment_length_;
   }
+  capture_bus_ = media::AudioBus::Create(audio_parameters_);
 
   // Indicate that browser side capture initialization has succeeded and IPC
   // channel initialized. This effectively completes the
@@ -429,16 +432,26 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   const AudioInputBuffer* buffer =
       reinterpret_cast<const AudioInputBuffer*>(ptr);
 
+  AudioInputBufferParameters params = buffer->params;
+  audio_buses_[current_segment_id_]->CopyTo(capture_bus_.get());
+  recordreplay::RecordReplayBytes("AudioInputDevice::Process params", &params,
+                                  sizeof(params));
+  for (int ch = 0; ch < capture_bus_->channels(); ++ch) {
+    recordreplay::RecordReplayBytes(
+        "AudioInputDevice::Process", capture_bus_->channel(ch),
+        static_cast<size_t>(capture_bus_->frames()) * sizeof(float));
+  }
+
   // Usually this will be equal but in the case of low sample rate (e.g. 8kHz,
   // the buffer may be bigger (on mac at least)).
-  DCHECK_GE(buffer->params.size,
+  DCHECK_GE(params.size,
             segment_length_ - sizeof(AudioInputBufferParameters));
 
   // Verify correct sequence.
-  if (buffer->params.id != last_buffer_id_ + 1) {
+  if (params.id != last_buffer_id_ + 1) {
     std::string message = base::StringPrintf(
         "Incorrect buffer sequence. Expected = %u. Actual = %u.",
-        last_buffer_id_ + 1, buffer->params.id);
+        last_buffer_id_ + 1, params.id);
     LOG(ERROR) << message;
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
@@ -451,13 +464,10 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
   }
-  last_buffer_id_ = buffer->params.id;
-
-  // Use pre-allocated audio bus wrapping existing block of shared memory.
-  const media::AudioBus* audio_bus = audio_buses_[current_segment_id_].get();
+  last_buffer_id_ = params.id;
 
   // Regularly inform that we have gotten data.
-  frames_since_last_got_data_callback_ += audio_bus->frames();
+  frames_since_last_got_data_callback_ += capture_bus_->frames();
   if (frames_since_last_got_data_callback_ >=
       got_data_callback_interval_in_frames_) {
     got_data_callback_.Run();
@@ -468,12 +478,12 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   // the audio delay measurement.
   // TODO(olka, tommi): Take advantage of |capture_time| in the renderer.
   const base::TimeTicks capture_time =
-      base::TimeTicks() + base::Microseconds(buffer->params.capture_time_us);
+      base::TimeTicks() + base::Microseconds(params.capture_time_us);
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
-  capture_callback_->Capture(audio_bus, capture_time, buffer->params.volume,
-                             buffer->params.key_pressed);
+  capture_callback_->Capture(capture_bus_.get(), capture_time, params.volume,
+                             params.key_pressed);
 
   if (++current_segment_id_ >= total_segments_)
     current_segment_id_ = 0u;

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -433,13 +433,10 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
 
   // Use pre-allocated audio bus wrapping existing block of shared memory.
   const media::AudioBus* audio_bus = audio_buses_[current_segment_id_].get();
-  const AudioInputBufferParameters* params = &buffer->params;
-  AudioInputBufferParameters recorded_params;
+  AudioInputBufferParameters params = buffer->params;
   if (recordreplay::IsRecordingOrReplaying()) {
-    recorded_params = buffer->params;
-    recordreplay::RecordReplayBytes("AudioInputDevice::Process params",
-                                    &recorded_params, sizeof(recorded_params));
-    params = &recorded_params;
+    recordreplay::RecordReplayBytes("AudioInputDevice::Process params", &params,
+                                    sizeof(params));
     if (recordreplay::IsReplaying()) {
       if (!capture_bus_)
         capture_bus_ = media::AudioBus::Create(audio_parameters_);
@@ -461,14 +458,14 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
 
   // Usually this will be equal but in the case of low sample rate (e.g. 8kHz,
   // the buffer may be bigger (on mac at least)).
-  DCHECK_GE(params->size,
+  DCHECK_GE(params.size,
             segment_length_ - sizeof(AudioInputBufferParameters));
 
   // Verify correct sequence.
-  if (params->id != last_buffer_id_ + 1) {
+  if (params.id != last_buffer_id_ + 1) {
     std::string message = base::StringPrintf(
         "Incorrect buffer sequence. Expected = %u. Actual = %u.",
-        last_buffer_id_ + 1, params->id);
+        last_buffer_id_ + 1, params.id);
     LOG(ERROR) << message;
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
@@ -481,7 +478,7 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
     capture_callback_->OnCaptureError(
         media::AudioCapturerSource::ErrorCode::kUnknown, message);
   }
-  last_buffer_id_ = params->id;
+  last_buffer_id_ = params.id;
 
   // Regularly inform that we have gotten data.
   frames_since_last_got_data_callback_ += audio_bus->frames();
@@ -495,12 +492,12 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   // the audio delay measurement.
   // TODO(olka, tommi): Take advantage of |capture_time| in the renderer.
   const base::TimeTicks capture_time =
-      base::TimeTicks() + base::Microseconds(params->capture_time_us);
+      base::TimeTicks() + base::Microseconds(params.capture_time_us);
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
-  capture_callback_->Capture(audio_bus, capture_time, params->volume,
-                             params->key_pressed);
+  capture_callback_->Capture(audio_bus, capture_time, params.volume,
+                             params.key_pressed);
 
   if (++current_segment_id_ >= total_segments_)
     current_segment_id_ = 0u;

--- a/media/audio/audio_output_device_thread_callback.cc
+++ b/media/audio/audio_output_device_thread_callback.cc
@@ -54,7 +54,8 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
   media::AudioOutputBuffer* buffer =
       reinterpret_cast<media::AudioOutputBuffer*>(
           shared_memory_mapping_.memory());
-  uint32_t frames_skipped = buffer->params.frames_skipped;
+  uint32_t frames_skipped = recordreplay::RecordReplayValue(
+      "audioparams::frames_skipped", buffer->params.frames_skipped);
   buffer->params.frames_skipped = 0;
 
   TRACE_EVENT_BEGIN2("audio", "AudioOutputDevice::FireRenderCallback",
@@ -66,7 +67,8 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
     recordreplay::RecordReplayValue("audioparams::delay_us", buffer->params.delay_us));
 
   base::TimeTicks delay_timestamp =
-      base::TimeTicks() + base::Microseconds(buffer->params.delay_timestamp_us);
+      base::TimeTicks() + base::Microseconds(recordreplay::RecordReplayValue(
+          "audioparams::delay_timestamp_us", buffer->params.delay_timestamp_us));
 
   DVLOG(4) << __func__ << " delay:" << delay << " delay_timestamp:" << delay
            << " frames_skipped:" << frames_skipped;

--- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
@@ -798,9 +798,8 @@ void AudioContext::HandleAudibility(AudioBus* destination_bus) {
     ++total_audible_renders_;
   }
 
+  recordreplay::Assert("[RUN-1506] AudioContext::HandleAudibility %d %d", was_audible_, is_audible);
   if (was_audible_ != is_audible) {
-    recordreplay::Assert("[RUN-1506] AudioContext::HandleAudibility %d %d", was_audible_, is_audible);
-
     // Audibility changed in this render, so report the change.
     was_audible_ = is_audible;
     if (is_audible) {


### PR DESCRIPTION
# [HandleAudibility] Summary

* `AudioContext::HandleAudibility` `[RUN-1506]` Assert sat inside `if (was_audible_ != is_audible)`.
  * It fired only on an audibility flip.
  * Replay could skip the Assert entirely and still look matching on no-flip renders.
* Hoist the Assert above that branch.
  * Every render records HandleAudibility control flow.

# [AudioParams] Summary

* `AudioOutputDeviceThreadCallback::Process` already `RecordReplayValue`s `delay_us` from audio-service shm.
* `frames_skipped` and `delay_timestamp_us` were still read raw from the same buffer.
* Wrap both like `delay_us`.

# [CaptureInput] Summary

* `AudioInputDevice::Process` consumed capture `AudioInputBuffer` shm via `WrapReadOnlyMemory` with no `RecordReplayBytes`.
  * Browser keeps writing that region after map.
  * Mac map-time snapshot does not cover later writer updates.
* Gate on `IsRecordingOrReplaying()`.
  * Record: `CopyTo` a process-local bus (one consistent shm read), `RecordReplayBytes` that snapshot, `Capture(local)`.
  * Replay: no `CopyTo`; `RecordReplayBytes` fills the local bus, `Capture(local)`.
  * Not RR: unchanged shm wrap `Capture`.

<hr>

# [HandleAudibility] Problem

* ReplayMismatch.
  * MismatchKind: StackCommonFrame.
  * Bucket: `Mismatch/[RUN-1506] AudioContext::HandleAudibility`.
  * `operatorId`: `4551e039-f4df-437a-b7a4-1500320e2718`.
  * `recordingId`: `c0e5a7df-241e-4159-a6eb-6b71ce3e6831`.
  * `buildId`: `linux-chromium-20260904-2dd4908bb87d-2b9136be15b4`.
  * `linkerVersion`: `linker-linux-16154-2b9136be15b4`.

* Recorded leaf: `"[RUN-1506] AudioContext::HandleAudibility 0 1"`.
* Replayed leaf: `"OrderedLock atomic 159098"`.
* Shared frame: `blink::RealtimeAudioDestinationHandler::Render`.
  * Recorded continues at `HandleAudibility` (`+522`).
  * Replayed continues later at `UpdateWorkletGlobalScopeOnRenderingThread` (`+545`).
  * Both stacks share `media::AudioOutputDeviceThreadCallback::Process`.

* `Render` span is straight-line:
  * `HandlePostRenderTasks`
  * `HandleAudibility` — recorded side
  * `AdvanceCurrentSampleFrame`
  * `UpdateWorkletGlobalScopeOnRenderingThread` — replayed side
* Replay skipped past `HandleAudibility` at this callsite.

* Inside `HandleAudibility`, the mismatch Assert was gated:

```cpp
void AudioContext::HandleAudibility(AudioBus* destination_bus) {
  bool is_audible = IsAudible(destination_bus);

  if (was_audible_ != is_audible) {
    recordreplay::Assert("[RUN-1506] AudioContext::HandleAudibility %d %d", was_audible_, is_audible);
    was_audible_ = is_audible;
    ...
  }
}
```

* `is_audible` comes from `destination_bus` sample energy.
* `was_audible_` is written only after that Assert, inside the same guard.
* The Assert therefore records control flow only when audibility changes.
  * Recorded this hit: `0` → `1`.
  * A replay that never enters the branch emits no `[RUN-1506]` Assert.
  * That is indistinguishable from a matching no-flip render.

* Replayed side has no AssertCandidate.
  * `UpdateWorkletGlobalScopeOnRenderingThread` opens with `TryLock()`.
  * Lock internals are not assertable.
* Recorded-side candidates (`IsAudible` write, `was_audible_` branch) were unproven.
  * The gated Assert cannot witness HandleAudibility on every render.

## Solution

* Move `[RUN-1506]` above `if (was_audible_ != is_audible)`.
* Every `HandleAudibility` call records `was_audible_` and `is_audible`.
* A future mismatch then pins the inner branch instead of skipping the Assert.

<hr>

# [AudioParams] Problem

* `Process` reads audio-service shm `AudioOutputBuffer::params`.
  * The other end mutates that buffer.
* `delay_us` is already `RecordReplayValue("audioparams::delay_us", ...)`.
* `frames_skipped` and `delay_timestamp_us` were not.
  * Both feed `render_callback_->Render(delay, delay_timestamp, frames_skipped, ...)`.
  * That is the shared ancestor of the HandleAudibility mismatch stacks.

## Solution

* `RecordReplayValue("audioparams::frames_skipped", buffer->params.frames_skipped)`.
* `RecordReplayValue("audioparams::delay_timestamp_us", buffer->params.delay_timestamp_us)`.
* Same pattern as existing `delay_us`.

<hr>

# [CaptureInput] Problem

* Capture path: browser writes `AudioInputBuffer` segments into a `ReadOnlySharedMemoryRegion`.
* Renderer `AudioInputDevice::AudioThreadCallback::Process` mapped those floats with `WrapReadOnlyMemory` and passed the shm-backed bus straight to `Capture`.
* That payload is not in any redirected library-call stream.
* Replay therefore sees whatever sits in the local mapping instead of record-time bytes.
* Mac `MapAt` can snapshot once at map time.
  * The browser keeps writing after map.
  * Map-time snapshots miss later writer updates.
* Linux had no snapshot at all.
* Any `MediaStreamAudioSource` fed by this capture path can drive WebAudio `IsAudible` / graph energy from unordered floats.

## Solution

* Recipe: `determinism-shared-memory` — consistent process-local snapshot, `RecordReplayBytes` that snapshot, consume the snapshot.
* Gate on `IsRecordingOrReplaying()`.
  * `MapSharedMemory` creates heap `capture_bus_` when gated.
* Record:
  * `audio_buses_[seg]->CopyTo(capture_bus_)` once (the consistent shm read).
  * `RecordReplayBytes` on `params` and each `capture_bus_` channel.
  * `Capture(capture_bus_, …)` with those recorded values.
* Replay:
  * No `CopyTo`.
  * `RecordReplayBytes` fills `params` and `capture_bus_` channels.
  * `Capture(capture_bus_, …)`.
* Not RR: unchanged — `Capture(shm wrap, buffer->params…)`.
* Do not instrument map / seqlock / the post-HandleAudibility output shm sink for this gap.
