### PR TITLE
crash-0100: Diagnostic before Mojo NotifyError handler invoke

### DIFF
--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -762,12 +762,57 @@ void InterfaceEndpointClient::NotifyError(
   // callback may own this endpoint, so we simply move the responders onto the
   // stack here and let them be destroyed when the stack unwinds.
   AsyncResponderMap responders;
+  size_t async_n;
   {
     base::AutoLock lock(async_responders_lock_);
+    async_n = async_responders_.size();
     std::swap(responders, async_responders_);
   }
 
   control_message_proxy_.OnConnectionError();
+
+  // crash-0100: breadcrumb before possibly-bad handler invoke.
+  {
+    const bool has_eh = !!error_handler_;
+    const bool has_ewrh = !!error_with_reason_handler_;
+    const int branch = has_eh ? 1 : (has_ewrh ? (reason ? 2 : 3) : 0);
+    const void* cb =
+        has_eh ? static_cast<const void*>(&error_handler_)
+               : (has_ewrh ? static_cast<const void*>(&error_with_reason_handler_)
+                           : nullptr);
+    uintptr_t bind_state = 0;
+    uintptr_t invoke = 0;
+    if (cb) {
+      // OnceCallback layout: sole member is CallbackBase::bind_state_.
+      bind_state = *reinterpret_cast<const uintptr_t*>(cb);
+      if (bind_state)
+        invoke = *reinterpret_cast<const uintptr_t*>(bind_state + 8);
+    }
+    const auto& hr = handle_.disconnect_reason();
+    recordreplay::Diagnostic(
+        "[crash-0100] NotifyError this=%d iface=%s "
+        "handle_valid=%d handle_id=%u pending=%d "
+        "arg_reason=%d arg_custom=%u arg_desc=%s "
+        "handle_reason=%d handle_custom=%u handle_desc=%s "
+        "has_eh=%d has_ewrh=%d branch=%d "
+        "bind_state=%p invoke=%p leaked=%d "
+        "next_req=%llu async_n=%zu sync_n=%zu ctrl=%d recv=%d",
+        recordreplay::PointerId(this),
+        interface_name_ ? interface_name_ : "",
+        handle_.is_valid(), handle_.id(), handle_.pending_association(),
+        !!reason, reason ? reason->custom_reason : 0u,
+        reason ? reason->description.c_str() : "",
+        hr.has_value(), hr ? hr->custom_reason : 0u,
+        hr ? hr->description.c_str() : "",
+        has_eh, has_ewrh, branch,
+        reinterpret_cast<void*>(bind_state),
+        reinterpret_cast<void*>(invoke),
+        record_replay_leaked_,
+        static_cast<unsigned long long>(next_request_id_),
+        async_n, sync_responses_.size(),
+        recordreplay::PointerId(controller_),
+        recordreplay::PointerId(incoming_receiver_));
+  }
 
   if (error_handler_) {
     std::move(error_handler_).Run();

--- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
+++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
@@ -1038,6 +1038,16 @@ bool MultiplexRouter::ProcessNotifyErrorTask(
   absl::optional<DisconnectReason> disconnect_reason(
       endpoint->disconnect_reason());
 
+  // crash-0100: router→client breadcrumb before NotifyError.
+  recordreplay::Diagnostic(
+      "[crash-0100] ProcessNotifyErrorTask this=%d endpoint=%u client=%d "
+      "reason=%d custom=%u desc=%s",
+      recordreplay::PointerId(this), endpoint->id(),
+      recordreplay::PointerId(client),
+      disconnect_reason.has_value(),
+      disconnect_reason ? disconnect_reason->custom_reason : 0u,
+      disconnect_reason ? disconnect_reason->description.c_str() : "");
+
   {
     // We must unlock before calling into |client| because it may call this
     // object within NotifyError(). Holding the lock will lead to deadlock.


### PR DESCRIPTION
# Summary

* Recorder SIGSEGV: insn-fetch at `0x21` inside `InterfaceEndpointClient::NotifyError` handler `.Run()`.
* Static data cannot pick which of the three callback sites faulted.
* Add `recordreplay::Diagnostic` breadcrumbs at `NotifyError` and `ProcessNotifyErrorTask` before invoke.

# Problem

* Problem type: Recorder.
* Buckets: Recorder/mojo::internal::MultiplexRouter::ProcessNotifyErro.

## Important Context

* buildId: linux-chromium-20260909-4185a755518c-b9da175f25b5
* linkerVersion: linker-linux-16191-b9da175f25b5
* recordingId: 52efefbe-e675-4663-9389-854f114fedb8

### Crash Report Core

```json
{
  "why": "Crash",
  "text": "crashed",
  "signal": 11,
  "backtrace": {
    "frames": [
      "mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(...)+342",
      "mojo::internal::MultiplexRouter::ProcessTasks(...)+316",
      "mojo::internal::MultiplexRouter::OnPipeConnectionError(bool)+1022",
      "mojo::Connector::HandleError(bool,.bool)+539",
      "...",
      "ChromeMain+629",
      "driver+21389898"
    ],
    "progress": 4151353,
    "threadId": 1,
    "checkpoint": 1358,
    "stackPointerSet": false
  },
  "faultAddress": "0x21",
  "unknownThread": false,
  "instructionPointer": "0x21"
}
```

# Data

## Previous Work

* No prior issue matches both `Problem type: Recorder.` and this `Buckets:` NamedBucket.
* Bucket string `MultiplexRouter::ProcessNotifyErro` only appears under `Mismatch/` in older issues — different `Problem type`.
* `PlacementParent: none`

## FaultSiteData

* Branch used: StaticFaultSiteData.
* No local `rr` trace for this `recordingId`.
* `faultAddress` = `si_addr`, `instructionPointer` = `REG_RIP`.
* Report has both `== "0x21"`.
* On Linux x86-64 that equality is the kernel signature of SIGSEGV on **instruction fetch**: control transferred to `0x21`, fetch faulted.
* Frame `ProcessNotifyErrorTask+342` is a **return address**, not the fault PC.
  * It is the insn after `call NotifyError`.
  * Actual fault PC=`0x21` occurred inside `NotifyError` or a callee.
  * `NotifyError` itself does not appear as a frame.
* `NotifyError` has exactly 3 indirect calls, all `call *0x8(%rdi)`.
  * Callback → `BindStateBase::polymorphic_invoke_` dispatch.
  * Each preceded by `test rdi,rdi; je` proving `rdi != 0`.
  * Sites map to:
    * `error_handler_.Run()`
    * `error_with_reason_handler_.Run(custom_reason, description)` when `reason` present
    * `error_with_reason_handler_.Run(0, "")` when `reason` absent
  * Statically indistinguishable without register / `rr` state.
* Fault-address shape: `call *0x8(%rdi)` ⇒ new IP = `*(rdi+8)` = `0x21`.
* What went wrong:
  * Handler object behind `error_handler_` or `error_with_reason_handler_` is bad.
  * `.Run()` jumps through a slot that holds `0x21`.

# Implementation

* Goal: crash-report breadcrumb via `recordreplay::Diagnostic` so the next hit names interface / reason / which `.Run()` branch before the bad invoke.
* Sites:
  * `InterfaceEndpointClient::NotifyError` — after `control_message_proxy_.OnConnectionError()`, before any `.Run()`
  * `MultiplexRouter::ProcessNotifyErrorTask` — immediately before `client->NotifyError(...)`
* Safety: never `.Run()` / never call through `polymorphic_invoke_`. Only Callback null-checks, field reads, and a plain load of `*(bind_state+8)`.

* `NotifyError` dump:
  * Both reason sources: arg `reason` and `handle_.disconnect_reason()` (`custom_reason` + `description` each)
  * Handle: valid / id / pending_association
  * Client: `PointerId(this)`, handler presence, `record_replay_leaked_`, `next_request_id_`, pre-swap async responder count, sync response count, controller/receiver PointerIds
  * Branch tag: which of the three `.Run()` paths will execute
  * Active handler `bind_state` + `polymorphic_invoke_` at `+8` (matches fault IP when `0x21`)

* `ProcessNotifyErrorTask` dump (required sibling):
  * `PointerId(this)`, `endpoint->id()`, `PointerId(client)`, endpoint disconnect reason custom/desc

* Keep existing RUN-965 `recordreplay::Assert`.
