### PR TITLE
Key opcode-emit freeze per isolate (CrossIsolateIdAlias)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '9d0f366506ad18eb4ca0a51699bb1ea72b65685b',
+  'v8_revision': 'e072eacb3b7973fc0ecb570001bfb1af8e303b79',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.

--- a/DEPS
+++ b/DEPS
@@ -311,7 +311,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling V8
   # and whatever else without interference from each other.
-  'v8_revision': '58bb081132fda47458565fa4446b2c777d650ac7',
+  'v8_revision': '9d0f366506ad18eb4ca0a51699bb1ea72b65685b',
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling swarming_client
   # and whatever else without interference from each other.


### PR DESCRIPTION
Paired with: https://github.com/replayio/chromium-v8/pull/325

# Summary
* Criterion: false FailedToReinstrument Warning on DedicatedWorker eval compile
* Root: isolate-blind bookkeeping in gOpcodeEmitByScript
* Solution Recipe: key opcode-emit freeze by Isolate* + script_id

# Problem
* Criterion: false FailedToReinstrument Warning on DedicatedWorker eval compile
* Worker isolate allocates its own script_id integers
  * Independent GetNextScriptId
* RecordReplayShouldEmitOpcodes consulted gOpcodeEmitByScript keyed only by bare script_id
  * Process-global map
* Main-isolate LitFreeze of id N falsely matches worker compile of unrelated Script with id N
* Root: isolate-blind bookkeeping in gOpcodeEmitByScript

# Solution
* Solution Recipe: key opcode-emit freeze by Isolate* + script_id
* Implementation
  * Nested map Isolate* → script_id → bool in debug.cc
  * BytecodeArrayBuilder / BytecodeGenerator pass Isolate* into RecordReplayShouldEmitOpcodes
* Why does this work?
  * Same-isolate reinstrument freeze unchanged
  * Cross-isolate bare-id collision no longer shares freeze state
