### PR TITLE
Mojo leak-path Invoker guards + NotifyError Diagnostic

### DIFF
--- a/mojo/public/cpp/bindings/associated_remote.h
+++ b/mojo/public/cpp/bindings/associated_remote.h
@@ -273,6 +273,8 @@ class AssociatedRemote {
     return &internal_state_;
   }
 
+  void record_replay_leak() const { internal_state_.record_replay_leak(); }
+
  private:
   using State = internal::AssociatedInterfacePtrState<Interface>;
   mutable State internal_state_;

--- a/mojo/public/cpp/bindings/lib/associated_interface_ptr_state.cc
+++ b/mojo/public/cpp/bindings/lib/associated_interface_ptr_state.cc
@@ -16,6 +16,8 @@ AssociatedInterfacePtrStateBase::~AssociatedInterfacePtrStateBase() {
   // Endpoint clients must be destroyed at deterministic points, so leak the endpoint
   // if this state is destroyed during a GC.
   if (recordreplay::AreEventsDisallowed("~AssociatedInterfacePtrStateBase")) {
+    if (endpoint_client_)
+      endpoint_client_->record_replay_leak();
     endpoint_client_.release();
   }
 }

--- a/mojo/public/cpp/bindings/lib/associated_interface_ptr_state.h
+++ b/mojo/public/cpp/bindings/lib/associated_interface_ptr_state.h
@@ -80,6 +80,11 @@ class COMPONENT_EXPORT(MOJO_CPP_BINDINGS) AssociatedInterfacePtrStateBase {
     return endpoint_client_->CreateThreadSafeProxy(std::move(target));
   }
 
+  void record_replay_leak() {
+    if (endpoint_client_)
+      endpoint_client_->record_replay_leak();
+  }
+
  protected:
   void Swap(AssociatedInterfacePtrStateBase* other);
   void Bind(ScopedInterfaceEndpointHandle handle,

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -1051,8 +1051,8 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
           weak_ptr_factory_.GetWeakPtr(), task_runner_);
       if (idle_tracking_connection_group_)
         responder->set_connection_group(idle_tracking_connection_group_);
-      accepted_interface_message =
-          incoming_receiver_->AcceptWithResponder(message, std::move(responder));
+      accepted_interface_message = incoming_receiver_->AcceptWithResponder(
+          message, std::move(responder));
     }
   } else if (message->has_flag(Message::kFlagIsResponse)) {
     uint64_t request_id = message->request_id();

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -762,12 +762,57 @@ void InterfaceEndpointClient::NotifyError(
   // callback may own this endpoint, so we simply move the responders onto the
   // stack here and let them be destroyed when the stack unwinds.
   AsyncResponderMap responders;
+  size_t async_n;
   {
     base::AutoLock lock(async_responders_lock_);
+    async_n = async_responders_.size();
     std::swap(responders, async_responders_);
   }
 
   control_message_proxy_.OnConnectionError();
+
+  // crash-0100: breadcrumb before possibly-bad handler invoke.
+  {
+    const bool has_eh = !!error_handler_;
+    const bool has_ewrh = !!error_with_reason_handler_;
+    const int branch = has_eh ? 1 : (has_ewrh ? (reason ? 2 : 3) : 0);
+    const void* cb =
+        has_eh ? static_cast<const void*>(&error_handler_)
+               : (has_ewrh ? static_cast<const void*>(&error_with_reason_handler_)
+                           : nullptr);
+    uintptr_t bind_state = 0;
+    uintptr_t invoke = 0;
+    if (cb) {
+      // OnceCallback layout: sole member is CallbackBase::bind_state_.
+      bind_state = *reinterpret_cast<const uintptr_t*>(cb);
+      if (bind_state)
+        invoke = *reinterpret_cast<const uintptr_t*>(bind_state + 8);
+    }
+    const auto& hr = handle_.disconnect_reason();
+    recordreplay::Diagnostic(
+        "[crash-0100] NotifyError this=%d iface=%s "
+        "handle_valid=%d handle_id=%u pending=%d "
+        "arg_reason=%d arg_custom=%u arg_desc=%s "
+        "handle_reason=%d handle_custom=%u handle_desc=%s "
+        "has_eh=%d has_ewrh=%d branch=%d "
+        "bind_state=%p invoke=%p leaked=%d "
+        "next_req=%llu async_n=%zu sync_n=%zu ctrl=%d recv=%d",
+        recordreplay::PointerId(this),
+        interface_name_ ? interface_name_ : "",
+        handle_.is_valid(), handle_.id(), handle_.pending_association(),
+        !!reason, reason ? reason->custom_reason : 0u,
+        reason ? reason->description.c_str() : "",
+        hr.has_value(), hr ? hr->custom_reason : 0u,
+        hr ? hr->description.c_str() : "",
+        has_eh, has_ewrh, branch,
+        reinterpret_cast<void*>(bind_state),
+        reinterpret_cast<void*>(invoke),
+        record_replay_leaked_,
+        static_cast<unsigned long long>(next_request_id_),
+        async_n, sync_responses_.size(),
+        recordreplay::PointerId(controller_),
+        recordreplay::PointerId(incoming_receiver_));
+  }
 
   if (error_handler_) {
     std::move(error_handler_).Run();

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -814,6 +814,10 @@ void InterfaceEndpointClient::NotifyError(
         recordreplay::PointerId(incoming_receiver_));
   }
 
+  // Skip user Callback Invokes on a leaked client (owner already gone).
+  if (record_replay_leaked_)
+    return;
+
   if (error_handler_) {
     std::move(error_handler_).Run();
   } else if (error_with_reason_handler_) {

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -894,7 +894,8 @@ bool InterfaceEndpointClient::AcceptNotifyIdle() {
 
   // With no outstanding unacked messages, a NotifyIdle received implies that
   // the peer really is idle. We can invoke our idle handler.
-  idle_handler_.Run();
+  if (!record_replay_leaked_)
+    idle_handler_.Run();
   return true;
 }
 
@@ -1044,8 +1045,9 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
     } else {
       if (idle_tracking_connection_group_)
         responder->set_connection_group(idle_tracking_connection_group_);
-      accepted_interface_message = incoming_receiver_->AcceptWithResponder(
-          message, std::move(responder));
+      accepted_interface_message =
+          record_replay_leaked_ ||
+          incoming_receiver_->AcceptWithResponder(message, std::move(responder));
     }
   } else if (message->has_flag(Message::kFlagIsResponse)) {
     uint64_t request_id = message->request_id();
@@ -1101,7 +1103,8 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
     internal::MessageDispatchContext dispatch_context(message);
     recordreplay::Assert(
         "[RUN-2229-2231] InterfaceEndpointClient::HandleValidatedMessage J");
-    return pending_response->responder->Accept(message);
+    return record_replay_leaked_ ||
+           pending_response->responder->Accept(message);
   } else {
     if (mojo::internal::ControlMessageHandler::IsControlMessage(message)) {
       recordreplay::Assert(

--- a/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
+++ b/mojo/public/cpp/bindings/lib/interface_endpoint_client.cc
@@ -1035,18 +1035,23 @@ bool InterfaceEndpointClient::HandleValidatedMessage(Message* message) {
   if (message->has_flag(Message::kFlagExpectsResponse)) {
     recordreplay::Assert("[RUN-2229-2231] InterfaceEndpointClient::HandleValidatedMessage B");
     has_response = true;
-    auto responder = std::make_unique<ResponderThunk>(
-        weak_ptr_factory_.GetWeakPtr(), task_runner_);
     if (mojo::internal::ControlMessageHandler::IsControlMessage(message)) {
       recordreplay::Assert(
           "[RUN-2229-2231] InterfaceEndpointClient::HandleValidatedMessage C");
+      auto responder = std::make_unique<ResponderThunk>(
+          weak_ptr_factory_.GetWeakPtr(), task_runner_);
       return control_message_handler_.AcceptWithResponder(message,
                                                           std::move(responder));
+    } else if (record_replay_leaked_) {
+      // Do not build a ResponderThunk: its dtor RaiseError() would reset the
+      // pipe (shared MultiplexRouter) after a leak skip.
+      accepted_interface_message = true;
     } else {
+      auto responder = std::make_unique<ResponderThunk>(
+          weak_ptr_factory_.GetWeakPtr(), task_runner_);
       if (idle_tracking_connection_group_)
         responder->set_connection_group(idle_tracking_connection_group_);
       accepted_interface_message =
-          record_replay_leaked_ ||
           incoming_receiver_->AcceptWithResponder(message, std::move(responder));
     }
   } else if (message->has_flag(Message::kFlagIsResponse)) {

--- a/mojo/public/cpp/bindings/lib/interface_ptr_state.cc
+++ b/mojo/public/cpp/bindings/lib/interface_ptr_state.cc
@@ -16,6 +16,8 @@ InterfacePtrStateBase::~InterfacePtrStateBase() {
   // Let the mojo resources leak if this is being destroyed at a non-deterministic
   // point. Mojo resources must be destroyed deterministically.
   if (recordreplay::AreEventsDisallowed("~InterfacePtrStateBase")) {
+    if (endpoint_client_)
+      endpoint_client_->record_replay_leak();
     endpoint_client_.release();
     (void)router_.release();
     return;

--- a/mojo/public/cpp/bindings/lib/interface_ptr_state.h
+++ b/mojo/public/cpp/bindings/lib/interface_ptr_state.h
@@ -75,6 +75,11 @@ class COMPONENT_EXPORT(MOJO_CPP_BINDINGS) InterfacePtrStateBase {
     return endpoint_client_->CreateThreadSafeProxy(std::move(target));
   }
 
+  void record_replay_leak() {
+    if (endpoint_client_)
+      endpoint_client_->record_replay_leak();
+  }
+
 #if DCHECK_IS_ON()
   void SetNextCallLocation(const base::Location& location) {
     endpoint_client_->SetNextCallLocation(location);

--- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
+++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
@@ -1038,6 +1038,16 @@ bool MultiplexRouter::ProcessNotifyErrorTask(
   absl::optional<DisconnectReason> disconnect_reason(
       endpoint->disconnect_reason());
 
+  // crash-0100: router→client breadcrumb before NotifyError.
+  recordreplay::Diagnostic(
+      "[crash-0100] ProcessNotifyErrorTask this=%d endpoint=%u client=%d "
+      "reason=%d custom=%u desc=%s",
+      recordreplay::PointerId(this), endpoint->id(),
+      recordreplay::PointerId(client),
+      disconnect_reason.has_value(),
+      disconnect_reason ? disconnect_reason->custom_reason : 0u,
+      disconnect_reason ? disconnect_reason->description.c_str() : "");
+
   {
     // We must unlock before calling into |client| because it may call this
     // object within NotifyError(). Holding the lock will lead to deadlock.

--- a/mojo/public/cpp/bindings/remote.h
+++ b/mojo/public/cpp/bindings/remote.h
@@ -390,6 +390,8 @@ class Remote {
     return &internal_state_;
   }
 
+  void record_replay_leak() const { internal_state_.record_replay_leak(); }
+
  private:
   using State = internal::InterfacePtrState<Interface>;
   mutable State internal_state_;

--- a/mojo/public/cpp/bindings/shared_remote.h
+++ b/mojo/public/cpp/bindings/shared_remote.h
@@ -188,6 +188,9 @@ class SharedRemoteBase
         // points when recording/replaying, so leak the remote instead.
         if (recordreplay::AreEventsDisallowed() &&
             recordreplay::FeatureEnabled("leak-references", "RemoteWrapper::DeleteOnCorrectThread")) {
+          // Skip-delete never runs ~InterfacePtrState*; arm flag so Invoker
+          // guards see the IEC MultiplexRouter still holds.
+          remote_.record_replay_leak();
           return;
         }
 


### PR DESCRIPTION
# [Diagnostic] Summary

* Breadcrumbs in `NotifyError` + `ProcessNotifyErrorTask` before handler Invoke.
* Load invoke word only.
* Keep RUN-965 Assert.

# [FlagParity] Summary

* Remote ptr-state dtors set `record_replay_leaked_` before `release`.
* Match Binding / AssociatedReceiver.

# [SharedRemoteFlagParity] Summary

* `RemoteWrapper::DeleteOnCorrectThread` skip-delete arms `record_replay_leak` on bound IEC.
* Covers SharedRemote + SharedAssociatedRemote (`SharedRemoteBase`).
* No PostTask / no delete / no handler reset.

# [SkipInvokerC] Summary

* `NotifyError` skips error-handler `.Run()` when leaked.

# [DispatchGuards] Summary

* Skip `AcceptWithResponder` / response `Accept` / `idle_handler` when leaked.
* Do not construct `ResponderThunk` when leaked.
  * Avoids RaiseError / pipe reset.

# [Diagnostic] Problem

* Crash site: `MultiplexRouter::ProcessNotifyErrorTask` → `InterfaceEndpointClient::NotifyError` → Callback `.Run()`.
* This report: IP=`0x21` / faultAddress=`0x21` (shape B — instruction fetch).
* Twin report: same site / stack / `0x21` / recording / build.
* Which of three `.Run()` paths faulted: unknown from static crash alone.
* Need observe-only dump before Invoke.

# Solution

* `recordreplay::Diagnostic` at:
  * `NotifyError` — after `OnConnectionError()`, before any `.Run()`
  * `ProcessNotifyErrorTask` — immediately before `client->NotifyError(...)`
* Dump fields only.
  * Never `.Run()` / never call through `polymorphic_invoke_`.
  * Plain load of invoke word at `bind_state+8`.
* Keep existing RUN-965 Assert.

# Raw Data

* buildId: `linux-chromium-20260909-4185a755518c-b9da175f25b5`
* linkerVersion: `linker-linux-16191-b9da175f25b5`
* recordingId: `52efefbe-e675-4663-9389-854f114fedb8`

<hr>

# [FlagParity] Problem

* Under `AreEventsDisallowed`, Mojo GC-leak does `record_replay_leak` + `release`.
* Orphan `InterfaceEndpointClient` stays attached via MultiplexRouter `client_`.
* Binding / AssociatedReceiver already set `record_replay_leaked_`.
* Remote ptr-state dtors did not.
* Later NotifyError / Accept / idle can Invoke Callbacks with `Unretained(destroyed owner)` → latent shape-A UAF.
* Separate from observed IP=`0x21` shape B.
  * Not claimed fixed.

# Solution

* `~InterfacePtrStateBase` / `~AssociatedInterfacePtrStateBase`: call `record_replay_leak()` before `release()`.
* Arms flag on Remote orphans.
* No Invoker skip here.

<hr>

# [SharedRemoteFlagParity] Problem

* Off-sequence `DeleteOnCorrectThread` under `AreEventsDisallowed` early-returns (feature-gated).
* Intact `Remote` / `AssociatedRemote` → IEC → MultiplexRouter stay attached.
* Skip-delete never runs `~InterfacePtrStateBase` / `~AssociatedInterfacePtrStateBase`.
* FlagParity never arms this client; Invoker guards cannot see it.

# Solution

* Before skip-delete `return`, call `remote_.record_replay_leak()` → IEC `record_replay_leaked_`.
* Thin accessors on Remote / AssociatedRemote / ptr-state bases.
* Keep: no PostTask, no delete, no handler reset.

<hr>

# [SkipInvokerC] Problem

* Proven latent UAF hazard: pipe error after owner destroy while leaked client attached.
* `NotifyError` Invokes `error_handler_` / `error_with_reason_handler_` with no leaked-flag check.
* Handlers often `Unretained(owner)`.

# Solution

* If `record_replay_leaked_`, skip error-handler `.Run()` in `NotifyError`.
* Binding / AssociatedReceiver orphans already flagged.
* Closes disconnect-handler Invoker site for those without waiting on FlagParity.
* MultiplexRouter `Process*` needs no leaked-client gate.
  * `client_` stays set by design.
  * Guards belong at Invoker exits.

<hr>

# [DispatchGuards] Problem

* Sibling Unretained Invoker exits after leak, not covered by SkipInvokerC:
  * `AcceptWithResponder`
  * response `pending_response->responder->Accept`
  * `idle_handler_.Run()`
* FlagParity required so Remote orphans are flagged too.
* Skipping `AcceptWithResponder` after constructing `ResponderThunk` still RaiseError / pipe reset.

# Solution

* If `record_replay_leaked_`, skip those three Invoker entries.
* Do not construct `ResponderThunk` when skipping leaked `AcceptWithResponder`.
* Leak intent intact: no frees / no Mojo teardown under `AreEventsDisallowed`.
* Non-goal: this report’s IP=`0x21` shape B.
