### PR TITLE
HangBusy: defer and cheapen sourcemap SHA256DigestHex

### DIFF
--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -62,6 +62,7 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   if (!urls)
     return;
 
+  // Yield so full-source SHA256 runs after sync script registration, not under ProcessCompileEvent.
   await Promise.resolve();
 
   const scriptSource = getScriptSource(scriptId);

--- a/replay-assets/replay_sourcemap_handler.js
+++ b/replay-assets/replay_sourcemap_handler.js
@@ -62,6 +62,8 @@ addNewScriptHandler(async (scriptId, sourceURL, relativeSourceMapURL) => {
   if (!urls)
     return;
 
+  await Promise.resolve();
+
   const scriptSource = getScriptSource(scriptId);
   const generatedScriptHash = sha256DigestHex(scriptSource);
 

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -1040,7 +1040,8 @@ bool TryUpdateSha256FromAsciiOneByte(v8::Isolate* isolate,
       if (data[i] >= 0x80)
         return false;
     }
-    hasher->Update(data, len);
+    if (len)
+      hasher->Update(data, len);
     return true;
   }
 
@@ -1090,11 +1091,13 @@ void UpdateSha256FromUtf16ViaChunkedWriteUtf8(v8::Isolate* isolate,
                                              crypto::SecureHash* hasher) {
   const int length = str->Length();
   uint16_t chars[kSha256StringChunkChars];
-  char utf8[kSha256StringChunkChars * 3 + 1];
+  char utf8[kSha256StringChunkChars * 3 + 1];  // max 3 bytes/code unit
   int pos = 0;
   while (pos < length) {
+    v8::HandleScope chunk_scope(isolate);
     int n = std::min(kSha256StringChunkChars, length - pos);
     str->Write(isolate, chars, pos, n, v8::String::NO_NULL_TERMINATION);
+    // Keep surrogate pairs inside one chunk.
     if (n > 0 && pos + n < length && (chars[n - 1] & 0xFC00) == 0xD800)
       --n;
     if (n <= 0) {
@@ -1105,8 +1108,11 @@ void UpdateSha256FromUtf16ViaChunkedWriteUtf8(v8::Isolate* isolate,
         v8::String::NewFromTwoByte(isolate, chars, v8::NewStringType::kNormal,
                                    n)
             .ToLocalChecked();
-    const int nbytes = chunk->WriteUtf8(isolate, utf8, sizeof(utf8), nullptr,
-                                        v8::String::NO_NULL_TERMINATION);
+    int nchars = 0;
+    const int nbytes =
+        chunk->WriteUtf8(isolate, utf8, sizeof(utf8), &nchars,
+                         v8::String::NO_NULL_TERMINATION);
+    CHECK(nchars == n);
     hasher->Update(utf8, nbytes);
     pos += n;
   }
@@ -1130,7 +1136,8 @@ static void SHA256DigestHex(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
       "must be called with a single string");
   v8::Isolate* isolate = args.GetIsolate();
-  char* digestHex = new char[65];
+  // Zeroed: replay skips hash and only fills via RecordReplayBytes.
+  char* digestHex = new char[65]();
 
   if (!recordreplay::IsReplaying()) {
     std::unique_ptr<crypto::SecureHash> hasher =

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -47,6 +47,7 @@
 #include "third_party/inspector_protocol/crdtp/maybe.h"
 #include "v8/include/v8-inspector.h"
 
+#include <algorithm>
 #include <array>
 #include <cinttypes>
 #include <fstream>
@@ -1018,20 +1019,128 @@ static void GetRecordingId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   }
 }
 
+namespace {
+
+constexpr int kSha256StringChunkChars = 8192;
+
+bool TryUpdateSha256FromAsciiOneByte(v8::Isolate* isolate,
+                                     v8::Local<v8::String> str,
+                                     crypto::SecureHash* hasher) {
+  if (!str->ContainsOnlyOneByte())
+    return false;
+
+  const int length = str->Length();
+  if (str->IsExternalOneByte()) {
+    const v8::String::ExternalOneByteStringResource* resource =
+        str->GetExternalOneByteStringResource();
+    const uint8_t* data =
+        reinterpret_cast<const uint8_t*>(resource->data());
+    const size_t len = resource->length();
+    for (size_t i = 0; i < len; ++i) {
+      if (data[i] >= 0x80)
+        return false;
+    }
+    hasher->Update(data, len);
+    return true;
+  }
+
+  uint8_t buf[kSha256StringChunkChars];
+  for (int start = 0; start < length; start += kSha256StringChunkChars) {
+    const int n = std::min(kSha256StringChunkChars, length - start);
+    str->WriteOneByte(isolate, buf, start, n, v8::String::NO_NULL_TERMINATION);
+    for (int i = 0; i < n; ++i) {
+      if (buf[i] >= 0x80)
+        return false;
+    }
+  }
+  for (int start = 0; start < length; start += kSha256StringChunkChars) {
+    const int n = std::min(kSha256StringChunkChars, length - start);
+    str->WriteOneByte(isolate, buf, start, n, v8::String::NO_NULL_TERMINATION);
+    hasher->Update(buf, n);
+  }
+  return true;
+}
+
+void UpdateSha256FromLatin1AsUtf8(v8::Isolate* isolate,
+                                  v8::Local<v8::String> str,
+                                  crypto::SecureHash* hasher) {
+  const int length = str->Length();
+  uint8_t latin1[kSha256StringChunkChars];
+  char utf8[kSha256StringChunkChars * 2];
+  for (int start = 0; start < length; start += kSha256StringChunkChars) {
+    const int n = std::min(kSha256StringChunkChars, length - start);
+    str->WriteOneByte(isolate, latin1, start, n,
+                      v8::String::NO_NULL_TERMINATION);
+    int utf8_len = 0;
+    for (int i = 0; i < n; ++i) {
+      const uint8_t b = latin1[i];
+      if (b < 0x80) {
+        utf8[utf8_len++] = static_cast<char>(b);
+      } else {
+        utf8[utf8_len++] = static_cast<char>(0xC0 | (b >> 6));
+        utf8[utf8_len++] = static_cast<char>(0x80 | (b & 0x3F));
+      }
+    }
+    hasher->Update(utf8, utf8_len);
+  }
+}
+
+void UpdateSha256FromUtf16ViaChunkedWriteUtf8(v8::Isolate* isolate,
+                                             v8::Local<v8::String> str,
+                                             crypto::SecureHash* hasher) {
+  const int length = str->Length();
+  uint16_t chars[kSha256StringChunkChars];
+  char utf8[kSha256StringChunkChars * 3 + 1];
+  int pos = 0;
+  while (pos < length) {
+    int n = std::min(kSha256StringChunkChars, length - pos);
+    str->Write(isolate, chars, pos, n, v8::String::NO_NULL_TERMINATION);
+    if (n > 0 && pos + n < length && (chars[n - 1] & 0xFC00) == 0xD800)
+      --n;
+    if (n <= 0) {
+      n = std::min(2, length - pos);
+      str->Write(isolate, chars, pos, n, v8::String::NO_NULL_TERMINATION);
+    }
+    v8::Local<v8::String> chunk =
+        v8::String::NewFromTwoByte(isolate, chars, v8::NewStringType::kNormal,
+                                   n)
+            .ToLocalChecked();
+    const int nbytes = chunk->WriteUtf8(isolate, utf8, sizeof(utf8), nullptr,
+                                        v8::String::NO_NULL_TERMINATION);
+    hasher->Update(utf8, nbytes);
+    pos += n;
+  }
+}
+
+void UpdateSha256FromV8String(v8::Isolate* isolate,
+                              v8::Local<v8::String> str,
+                              crypto::SecureHash* hasher) {
+  if (TryUpdateSha256FromAsciiOneByte(isolate, str, hasher))
+    return;
+  if (str->ContainsOnlyOneByte()) {
+    UpdateSha256FromLatin1AsUtf8(isolate, str, hasher);
+    return;
+  }
+  UpdateSha256FromUtf16ViaChunkedWriteUtf8(isolate, str, hasher);
+}
+
+}  // namespace
+
 static void SHA256DigestHex(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
       "must be called with a single string");
   v8::Isolate* isolate = args.GetIsolate();
-  v8::String::Utf8Value content(isolate, args[0]);
-
-  std::unique_ptr<crypto::SecureHash> hasher =
-    crypto::SecureHash::Create(crypto::SecureHash::SHA256);
-  hasher->Update(*content, content.length());
-  uint8_t digest[crypto::kSHA256Length];
-  hasher->Finish(digest, crypto::kSHA256Length);
   char* digestHex = new char[65];
-  for (int i = 0; i < 32; i++) {
-    sprintf(digestHex + i * 2, "%02x", digest[i]);
+
+  if (!recordreplay::IsReplaying()) {
+    std::unique_ptr<crypto::SecureHash> hasher =
+        crypto::SecureHash::Create(crypto::SecureHash::SHA256);
+    UpdateSha256FromV8String(isolate, args[0].As<v8::String>(), hasher.get());
+    uint8_t digest[crypto::kSHA256Length];
+    hasher->Finish(digest, crypto::kSHA256Length);
+    for (int i = 0; i < 32; i++) {
+      sprintf(digestHex + i * 2, "%02x", digest[i]);
+    }
   }
 
   // The content being hashed can vary when replaying if source contents have been

--- a/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
+++ b/third_party/blink/renderer/bindings/core/v8/record_replay_interface.cc
@@ -47,7 +47,6 @@
 #include "third_party/inspector_protocol/crdtp/maybe.h"
 #include "v8/include/v8-inspector.h"
 
-#include <algorithm>
 #include <array>
 #include <cinttypes>
 #include <fstream>
@@ -1019,119 +1018,6 @@ static void GetRecordingId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   }
 }
 
-namespace {
-
-constexpr int kSha256StringChunkChars = 8192;
-
-bool TryUpdateSha256FromAsciiOneByte(v8::Isolate* isolate,
-                                     v8::Local<v8::String> str,
-                                     crypto::SecureHash* hasher) {
-  if (!str->ContainsOnlyOneByte())
-    return false;
-
-  const int length = str->Length();
-  if (str->IsExternalOneByte()) {
-    const v8::String::ExternalOneByteStringResource* resource =
-        str->GetExternalOneByteStringResource();
-    const uint8_t* data =
-        reinterpret_cast<const uint8_t*>(resource->data());
-    const size_t len = resource->length();
-    for (size_t i = 0; i < len; ++i) {
-      if (data[i] >= 0x80)
-        return false;
-    }
-    if (len)
-      hasher->Update(data, len);
-    return true;
-  }
-
-  uint8_t buf[kSha256StringChunkChars];
-  for (int start = 0; start < length; start += kSha256StringChunkChars) {
-    const int n = std::min(kSha256StringChunkChars, length - start);
-    str->WriteOneByte(isolate, buf, start, n, v8::String::NO_NULL_TERMINATION);
-    for (int i = 0; i < n; ++i) {
-      if (buf[i] >= 0x80)
-        return false;
-    }
-  }
-  for (int start = 0; start < length; start += kSha256StringChunkChars) {
-    const int n = std::min(kSha256StringChunkChars, length - start);
-    str->WriteOneByte(isolate, buf, start, n, v8::String::NO_NULL_TERMINATION);
-    hasher->Update(buf, n);
-  }
-  return true;
-}
-
-void UpdateSha256FromLatin1AsUtf8(v8::Isolate* isolate,
-                                  v8::Local<v8::String> str,
-                                  crypto::SecureHash* hasher) {
-  const int length = str->Length();
-  uint8_t latin1[kSha256StringChunkChars];
-  char utf8[kSha256StringChunkChars * 2];
-  for (int start = 0; start < length; start += kSha256StringChunkChars) {
-    const int n = std::min(kSha256StringChunkChars, length - start);
-    str->WriteOneByte(isolate, latin1, start, n,
-                      v8::String::NO_NULL_TERMINATION);
-    int utf8_len = 0;
-    for (int i = 0; i < n; ++i) {
-      const uint8_t b = latin1[i];
-      if (b < 0x80) {
-        utf8[utf8_len++] = static_cast<char>(b);
-      } else {
-        utf8[utf8_len++] = static_cast<char>(0xC0 | (b >> 6));
-        utf8[utf8_len++] = static_cast<char>(0x80 | (b & 0x3F));
-      }
-    }
-    hasher->Update(utf8, utf8_len);
-  }
-}
-
-void UpdateSha256FromUtf16ViaChunkedWriteUtf8(v8::Isolate* isolate,
-                                             v8::Local<v8::String> str,
-                                             crypto::SecureHash* hasher) {
-  const int length = str->Length();
-  uint16_t chars[kSha256StringChunkChars];
-  char utf8[kSha256StringChunkChars * 3 + 1];  // max 3 bytes/code unit
-  int pos = 0;
-  while (pos < length) {
-    v8::HandleScope chunk_scope(isolate);
-    int n = std::min(kSha256StringChunkChars, length - pos);
-    str->Write(isolate, chars, pos, n, v8::String::NO_NULL_TERMINATION);
-    // Keep surrogate pairs inside one chunk.
-    if (n > 0 && pos + n < length && (chars[n - 1] & 0xFC00) == 0xD800)
-      --n;
-    if (n <= 0) {
-      n = std::min(2, length - pos);
-      str->Write(isolate, chars, pos, n, v8::String::NO_NULL_TERMINATION);
-    }
-    v8::Local<v8::String> chunk =
-        v8::String::NewFromTwoByte(isolate, chars, v8::NewStringType::kNormal,
-                                   n)
-            .ToLocalChecked();
-    int nchars = 0;
-    const int nbytes =
-        chunk->WriteUtf8(isolate, utf8, sizeof(utf8), &nchars,
-                         v8::String::NO_NULL_TERMINATION);
-    CHECK(nchars == n);
-    hasher->Update(utf8, nbytes);
-    pos += n;
-  }
-}
-
-void UpdateSha256FromV8String(v8::Isolate* isolate,
-                              v8::Local<v8::String> str,
-                              crypto::SecureHash* hasher) {
-  if (TryUpdateSha256FromAsciiOneByte(isolate, str, hasher))
-    return;
-  if (str->ContainsOnlyOneByte()) {
-    UpdateSha256FromLatin1AsUtf8(isolate, str, hasher);
-    return;
-  }
-  UpdateSha256FromUtf16ViaChunkedWriteUtf8(isolate, str, hasher);
-}
-
-}  // namespace
-
 static void SHA256DigestHex(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
       "must be called with a single string");
@@ -1140,9 +1026,10 @@ static void SHA256DigestHex(const v8::FunctionCallbackInfo<v8::Value>& args) {
   char* digestHex = new char[65]();
 
   if (!recordreplay::IsReplaying()) {
+    v8::String::Utf8Value content(isolate, args[0]);
     std::unique_ptr<crypto::SecureHash> hasher =
         crypto::SecureHash::Create(crypto::SecureHash::SHA256);
-    UpdateSha256FromV8String(isolate, args[0].As<v8::String>(), hasher.get());
+    hasher->Update(*content, content.length());
     uint8_t digest[crypto::kSHA256Length];
     hasher->Finish(digest, crypto::kSHA256Length);
     for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
# Summary
- HangBusy stalls under sync compile when `collect-source-maps` hashes full script source via `SHA256DigestHex`.
- Fix: defer hash past first await; skip Utf8+SHA256 on replay; chunk Utf8 hashing; ASCII one-byte fast path.
- Same-build RR order shift from deferral is safe.

# Problem

## HangBusy
- Leaf runs under `ProcessCompileEvent`.
  - `RecordReplayRegisterScript` calls JS new-script handlers via `Execution::Call`.
  - Call does not await returned promises.
- `replay_sourcemap_handler.js` runs `getScriptSource` then `sha256DigestHex` before first `await`.
  - First `await` is the sourcemap fetch.
- Cost is O(n) in script source length.
  - Happens on record and replay.
  - Only when feature `collect-source-maps` is on.
  - Only when sourcemap URL is not a `data:` URL.

## SyncHash
- Sync compile path hashes the full script source before yielding.
- That work sits inside the register-script sync section.

## ReplayWaste
- `SHA256DigestHex` always builds `v8::String::Utf8Value` and SHA256-updates.
- Then `RecordReplayBytes("SHA256DigestHex", digestHex, 65)`.
- Content can differ on replay when sources are replaced.
  - Replay result comes from the recording stream.
- Utf8 + SHA256 on replay is wasted work for HangBusy-class stalls.

## Utf8Copy
- `Utf8Value` allocates length+1 and `WriteUtf8`s the entire string.
- TwoByte sources expand further in UTF-8.
- ASCII one-byte sources are already UTF-8-equivalent bytewise.
  - Still pay a full contiguous copy today.
- Peak allocation of a second full buffer can stress GC.
  - Related pressure shows up in sibling HangBusy MarkCompact samples.

# Solution

## DeferHashPastAwait
- Move `getScriptSource` + `sha256DigestHex` past an early `await Promise.resolve()`.
  - Keep sync early returns for missing / `data:` sourcemap URLs.
- Record win: yes.
- Replay win: yes.
- Why faster: O(n) hash leaves `ProcessCompileEvent` / register-script sync section.
- Same-build RR order shift: safe.
- Complexity: low.
  - One-line JS reorder in `replay_sourcemap_handler.js`.

## SkipHashOnReplay
- In `SHA256DigestHex`, when replaying, skip `Utf8Value` and SHA256.
- Only fill/receive via `RecordReplayBytes` on the 65-byte digest.
- Record win: none.
- Replay win: yes.
- Why faster: removes full-source copy + hash on replay.
- Determinism: digest still from RR stream.
- Complexity: low.
  - Branch in one native callback.

## ChunkedUtf8IncrementalHash
- Replace single `Utf8Value` with chunked `WriteUtf8` / `WriteOneByte` into a fixed buffer.
- Incremental SHA256 update per chunk.
- Record win: yes.
- Replay win: yes if hash still runs.
  - Redundant with SkipHashOnReplay on replay.
- Why faster: avoids one contiguous O(n) UTF-8 malloc.
  - Lower peak memory and GC pressure.
  - CPU still O(n).
- Digest bytes must match current UTF-8 SHA256.
- Complexity: med.
  - Careful encoding and chunk boundaries.

## AsciiOneByteFastPath
- If string is one-byte and all bytes `< 0x80`, hash backing bytes directly.
- Else use chunked UTF-8 path.
- Record win: yes for typical ASCII bundles.
- Replay win: yes if hash still runs.
- Why faster: skips UTF-8 expand/copy when ASCII equals UTF-8.
- Digest must remain UTF-8 SHA256.
- Complexity: med.
  - Encoding checks must be exact.
